### PR TITLE
Bug fixes

### DIFF
--- a/Cancelations/CancelationRegistration.cs
+++ b/Cancelations/CancelationRegistration.cs
@@ -5,7 +5,9 @@ namespace Proto.Promises
     /// <summary>
     /// Represents a callback delegate that has been registered with a <see cref="CancelationToken"/>.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public struct CancelationRegistration : IEquatable<CancelationRegistration>
     {
         private readonly Internal.CancelationRef _ref;

--- a/Cancelations/CancelationSource.cs
+++ b/Cancelations/CancelationSource.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+using System;
 
 namespace Proto.Promises
 {
@@ -8,7 +14,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
 #endif
-    public struct CancelationSource : ICancelableAny, IDisposable, IEquatable<CancelationSource>
+    public partial struct CancelationSource : ICancelableAny, IDisposable, IEquatable<CancelationSource>
     {
         private readonly Internal.CancelationRef _ref;
         private readonly ushort _id;
@@ -19,6 +25,7 @@ namespace Proto.Promises
         /// </summary>
         public static CancelationSource New()
         {
+            ValidateThreadAccess(1);
             return new CancelationSource(Internal.CancelationRef.GetOrCreate());
         }
 
@@ -36,6 +43,7 @@ namespace Proto.Promises
         /// <returns>A new <see cref="CancelationSource"/> that is linked to the source token.</returns>
         public static CancelationSource New(CancelationToken token)
         {
+            ValidateThreadAccess(1);
             CancelationSource newCancelationSource = New();
             token.MaybeLinkSourceInternal(newCancelationSource._ref);
             return newCancelationSource;
@@ -50,6 +58,7 @@ namespace Proto.Promises
         /// <returns>A new <see cref="CancelationSource"/> that is linked to the source token.</returns>
         public static CancelationSource New(CancelationToken token1, CancelationToken token2)
         {
+            ValidateThreadAccess(1);
             CancelationSource newCancelationSource = New(token1);
             if (!newCancelationSource._ref.IsCanceled)
             {
@@ -66,6 +75,7 @@ namespace Proto.Promises
         /// <returns>A new <see cref="CancelationSource"/> that is linked to the source token.</returns>
         public static CancelationSource New(params CancelationToken[] tokens)
         {
+            ValidateThreadAccess(1);
             CancelationSource newCancelationSource = New();
             Internal.CancelationRef newCancelation = newCancelationSource._ref;
             for (int i = 0, max = tokens.Length; i < max & !newCancelation.IsCanceled; ++i)
@@ -98,6 +108,7 @@ namespace Proto.Promises
         {
             get
             {
+                ValidateThreadAccess(1);
                 return _ref != null && _ref.SourceId == _id;
             }
         }
@@ -164,16 +175,24 @@ namespace Proto.Promises
 
         public override bool Equals(object obj)
         {
+#if CSHARP_7_OR_LATER
+            if (obj is CancelationSource cancelationSource)
+            {
+                return Equals(cancelationSource);
+            }
+#else
             if (obj is CancelationSource)
             {
                 return Equals((CancelationSource) obj);
             }
+#endif
             return false;
         }
 
         public override int GetHashCode()
         {
-            if (_ref == null)
+            var temp = _ref;
+            if (temp == null)
             {
                 return 0;
             }
@@ -181,7 +200,7 @@ namespace Proto.Promises
             {
                 int hash = 17;
                 hash = hash * 31 + _id.GetHashCode();
-                hash = hash * 31 + _ref.GetHashCode();
+                hash = hash * 31 + temp.GetHashCode();
                 return hash;
             }
         }
@@ -195,5 +214,14 @@ namespace Proto.Promises
         {
             return !(c1 == c2);
         }
+
+        // Calls to this get compiled away in RELEASE mode
+        static partial void ValidateThreadAccess(int skipFrames);
+#if PROMISE_DEBUG
+        static partial void ValidateThreadAccess(int skipFrames)
+        {
+            Internal.ValidateThreadAccess(skipFrames + 1);
+        }
+#endif
     }
 }

--- a/Cancelations/CancelationSource.cs
+++ b/Cancelations/CancelationSource.cs
@@ -5,7 +5,9 @@ namespace Proto.Promises
     /// <summary>
     /// Cancelation source used to cancel promises.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public struct CancelationSource : ICancelableAny, IDisposable, IEquatable<CancelationSource>
     {
         private readonly Internal.CancelationRef _ref;

--- a/Cancelations/CancelationToken.cs
+++ b/Cancelations/CancelationToken.cs
@@ -13,7 +13,9 @@ namespace Proto.Promises
     /// <summary>
     /// Propagates notification that operations should be canceled.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public partial struct CancelationToken : IRetainable, IEquatable<CancelationToken>
     {
         private readonly Internal.CancelationRef _ref;

--- a/Cancelations/CancelationToken.cs
+++ b/Cancelations/CancelationToken.cs
@@ -69,6 +69,7 @@ namespace Proto.Promises
         {
             get
             {
+                ValidateThreadAccess(1);
                 return _ref != null && _ref.TokenId == _id;
             }
         }
@@ -219,16 +220,24 @@ namespace Proto.Promises
 
         public override bool Equals(object obj)
         {
-            if (obj is CancelationSource)
+#if CSHARP_7_OR_LATER
+            if (obj is CancelationToken cancelationSource)
             {
-                return Equals((CancelationSource) obj);
+                return Equals(cancelationSource);
             }
+#else
+            if (obj is CancelationToken)
+            {
+                return Equals((CancelationToken) obj);
+            }
+#endif
             return false;
         }
 
         public override int GetHashCode()
         {
-            if (_ref == null)
+            var temp = _ref;
+            if (temp == null)
             {
                 return 0;
             }
@@ -236,7 +245,7 @@ namespace Proto.Promises
             {
                 int hash = 17;
                 hash = hash * 31 + _id.GetHashCode();
-                hash = hash * 31 + _ref.GetHashCode();
+                hash = hash * 31 + temp.GetHashCode();
                 return hash;
             }
         }
@@ -251,11 +260,18 @@ namespace Proto.Promises
             return !(c1 == c2);
         }
 
+        // Calls to these get compiled away in RELEASE mode
         static partial void ValidateArgument(object arg, string argName, int skipFrames);
+        static partial void ValidateThreadAccess(int skipFrames);
 #if PROMISE_DEBUG
         static partial void ValidateArgument(object arg, string argName, int skipFrames)
         {
             Internal.ValidateArgument(arg, argName, skipFrames + 1);
+        }
+
+        static partial void ValidateThreadAccess(int skipFrames)
+        {
+            Internal.ValidateThreadAccess(skipFrames + 1);
         }
 #endif
     }

--- a/InternalShared/CancelDelegateWrappersInternal.cs
+++ b/InternalShared/CancelDelegateWrappersInternal.cs
@@ -1,13 +1,14 @@
 ﻿#pragma warning disable IDE0034 // Simplify 'default' expression
 
 using System;
-using System.Diagnostics;
 
 namespace Proto.Promises
 {
     internal static partial class Internal
     {
-        [DebuggerNonUserCode]
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [System.Diagnostics.DebuggerNonUserCode]
+#endif
         internal struct CancelDelegatePromise : IDelegateCancel
         {
             private readonly Action<ReasonContainer> _callback;
@@ -41,7 +42,9 @@ namespace Proto.Promises
             public void MaybeDispose(IDisposable owner) { throw new System.InvalidOperationException(); }
         }
 
-        [DebuggerNonUserCode]
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [System.Diagnostics.DebuggerNonUserCode]
+#endif
         internal struct CancelDelegatePromise<TCapture> : IDelegateCancel
         {
             private readonly TCapture _captureValue;
@@ -77,7 +80,9 @@ namespace Proto.Promises
             public void MaybeDispose(IDisposable owner) { throw new System.InvalidOperationException(); }
         }
 
-        [DebuggerNonUserCode]
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [System.Diagnostics.DebuggerNonUserCode]
+#endif
         internal struct CancelDelegatePromiseCancel : IDelegateCancel
         {
             public CancelationRegistration cancelationRegistration;
@@ -143,7 +148,9 @@ namespace Proto.Promises
             }
         }
 
-        [DebuggerNonUserCode]
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [System.Diagnostics.DebuggerNonUserCode]
+#endif
         internal struct CancelDelegatePromiseCancel<TCapture> : IDelegateCancel
         {
             public CancelationRegistration cancelationRegistration;
@@ -211,7 +218,9 @@ namespace Proto.Promises
             }
         }
 
-        [DebuggerNonUserCode]
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [System.Diagnostics.DebuggerNonUserCode]
+#endif
         internal struct CancelDelegateToken : IDelegateCancel
         {
             private readonly Action<ReasonContainer> _callback;
@@ -238,7 +247,9 @@ namespace Proto.Promises
             public void InvokeFromPromise(ITraceable owner) { throw new System.InvalidOperationException(); }
         }
 
-        [DebuggerNonUserCode]
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [System.Diagnostics.DebuggerNonUserCode]
+#endif
         internal struct CancelDelegateToken<TCapture> : IDelegateCancel
         {
             private readonly TCapture _captureValue;

--- a/InternalShared/ExceptionsInternal.cs
+++ b/InternalShared/ExceptionsInternal.cs
@@ -13,7 +13,9 @@ namespace Proto.Promises
 {
     partial class Internal
     {
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         public sealed class UnhandledExceptionInternal : UnhandledException, IRejectionToContainer, IRejectValueContainer, ICantHandleException
         {
             private int _retainCounter;
@@ -77,7 +79,9 @@ namespace Proto.Promises
 #endif
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         public sealed class CanceledExceptionInternal : CanceledException, ICancelValueContainer, ICancelationToContainer
         {
             public CanceledExceptionInternal(object value, Type valueType, string message) :
@@ -105,7 +109,9 @@ namespace Proto.Promises
             }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         public sealed class RejectionException : Exception
         {
             private readonly string _stackTrace;
@@ -118,7 +124,9 @@ namespace Proto.Promises
             public override string StackTrace { get { return _stackTrace; } }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         public sealed class RejectExceptionInternal<T> : RejectException, IRejectionToContainer, ICantHandleException
         {
             // We can reuse the same object.
@@ -150,7 +158,9 @@ namespace Proto.Promises
             }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         public sealed class CancelExceptionVoidInternal : CancelException, ICancelationToContainer
         {
             // We can reuse the same object.
@@ -169,7 +179,9 @@ namespace Proto.Promises
             }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         public sealed class CancelExceptionInternal<T> : CancelException, ICancelationToContainer
         {
             // We can reuse the same object.

--- a/InternalShared/HelperFunctionsInternal.cs
+++ b/InternalShared/HelperFunctionsInternal.cs
@@ -46,6 +46,23 @@ namespace Proto.Promises
         static partial void _SetCurrentInvoker(ITraceable current);
         static partial void _ClearCurrentInvoker();
 #if PROMISE_DEBUG
+        private static readonly System.Threading.Thread _initialThread = System.Threading.Thread.CurrentThread;
+
+        public static void ValidateThreadAccess(int skipFrames, bool warn = true)
+        {
+            if (!ReferenceEquals(_initialThread, System.Threading.Thread.CurrentThread))
+            {
+                string message = "ProtoPromise library accessed from more than one thread. This is currently unsafe. All access should be from the UI/main thread.";
+                var temp = Promise.Config.WarningHandler;
+                if (!warn | temp == null)
+                {
+                    message += "\nPromise.Config.WarningHandler is null, set a warning handler to make this a warning instead of an exception.";
+                    throw new InvalidOperationException(message, GetFormattedStacktrace(skipFrames + 1));
+                }
+                temp.Invoke(message);
+            }
+        }
+
         static partial void _SetCreatedStacktrace(ITraceable traceable, int skipFrames)
         {
             SetCreatedStacktrace(traceable, skipFrames + 1);

--- a/InternalShared/HelperFunctionsInternal.cs
+++ b/InternalShared/HelperFunctionsInternal.cs
@@ -23,7 +23,9 @@ namespace Proto.Promises
     /// <summary>
     /// Members of this type are meant for INTERNAL USE ONLY! Do not use in user code! Use the documented public APIs.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     internal static partial class Internal
     {
         public static bool invokingRejected;

--- a/InternalShared/HelperFunctionsInternal.cs
+++ b/InternalShared/HelperFunctionsInternal.cs
@@ -277,7 +277,7 @@ namespace Proto.Promises
         }
 
         // Handle promises in a depth-first manner.
-        private static ValueLinkedQueue<ITreeHandleable> _handleQueue;
+        internal static ValueLinkedQueue<ITreeHandleable> _handleQueue;
         private static bool _runningHandles;
 
         public static void AddToHandleQueueFront(ITreeHandleable handleable)

--- a/InternalShared/HelperTypesInternal.cs
+++ b/InternalShared/HelperTypesInternal.cs
@@ -265,21 +265,6 @@ namespace Proto.Promises
                 return index >= 0 && (tokenId == TokenId & _registeredCallbacks[index].callback != null);
             }
 
-            public void Unregister(uint order)
-            {
-                int index = IndexOf(order);
-                RegisteredDelegate del = _registeredCallbacks[index];
-                if (_isInvoking)
-                {
-                    _registeredCallbacks[index] = new RegisteredDelegate(del.order);
-                }
-                else
-                {
-                    _registeredCallbacks.RemoveAt(index);
-                }
-                del.callback.Dispose();
-            }
-
             public bool TryUnregister(ushort tokenId, uint order)
             {
                 int index = IndexOf(order);

--- a/InternalShared/HelperTypesInternal.cs
+++ b/InternalShared/HelperTypesInternal.cs
@@ -16,7 +16,9 @@ namespace Proto.Promises
     internal static partial class Internal
     {
 #if PROMISE_DEBUG
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         public class CausalityTrace
         {
             private readonly StackTrace _stackTrace;
@@ -48,7 +50,9 @@ namespace Proto.Promises
         }
 #endif
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         public sealed class CancelDelegate<TCanceler> : ICancelDelegate, IDisposableTreeHandleable, ITraceable where TCanceler : IDelegateCancel
         {
 #if PROMISE_DEBUG
@@ -148,7 +152,9 @@ namespace Proto.Promises
             }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         internal sealed class CancelationRef : ICancelDelegate, ILinked<CancelationRef>, ITraceable
         {
             private struct RegisteredDelegate : IComparable<RegisteredDelegate>

--- a/InternalShared/HelperTypesInternal.cs
+++ b/InternalShared/HelperTypesInternal.cs
@@ -78,7 +78,7 @@ namespace Proto.Promises
                 return del;
             }
 
-            void ITreeHandleable.MakeReady(IValueContainer valueContainer, ref ValueLinkedQueue<ITreeHandleable> handleQueue)
+            void ITreeHandleable.MakeReady(Promise owner, IValueContainer valueContainer, ref ValueLinkedQueue<ITreeHandleable> handleQueue)
             {
                 if (valueContainer.GetState() == Promise.State.Canceled)
                 {
@@ -91,7 +91,7 @@ namespace Proto.Promises
                 }
             }
 
-            void ITreeHandleable.MakeReadyFromSettled(IValueContainer valueContainer)
+            void ITreeHandleable.MakeReadyFromSettled(Promise owner, IValueContainer valueContainer)
             {
                 if (valueContainer.GetState() == Promise.State.Canceled)
                 {

--- a/InternalShared/InterfacesInternal.cs
+++ b/InternalShared/InterfacesInternal.cs
@@ -33,8 +33,8 @@ namespace Proto.Promises
         public interface ITreeHandleable : ILinked<ITreeHandleable>
         {
             void Handle();
-            void MakeReady(IValueContainer valueContainer, ref ValueLinkedQueue<ITreeHandleable> handleQueue);
-            void MakeReadyFromSettled(IValueContainer valueContainer);
+            void MakeReady(Promise owner, IValueContainer valueContainer, ref ValueLinkedQueue<ITreeHandleable> handleQueue);
+            void MakeReadyFromSettled(Promise owner, IValueContainer valueContainer);
         }
 
         public interface IDisposableTreeHandleable : ITreeHandleable, IDisposable { }

--- a/InternalShared/ValueContainersInternal.cs
+++ b/InternalShared/ValueContainersInternal.cs
@@ -19,7 +19,9 @@ namespace Proto.Promises
 {
     internal static partial class Internal
     {
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public sealed class RejectionContainer<T> : ILinked<RejectionContainer<T>>, IRejectValueContainer, IValueContainer<T>, IRejectionToContainer, ICantHandleException
         {
             RejectionContainer<T> ILinked<RejectionContainer<T>>.Next { get; set; }
@@ -181,7 +183,9 @@ namespace Proto.Promises
             }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public sealed class CancelContainer<T> : ILinked<CancelContainer<T>>, ICancelValueContainer, IValueContainer<T>, ICancelationToContainer
         {
             CancelContainer<T> ILinked<CancelContainer<T>>.Next { get; set; }
@@ -271,7 +275,9 @@ namespace Proto.Promises
             }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public sealed class CancelContainerVoid : ICancelValueContainer, ICancelationToContainer
         {
             // We can reuse the same object.
@@ -307,7 +313,9 @@ namespace Proto.Promises
             }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public sealed class ResolveContainer<T> : ILinked<ResolveContainer<T>>, IValueContainer, IValueContainer<T>
         {
             ResolveContainer<T> ILinked<ResolveContainer<T>>.Next { get; set; }
@@ -384,7 +392,9 @@ namespace Proto.Promises
             }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public sealed class ResolveContainerVoid : IValueContainer
         {
             // We can reuse the same object.

--- a/Promises/Config.cs
+++ b/Promises/Config.cs
@@ -60,7 +60,9 @@ namespace Proto.Promises
         /// <summary>
         /// Promise configuration. Configuration settings affect the global behaviour of promises.
         /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public static class Config
         {
 #if PROMISE_PROGRESS

--- a/Promises/Config.cs
+++ b/Promises/Config.cs
@@ -73,6 +73,7 @@ namespace Proto.Promises
             /// Precision: 1/(N*2^<see cref="ProgressDecimalBits"/>) where N is the number of wait promises in the chain where Progress is subscribed.
             /// <para/>
             /// NOTE: promises that don't wait (.Then with an onResolved that simply returns a value or void) don't count towards the promise chain limit.
+            /// The limit is removed when progress is disabled (this is compiled with the symbol PROTO_PROMISE_PROGRESS_DISABLE defined).
             /// </summary>
             public const int ProgressDecimalBits = 13;
 #endif

--- a/Promises/Deferred.cs
+++ b/Promises/Deferred.cs
@@ -14,7 +14,9 @@ namespace Proto.Promises
         /// Deferred base. An instance of this can be used to report progress and reject the attached <see cref="Promises.Promise"/>.
         /// <para/>You must use <see cref="Deferred"/> or <see cref="Promise{T}.Deferred"/> to resolve the attached <see cref="Promises.Promise"/>.
         /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public struct DeferredBase : IRetainable
         {
             private readonly Promise _promise;
@@ -182,7 +184,9 @@ namespace Proto.Promises
         /// <summary>
         /// An instance of this is used to report progress and resolve or reject the attached <see cref="Promises.Promise"/>.
         /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public struct Deferred
         {
             private readonly Promise _promise;
@@ -389,7 +393,9 @@ namespace Proto.Promises
         /// <summary>
         /// An instance of this is used to handle the state of the <see cref="Promise"/>.
         /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public new struct Deferred
         {
             private readonly Promise<T> _promise;

--- a/Promises/Deferred.cs
+++ b/Promises/Deferred.cs
@@ -60,6 +60,8 @@ namespace Proto.Promises
             {
                 get
                 {
+                    ValidateThreadAccess(1);
+
                     return _promise != null && _id == _promise.Id;
                 }
             }
@@ -230,6 +232,8 @@ namespace Proto.Promises
             {
                 get
                 {
+                    ValidateThreadAccess(1);
+
                     return _promise != null && _id == _promise.Id;
                 }
             }
@@ -259,6 +263,8 @@ namespace Proto.Promises
             /// </summary>
             public static Deferred New(CancelationToken cancelationToken = default(CancelationToken))
             {
+                ValidateThreadAccess(1);
+
                 return new Deferred(cancelationToken);
             }
 
@@ -439,6 +445,8 @@ namespace Proto.Promises
             {
                 get
                 {
+                    ValidateThreadAccess(1);
+
                     return _promise != null && _id == _promise.Id;
                 }
             }
@@ -468,6 +476,8 @@ namespace Proto.Promises
             /// </summary>
             public static Deferred New(CancelationToken cancelationToken = default(CancelationToken))
             {
+                ValidateThreadAccess(1);
+
                 return new Deferred(cancelationToken);
             }
 

--- a/Promises/Exceptions.cs
+++ b/Promises/Exceptions.cs
@@ -14,7 +14,9 @@ using System.Globalization;
 
 namespace Proto.Promises
 {
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public class InvalidOperationException : System.InvalidOperationException
     {
         public InvalidOperationException(string message, string stackTrace = null) : base(message)
@@ -26,7 +28,9 @@ namespace Proto.Promises
         public override string StackTrace { get { return _stackTrace ?? base.StackTrace; } }
     }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public class EmptyArgumentException : ArgumentException
     {
         public EmptyArgumentException(string paramName, string message, string stackTrace = null) : base(message, paramName)
@@ -38,7 +42,9 @@ namespace Proto.Promises
         public override string StackTrace { get { return _stackTrace ?? base.StackTrace; } }
     }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public class ArgumentNullException : System.ArgumentNullException
     {
         public ArgumentNullException(string paramName, string message, string stackTrace = null) : base(paramName, message)
@@ -50,7 +56,9 @@ namespace Proto.Promises
         public override string StackTrace { get { return _stackTrace ?? base.StackTrace; } }
     }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public class ArgumentOutOfRangeException : System.ArgumentOutOfRangeException
     {
         public ArgumentOutOfRangeException(string paramName, string message, string stackTrace = null) : base(paramName, message)
@@ -67,7 +75,9 @@ namespace Proto.Promises
         public override string StackTrace { get { return _stackTrace ?? base.StackTrace; } }
     }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public class ElementNullException : System.ArgumentNullException
     {
         public ElementNullException(string paramName, string message, string stackTrace = null) : base(paramName, message)
@@ -79,7 +89,9 @@ namespace Proto.Promises
         public override string StackTrace { get { return _stackTrace ?? base.StackTrace; } }
     }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public class PromiseDisposedException : ObjectDisposedException
     {
         public PromiseDisposedException(string message, string stackTrace = null) : base(message, default(Exception))
@@ -91,7 +103,9 @@ namespace Proto.Promises
         public override string StackTrace { get { return _stackTrace ?? base.StackTrace; } }
     }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public class InvalidReturnException : System.InvalidOperationException
     {
         public InvalidReturnException(string message, string stackTrace = null, Exception innerException = null) : base(message, innerException)
@@ -103,7 +117,9 @@ namespace Proto.Promises
         public override string StackTrace { get { return _stackTrace ?? base.StackTrace; } }
     }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public class UnhandledDeferredException : Exception
     {
         public static readonly UnhandledDeferredException instance =
@@ -112,7 +128,9 @@ namespace Proto.Promises
         private UnhandledDeferredException(string message) : base(message) { }
     }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public class UnreleasedObjectException : Exception
     {
         public UnreleasedObjectException(string message) : base(message) { }
@@ -122,7 +140,9 @@ namespace Proto.Promises
     /// <summary>
     /// Exception that is thrown if a promise is rejected and that rejection is never handled.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public abstract class UnhandledException : Exception
     {
         private readonly object _value;
@@ -157,7 +177,9 @@ namespace Proto.Promises
     /// <summary>
     /// Exception that is thrown if an awaited promise is canceled.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public abstract class CanceledException : OperationCanceledException
     {
         private readonly object _value;
@@ -189,7 +211,9 @@ namespace Proto.Promises
     /// <summary>
     /// Special Exception that is used to rethrow a rejection from a Promise onRejected callback.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public sealed class RethrowException : Exception
     {
         internal static readonly RethrowException instance = new RethrowException();
@@ -200,7 +224,9 @@ namespace Proto.Promises
     /// <summary>
     /// Special Exception that is used to reject a Promise from an onResolved or onRejected callback.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public abstract class RejectException : Exception
     {
         internal RejectException() { }
@@ -217,7 +243,9 @@ namespace Proto.Promises
     /// <summary>
     /// Special Exception that is used to cancel a Promise from an onResolved or onRejected callback.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public abstract class CancelException : OperationCanceledException
     {
         internal CancelException() { }

--- a/Promises/Extensions.cs
+++ b/Promises/Extensions.cs
@@ -1,6 +1,5 @@
 ﻿#if CSHARP_7_OR_LATER
 using System.Threading.Tasks;
-using Proto.Promises.Await;
 #endif
 
 namespace Proto.Promises

--- a/Promises/Extensions.cs
+++ b/Promises/Extensions.cs
@@ -1,11 +1,20 @@
-﻿#if CSHARP_7_OR_LATER
+﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable IDE0060 // Remove unused parameter
+
+#if CSHARP_7_OR_LATER
 using System.Threading.Tasks;
 #endif
 
 namespace Proto.Promises
 {
     [System.Diagnostics.DebuggerNonUserCode]
-    public static class Extensions
+    public static partial class Extensions
     {
 #if CSHARP_7_OR_LATER
         /// <summary>
@@ -13,6 +22,8 @@ namespace Proto.Promises
         /// </summary>
         public static async Task ToTask(this Promise promise)
         {
+            ValidateThreadAccess(1);
+
             await promise;
         }
 
@@ -21,29 +32,40 @@ namespace Proto.Promises
         /// </summary>
         public static async Task<T> ToTask<T>(this Promise<T> promise)
         {
+            ValidateThreadAccess(1);
+
             return await promise;
         }
 
         /// <summary>
         /// Convert the <see cref="Task"/> to a <see cref="Promise"/>.
-        /// <para/>NOTE: This must be called from the UI/main thread. If called from a different thread, Promise states could get corrupted from a race condition.
         /// </summary>
         public static async Promise ToPromise(this Task task)
         {
             // No thread safety in the Promise library yet, so try to force continuation on main thread.
             // User must call this method from the main thread in order for this to work.
+            ValidateThreadAccess(1);
             await task.ConfigureAwait(true);
         }
 
         /// <summary>
         /// Convert the <see cref="Task{T}"/> to a <see cref="Promise{T}"/>.
-        /// <para/>NOTE: This must be called from the UI/main thread. If called from a different thread, Promise states could get corrupted from a race condition.
         /// </summary>
         public static async Promise<T> ToPromise<T>(this Task<T> task)
         {
             // No thread safety in the Promise library yet, so try to force continuation on main thread.
             // User must call this method from the main thread in order for this to work.
+            ValidateThreadAccess(1);
             return await task.ConfigureAwait(true);
+        }
+#endif
+
+        // Calls to this get compiled away in RELEASE mode
+        static partial void ValidateThreadAccess(int skipFrames);
+#if PROMISE_DEBUG
+        static partial void ValidateThreadAccess(int skipFrames)
+        {
+            Internal.ValidateThreadAccess(skipFrames + 1);
         }
 #endif
     }

--- a/Promises/Internal/AllInternal.cs
+++ b/Promises/Internal/AllInternal.cs
@@ -21,7 +21,6 @@ namespace Proto.Promises
 {
     partial class Promise
     {
-        [System.Diagnostics.DebuggerNonUserCode]
         partial class InternalProtected
         {
             public static Promise CreateAll<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise>
@@ -73,7 +72,9 @@ namespace Proto.Promises
                 }, count);
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed partial class AllPromise0 : PromiseIntermediate, IMultiTreeHandleable
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;

--- a/Promises/Internal/AllInternal.cs
+++ b/Promises/Internal/AllInternal.cs
@@ -167,8 +167,9 @@ namespace Proto.Promises
             partial class AllPromiseVoid : IInvokable
             {
                 // These are used to avoid rounding errors when normalizing the progress.
-                private uint _expected;
-                private UnsignedFixed32 _currentAmount;
+                // Use 64 bits to allow combining many promises with very deep chains.
+                private double _progressScaler;
+                private UnsignedFixed64 _unscaledProgress;
                 private bool _invokingProgress;
 
                 protected override void Reset()
@@ -178,10 +179,10 @@ namespace Proto.Promises
 #endif
                     {
                         base.Reset();
-                        _currentAmount = default(UnsignedFixed32);
+                        _unscaledProgress = default(UnsignedFixed64);
                         _invokingProgress = false;
 
-                        uint expectedProgressCounter = 0;
+                        ulong expectedProgressCounter = 0L;
                         uint maxWaitDepth = 0;
                         foreach (var passThrough in _passThroughs)
                         {
@@ -193,10 +194,11 @@ namespace Proto.Promises
                                 maxWaitDepth = Math.Max(maxWaitDepth, waitDepth);
                             }
                         }
-                        _expected = expectedProgressCounter + _waitCount;
 
                         // Use the longest chain as this depth.
                         _waitDepthAndProgress = new UnsignedFixed32(maxWaitDepth);
+                        // Pre-calculate the progress scaler.
+                        _progressScaler = (double) NextWholeProgress / (double) (expectedProgressCounter + _waitCount);
                     }
                 }
 
@@ -228,10 +230,7 @@ namespace Proto.Promises
 
                 protected override UnsignedFixed32 CurrentProgress()
                 {
-                    // Calculate the normalized progress for all the awaited promises.
-                    // Use double for better precision. Scale to the calculated depth.
-                    double progress = _currentAmount.ToDouble() * NextWholeProgress / (double) _expected;
-                    return new UnsignedFixed32((float) progress);
+                    return new UnsignedFixed32(_unscaledProgress.ToDouble() * _progressScaler);
                 }
 
                 void IMultiTreeHandleable.IncrementProgress(uint amount, UnsignedFixed32 senderAmount, UnsignedFixed32 ownerAmount)
@@ -241,7 +240,7 @@ namespace Proto.Promises
 
                 private void IncrementProgress(uint amount)
                 {
-                    _currentAmount.Increment(amount);
+                    _unscaledProgress.Increment(amount);
                     if (!_invokingProgress & _state == State.Pending)
                     {
                         RetainInternal();

--- a/Promises/Internal/AsyncAwaitInternal.cs
+++ b/Promises/Internal/AsyncAwaitInternal.cs
@@ -172,7 +172,9 @@ namespace Proto.Promises
         /// <summary>
         /// This type and its members are intended for use by the compiler (async Promise functions).
         /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         internal abstract class PromiseMethodContinuer : IDisposable
         {
             public abstract Action Continuation { get; }
@@ -196,7 +198,9 @@ namespace Proto.Promises
             /// <summary>
             /// Generic class to reference the state machine without boxing it.
             /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode]
+#endif
             private sealed class Continuer<TStateMachine> : PromiseMethodContinuer, ILinked<Continuer<TStateMachine>> where TStateMachine : IAsyncStateMachine
             {
                 private static ValueLinkedStack<Continuer<TStateMachine>> _pool;
@@ -263,10 +267,14 @@ namespace Proto.Promises.Async.CompilerServices
     /// <summary>
     /// This type and its members are intended for use by the compiler.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public struct PromiseMethodBuilder
     {
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         private sealed class AsyncPromise : Promise, Internal.ITreeHandleable
         {
             private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -397,10 +405,14 @@ namespace Proto.Promises.Async.CompilerServices
     /// <summary>
     /// This type and its members are intended for use by the compiler.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public struct PromiseMethodBuilder<T>
     {
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         private sealed class AsyncPromise : Promise<T>, Internal.ITreeHandleable
         {
             private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -534,11 +546,15 @@ namespace Proto.Promises.Async.CompilerServices
     /// <summary>
     /// This type and its members are intended for use by the compiler.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public struct PromiseMethodBuilder
     {
         // Using a promise object as its own continuer saves 16 bytes of object overhead (x64).
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         private abstract class AsyncPromise : Promise
         {
             // Cache the delegate to prevent new allocations.
@@ -574,7 +590,9 @@ namespace Proto.Promises.Async.CompilerServices
             }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         private sealed class AsyncPromise<TStateMachine> : AsyncPromise, Internal.ITreeHandleable where TStateMachine : IAsyncStateMachine
         {
             private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -693,11 +711,15 @@ namespace Proto.Promises.Async.CompilerServices
     /// <summary>
     /// This type and its members are intended for use by the compiler.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode]
+#endif
     public struct PromiseMethodBuilder<T>
     {
         // Using a promise object as its own continuer saves 16 bytes of object overhead (x64).
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         private abstract class AsyncPromise : Promise<T>
         {
             // Cache the delegate to prevent new allocations.
@@ -733,7 +755,9 @@ namespace Proto.Promises.Async.CompilerServices
             }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         private sealed class AsyncPromise<TStateMachine> : AsyncPromise, Internal.ITreeHandleable where TStateMachine : IAsyncStateMachine
         {
             private static ValueLinkedStack<Internal.ITreeHandleable> _pool;

--- a/Promises/Internal/AsyncAwaitInternal.cs
+++ b/Promises/Internal/AsyncAwaitInternal.cs
@@ -584,13 +584,12 @@ namespace Proto.Promises.Async.CompilerServices
                 Internal.OnClearPool += () => _pool.Clear();
             }
 
-            private TStateMachine _stateMachine;
+            public TStateMachine stateMachine;
 
-            public static AsyncPromise<TStateMachine> GetOrCreate(ref TStateMachine stateMachine)
+            public static AsyncPromise<TStateMachine> GetOrCreate()
             {
                 var promise = _pool.IsNotEmpty ? (AsyncPromise<TStateMachine>) _pool.Pop() : new AsyncPromise<TStateMachine>();
                 promise.Reset();
-                promise._stateMachine = stateMachine;
                 return promise;
             }
 
@@ -602,7 +601,7 @@ namespace Proto.Promises.Async.CompilerServices
             protected override void Dispose()
             {
                 base.Dispose();
-                _stateMachine = default;
+                stateMachine = default;
                 if (Config.ObjectPooling != PoolType.None)
                 {
                     _pool.Push(this);
@@ -611,20 +610,17 @@ namespace Proto.Promises.Async.CompilerServices
 
             protected override void ContinueMethod()
             {
-                _stateMachine.MoveNext();
+                stateMachine.MoveNext();
             }
         }
 
-        [DebuggerHidden]
         public Promise Task { get; private set; }
 
-        [DebuggerHidden]
         public static PromiseMethodBuilder Create()
         {
             return new PromiseMethodBuilder();
         }
 
-        [DebuggerHidden]
         public void SetException(Exception exception)
         {
             if (Task is null)
@@ -644,7 +640,6 @@ namespace Proto.Promises.Async.CompilerServices
             }
         }
 
-        [DebuggerHidden]
         public void SetResult()
         {
             if (Task is null)
@@ -657,45 +652,44 @@ namespace Proto.Promises.Async.CompilerServices
             }
         }
 
-        [DebuggerHidden]
         public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
             where TAwaiter : INotifyCompletion
             where TStateMachine : IAsyncStateMachine
         {
-            SetContinuation(ref stateMachine);
-            awaiter.OnCompleted(((AsyncPromise) Task).continuation);
+            awaiter.OnCompleted(GetContinuation(ref stateMachine));
         }
 
-        [DebuggerHidden]
         [SecuritySafeCritical]
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
             where TAwaiter : ICriticalNotifyCompletion
             where TStateMachine : IAsyncStateMachine
         {
-            SetContinuation(ref stateMachine);
-            awaiter.UnsafeOnCompleted(((AsyncPromise) Task).continuation);
+            awaiter.UnsafeOnCompleted(GetContinuation(ref stateMachine));
         }
 
-        [DebuggerHidden]
         public void Start<TStateMachine>(ref TStateMachine stateMachine)
             where TStateMachine : IAsyncStateMachine
         {
             stateMachine.MoveNext();
         }
 
-        [DebuggerHidden]
         public void SetStateMachine(IAsyncStateMachine stateMachine) { }
 
-        [DebuggerHidden]
-        private void SetContinuation<TStateMachine>(ref TStateMachine stateMachine)
+        private Action GetContinuation<TStateMachine>(ref TStateMachine stateMachine)
             where TStateMachine : IAsyncStateMachine
         {
             if (Task is null)
             {
-                Task = AsyncPromise<TStateMachine>.GetOrCreate(ref stateMachine);
+                var promise = AsyncPromise<TStateMachine>.GetOrCreate();
+                // ORDER VERY IMPORTANT, Task must be set before copying stateMachine.
+                Task = promise;
+                promise.stateMachine = stateMachine;
+                return promise.continuation;
             }
+            return ((AsyncPromise) Task).continuation;
         }
     }
+
     /// <summary>
     /// This type and its members are intended for use by the compiler.
     /// </summary>
@@ -749,13 +743,12 @@ namespace Proto.Promises.Async.CompilerServices
                 Internal.OnClearPool += () => _pool.Clear();
             }
 
-            private TStateMachine _stateMachine;
+            public TStateMachine stateMachine;
 
-            public static AsyncPromise<TStateMachine> GetOrCreate(ref TStateMachine stateMachine)
+            public static AsyncPromise<TStateMachine> GetOrCreate()
             {
                 var promise = _pool.IsNotEmpty ? (AsyncPromise<TStateMachine>) _pool.Pop() : new AsyncPromise<TStateMachine>();
                 promise.Reset();
-                promise._stateMachine = stateMachine;
                 return promise;
             }
 
@@ -767,7 +760,7 @@ namespace Proto.Promises.Async.CompilerServices
             protected override void Dispose()
             {
                 base.Dispose();
-                _stateMachine = default;
+                stateMachine = default;
                 if (Config.ObjectPooling != PoolType.None)
                 {
                     _pool.Push(this);
@@ -776,20 +769,17 @@ namespace Proto.Promises.Async.CompilerServices
 
             protected override void ContinueMethod()
             {
-                _stateMachine.MoveNext();
+                stateMachine.MoveNext();
             }
         }
 
-        [DebuggerHidden]
         public Promise<T> Task { get; set; }
 
-        [DebuggerHidden]
         public static PromiseMethodBuilder<T> Create()
         {
             return new PromiseMethodBuilder<T>();
         }
 
-        [DebuggerHidden]
         public void SetException(Exception exception)
         {
             if (Task is null)
@@ -809,7 +799,6 @@ namespace Proto.Promises.Async.CompilerServices
             }
         }
 
-        [DebuggerHidden]
         public void SetResult(T result)
         {
             if (Task is null)
@@ -822,43 +811,41 @@ namespace Proto.Promises.Async.CompilerServices
             }
         }
 
-        [DebuggerHidden]
         public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
             where TAwaiter : INotifyCompletion
             where TStateMachine : IAsyncStateMachine
         {
-            SetContinuation(ref stateMachine);
-            awaiter.OnCompleted(((AsyncPromise) Task).continuation);
+            awaiter.OnCompleted(GetContinuation(ref stateMachine));
         }
 
-        [DebuggerHidden]
         [SecuritySafeCritical]
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
             where TAwaiter : ICriticalNotifyCompletion
             where TStateMachine : IAsyncStateMachine
         {
-            SetContinuation(ref stateMachine);
-            awaiter.UnsafeOnCompleted(((AsyncPromise) Task).continuation);
+            awaiter.UnsafeOnCompleted(GetContinuation(ref stateMachine));
         }
 
-        [DebuggerHidden]
         public void Start<TStateMachine>(ref TStateMachine stateMachine)
             where TStateMachine : IAsyncStateMachine
         {
             stateMachine.MoveNext();
         }
 
-        [DebuggerHidden]
         public void SetStateMachine(IAsyncStateMachine stateMachine) { }
 
-        [DebuggerHidden]
-        private void SetContinuation<TStateMachine>(ref TStateMachine stateMachine)
+        private Action GetContinuation<TStateMachine>(ref TStateMachine stateMachine)
             where TStateMachine : IAsyncStateMachine
         {
             if (Task is null)
             {
-                Task = AsyncPromise<TStateMachine>.GetOrCreate(ref stateMachine);
+                var promise = AsyncPromise<TStateMachine>.GetOrCreate();
+                // ORDER VERY IMPORTANT, Task must be set before copying stateMachine.
+                Task = promise;
+                promise.stateMachine = stateMachine;
+                return promise.continuation;
             }
+            return ((AsyncPromise) Task).continuation;
         }
     }
 }

--- a/Promises/Internal/CancelInternal.cs
+++ b/Promises/Internal/CancelInternal.cs
@@ -43,6 +43,7 @@ namespace Proto.Promises
         void Internal.ICancelDelegate.Invoke(Internal.ICancelValueContainer valueContainer)
         {
             CancelCallbacks();
+            CancelProgressListeners();
 
             object currentValue = _valueOrPrevious;
             _valueOrPrevious = valueContainer;

--- a/Promises/Internal/DebugInternal.cs
+++ b/Promises/Internal/DebugInternal.cs
@@ -25,6 +25,7 @@ namespace Proto.Promises
     partial class Promise
     {
         // Calls to these get compiled away in RELEASE mode
+        static partial void ValidateThreadAccess(int skipFrames, bool warn = true);
         static partial void ValidateOperation(Promise promise, int skipFrames);
         static partial void ValidateProgress(float progress, int skipFrames);
         static partial void ValidateArgument(object arg, string argName, int skipFrames);
@@ -37,8 +38,10 @@ namespace Proto.Promises
         static partial void SetCurrentInvoker(Internal.ITraceable current);
         static partial void ClearCurrentInvoker();
 #if PROMISE_DEBUG
-        // TODO: Check thread at all public access.
-        //private static readonly System.Threading.Thread initialThread = System.Threading.Thread.CurrentThread;
+        static partial void ValidateThreadAccess(int skipFrames, bool warn)
+        {
+            Internal.ValidateThreadAccess(skipFrames + 1, warn);
+        }
 
         private static readonly object disposedObject = DisposedChecker.instance;
 
@@ -123,6 +126,7 @@ namespace Proto.Promises
 
         static protected void ValidateNotDisposed(object valueContainer, int skipFrames)
         {
+            Internal.ValidateThreadAccess(skipFrames + 1);
             if (IsDisposed(valueContainer))
             {
                 throw new PromiseDisposedException("Always nullify your references when you are finished with them!" +
@@ -187,11 +191,16 @@ namespace Proto.Promises
     partial class Promise<T>
     {
         // Calls to these get compiled away in RELEASE mode
+        static partial void ValidateThreadAccess(int skipFrames, bool warn = true);
         static partial void ValidateYieldInstructionOperation(object valueContainer, int skipFrames);
         static partial void ValidateOperation(Promise<T> promise, int skipFrames);
         static partial void ValidateArgument(object arg, string argName, int skipFrames);
         static partial void ValidateProgress(float progress, int skipFrames);
 #if PROMISE_DEBUG
+        static partial void ValidateThreadAccess(int skipFrames, bool warn)
+        {
+            Internal.ValidateThreadAccess(skipFrames + 1, warn);
+        }
         static partial void ValidateProgress(float progress, int skipFrames)
         {
             ValidateProgressValue(progress, skipFrames + 1);

--- a/Promises/Internal/DebugInternal.cs
+++ b/Promises/Internal/DebugInternal.cs
@@ -165,7 +165,9 @@ namespace Proto.Promises
         }
 
         // This allows us to re-use a reference field without having to add another bool field.
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
+#endif
         private sealed class DisposedChecker
         {
             public static readonly DisposedChecker instance = new DisposedChecker();

--- a/Promises/Internal/DelegateWrappersInternal.cs
+++ b/Promises/Internal/DelegateWrappersInternal.cs
@@ -18,7 +18,9 @@ namespace Proto.Promises
     {
         partial class InternalProtected
         {
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateResolvePassthrough : IDelegateResolve, IDelegateResolvePromise
             {
                 public void InvokeResolver(Internal.IValueContainer valueContainer, Promise owner)
@@ -31,7 +33,9 @@ namespace Proto.Promises
             }
 
             #region Regular Delegates
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class FinallyDelegate : Internal.ITreeHandleable, Internal.ITraceable
             {
 #if PROMISE_DEBUG
@@ -100,7 +104,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateVoidVoid : IDelegateResolve, IDelegateReject, IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly Action _callback;
@@ -127,7 +133,9 @@ namespace Proto.Promises
                 public void MaybeUnregisterCancelation() { }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateArgVoid<TArg> : IDelegateResolve, IDelegateReject, IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly Action<TArg> _callback;
@@ -166,7 +174,9 @@ namespace Proto.Promises
                 public void MaybeUnregisterCancelation() { }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateVoidResult<TResult> : IDelegateResolve, IDelegateReject, IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly Func<TResult> _callback;
@@ -193,7 +203,9 @@ namespace Proto.Promises
                 public void MaybeUnregisterCancelation() { }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateArgResult<TArg, TResult> : IDelegateResolve, IDelegateReject, IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly Func<TArg, TResult> _callback;
@@ -234,7 +246,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateVoidPromise : IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly Func<Promise> _callback;
@@ -259,7 +273,9 @@ namespace Proto.Promises
                 public void MaybeUnregisterCancelation() { }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateArgPromise<TArg> : IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly Func<TArg, Promise> _callback;
@@ -297,7 +313,9 @@ namespace Proto.Promises
                 public void MaybeUnregisterCancelation() { }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateVoidPromiseT<TPromise> : IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly Func<Promise<TPromise>> _callback;
@@ -322,7 +340,9 @@ namespace Proto.Promises
                 public void MaybeUnregisterCancelation() { }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateArgPromiseT<TArg, TPromise> : IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly Func<TArg, Promise<TPromise>> _callback;
@@ -361,7 +381,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueVoidVoid : IDelegateContinue
             {
                 private readonly Action<ResultContainer> _callback;
@@ -380,7 +402,9 @@ namespace Proto.Promises
                 public void CancelCallback() { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueVoidResult<TResult> : IDelegateContinue
             {
                 private readonly Func<ResultContainer, TResult> _callback;
@@ -399,7 +423,9 @@ namespace Proto.Promises
                 public void CancelCallback() { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueArgVoid<TArg> : IDelegateContinue
             {
                 private readonly Action<Promise<TArg>.ResultContainer> _callback;
@@ -418,7 +444,9 @@ namespace Proto.Promises
                 public void CancelCallback() { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueArgResult<TArg, TResult> : IDelegateContinue
             {
                 private readonly Func<Promise<TArg>.ResultContainer, TResult> _callback;
@@ -438,7 +466,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueVoidPromise : IDelegateContinuePromise
             {
                 private readonly Func<ResultContainer, Promise> _callback;
@@ -459,7 +489,9 @@ namespace Proto.Promises
                 public void CancelCallback() { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueVoidPromiseT<TPromise> : IDelegateContinuePromise
             {
                 private readonly Func<ResultContainer, Promise<TPromise>> _callback;
@@ -480,7 +512,9 @@ namespace Proto.Promises
                 public void CancelCallback() { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueArgPromise<TArg> : IDelegateContinuePromise
             {
                 private readonly Func<Promise<TArg>.ResultContainer, Promise> _callback;
@@ -501,7 +535,9 @@ namespace Proto.Promises
                 public void CancelCallback() { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueArgPromiseT<TArg, TPromise> : IDelegateContinuePromise
             {
                 private readonly Func<Promise<TArg>.ResultContainer, Promise<TPromise>> _callback;
@@ -524,7 +560,9 @@ namespace Proto.Promises
             #endregion
 
             #region Delegates with capture value
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             public sealed class FinallyDelegateCapture<TCapture> : Internal.ITreeHandleable, Internal.ITraceable
             {
 #if PROMISE_DEBUG
@@ -597,7 +635,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureVoidVoid<TCapture> : IDelegateResolve, IDelegateReject, IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly TCapture _capturedValue;
@@ -626,7 +666,9 @@ namespace Proto.Promises
                 public void MaybeUnregisterCancelation() { }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureArgVoid<TCapture, TArg> : IDelegateResolve, IDelegateReject, IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly TCapture _capturedValue;
@@ -667,7 +709,9 @@ namespace Proto.Promises
                 public void MaybeUnregisterCancelation() { }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureVoidResult<TCapture, TResult> : IDelegateResolve, IDelegateReject, IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly TCapture _capturedValue;
@@ -696,7 +740,9 @@ namespace Proto.Promises
                 public void MaybeUnregisterCancelation() { }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureArgResult<TCapture, TArg, TResult> : IDelegateResolve, IDelegateReject, IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly TCapture _capturedValue;
@@ -738,7 +784,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureVoidPromise<TCapture> : IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly TCapture _capturedValue;
@@ -765,7 +813,9 @@ namespace Proto.Promises
                 public void MaybeUnregisterCancelation() { }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureArgPromise<TCapture, TArg> : IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly TCapture _capturedValue;
@@ -805,7 +855,9 @@ namespace Proto.Promises
                 public void MaybeUnregisterCancelation() { }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureVoidPromiseT<TCapture, TPromise> : IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly TCapture _capturedValue;
@@ -832,7 +884,9 @@ namespace Proto.Promises
                 public void MaybeUnregisterCancelation() { }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureArgPromiseT<TCapture, TArg, TPromise> : IDelegateResolvePromise, IDelegateRejectPromise
             {
                 private readonly TCapture _capturedValue;
@@ -873,7 +927,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureVoidVoid<TCapture> : IDelegateContinue
             {
                 private readonly TCapture _capturedValue;
@@ -894,7 +950,9 @@ namespace Proto.Promises
                 public void CancelCallback() { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureVoidResult<TCapture, TResult> : IDelegateContinue
             {
                 private readonly TCapture _capturedValue;
@@ -915,7 +973,9 @@ namespace Proto.Promises
                 public void CancelCallback() { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureArgVoid<TCapture, TArg> : IDelegateContinue
             {
                 private readonly TCapture _capturedValue;
@@ -936,7 +996,9 @@ namespace Proto.Promises
                 public void CancelCallback() { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureArgResult<TCapture, TArg, TResult> : IDelegateContinue
             {
                 private readonly TCapture _capturedValue;
@@ -958,7 +1020,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureVoidPromise<TCapture> : IDelegateContinuePromise
             {
                 private readonly TCapture _capturedValue;
@@ -981,7 +1045,9 @@ namespace Proto.Promises
                 public void CancelCallback() { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureVoidPromiseT<TCapture, TPromise> : IDelegateContinuePromise
             {
                 private readonly TCapture _capturedValue;
@@ -1004,7 +1070,9 @@ namespace Proto.Promises
                 public void CancelCallback() { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureArgPromise<TCapture, TArg> : IDelegateContinuePromise
             {
                 private readonly TCapture _capturedValue;
@@ -1027,7 +1095,9 @@ namespace Proto.Promises
                 public void CancelCallback() { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureArgPromiseT<TCapture, TArg, TPromise> : IDelegateContinuePromise
             {
                 private readonly TCapture _capturedValue;
@@ -1051,7 +1121,9 @@ namespace Proto.Promises
             }
             #endregion
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateResolvePassthroughCancel : IDelegateResolve, IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1078,7 +1150,9 @@ namespace Proto.Promises
             }
 
             #region Delegates with cancelation token
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateVoidVoidCancel : IDelegateResolve, IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1105,7 +1179,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateArgVoidCancel<TArg> : IDelegateResolve, IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1132,7 +1208,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateVoidResultCancel<TResult> : IDelegateResolve, IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1159,7 +1237,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateArgResultCancel<TArg, TResult> : IDelegateResolve, IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1187,7 +1267,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateVoidPromiseCancel : IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1213,7 +1295,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateArgPromiseCancel<TArg> : IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1240,7 +1324,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateVoidPromiseTCancel<TPromise> : IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1266,7 +1352,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateArgPromiseTCancel<TArg, TPromise> : IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1294,7 +1382,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueVoidVoidCancel : IDelegateContinue
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1331,7 +1421,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueVoidResultCancel<TResult> : IDelegateContinue
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1368,7 +1460,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueArgVoidCancel<TArg> : IDelegateContinue
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1410,7 +1504,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueArgResultCancel<TArg, TResult> : IDelegateContinue
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1448,7 +1544,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueVoidPromiseCancel : IDelegateContinuePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1485,7 +1583,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueVoidPromiseTCancel<TPromise> : IDelegateContinuePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1522,7 +1622,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueArgPromiseCancel<TArg> : IDelegateContinuePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1564,7 +1666,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueArgPromiseTCancel<TArg, TPromise> : IDelegateContinuePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1603,7 +1707,9 @@ namespace Proto.Promises
             #endregion
 
             #region Delegates with capture value and cancelation token
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureVoidVoidCancel<TCapture> : IDelegateResolve, IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1632,7 +1738,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureArgVoidCancel<TCapture, TArg> : IDelegateResolve, IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1661,7 +1769,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureVoidResultCancel<TCapture, TResult> : IDelegateResolve, IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1690,7 +1800,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureArgResultCancel<TCapture, TArg, TResult> : IDelegateResolve, IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1720,7 +1832,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureVoidPromiseCancel<TCapture> : IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1748,7 +1862,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureArgPromiseCancel<TCapture, TArg> : IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1777,7 +1893,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureVoidPromiseTCancel<TCapture, TPromise> : IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1805,7 +1923,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateCaptureArgPromiseTCancel<TCapture, TArg, TPromise> : IDelegateResolvePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1835,7 +1955,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureVoidVoidCancel<TCapture> : IDelegateContinue
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1874,7 +1996,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureVoidResultCancel<TCapture, TResult> : IDelegateContinue
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1913,7 +2037,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureArgVoidCancel<TCapture, TArg> : IDelegateContinue
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1952,7 +2078,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureArgResultCancel<TCapture, TArg, TResult> : IDelegateContinue
             {
                 public CancelationRegistration cancelationRegistration;
@@ -1992,7 +2120,9 @@ namespace Proto.Promises
             }
 
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureVoidPromiseCancel<TCapture> : IDelegateContinuePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -2031,7 +2161,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureVoidPromiseTCancel<TCapture, TPromise> : IDelegateContinuePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -2070,7 +2202,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureArgPromiseCancel<TCapture, TArg> : IDelegateContinuePromise
             {
                 public CancelationRegistration cancelationRegistration;
@@ -2109,7 +2243,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal struct DelegateContinueCaptureArgPromiseTCancel<TCapture, TArg, TPromise> : IDelegateContinuePromise
             {
                 public CancelationRegistration cancelationRegistration;

--- a/Promises/Internal/DelegateWrappersInternal.cs
+++ b/Promises/Internal/DelegateWrappersInternal.cs
@@ -92,12 +92,12 @@ namespace Proto.Promises
                     InvokeAndCatchAndDispose();
                 }
 
-                void Internal.ITreeHandleable.MakeReady(Internal.IValueContainer valueContainer, ref ValueLinkedQueue<Internal.ITreeHandleable> handleQueue)
+                void Internal.ITreeHandleable.MakeReady(Promise owner, Internal.IValueContainer valueContainer, ref ValueLinkedQueue<Internal.ITreeHandleable> handleQueue)
                 {
                     handleQueue.Push(this);
                 }
 
-                void Internal.ITreeHandleable.MakeReadyFromSettled(Internal.IValueContainer valueContainer)
+                void Internal.ITreeHandleable.MakeReadyFromSettled(Promise owner, Internal.IValueContainer valueContainer)
                 {
                     Internal.AddToHandleQueueBack(this);
                 }
@@ -623,12 +623,12 @@ namespace Proto.Promises
                     InvokeAndCatchAndDispose();
                 }
 
-                void Internal.ITreeHandleable.MakeReady(Internal.IValueContainer valueContainer, ref ValueLinkedQueue<Internal.ITreeHandleable> handleQueue)
+                void Internal.ITreeHandleable.MakeReady(Promise owner, Internal.IValueContainer valueContainer, ref ValueLinkedQueue<Internal.ITreeHandleable> handleQueue)
                 {
                     handleQueue.Push(this);
                 }
 
-                void Internal.ITreeHandleable.MakeReadyFromSettled(Internal.IValueContainer valueContainer)
+                void Internal.ITreeHandleable.MakeReadyFromSettled(Promise owner, Internal.IValueContainer valueContainer)
                 {
                     Internal.AddToHandleQueueBack(this);
                 }

--- a/Promises/Internal/FirstInternal.cs
+++ b/Promises/Internal/FirstInternal.cs
@@ -47,7 +47,9 @@ namespace Proto.Promises
                 return FirstPromise<T>.GetOrCreate(passThroughs, count);
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed partial class FirstPromise0 : PromiseIntermediate, IMultiTreeHandleable
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -125,7 +127,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed partial class FirstPromise<T> : PromiseIntermediate<T>, IMultiTreeHandleable
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;

--- a/Promises/Internal/FirstInternal.cs
+++ b/Promises/Internal/FirstInternal.cs
@@ -260,8 +260,7 @@ namespace Proto.Promises
                 void IMultiTreeHandleable.IncrementProgress(uint amount, UnsignedFixed32 senderAmount, UnsignedFixed32 ownerAmount)
                 {
                     // Use double for better precision.
-                    float progress = (float) (senderAmount.ToDouble() * NextWholeProgress / (double) (ownerAmount.WholePart + 1u));
-                    var newAmount = new UnsignedFixed32(progress);
+                    var newAmount = new UnsignedFixed32(senderAmount.ToDouble() * NextWholeProgress / (double) (ownerAmount.WholePart + 1u));
                     if (newAmount > _currentAmount)
                     {
                         _currentAmount = newAmount;
@@ -343,8 +342,7 @@ namespace Proto.Promises
                 void IMultiTreeHandleable.IncrementProgress(uint amount, UnsignedFixed32 senderAmount, UnsignedFixed32 ownerAmount)
                 {
                     // Use double for better precision.
-                    float progress = (float) (senderAmount.ToDouble() * NextWholeProgress / (double) (ownerAmount.WholePart + 1u));
-                    var newAmount = new UnsignedFixed32(progress);
+                    var newAmount = new UnsignedFixed32(senderAmount.ToDouble() * NextWholeProgress / (double) (ownerAmount.WholePart + 1u));
                     if (newAmount > _currentAmount)
                     {
                         _currentAmount = newAmount;

--- a/Promises/Internal/InterfacesInternal.cs
+++ b/Promises/Internal/InterfacesInternal.cs
@@ -6,7 +6,7 @@
         {
             internal partial interface IMultiTreeHandleable : Internal.ITreeHandleable
             {
-                bool Handle(Internal.IValueContainer valueContainer, Promise owner, int index);
+                bool Handle(Internal.IValueContainer valueContainer, PromisePassThrough passThrough, int index);
                 void ReAdd(PromisePassThrough passThrough);
             }
 

--- a/Promises/Internal/MergeInternal.cs
+++ b/Promises/Internal/MergeInternal.cs
@@ -22,7 +22,9 @@ namespace Proto.Promises
     {
         partial class InternalProtected
         {
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed partial class MergePromise<T> : PromiseIntermediate<T>, IMultiTreeHandleable
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;

--- a/Promises/Internal/ProgressInternal.cs
+++ b/Promises/Internal/ProgressInternal.cs
@@ -380,8 +380,8 @@ namespace Proto.Promises
 #endif
             public struct UnsignedFixed32
             {
-                private const uint DecimalMax = 1u << Config.ProgressDecimalBits;
-                private const uint DecimalMask = DecimalMax - 1u;
+                private const double DecimalMax = 1u << Config.ProgressDecimalBits;
+                private const uint DecimalMask = (1u << Config.ProgressDecimalBits) - 1u;
                 private const uint WholeMask = ~DecimalMask;
 
                 private uint _value;
@@ -391,14 +391,14 @@ namespace Proto.Promises
                     _value = wholePart << Config.ProgressDecimalBits;
                 }
 
-                public UnsignedFixed32(float decimalPart)
+                public UnsignedFixed32(double decimalPart)
                 {
                     // Don't bother rounding, we don't want to accidentally round to 1.0.
                     _value = (uint) (decimalPart * DecimalMax);
                 }
 
                 public uint WholePart { get { return _value >> Config.ProgressDecimalBits; } }
-                private double DecimalPart { get { return (double) DecimalPartAsUInt32 / (double) DecimalMax; } }
+                private double DecimalPart { get { return (double) DecimalPartAsUInt32 / DecimalMax; } }
                 private uint DecimalPartAsUInt32 { get { return _value & DecimalMask; } }
 
                 public uint ToUInt32()
@@ -431,11 +431,6 @@ namespace Proto.Promises
                     }
                 }
 
-                public void Increment(uint increment)
-                {
-                    _value += increment;
-                }
-
                 public static bool operator >(UnsignedFixed32 a, UnsignedFixed32 b)
                 {
                     return a._value > b._value;
@@ -444,6 +439,35 @@ namespace Proto.Promises
                 public static bool operator <(UnsignedFixed32 a, UnsignedFixed32 b)
                 {
                     return a._value < b._value;
+                }
+            }
+
+            /// <summary>
+            /// Max Whole Number: 2^(64-<see cref="Config.ProgressDecimalBits"/>)
+            /// Precision: 1/(2^<see cref="Config.ProgressDecimalBits"/>)
+            /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [System.Diagnostics.DebuggerNonUserCode]
+#endif
+            public struct UnsignedFixed64 // Simplified compared to UnsignedFixed32 to remove unused functions.
+            {
+                private const double DecimalMax = 1ul << Config.ProgressDecimalBits;
+                private const ulong DecimalMask = (1ul << Config.ProgressDecimalBits) - 1ul;
+
+                private ulong _value;
+
+                public ulong WholePart { get { return _value >> Config.ProgressDecimalBits; } }
+                private double DecimalPart { get { return (double) DecimalPartAsUInt32 / DecimalMax; } }
+                private ulong DecimalPartAsUInt32 { get { return _value & DecimalMask; } }
+
+                public double ToDouble()
+                {
+                    return (double) WholePart + DecimalPart;
+                }
+
+                public void Increment(uint increment)
+                {
+                    _value += increment;
                 }
             }
 

--- a/Promises/Internal/ProgressInternal.cs
+++ b/Promises/Internal/ProgressInternal.cs
@@ -354,7 +354,9 @@ namespace Proto.Promises
             /// Max Whole Number: 2^(32-<see cref="Config.ProgressDecimalBits"/>)
             /// Precision: 1/(2^<see cref="Config.ProgressDecimalBits"/>)
             /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             public struct UnsignedFixed32
             {
                 private const uint DecimalMax = 1u << Config.ProgressDecimalBits;
@@ -451,7 +453,9 @@ namespace Proto.Promises
                 void CancelOrIncrementProgress(uint increment, UnsignedFixed32 senderAmount, UnsignedFixed32 ownerAmount);
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             public abstract class ProgressDelegateBase : IProgressListener, Internal.ITreeHandleable, IInvokable, Internal.ITraceable, Internal.ICancelDelegate
             {
 #if PROMISE_DEBUG
@@ -628,7 +632,9 @@ namespace Proto.Promises
                 void Internal.ITreeHandleable.MakeReadyFromSettled(Internal.IValueContainer valueContainer) { throw new System.InvalidOperationException(); }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             public sealed class ProgressDelegate : ProgressDelegateBase
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -666,7 +672,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             public sealed class ProgressDelegateCapture<TCapture> : ProgressDelegateBase
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -949,6 +957,32 @@ namespace Proto.Promises
             }
 
             partial class DeferredPromise<T>
+            {
+                protected override bool SubscribeProgressIfWaiterAndContinueLoop(ref IProgressListener progressListener, out Promise previous, ref ValueLinkedStack<PromisePassThrough> passThroughs)
+                {
+                    if (_state != State.Pending)
+                    {
+                        previous = null;
+                        return false;
+                    }
+                    return SubscribeProgressAndContinueLoop(ref progressListener, out previous);
+                }
+            }
+
+            partial class DeferredPromiseCancelVoid
+            {
+                protected override bool SubscribeProgressIfWaiterAndContinueLoop(ref IProgressListener progressListener, out Promise previous, ref ValueLinkedStack<PromisePassThrough> passThroughs)
+                {
+                    if (_state != State.Pending)
+                    {
+                        previous = null;
+                        return false;
+                    }
+                    return SubscribeProgressAndContinueLoop(ref progressListener, out previous);
+                }
+            }
+
+            partial class DeferredPromiseCancel<T>
             {
                 protected override bool SubscribeProgressIfWaiterAndContinueLoop(ref IProgressListener progressListener, out Promise previous, ref ValueLinkedStack<PromisePassThrough> passThroughs)
                 {

--- a/Promises/Internal/PromiseInternal.cs
+++ b/Promises/Internal/PromiseInternal.cs
@@ -326,10 +326,15 @@ namespace Proto.Promises
             Internal.AddToHandleQueueBack(ref handleQueue);
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [System.Diagnostics.DebuggerNonUserCode]
+#endif
         protected static partial class InternalProtected
         {
             // PromiseIntermediate is annoyingly necessary since private protected isn't available in old C# versions.
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal abstract partial class PromiseIntermediate : Promise
             {
 #if !CSHARP_7_3_OR_NEWER // Really C# 7.2 but this is the closest symbol Unity offers.
@@ -342,7 +347,9 @@ namespace Proto.Promises
 #endif
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal abstract partial class PromiseIntermediate<T> : Promise<T>
             {
 #if !CSHARP_7_3_OR_NEWER // Really C# 7.2 but this is the closest symbol Unity offers.
@@ -355,7 +362,9 @@ namespace Proto.Promises
 #endif
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal abstract partial class PromiseWaitPromise : PromiseIntermediate
             {
                 public void WaitFor(Promise other)
@@ -373,7 +382,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal abstract partial class PromiseWaitPromise<T> : PromiseIntermediate<T>
             {
                 public void WaitFor(Promise<T> other)
@@ -391,7 +402,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed partial class DeferredPromiseVoid : Promise, Internal.ITreeHandleable
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -439,7 +452,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed partial class DeferredPromise<T> : Promise<T>, Internal.ITreeHandleable
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -487,7 +502,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed partial class DeferredPromiseCancelVoid : Promise, Internal.ITreeHandleable, Internal.ICancelDelegate
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -548,7 +565,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed partial class DeferredPromiseCancel<T> : Promise<T>, Internal.ITreeHandleable, Internal.ICancelDelegate
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -610,7 +629,9 @@ namespace Proto.Promises
             }
 
 #if !PROMISE_DEBUG
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class SettledPromise : Promise
             {
                 private SettledPromise() { }
@@ -649,7 +670,9 @@ namespace Proto.Promises
             // The only downside is that more classes are created than if we just used straight interfaces (not a problem with JIT, but makes the code size larger with AOT).
 
             // Resolve types for more common .Then(onResolved) calls to be more efficient.
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class PromiseResolve<TResolver> : PromiseIntermediate where TResolver : IDelegateResolve
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -698,7 +721,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class PromiseResolve<T, TResolver> : PromiseIntermediate<T> where TResolver : IDelegateResolve
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -747,7 +772,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class PromiseResolvePromise<TResolver> : PromiseWaitPromise where TResolver : IDelegateResolvePromise
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -803,7 +830,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class PromiseResolvePromise<T, TResolver> : PromiseWaitPromise<T> where TResolver : IDelegateResolvePromise
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -861,7 +890,9 @@ namespace Proto.Promises
             #endregion
 
             #region Resolve or Reject Promises
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class PromiseResolveReject<TResolver, TRejecter> : PromiseIntermediate where TResolver : IDelegateResolve where TRejecter : IDelegateReject
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -920,7 +951,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class PromiseResolveReject<T, TResolver, TRejecter> : PromiseIntermediate<T> where TResolver : IDelegateResolve where TRejecter : IDelegateReject
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -979,7 +1012,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class PromiseResolveRejectPromise<TResolver, TRejecter> : PromiseWaitPromise where TResolver : IDelegateResolvePromise where TRejecter : IDelegateRejectPromise
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -1048,7 +1083,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class PromiseResolveRejectPromise<TPromise, TResolver, TRejecter> : PromiseWaitPromise<TPromise> where TResolver : IDelegateResolvePromise where TRejecter : IDelegateRejectPromise
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -1119,7 +1156,9 @@ namespace Proto.Promises
             #endregion
 
             #region Continue Promises
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class PromiseContinue<TContinuer> : PromiseIntermediate where TContinuer : IDelegateContinue
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -1165,7 +1204,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class PromiseContinue<TResult, TContinuer> : PromiseIntermediate<TResult> where TContinuer : IDelegateContinue
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -1211,7 +1252,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class PromiseContinuePromise<TContinuer> : PromiseWaitPromise where TContinuer : IDelegateContinuePromise
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -1264,7 +1307,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed class PromiseContinuePromise<TPromise, TContinuer> : PromiseWaitPromise<TPromise> where TContinuer : IDelegateContinuePromise
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -1318,7 +1363,9 @@ namespace Proto.Promises
             }
             #endregion
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             public sealed partial class PromisePassThrough : Internal.ITreeHandleable, IRetainable, ILinked<PromisePassThrough>
             {
                 private static ValueLinkedStack<PromisePassThrough> _pool;

--- a/Promises/Internal/PromiseInternal.cs
+++ b/Promises/Internal/PromiseInternal.cs
@@ -341,7 +341,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal abstract partial class PromiseIntermediate : Promise
+            internal abstract class PromiseIntermediate : Promise
             {
 #if !CSHARP_7_3_OR_NEWER // Really C# 7.2 but this is the closest symbol Unity offers.
                 protected override sealed void Execute(object valueContainer)
@@ -356,7 +356,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal abstract partial class PromiseIntermediate<T> : Promise<T>
+            internal abstract class PromiseIntermediate<T> : Promise<T>
             {
 #if !CSHARP_7_3_OR_NEWER // Really C# 7.2 but this is the closest symbol Unity offers.
                 protected override sealed void Execute(object valueContainer)

--- a/Promises/Internal/RaceInternal.cs
+++ b/Promises/Internal/RaceInternal.cs
@@ -47,7 +47,9 @@ namespace Proto.Promises
                 return RacePromise<T>.GetOrCreate(passThroughs, count);
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed partial class RacePromise0 : PromiseIntermediate, IMultiTreeHandleable
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -124,7 +126,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal sealed partial class RacePromise<T> : PromiseIntermediate<T>, IMultiTreeHandleable
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;

--- a/Promises/Internal/RaceInternal.cs
+++ b/Promises/Internal/RaceInternal.cs
@@ -262,8 +262,7 @@ namespace Proto.Promises
                 void IMultiTreeHandleable.IncrementProgress(uint amount, UnsignedFixed32 senderAmount, UnsignedFixed32 ownerAmount)
                 {
                     // Use double for better precision.
-                    float progress = (float) (senderAmount.ToDouble() * NextWholeProgress / (double) (ownerAmount.WholePart + 1u));
-                    var newAmount = new UnsignedFixed32(progress);
+                    var newAmount = new UnsignedFixed32(senderAmount.ToDouble() * NextWholeProgress / (double) (ownerAmount.WholePart + 1u));
                     if (newAmount > _currentAmount)
                     {
                         _currentAmount = newAmount;
@@ -349,8 +348,7 @@ namespace Proto.Promises
                 void IMultiTreeHandleable.IncrementProgress(uint amount, UnsignedFixed32 senderAmount, UnsignedFixed32 ownerAmount)
                 {
                     // Use double for better precision.
-                    float progress = (float) (senderAmount.ToDouble() * NextWholeProgress / (double) (ownerAmount.WholePart + 1u));
-                    var newAmount = new UnsignedFixed32(progress);
+                    var newAmount = new UnsignedFixed32(senderAmount.ToDouble() * NextWholeProgress / (double) (ownerAmount.WholePart + 1u));
                     if (newAmount > _currentAmount)
                     {
                         _currentAmount = newAmount;

--- a/Promises/Internal/RaceInternal.cs
+++ b/Promises/Internal/RaceInternal.cs
@@ -32,7 +32,7 @@ namespace Proto.Promises
                 }
                 int count;
                 var passThroughs = WrapInPassThroughs(promises, out count);
-                return RacePromise0.GetOrCreate(passThroughs, count);
+                return RacePromiseVoid.GetOrCreate(passThroughs, count);
             }
 
             public static Promise<T> CreateRace<T, TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
@@ -50,11 +50,11 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal sealed partial class RacePromise0 : PromiseIntermediate, IMultiTreeHandleable
+            internal sealed partial class RacePromiseVoid : PromiseIntermediate, IMultiTreeHandleable
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
 
-                static RacePromise0()
+                static RacePromiseVoid()
                 {
                     Internal.OnClearPool += () => _pool.Clear();
                 }
@@ -71,11 +71,11 @@ namespace Proto.Promises
                 private ValueLinkedStack<PromisePassThrough> _passThroughs;
                 private uint _waitCount;
 
-                private RacePromise0() { }
+                private RacePromiseVoid() { }
 
                 public static Promise GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int count)
                 {
-                    var promise = _pool.IsNotEmpty ? (RacePromise0) _pool.Pop() : new RacePromise0();
+                    var promise = _pool.IsNotEmpty ? (RacePromiseVoid) _pool.Pop() : new RacePromiseVoid();
 
                     promise._passThroughs = promisePassThroughs;
 
@@ -100,8 +100,9 @@ namespace Proto.Promises
                     HandleSelf(valueContainer);
                 }
 
-                bool IMultiTreeHandleable.Handle(Internal.IValueContainer valueContainer, Promise owner, int index)
+                bool IMultiTreeHandleable.Handle(Internal.IValueContainer valueContainer, PromisePassThrough passThrough, int index)
                 {
+                    Promise owner = passThrough.Owner;
                     bool handle = _valueOrPrevious == null;
                     if (handle)
                     {
@@ -179,8 +180,9 @@ namespace Proto.Promises
                     HandleSelf(valueContainer);
                 }
 
-                bool IMultiTreeHandleable.Handle(Internal.IValueContainer valueContainer, Promise owner, int index)
+                bool IMultiTreeHandleable.Handle(Internal.IValueContainer valueContainer, PromisePassThrough passThrough, int index)
                 {
+                    Promise owner = passThrough.Owner;
                     bool handle = _valueOrPrevious == null;
                     if (handle)
                     {
@@ -206,18 +208,16 @@ namespace Proto.Promises
             }
 
 #if PROMISE_PROGRESS
-            partial class RacePromise0 : IInvokable
+            partial class RacePromiseVoid : IInvokable
             {
                 private UnsignedFixed32 _currentAmount;
                 private bool _invokingProgress;
-                private bool _suspended;
 
                 protected override void Reset()
                 {
                     base.Reset();
                     _currentAmount = default(UnsignedFixed32);
                     _invokingProgress = false;
-                    _suspended = false;
 
                     uint minWaitDepth = uint.MaxValue;
                     foreach (var passThrough in _passThroughs)
@@ -254,11 +254,15 @@ namespace Proto.Promises
                     return false;
                 }
 
+                protected override UnsignedFixed32 CurrentProgress()
+                {
+                    return _currentAmount;
+                }
+
                 void IMultiTreeHandleable.IncrementProgress(uint amount, UnsignedFixed32 senderAmount, UnsignedFixed32 ownerAmount)
                 {
-                    _suspended = false;
                     // Use double for better precision.
-                    float progress = (float) ((double) senderAmount.ToUInt32() * (double) GetIncrementMultiplier() / (double) ownerAmount.GetIncrementedWholeTruncated().ToUInt32());
+                    float progress = (float) (senderAmount.ToDouble() * NextWholeProgress / (double) (ownerAmount.WholePart + 1u));
                     var newAmount = new UnsignedFixed32(progress);
                     if (newAmount > _currentAmount)
                     {
@@ -272,26 +276,9 @@ namespace Proto.Promises
                     }
                 }
 
-                void IMultiTreeHandleable.CancelOrIncrementProgress(uint amount, UnsignedFixed32 senderAmount, UnsignedFixed32 ownerAmount)
-                {
-                    _suspended = true;
-                    // Use double for better precision.
-                    float progress = (float) ((double) senderAmount.ToUInt32() * (double) GetIncrementMultiplier() / (double) ownerAmount.GetIncrementedWholeTruncated().ToUInt32());
-                    var newAmount = new UnsignedFixed32(progress);
-                    if (newAmount > _currentAmount)
-                    {
-                        _currentAmount = newAmount;
-                    }
-                }
-
-                protected override uint GetIncrementMultiplier()
-                {
-                    return _waitDepthAndProgress.WholePart + 1u;
-                }
-
                 void IInvokable.Invoke()
                 {
-                    if (_state != State.Pending | _suspended)
+                    if (_state != State.Pending)
                     {
                         ReleaseInternal();
                         return;
@@ -299,17 +286,9 @@ namespace Proto.Promises
 
                     _invokingProgress = false;
 
-                    uint multiplier = GetIncrementMultiplier();
-
-                    // Calculate the normalized progress.
-                    // Use double for better precision.
-                    float progress = (float) (_currentAmount.ToDouble() / multiplier);
-
-                    uint increment = _waitDepthAndProgress.AssignNewDecimalPartAndGetDifferenceAsUInt32(progress) * multiplier;
-
                     foreach (var progressListener in _progressListeners)
                     {
-                        progressListener.IncrementProgress(this, increment);
+                        progressListener.SetProgress(this, _currentAmount);
                     }
 
                     ReleaseInternal();
@@ -320,14 +299,12 @@ namespace Proto.Promises
             {
                 private UnsignedFixed32 _currentAmount;
                 private bool _invokingProgress;
-                private bool _suspended;
 
                 protected override void Reset()
                 {
                     base.Reset();
                     _currentAmount = default(UnsignedFixed32);
                     _invokingProgress = false;
-                    _suspended = false;
 
                     uint minWaitDepth = uint.MaxValue;
                     foreach (var passThrough in _passThroughs)
@@ -364,11 +341,15 @@ namespace Proto.Promises
                     return false;
                 }
 
+                protected override UnsignedFixed32 CurrentProgress()
+                {
+                    return _currentAmount;
+                }
+
                 void IMultiTreeHandleable.IncrementProgress(uint amount, UnsignedFixed32 senderAmount, UnsignedFixed32 ownerAmount)
                 {
-                    _suspended = false;
                     // Use double for better precision.
-                    float progress = (float) ((double) senderAmount.ToUInt32() * (double) GetIncrementMultiplier() / (double) ownerAmount.GetIncrementedWholeTruncated().ToUInt32());
+                    float progress = (float) (senderAmount.ToDouble() * NextWholeProgress / (double) (ownerAmount.WholePart + 1u));
                     var newAmount = new UnsignedFixed32(progress);
                     if (newAmount > _currentAmount)
                     {
@@ -382,26 +363,9 @@ namespace Proto.Promises
                     }
                 }
 
-                void IMultiTreeHandleable.CancelOrIncrementProgress(uint amount, UnsignedFixed32 senderAmount, UnsignedFixed32 ownerAmount)
-                {
-                    _suspended = true;
-                    // Use double for better precision.
-                    float progress = (float) ((double) senderAmount.ToUInt32() * (double) GetIncrementMultiplier() / (double) ownerAmount.GetIncrementedWholeTruncated().ToUInt32());
-                    var newAmount = new UnsignedFixed32(progress);
-                    if (newAmount > _currentAmount)
-                    {
-                        _currentAmount = newAmount;
-                    }
-                }
-
-                protected override uint GetIncrementMultiplier()
-                {
-                    return _waitDepthAndProgress.WholePart + 1u;
-                }
-
                 void IInvokable.Invoke()
                 {
-                    if (_state != State.Pending | _suspended)
+                    if (_state != State.Pending)
                     {
                         ReleaseInternal();
                         return;
@@ -409,17 +373,9 @@ namespace Proto.Promises
 
                     _invokingProgress = false;
 
-                    uint multiplier = GetIncrementMultiplier();
-
-                    // Calculate the normalized progress.
-                    // Use double for better precision.
-                    float progress = (float) (_currentAmount.ToDouble() / multiplier);
-
-                    uint increment = _waitDepthAndProgress.AssignNewDecimalPartAndGetDifferenceAsUInt32(progress) * multiplier;
-
                     foreach (var progressListener in _progressListeners)
                     {
-                        progressListener.IncrementProgress(this, increment);
+                        progressListener.SetProgress(this, _currentAmount);
                     }
 
                     ReleaseInternal();

--- a/Promises/Manager.cs
+++ b/Promises/Manager.cs
@@ -22,6 +22,8 @@ namespace Proto.Promises
             /// </summary>
             public static void HandleCompletes()
             {
+                ValidateThreadAccess(1, false);
+
                 bool willThrow = _willThrow;
                 _willThrow = true;
 
@@ -43,6 +45,8 @@ namespace Proto.Promises
             /// </summary>
             public static void HandleCompletesAndProgress()
             {
+                ValidateThreadAccess(1, false);
+
                 bool willThrow = _willThrow;
                 _willThrow = true;
 
@@ -64,6 +68,8 @@ namespace Proto.Promises
             /// </summary>
             public static void HandleProgress()
             {
+                ValidateThreadAccess(1, false);
+
                 bool willThrow = _willThrow;
                 _willThrow = true;
 
@@ -81,6 +87,8 @@ namespace Proto.Promises
             /// </summary>
             public static void ClearObjectPool()
             {
+                ValidateThreadAccess(1);
+
                 ClearPooledProgress();
                 Internal.ClearPool();
             }

--- a/Promises/Manager.cs
+++ b/Promises/Manager.cs
@@ -7,7 +7,9 @@ namespace Proto.Promises
         /// <summary>
         /// Promise manager. This can be used to cleared pooled objects (if enabled) or manually handle promises (not recommended for RELEASE builds).
         /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public static class Manager
         {
             private static bool _willThrow;

--- a/Promises/Promise.cs
+++ b/Promises/Promise.cs
@@ -25,7 +25,9 @@ namespace Proto.Promises
     /// which registers callbacks to be invoked when the <see cref="Promise"/> is resolved,
     /// or the reason why the <see cref="Promise"/> cannot be resolved.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public abstract partial class Promise : IRetainable
     {
         public enum State : byte
@@ -1110,7 +1112,9 @@ namespace Proto.Promises
     /// which registers callbacks to be invoked with its resolve value when the <see cref="Promise{T}"/> is resolved,
     /// or the reason why the <see cref="Promise{T}"/> cannot be resolved.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public abstract partial class Promise<T> : Promise
     {
         internal Promise() { }

--- a/Promises/PromiseStatic.cs
+++ b/Promises/PromiseStatic.cs
@@ -20,6 +20,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise All(Promise promise1, Promise promise2)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             var passThroughs = new ValueLinkedStack<InternalProtected.PromisePassThrough>(InternalProtected.PromisePassThrough.GetOrCreate(promise1, 0));
@@ -34,6 +35,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise All(Promise promise1, Promise promise2, Promise promise3)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -50,6 +52,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise All(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -68,6 +71,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise All(params Promise[] promises)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateAll(new ArrayEnumerator<Promise>(promises));
         }
 
@@ -77,6 +81,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise All(IEnumerable<Promise> promises)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateAll(promises.GetEnumerator());
         }
 
@@ -86,6 +91,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise All<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise>
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateAll(promises);
         }
 
@@ -95,6 +101,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<IList<T>> All<T>(params Promise<T>[] promises)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateAll(new ArrayEnumerator<Promise<T>>(promises), new List<T>(promises.Length));
         }
 
@@ -104,6 +111,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<IList<T>> All<T>(IEnumerable<Promise<T>> promises)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateAll(promises.GetEnumerator(), new List<T>());
         }
 
@@ -113,6 +121,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<IList<T>> All<T, TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateAll(promises, new List<T>());
         }
 
@@ -122,6 +131,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<IList<T>> AllNonAlloc<T, TEnumerator>(TEnumerator promises, IList<T> valueContainer) where TEnumerator : IEnumerator<Promise<T>>
         {
+            ValidateThreadAccess(1);
             ValidateArgument(valueContainer, "valueContainer", 1);
             return InternalProtected.CreateAll(promises, valueContainer);
         }
@@ -132,6 +142,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Race(Promise promise1, Promise promise2)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             var passThroughs = new ValueLinkedStack<InternalProtected.PromisePassThrough>(InternalProtected.PromisePassThrough.GetOrCreate(promise1, 0));
@@ -146,6 +157,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Race(Promise promise1, Promise promise2, Promise promise3)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -162,6 +174,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Race(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -180,6 +193,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Race(params Promise[] promises)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateRace(new ArrayEnumerator<Promise>(promises));
         }
 
@@ -189,6 +203,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Race(IEnumerable<Promise> promises)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateRace(promises.GetEnumerator());
         }
 
@@ -198,6 +213,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Race<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise>
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateRace(promises);
         }
 
@@ -207,6 +223,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> Race<T>(Promise<T> promise1, Promise<T> promise2)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             var passThroughs = new ValueLinkedStack<InternalProtected.PromisePassThrough>(InternalProtected.PromisePassThrough.GetOrCreate(promise1, 0));
@@ -221,6 +238,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> Race<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -237,6 +255,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> Race<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -255,6 +274,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> Race<T>(params Promise<T>[] promises)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateRace<T, ArrayEnumerator<Promise<T>>>(new ArrayEnumerator<Promise<T>>(promises));
         }
 
@@ -264,6 +284,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> Race<T>(IEnumerable<Promise<T>> promises)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateRace<T, IEnumerator<Promise<T>>>(promises.GetEnumerator());
         }
 
@@ -273,6 +294,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> Race<T, TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateRace<T, TEnumerator>(promises);
         }
 
@@ -282,6 +304,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Sequence(params Func<Promise>[] promiseFuncs)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateSequence(new ArrayEnumerator<Func<Promise>>(promiseFuncs));
         }
 
@@ -294,6 +317,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Sequence(CancelationToken cancelationToken, params Func<Promise>[] promiseFuncs)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateSequence(new ArrayEnumerator<Func<Promise>>(promiseFuncs), cancelationToken);
         }
 
@@ -303,6 +327,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Sequence(IEnumerable<Func<Promise>> promiseFuncs)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateSequence(promiseFuncs.GetEnumerator());
         }
 
@@ -315,6 +340,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Sequence(CancelationToken cancelationToken, IEnumerable<Func<Promise>> promiseFuncs)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateSequence(promiseFuncs.GetEnumerator(), cancelationToken);
         }
 
@@ -324,6 +350,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Sequence<TEnumerator>(TEnumerator promiseFuncs) where TEnumerator : IEnumerator<Func<Promise>>
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateSequence(promiseFuncs);
         }
 
@@ -336,6 +363,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Sequence<TEnumerator>(CancelationToken cancelationToken, TEnumerator promiseFuncs) where TEnumerator : IEnumerator<Func<Promise>>
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateSequence(promiseFuncs, cancelationToken);
         }
 
@@ -345,6 +373,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise First(Promise promise1, Promise promise2)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             var passThroughs = new ValueLinkedStack<InternalProtected.PromisePassThrough>(InternalProtected.PromisePassThrough.GetOrCreate(promise1, 0));
@@ -359,6 +388,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise First(Promise promise1, Promise promise2, Promise promise3)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -375,6 +405,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise First(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -393,6 +424,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise First(params Promise[] promises)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateFirst(new ArrayEnumerator<Promise>(promises));
         }
 
@@ -402,6 +434,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise First(IEnumerable<Promise> promises)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateFirst(promises.GetEnumerator());
         }
 
@@ -411,6 +444,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise First<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise>
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateFirst(promises);
         }
 
@@ -420,6 +454,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> First<T>(Promise<T> promise1, Promise<T> promise2)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             var passThroughs = new ValueLinkedStack<InternalProtected.PromisePassThrough>(InternalProtected.PromisePassThrough.GetOrCreate(promise1, 0));
@@ -434,6 +469,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> First<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -450,6 +486,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> First<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -468,6 +505,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> First<T>(params Promise<T>[] promises)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateFirst<T, ArrayEnumerator<Promise<T>>>(new ArrayEnumerator<Promise<T>>(promises));
         }
 
@@ -477,6 +515,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> First<T>(IEnumerable<Promise<T>> promises)
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateFirst<T, IEnumerator<Promise<T>>>(promises.GetEnumerator());
         }
 
@@ -486,6 +525,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> First<T, TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
         {
+            ValidateThreadAccess(1);
             return InternalProtected.CreateFirst<T, TEnumerator>(promises);
         }
 
@@ -495,6 +535,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T1> Merge<T1>(Promise<T1> promise1, Promise promise2)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             var passThroughs = new ValueLinkedStack<InternalProtected.PromisePassThrough>(InternalProtected.PromisePassThrough.GetOrCreate(promise1, 0));
@@ -516,6 +557,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<T1, T2>> Merge<T1, T2>(Promise<T1> promise1, Promise<T2> promise2)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             var passThroughs = new ValueLinkedStack<InternalProtected.PromisePassThrough>(InternalProtected.PromisePassThrough.GetOrCreate(promise1, 0));
@@ -541,6 +583,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<T1, T2>> Merge<T1, T2>(Promise<T1> promise1, Promise<T2> promise2, Promise promise3)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -569,6 +612,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<T1, T2, T3>> Merge<T1, T2, T3>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -600,6 +644,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<T1, T2, T3>> Merge<T1, T2, T3>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise promise4)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -633,6 +678,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<T1, T2, T3, T4>> Merge<T1, T2, T3, T4>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -669,6 +715,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<T1, T2, T3, T4>> Merge<T1, T2, T3, T4>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise promise5)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -707,6 +754,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<T1, T2, T3, T4, T5>> Merge<T1, T2, T3, T4, T5>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -748,6 +796,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<T1, T2, T3, T4, T5>> Merge<T1, T2, T3, T4, T5>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise promise6)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -791,6 +840,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<T1, T2, T3, T4, T5, T6>> Merge<T1, T2, T3, T4, T5, T6>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -837,6 +887,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<T1, T2, T3, T4, T5, T6>> Merge<T1, T2, T3, T4, T5, T6>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6, Promise promise7)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -885,6 +936,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<T1, T2, T3, T4, T5, T6, T7>> Merge<T1, T2, T3, T4, T5, T6, T7>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6, Promise<T7> promise7)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -936,6 +988,7 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<T1, T2, T3, T4, T5, T6, T7>> Merge<T1, T2, T3, T4, T5, T6, T7>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6, Promise<T7> promise7, Promise promise8)
         {
+            ValidateThreadAccess(1);
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
@@ -989,6 +1042,8 @@ namespace Proto.Promises
         /// </summary>
 		public static Promise New(Action<Deferred> resolver)
         {
+            ValidateThreadAccess(1);
+
             Deferred deferred = Deferred.New();
             try
             {
@@ -1014,6 +1069,8 @@ namespace Proto.Promises
         /// </summary>
 		public static Promise<T> New<T>(Action<Promise<T>.Deferred> resolver)
         {
+            ValidateThreadAccess(1);
+
             Promise<T>.Deferred deferred = Promise<T>.Deferred.New();
             try
             {
@@ -1039,6 +1096,8 @@ namespace Proto.Promises
         /// </summary>
         public static Promise New<TCapture>(TCapture captureValue, Action<TCapture, Deferred> resolver)
         {
+            ValidateThreadAccess(1);
+
             Deferred deferred = Deferred.New();
             try
             {
@@ -1064,6 +1123,8 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> New<TCapture, T>(TCapture captureValue, Action<TCapture, Promise<T>.Deferred> resolver)
         {
+            ValidateThreadAccess(1);
+
             Promise<T>.Deferred deferred = Promise<T>.Deferred.New();
             try
             {
@@ -1088,6 +1149,8 @@ namespace Proto.Promises
         /// </summary>
 		public static Promise Resolved()
         {
+            ValidateThreadAccess(1);
+
 #if PROMISE_DEBUG
             // Make new promise in DEBUG mode for separate causality traces.
             var promise = InternalProtected.DeferredPromiseVoid.GetOrCreate();
@@ -1104,6 +1167,8 @@ namespace Proto.Promises
         /// </summary>
 		public static Promise<T> Resolved<T>(T value)
         {
+            ValidateThreadAccess(1);
+
             var promise = InternalProtected.DeferredPromise<T>.GetOrCreate();
             promise.ResolveDirect(ref value);
             return promise;
@@ -1114,6 +1179,8 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Rejected<TReject>(TReject reason)
         {
+            ValidateThreadAccess(1);
+
             var promise = InternalProtected.DeferredPromiseVoid.GetOrCreate();
             promise.RejectDirect(ref reason, int.MinValue);
             return promise;
@@ -1124,6 +1191,8 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> Rejected<T, TReject>(TReject reason)
         {
+            ValidateThreadAccess(1);
+
             var promise = InternalProtected.DeferredPromise<T>.GetOrCreate();
             promise.RejectDirect(ref reason, int.MinValue);
             return promise;
@@ -1134,6 +1203,8 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Canceled()
         {
+            ValidateThreadAccess(1);
+
 #if PROMISE_DEBUG
             // Make new promise in DEBUG mode for separate causality traces.
             var promise = InternalProtected.DeferredPromiseVoid.GetOrCreate();
@@ -1150,6 +1221,8 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Canceled<TCancel>(TCancel reason)
         {
+            ValidateThreadAccess(1);
+
             var promise = InternalProtected.DeferredPromiseVoid.GetOrCreate();
             promise.CancelDirect(ref reason);
             return promise;
@@ -1160,6 +1233,8 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> Canceled<T>()
         {
+            ValidateThreadAccess(1);
+
             var promise = InternalProtected.DeferredPromise<T>.GetOrCreate();
             promise.CancelDirect();
             return promise;
@@ -1170,6 +1245,8 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> Canceled<T, TCancel>(TCancel reason)
         {
+            ValidateThreadAccess(1);
+
             var promise = InternalProtected.DeferredPromise<T>.GetOrCreate();
             promise.CancelDirect(ref reason);
             return promise;
@@ -1203,6 +1280,8 @@ namespace Proto.Promises
         {
             get
             {
+                ValidateThreadAccess(1);
+
                 if (Internal.invokingRejected)
                 {
                     return RethrowException.instance;
@@ -1218,6 +1297,8 @@ namespace Proto.Promises
         /// <exception cref="InvalidOperationException"/>
         public static CancelException CancelException()
         {
+            ValidateThreadAccess(1);
+
             return Internal.CancelExceptionVoidInternal.GetOrCreate();
         }
 
@@ -1228,6 +1309,8 @@ namespace Proto.Promises
         /// <exception cref="InvalidOperationException"/>
         public static CancelException CancelException<T>(T value)
         {
+            ValidateThreadAccess(1);
+
             return Internal.CancelExceptionInternal<T>.GetOrCreate(value);
         }
 
@@ -1238,6 +1321,8 @@ namespace Proto.Promises
         /// <exception cref="InvalidOperationException"/>
         public static RejectException RejectException<T>(T value)
         {
+            ValidateThreadAccess(1);
+
             return Internal.RejectExceptionInternal<T>.GetOrCreate(value);
         }
     }

--- a/Promises/PromiseStatic.cs
+++ b/Promises/PromiseStatic.cs
@@ -25,7 +25,7 @@ namespace Proto.Promises
             var passThroughs = new ValueLinkedStack<InternalProtected.PromisePassThrough>(InternalProtected.PromisePassThrough.GetOrCreate(promise1, 0));
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise2, 1));
 
-            return InternalProtected.AllPromise0.GetOrCreate(passThroughs, 2);
+            return InternalProtected.AllPromiseVoid.GetOrCreate(passThroughs, 2);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace Proto.Promises
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise2, 1));
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise3, 2));
 
-            return InternalProtected.AllPromise0.GetOrCreate(passThroughs, 3);
+            return InternalProtected.AllPromiseVoid.GetOrCreate(passThroughs, 3);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Proto.Promises
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise3, 2));
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise4, 3));
 
-            return InternalProtected.AllPromise0.GetOrCreate(passThroughs, 4);
+            return InternalProtected.AllPromiseVoid.GetOrCreate(passThroughs, 4);
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace Proto.Promises
             var passThroughs = new ValueLinkedStack<InternalProtected.PromisePassThrough>(InternalProtected.PromisePassThrough.GetOrCreate(promise1, 0));
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise2, 0));
 
-            return InternalProtected.RacePromise0.GetOrCreate(passThroughs, 2);
+            return InternalProtected.RacePromiseVoid.GetOrCreate(passThroughs, 2);
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace Proto.Promises
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise2, 0));
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise3, 0));
 
-            return InternalProtected.RacePromise0.GetOrCreate(passThroughs, 3);
+            return InternalProtected.RacePromiseVoid.GetOrCreate(passThroughs, 3);
         }
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace Proto.Promises
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise3, 0));
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise4, 0));
 
-            return InternalProtected.RacePromise0.GetOrCreate(passThroughs, 4);
+            return InternalProtected.RacePromiseVoid.GetOrCreate(passThroughs, 4);
         }
 
         /// <summary>
@@ -350,7 +350,7 @@ namespace Proto.Promises
             var passThroughs = new ValueLinkedStack<InternalProtected.PromisePassThrough>(InternalProtected.PromisePassThrough.GetOrCreate(promise1, 0));
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise2, 0));
 
-            return InternalProtected.FirstPromise0.GetOrCreate(passThroughs, 2);
+            return InternalProtected.FirstPromiseVoid.GetOrCreate(passThroughs, 2);
         }
 
         /// <summary>
@@ -366,7 +366,7 @@ namespace Proto.Promises
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise2, 0));
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise3, 0));
 
-            return InternalProtected.FirstPromise0.GetOrCreate(passThroughs, 3);
+            return InternalProtected.FirstPromiseVoid.GetOrCreate(passThroughs, 3);
         }
 
         /// <summary>
@@ -384,7 +384,7 @@ namespace Proto.Promises
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise3, 0));
             passThroughs.Push(InternalProtected.PromisePassThrough.GetOrCreate(promise4, 0));
 
-            return InternalProtected.FirstPromise0.GetOrCreate(passThroughs, 4);
+            return InternalProtected.FirstPromiseVoid.GetOrCreate(passThroughs, 4);
         }
 
         /// <summary>

--- a/Promises/ResultContainers.cs
+++ b/Promises/ResultContainers.cs
@@ -4,6 +4,8 @@
 #undef PROMISE_DEBUG
 # endif
 
+#pragma warning disable IDE0041 // Use 'is null' check
+
 using System;
 
 namespace Proto.Promises
@@ -74,6 +76,7 @@ namespace Proto.Promises
 #if PROMISE_DEBUG
         partial void Validate()
         {
+            Internal.ValidateThreadAccess(2);
             if (_id != Internal.InvokeId | ReferenceEquals(_valueContainer, null))
             {
                 throw new InvalidOperationException("An instance of Promise.ReasonContainer is only valid during the invocation of the delegate it is passed into.", Internal.GetFormattedStacktrace(2));
@@ -179,6 +182,7 @@ namespace Proto.Promises
 #if PROMISE_DEBUG
             partial void ValidateCall()
             {
+                Internal.ValidateThreadAccess(2);
                 if (_id != Internal.InvokeId | ReferenceEquals(_valueContainer, null))
                 {
                     throw new InvalidOperationException("An instance of Promise.CancelContainer is only valid during the invocation of the delegate it is passed into.", Internal.GetFormattedStacktrace(2));
@@ -187,6 +191,7 @@ namespace Proto.Promises
 
             partial void ValidateRejected()
             {
+                Internal.ValidateThreadAccess(2);
                 if (_valueContainer.GetState() != State.Rejected)
                 {
                     throw new InvalidOperationException("Promise must be rejected in order to access RejectContainer.", Internal.GetFormattedStacktrace(2));
@@ -195,6 +200,7 @@ namespace Proto.Promises
 
             partial void ValidateCanceled()
             {
+                Internal.ValidateThreadAccess(2);
                 if (_valueContainer.GetState() != State.Canceled)
                 {
                     throw new InvalidOperationException("Promise must be canceled in order to access CancelContainer.", Internal.GetFormattedStacktrace(2));
@@ -315,6 +321,7 @@ namespace Proto.Promises
 #if PROMISE_DEBUG
             partial void ValidateCall()
             {
+                Internal.ValidateThreadAccess(2);
                 if (_id != Internal.InvokeId | ReferenceEquals(_valueContainer, null))
                 {
                     throw new InvalidOperationException("An instance of Promise.CancelContainer is only valid during the invocation of the delegate it is passed into.", Internal.GetFormattedStacktrace(2));
@@ -323,6 +330,7 @@ namespace Proto.Promises
 
             partial void ValidateResolved()
             {
+                Internal.ValidateThreadAccess(2);
                 if (_valueContainer.GetState() != State.Resolved)
                 {
                     throw new InvalidOperationException("Promise must be resolved in order to access Result.", Internal.GetFormattedStacktrace(2));
@@ -331,6 +339,7 @@ namespace Proto.Promises
 
             partial void ValidateRejected()
             {
+                Internal.ValidateThreadAccess(2);
                 if (_valueContainer.GetState() != State.Rejected)
                 {
                     throw new InvalidOperationException("Promise must be rejected in order to access RejectContainer.", Internal.GetFormattedStacktrace(2));
@@ -339,6 +348,7 @@ namespace Proto.Promises
 
             partial void ValidateCanceled()
             {
+                Internal.ValidateThreadAccess(2);
                 if (_valueContainer.GetState() != State.Canceled)
                 {
                     throw new InvalidOperationException("Promise must be canceled in order to access CancelContainer.", Internal.GetFormattedStacktrace(2));

--- a/Promises/ResultContainers.cs
+++ b/Promises/ResultContainers.cs
@@ -12,7 +12,9 @@ namespace Proto.Promises
     /// Used to get the value of a rejection or cancelation.
     /// An instance of <see cref="ReasonContainer"/> is only valid during the invocation of the delegate it is passed into.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public partial struct ReasonContainer
     {
         private readonly Internal.IValueContainer _valueContainer;
@@ -86,7 +88,9 @@ namespace Proto.Promises
         /// Used to get the value of a settled <see cref="Promise"/>.
         /// An instance of <see cref="ResultContainer"/> is only valid during the invocation of the onContinue delegate it is passed into.
         /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public partial struct ResultContainer
         {
             private readonly Internal.IValueContainer _valueContainer;
@@ -206,7 +210,9 @@ namespace Proto.Promises
         /// Used to get the value of a settled <see cref="Promise{T}"/>.
         /// An instance of <see cref="ResultContainer"/> is only valid during the invocation of the onContinue delegate it is passed into.
         /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public new partial struct ResultContainer
         {
             private readonly Internal.IValueContainer _valueContainer;

--- a/Promises/Unity/PromiseBehaviour.cs
+++ b/Promises/Unity/PromiseBehaviour.cs
@@ -21,7 +21,9 @@ namespace Proto.Promises
     }
 
     // I would have nested this within Promise, but you can only change the execution order of un-nested behaviours.
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public sealed class PromiseBehaviour : MonoBehaviour
     {
         private static PromiseBehaviour _instance;

--- a/Promises/Unity/PromiseYielder.cs
+++ b/Promises/Unity/PromiseYielder.cs
@@ -93,14 +93,14 @@ namespace Proto.Promises
                 _value = disposedObject;
             }
 
-            void Internal.ITreeHandleable.MakeReady(Internal.IValueContainer valueContainer, ref ValueLinkedQueue<Internal.ITreeHandleable> handleQueue)
+            void Internal.ITreeHandleable.MakeReady(Promise owner, Internal.IValueContainer valueContainer, ref ValueLinkedQueue<Internal.ITreeHandleable> handleQueue)
             {
                 valueContainer.Retain();
                 _value = valueContainer;
                 _state = valueContainer.GetState();
             }
 
-            void Internal.ITreeHandleable.MakeReadyFromSettled(Internal.IValueContainer valueContainer)
+            void Internal.ITreeHandleable.MakeReadyFromSettled(Promise owner, Internal.IValueContainer valueContainer)
             {
                 valueContainer.Retain();
                 _value = valueContainer;

--- a/Promises/Unity/PromiseYielder.cs
+++ b/Promises/Unity/PromiseYielder.cs
@@ -14,7 +14,9 @@ namespace Proto.Promises
         /// Yield instruction that can be yielded in a coroutine to wait until the <see cref="Promise"/> it came from has settled.
         /// An instance of this should be disposed when you are finished with it.
         /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public abstract class YieldInstruction : CustomYieldInstruction, IDisposable, Internal.ITreeHandleable
         {
             Internal.ITreeHandleable ILinked<Internal.ITreeHandleable>.Next { get; set; }
@@ -127,7 +129,9 @@ namespace Proto.Promises
         /// Yield instruction that can be yielded in a coroutine to wait until the <see cref="Promise{T}"/> it came from has settled.
         /// An instance of this should be disposed when you are finished with it.
         /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         public abstract new class YieldInstruction : Promise.YieldInstruction
         {
             internal YieldInstruction() { }
@@ -172,7 +176,9 @@ namespace Proto.Promises
     {
         partial class InternalProtected
         {
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             public sealed class YieldInstructionVoid : YieldInstruction
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -201,7 +207,9 @@ namespace Proto.Promises
                 }
             }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
+#endif
             public sealed class YieldInstruction<T> : Promise<T>.YieldInstruction, Internal.ITreeHandleable
             {
                 private static ValueLinkedStack<Internal.ITreeHandleable> _pool;
@@ -235,7 +243,9 @@ namespace Proto.Promises
     /// <summary>
     /// Yielder used to wait for a yield instruction to complete in the form of a Promise, using Unity's coroutines.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public sealed class PromiseYielder : MonoBehaviour
     {
         static Action _onClearObjects;
@@ -289,7 +299,9 @@ namespace Proto.Promises
             }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         private class Routine : IEnumerator, ILinked<Routine>
         {
             Routine ILinked<Routine>.Next { get; set; }
@@ -345,7 +357,9 @@ namespace Proto.Promises
             void IEnumerator.Reset() { }
         }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
+#endif
         private class Routine<T> : IEnumerator, ILinked<Routine<T>>
         {
             Routine<T> ILinked<Routine<T>>.Next { get; set; }

--- a/Promises/Unity/PromiseYielder.cs
+++ b/Promises/Unity/PromiseYielder.cs
@@ -425,7 +425,7 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="yieldInstruction">Yield instruction.</param>
         /// <typeparam name="TYieldInstruction">The type of yieldInstruction.</typeparam>
-        public static Promise<TYieldInstruction> WaitFor<TYieldInstruction>(TYieldInstruction yieldInstruction) where TYieldInstruction : class // Class constraint to prevent boxing.
+        public static Promise<TYieldInstruction> WaitFor<TYieldInstruction>(TYieldInstruction yieldInstruction)
         {
             Routine<TYieldInstruction> routine = Routine<TYieldInstruction>.GetOrCreate();
             routine.Current = yieldInstruction;

--- a/Tests/AllTests.cs
+++ b/Tests/AllTests.cs
@@ -385,39 +385,39 @@ namespace Proto.Promises.Tests
                 .Progress(p => progress = p);
 
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(0f / 8f, progress, 0f);
+            Assert.AreEqual(0f / 4f, progress, 0f);
 
             deferred1.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(1f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(0.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred1.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(2f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(1f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred2.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(3f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred2.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(4f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(2f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred3.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(5f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(2.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred3.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(6f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(3f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred4.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(7f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(3.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred4.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(8f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(4f / 4f, progress, TestHelper.progressEpsilon);
 
             TestHelper.Cleanup();
         }
@@ -436,39 +436,39 @@ namespace Proto.Promises.Tests
                 .Progress(p => progress = p);
 
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(0f / 8f, progress, 0f);
+            Assert.AreEqual(0f / 4f, progress, 0f);
 
             deferred1.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(1f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(0.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred1.Resolve(1);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(2f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(1f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred2.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(3f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred2.Resolve(1);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(4f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(2f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred3.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(5f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(2.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred3.Resolve(1);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(6f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(3f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred4.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(7f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(3.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred4.Resolve(1);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(8f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(4f / 4f, progress, TestHelper.progressEpsilon);
 
             TestHelper.Cleanup();
         }
@@ -486,31 +486,31 @@ namespace Proto.Promises.Tests
                 .Progress(p => progress = p);
 
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(2f / 8f, progress, 0f);
+            Assert.AreEqual(1f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred1.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(3f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred1.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(4f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(2f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred3.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(5f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(2.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred3.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(6f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(3f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred4.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(7f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(3.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred4.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(8f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(4f / 4f, progress, TestHelper.progressEpsilon);
 
             TestHelper.Cleanup();
         }
@@ -528,32 +528,119 @@ namespace Proto.Promises.Tests
                 .Progress(p => progress = p);
 
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(2f / 8f, progress, 0f);
+            Assert.AreEqual(1f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred1.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(3f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred1.Resolve(1);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(4f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(2f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred3.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(5f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(2.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred3.Resolve(1);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(6f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(3f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred4.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(7f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(3.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred4.Resolve(1);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(8f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(4f / 4f, progress, TestHelper.progressEpsilon);
 
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AllProgressIsNoLongerReportedFromRejected()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+            var deferred3 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.All(deferred1.Promise, deferred2.Promise, deferred3.Promise)
+                .Progress(p => progress = p)
+                .Catch(() => { });
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Reject("Reject");
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AllProgressIsNoLongerReportedFromCanceled()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var cancelationSource = CancelationSource.New();
+            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred3 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.All(deferred1.Promise, deferred2.Promise, deferred3.Promise)
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
             TestHelper.Cleanup();
         }
 #endif

--- a/Tests/AllTests.cs
+++ b/Tests/AllTests.cs
@@ -6,6 +6,7 @@
 
 using System.Linq;
 using NUnit.Framework;
+using UnityEngine.TestTools;
 
 namespace Proto.Promises.Tests
 {
@@ -558,7 +559,277 @@ namespace Proto.Promises.Tests
         }
 
         [Test]
-        public void AllProgressIsNoLongerReportedFromRejected()
+        public void AllProgressIsNormalized4()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.All
+            (
+                deferred1.Promise
+                    .Then(() => { }),
+                deferred2.Promise
+                    .Then(() => { })
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 2f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 2f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AllProgressIsNormalized5()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.All
+            (
+                deferred1.Promise
+                    .Then(() => 1),
+                deferred2.Promise
+                    .Then(() => 1)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 2f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 2f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AllProgressIsNormalized6()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+            var deferred3 = Promise.NewDeferred();
+            var deferred4 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.All
+            (
+                deferred1.Promise
+                    .Then(() => deferred3.Promise),
+                deferred2.Promise
+                    .Then(() => deferred4.Promise)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 4f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(3f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(3.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(4f / 4f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AllProgressIsNormalized7()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+            var deferred3 = Promise.NewDeferred<int>();
+            var deferred4 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.All
+            (
+                deferred1.Promise
+                    .Then(() => deferred3.Promise),
+                deferred2.Promise
+                    .Then(() => deferred4.Promise)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 4f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(3f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(3.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(4f / 4f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AllProgressIsNormalized8()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.All
+            (
+                deferred1.Promise
+                    .Then(Promise.Resolved),
+                deferred2.Promise
+                    .Then(Promise.Resolved)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 4f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(4f / 4f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AllProgressIsNormalized9()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.All
+            (
+                deferred1.Promise
+                    .Then(x => Promise.Resolved(x)),
+                deferred2.Promise
+                    .Then(x => Promise.Resolved(x))
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 4f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(4f / 4f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AllProgressIsNoLongerReportedFromRejected0()
         {
             var deferred1 = Promise.NewDeferred();
             var deferred2 = Promise.NewDeferred();
@@ -601,7 +872,50 @@ namespace Proto.Promises.Tests
         }
 
         [Test]
-        public void AllProgressIsNoLongerReportedFromCanceled()
+        public void AllProgressIsNoLongerReportedFromRejected1()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+            var deferred3 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.All(deferred1.Promise, deferred2.Promise, deferred3.Promise)
+                .Progress(p => progress = p)
+                .Catch(() => { });
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Reject("Reject");
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AllProgressIsNoLongerReportedFromCanceled0()
         {
             var deferred1 = Promise.NewDeferred();
             var cancelationSource = CancelationSource.New();
@@ -639,6 +953,206 @@ namespace Proto.Promises.Tests
             deferred3.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
             Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AllProgressIsNoLongerReportedFromCanceled1()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var cancelationSource = CancelationSource.New();
+            var deferred2 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred3 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.All(deferred1.Promise, deferred2.Promise, deferred3.Promise)
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AllProgressWillBeInvokedProperlyFromARecoveredPromise0()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+            var deferred3 = Promise.NewDeferred();
+            var deferred4 = Promise.NewDeferred();
+            var cancelationSource = CancelationSource.New();
+
+            float progress = float.NaN;
+
+            Promise.All
+            (
+                // Make first and second promise chains the same length
+                deferred1.Promise
+                    .Then(Promise.Resolved)
+                    .Then(Promise.Resolved),
+                deferred2.Promise
+                    .Then(() => deferred3.Promise, cancelationSource.Token)
+                    .ContinueWith(_ => deferred4.Promise)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(3f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.25f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(3.25f / 6f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(5.5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AllProgressWillBeInvokedProperlyFromARecoveredPromise1()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+            var deferred3 = Promise.NewDeferred<int>();
+            var deferred4 = Promise.NewDeferred<int>();
+            var cancelationSource = CancelationSource.New();
+
+            float progress = float.NaN;
+
+            Promise.All
+            (
+                // Make first and second promise chains the same length
+                deferred1.Promise
+                    .Then(x => Promise.Resolved(x))
+                    .Then(x => Promise.Resolved(x)),
+                deferred2.Promise
+                    .Then(() => deferred3.Promise, cancelationSource.Token)
+                    .ContinueWith(_ => deferred4.Promise)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(3f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.25f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(3.25f / 6f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(5.5f / 6f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
 
             cancelationSource.Dispose();
             TestHelper.Cleanup();

--- a/Tests/FirstTests.cs
+++ b/Tests/FirstTests.cs
@@ -506,7 +506,389 @@ namespace Proto.Promises.Tests
         }
 
         [Test]
-        public void FirstProgressIsNoLongerReportedFromRejected()
+        public void FirstProgressReportsTheMaximumProgress4()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.First
+            (
+                deferred1.Promise
+                    .Then(() => { }),
+                deferred2.Promise
+                    .Then(() => { })
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.8f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void FirstProgressReportsTheMaximumProgress5()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.First
+            (
+                deferred1.Promise
+                    .Then(() => 1),
+                deferred2.Promise
+                    .Then(() => 1)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.8f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void FirstProgressReportsTheMaximumProgress6()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+            var deferred3 = Promise.NewDeferred();
+            var deferred4 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.First
+            (
+                deferred1.Promise
+                    .Then(() => deferred3.Promise),
+                deferred2.Promise
+                    .Then(() => deferred4.Promise)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.8f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void FirstProgressReportsTheMaximumProgress7()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+            var deferred3 = Promise.NewDeferred<int>();
+            var deferred4 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.First
+            (
+                deferred1.Promise
+                    .Then(() => deferred3.Promise),
+                deferred2.Promise
+                    .Then(() => deferred4.Promise)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.8f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void FirstProgressReportsTheMaximumProgress8()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.First
+            (
+                deferred1.Promise
+                    .Then(Promise.Resolved),
+                deferred2.Promise
+                    .Then(Promise.Resolved)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.8f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void FirstProgressReportsTheMaximumProgress9()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.First
+            (
+                deferred1.Promise
+                    .Then(x => Promise.Resolved(x)),
+                deferred2.Promise
+                    .Then(x => Promise.Resolved(x))
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.8f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void FirstProgressIsNoLongerReportedFromRejected0()
         {
             var deferred1 = Promise.NewDeferred();
             var deferred2 = Promise.NewDeferred();
@@ -540,7 +922,41 @@ namespace Proto.Promises.Tests
         }
 
         [Test]
-        public void FirstProgressIsNoLongerReportedFromCanceled()
+        public void FirstProgressIsNoLongerReportedFromRejected1()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.First(deferred1.Promise, deferred2.Promise)
+                .Progress(p => progress = p)
+                .Catch(() => { });
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Reject("Reject");
+            deferred1.Reject("Reject");
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void FirstProgressIsNoLongerReportedFromCanceled0()
         {
             var cancelationSource1 = CancelationSource.New();
             var cancelationSource2 = CancelationSource.New();
@@ -573,6 +989,207 @@ namespace Proto.Promises.Tests
 
             cancelationSource1.Dispose();
             cancelationSource2.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void FirstProgressIsNoLongerReportedFromCanceled1()
+        {
+            var cancelationSource1 = CancelationSource.New();
+            var cancelationSource2 = CancelationSource.New();
+            var deferred1 = Promise.NewDeferred<int>(cancelationSource1.Token);
+            var deferred2 = Promise.NewDeferred<int>(cancelationSource2.Token);
+
+            float progress = float.NaN;
+
+            Promise.First(deferred1.Promise, deferred2.Promise)
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource1.Cancel();
+            cancelationSource2.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource1.Dispose();
+            cancelationSource2.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void FirstProgressWillBeInvokedProperlyFromARecoveredPromise0()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+            var deferred3 = Promise.NewDeferred();
+            var deferred4 = Promise.NewDeferred();
+            var cancelationSource = CancelationSource.New();
+
+            float progress = float.NaN;
+
+            Promise.First
+            (
+                // Make first and second promise chains the same length
+                deferred1.Promise
+                    .Then(Promise.Resolved)
+                    .Then(Promise.Resolved),
+                deferred2.Promise
+                    .Then(() => deferred3.Promise, cancelationSource.Token)
+                    .ContinueWith(_ => deferred4.Promise)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.25f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.6f / 3f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void FirstProgressWillBeInvokedProperlyFromARecoveredPromise1()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+            var deferred3 = Promise.NewDeferred<int>();
+            var deferred4 = Promise.NewDeferred<int>();
+            var cancelationSource = CancelationSource.New();
+
+            float progress = float.NaN;
+
+            Promise.First
+            (
+                // Make first and second promise chains the same length
+                deferred1.Promise
+                    .Then(x => Promise.Resolved(x))
+                    .Then(x => Promise.Resolved(x)),
+                deferred2.Promise
+                    .Then(() => deferred3.Promise, cancelationSource.Token)
+                    .ContinueWith(_ => deferred4.Promise)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.25f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.6f / 3f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
             TestHelper.Cleanup();
         }
 #endif

--- a/Tests/ProgressTests.cs
+++ b/Tests/ProgressTests.cs
@@ -31,7 +31,7 @@ namespace Proto.Promises.Tests
         }
 
         [Test]
-        public void OnProgressMayBeInvokedWhenThePromisesProgressHasChanged()
+        public void OnProgressMayBeInvokedWhenThePromisesProgressHasChanged0()
         {
             var deferred = Promise.NewDeferred();
             Assert.AreEqual(Promise.State.Pending, deferred.State);
@@ -54,6 +54,91 @@ namespace Proto.Promises.Tests
 
             deferred.Resolve();
 
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void OnProgressMayBeInvokedWhenThePromisesProgressHasChanged1()
+        {
+            var deferred = Promise.NewDeferred<int>();
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise.Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred.ReportProgress(0.25f);
+            Assert.AreEqual(0f, progress, TestHelper.progressEpsilon);
+
+            deferred.ReportProgress(0.5f);
+            Assert.AreEqual(0f, progress, TestHelper.progressEpsilon);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred.Resolve(1);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void OnProgressMayBeInvokedWhenThePromisesProgressHasChanged2()
+        {
+            var cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise.Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred.ReportProgress(0.25f);
+            Assert.AreEqual(0f, progress, TestHelper.progressEpsilon);
+
+            deferred.ReportProgress(0.5f);
+            Assert.AreEqual(0f, progress, TestHelper.progressEpsilon);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred.Resolve();
+
+            cancelationSource.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void OnProgressMayBeInvokedWhenThePromisesProgressHasChanged3()
+        {
+            var cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise.Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred.ReportProgress(0.25f);
+            Assert.AreEqual(0f, progress, TestHelper.progressEpsilon);
+
+            deferred.ReportProgress(0.5f);
+            Assert.AreEqual(0f, progress, TestHelper.progressEpsilon);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred.Resolve(1);
+
+            cancelationSource.Dispose();
             TestHelper.Cleanup();
         }
 
@@ -110,7 +195,7 @@ namespace Proto.Promises.Tests
         }
 
         [Test]
-        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsRejected()
+        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsRejected0()
         {
             var deferred = Promise.NewDeferred();
             Assert.AreEqual(Promise.State.Pending, deferred.State);
@@ -120,6 +205,7 @@ namespace Proto.Promises.Tests
             deferred.Promise.Progress(p => progress = p)
                 .Catch(() => { });
 
+            deferred.ReportProgress(0.5f);
             deferred.Reject("Fail Value");
             Promise.Manager.HandleCompletesAndProgress();
             Assert.IsNaN(progress);
@@ -128,7 +214,29 @@ namespace Proto.Promises.Tests
         }
 
         [Test]
-        public void OnProgressWillNoLongerBeInvokedWhenAPromiseIsRejectedAndContinueBeingInvokedWhenAChainedPromisesProgressIsUpdated()
+        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsRejected1()
+        {
+            var deferred = Promise.NewDeferred();
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise.Progress(p => progress = p)
+                .Catch(() => { });
+
+            deferred.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred.Reject("Fail Value");
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void OnProgressWillNoLongerBeInvokedWhenAPromiseIsRejectedAndContinueBeingInvokedWhenAChainedPromisesProgressIsUpdated0()
         {
             var deferred = Promise.NewDeferred();
             var deferred2 = Promise.NewDeferred();
@@ -158,6 +266,39 @@ namespace Proto.Promises.Tests
         }
 
         [Test]
+        public void OnProgressWillNoLongerBeInvokedWhenAPromiseIsRejectedAndContinueBeingInvokedWhenAChainedPromisesProgressIsUpdated1()
+        {
+            var deferred = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+            Assert.AreEqual(Promise.State.Pending, deferred2.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise
+                .Catch(() => deferred2.Promise)
+                .Progress(p => progress = p);
+
+            deferred.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred.Reject("Fail Value");
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 2f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
         public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled0()
         {
             CancelationSource cancelationSource = CancelationSource.New();
@@ -178,6 +319,29 @@ namespace Proto.Promises.Tests
 
         [Test]
         public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled1()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise.Progress(p => progress = p);
+
+            deferred.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled2()
         {
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred();
@@ -208,7 +372,106 @@ namespace Proto.Promises.Tests
         }
 
         [Test]
-        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled2()
+        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled3()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred();
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise
+                .Then(() => { }, cancelationSource.Token)
+                .ThenDuplicate()
+                .Progress(p => progress = p)
+                .Finally(cancelationSource.Dispose);
+
+            deferred.ReportProgress(0.25f);
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.IsNaN(progress);
+
+            deferred.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.IsNaN(progress);
+
+            deferred.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.IsNaN(progress);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled4()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred();
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise
+                .ThenDuplicate()
+                .Then(() => { }, cancelationSource.Token)
+                .Progress(p => progress = p)
+                .Finally(cancelationSource.Dispose);
+
+            deferred.ReportProgress(0.25f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.25f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.25f, progress, TestHelper.progressEpsilon);
+
+            deferred.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.25f, progress, TestHelper.progressEpsilon);
+
+            deferred.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.25f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled5()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred();
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise
+                .Then(() => { }, cancelationSource.Token)
+                .ThenDuplicate()
+                .Progress(p => progress = p)
+                .Finally(cancelationSource.Dispose);
+
+            deferred.ReportProgress(0.25f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.25f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.25f, progress, TestHelper.progressEpsilon);
+
+            deferred.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.25f, progress, TestHelper.progressEpsilon);
+
+            deferred.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.25f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled6()
         {
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred();
@@ -248,7 +511,47 @@ namespace Proto.Promises.Tests
         }
 
         [Test]
-        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled3()
+        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled7()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred();
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+            var deferred2 = Promise.NewDeferred();
+            Assert.AreEqual(Promise.State.Pending, deferred2.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise
+                .Then(() =>
+                    deferred2.Promise
+                        .Then(() => { }, cancelationSource.Token)
+                )
+                .ThenDuplicate()
+                .Progress(p => progress = p)
+                .Finally(cancelationSource.Dispose);
+
+            deferred.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.25f, progress, TestHelper.progressEpsilon);
+
+            deferred.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled8()
         {
             var deferred = Promise.NewDeferred();
             Assert.AreEqual(Promise.State.Pending, deferred.State);
@@ -272,6 +575,93 @@ namespace Proto.Promises.Tests
             Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
 
             deferred2.ReportProgress(0.5f);
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled9()
+        {
+            var deferred = Promise.NewDeferred();
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            Assert.AreEqual(Promise.State.Pending, deferred2.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise
+                .Then(() => deferred2.Promise)
+                .ThenDuplicate()
+                .Progress(p => progress = p);
+
+            deferred.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.25f, progress, TestHelper.progressEpsilon);
+
+            deferred.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled10()
+        {
+            var cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise.Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred.ReportProgress(0.75f);
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void OnProgressWillNoLongerBeInvokedWhenPromiseIsCanceled11()
+        {
+            var cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            Assert.AreEqual(Promise.State.Pending, deferred.State);
+
+            float progress = float.NaN;
+
+            deferred.Promise.Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred.ReportProgress(0.75f);
             cancelationSource.Cancel();
             Promise.Manager.HandleCompletesAndProgress();
             Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
@@ -423,6 +813,10 @@ namespace Proto.Promises.Tests
             {
                 deferred.Promise.Progress(default(Action<float>));
             });
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                deferred.Promise.Progress(1, default(Action<int, float>));
+            });
 
             deferred.Resolve();
 
@@ -432,6 +826,10 @@ namespace Proto.Promises.Tests
             Assert.Throws<ArgumentNullException>(() =>
             {
                 deferredInt.Promise.Progress(default(Action<float>));
+            });
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                deferredInt.Promise.Progress(1, default(Action<int, float>));
             });
 
             deferredInt.Resolve(0);

--- a/Tests/RaceTests.cs
+++ b/Tests/RaceTests.cs
@@ -222,7 +222,13 @@ namespace Proto.Promises.Tests
             Promise.Manager.HandleCompletesAndProgress();
             Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
 
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
             deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
 
             TestHelper.Cleanup();
         }
@@ -265,7 +271,13 @@ namespace Proto.Promises.Tests
             Promise.Manager.HandleCompletesAndProgress();
             Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
 
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
             deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
 
             TestHelper.Cleanup();
         }
@@ -285,6 +297,7 @@ namespace Proto.Promises.Tests
 
             deferred1.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, 0f);
 
             TestHelper.Cleanup();
         }
@@ -304,12 +317,395 @@ namespace Proto.Promises.Tests
 
             deferred1.Resolve(1);
             Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, 0f);
 
             TestHelper.Cleanup();
         }
 
         [Test]
-        public void RaceProgressIsNoLongerReportedFromRejected()
+        public void RaceProgressReportsTheMaximumProgress4()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.Race
+            (
+                deferred1.Promise
+                    .Then(() => { }),
+                deferred2.Promise
+                    .Then(() => { })
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.8f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void RaceProgressReportsTheMaximumProgress5()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.Race
+            (
+                deferred1.Promise
+                    .Then(() => 1),
+                deferred2.Promise
+                    .Then(() => 1)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.8f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void RaceProgressReportsTheMaximumProgress6()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+            var deferred3 = Promise.NewDeferred();
+            var deferred4 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.Race
+            (
+                deferred1.Promise
+                    .Then(() => deferred3.Promise),
+                deferred2.Promise
+                    .Then(() => deferred4.Promise)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.8f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void RaceProgressReportsTheMaximumProgress7()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+            var deferred3 = Promise.NewDeferred<int>();
+            var deferred4 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.Race
+            (
+                deferred1.Promise
+                    .Then(() => deferred3.Promise),
+                deferred2.Promise
+                    .Then(() => deferred4.Promise)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.8f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void RaceProgressReportsTheMaximumProgress8()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.Race
+            (
+                deferred1.Promise
+                    .Then(Promise.Resolved),
+                deferred2.Promise
+                    .Then(Promise.Resolved)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.8f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void RaceProgressReportsTheMaximumProgress9()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.Race
+            (
+                deferred1.Promise
+                    .Then(x => Promise.Resolved(x)),
+                deferred2.Promise
+                    .Then(x => Promise.Resolved(x))
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.3f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.8f / 2f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.9f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void RaceProgressIsNoLongerReportedFromRejected0()
         {
             var deferred1 = Promise.NewDeferred();
             var deferred2 = Promise.NewDeferred();
@@ -347,7 +743,45 @@ namespace Proto.Promises.Tests
         }
 
         [Test]
-        public void RaceProgressIsNoLongerReportedFromCanceled()
+        public void RaceProgressIsNoLongerReportedFromRejected1()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            float progress = float.NaN;
+
+            Promise.Race(deferred1.Promise, deferred2.Promise)
+                .Progress(p => progress = p)
+                .Catch(() => { });
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Reject("Reject");
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void RaceProgressIsNoLongerReportedFromCanceled0()
         {
             var deferred1 = Promise.NewDeferred();
             var cancelationSource1 = CancelationSource.New();
@@ -382,6 +816,209 @@ namespace Proto.Promises.Tests
             Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
 
             cancelationSource1.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void RaceProgressIsNoLongerReportedFromCanceled1()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var cancelationSource1 = CancelationSource.New();
+            var deferred2 = Promise.NewDeferred(cancelationSource1.Token);
+
+            float progress = float.NaN;
+
+            Promise.Race(deferred1.Promise, deferred2.Promise)
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource1.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.7f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource1.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void RaceProgressWillBeInvokedProperlyFromARecoveredPromise0()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+            var deferred3 = Promise.NewDeferred();
+            var deferred4 = Promise.NewDeferred();
+            var cancelationSource = CancelationSource.New();
+
+            float progress = float.NaN;
+
+            Promise.Race
+            (
+                // Make first and second promise chains the same length
+                deferred1.Promise
+                    .Then(Promise.Resolved)
+                    .Then(Promise.Resolved),
+                deferred2.Promise
+                    .Then(() => deferred3.Promise, cancelationSource.Token)
+                    .ContinueWith(_ => deferred4.Promise)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.25f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.6f / 3f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void RaceProgressWillBeInvokedProperlyFromARecoveredPromise1()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+            var deferred3 = Promise.NewDeferred<int>();
+            var deferred4 = Promise.NewDeferred<int>();
+            var cancelationSource = CancelationSource.New();
+
+            float progress = float.NaN;
+
+            Promise.Race
+            (
+                // Make first and second promise chains the same length
+                deferred1.Promise
+                    .Then(x => Promise.Resolved(x))
+                    .Then(x => Promise.Resolved(x)),
+                deferred2.Promise
+                    .Then(() => deferred3.Promise, cancelationSource.Token)
+                    .ContinueWith(_ => deferred4.Promise)
+            )
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.25f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.6f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.6f / 3f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.7f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(2.5f / 3f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.8f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve(1);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
             TestHelper.Cleanup();
         }
 #endif

--- a/Tests/SequenceTests.cs
+++ b/Tests/SequenceTests.cs
@@ -467,36 +467,141 @@ namespace Proto.Promises.Tests
 
             deferred1.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(1f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(0.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred1.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(2f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(1f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred2.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(3f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred2.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(4f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(2f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred3.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(5f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(2.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred3.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(6f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(3f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred4.ReportProgress(0.5f);
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(7f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(3.5f / 4f, progress, TestHelper.progressEpsilon);
 
             deferred4.Resolve();
             Promise.Manager.HandleCompletesAndProgress();
-            Assert.AreEqual(8f / 8f, progress, TestHelper.progressEpsilon);
+            Assert.AreEqual(4f / 4f, progress, TestHelper.progressEpsilon);
 
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void SequenceProgressIsNoLongerReportedFromRejected()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+            var deferred3 = Promise.NewDeferred();
+            var deferred4 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.Sequence(() => deferred1.Promise, () => deferred2.Promise, () => deferred3.Promise, () => deferred4.Promise)
+                .Progress(p => progress = p)
+                .Catch(() => { });
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred2.Reject("Reject");
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void SequenceProgressIsNoLongerReportedFromCanceled()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var cancelationSource = CancelationSource.New();
+            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred3 = Promise.NewDeferred();
+            var deferred4 = Promise.NewDeferred();
+
+            float progress = float.NaN;
+
+            Promise.Sequence(() => deferred1.Promise, () => deferred2.Promise, () => deferred3.Promise, () => deferred4.Promise)
+                .Progress(p => progress = p);
+
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0f, progress, 0f);
+
+            deferred1.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(0.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred1.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred2.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Cancel();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred3.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred3.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred4.ReportProgress(0.5f);
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            deferred4.Resolve();
+            Promise.Manager.HandleCompletesAndProgress();
+            Assert.AreEqual(1.5f / 4f, progress, TestHelper.progressEpsilon);
+
+            cancelationSource.Dispose();
             TestHelper.Cleanup();
         }
 #endif

--- a/Utilities/Utils.cs
+++ b/Utilities/Utils.cs
@@ -353,11 +353,11 @@ namespace Proto.Utils
         /// Don't try to access it after disposing! Results are undefined.
         /// </summary>
         /// <remarks>Call <see cref="Dispose"/> when you are finished using the
-        /// <see cref="T:ProtoPromise.ReusableValueContainer`1"/>. The <see cref="Dispose"/> method leaves the
-        /// <see cref="T:ProtoPromise.ReusableValueContainer`1"/> in an unusable state. After calling
+        /// <see cref="ReusableValueContainer{T}"/>. The <see cref="Dispose"/> method leaves the
+        /// <see cref="ReusableValueContainer{T}"/> in an unusable state. After calling
         /// <see cref="Dispose"/>, you must release all references to the
-        /// <see cref="T:ProtoPromise.ReusableValueContainer`1"/> so the garbage collector can reclaim the memory that
-        /// the <see cref="T:ProtoPromise.ReusableValueContainer`1"/> was occupying.</remarks>
+        /// <see cref="ReusableValueContainer{T}"/> so the garbage collector can reclaim the memory that
+        /// the <see cref="ReusableValueContainer{T}"/> was occupying.</remarks>
         public void Dispose()
         {
             Value = default(T);
@@ -444,6 +444,20 @@ namespace Proto.Utils
         public T Peek()
         {
             return _stack.Peek().Value;
+        }
+
+        // TODO: This creates new allocations if T is a struct. It's also just horribly inefficient (scans the linked list twice).
+        // Remove this method with the progress refactor.
+        internal void Remove(T item)
+        {
+            foreach (var node in _stack)
+            {
+                if (node.Value.Equals(item))
+                {
+                    _stack.Remove(node);
+                    return;
+                }
+            }
         }
 
         public Enumerator GetEnumerator()

--- a/Utilities/Utils.cs
+++ b/Utilities/Utils.cs
@@ -17,7 +17,9 @@ namespace Proto.Utils
         T Next { get; set; }
     }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public struct Enumerator<T> : IEnumerator<T> where T : class, ILinked<T>
     {
         private T _current;
@@ -65,7 +67,9 @@ namespace Proto.Utils
     /// <summary>
     /// This structure is unsuitable for general purpose.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public struct ValueLinkedStack<T> : IEnumerable<T> where T : class, ILinked<T>
     {
         private T _first;
@@ -155,7 +159,9 @@ namespace Proto.Utils
     /// <summary>
     /// This structure is unsuitable for general purpose.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public struct ValueLinkedQueue<T> : IEnumerable<T> where T : class, ILinked<T>
     {
         private T _first;
@@ -312,7 +318,9 @@ namespace Proto.Utils
     /// <summary>
     /// Reusable value container. Use <see cref="New(T)"/> to reuse a pooled instance or create a new instance, use <see cref="Dispose"/> to add the instance back to the pool.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public sealed class ReusableValueContainer<T> : IValueContainer<T>, IDisposable, ILinked<ReusableValueContainer<T>>
     {
 #pragma warning disable RECS0108 // Warns about static fields in generic types
@@ -357,7 +365,9 @@ namespace Proto.Utils
         }
     }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public struct ValueLinkedStackZeroGC<T> : IEnumerable<T>
     {
         public struct Enumerator : IEnumerator<T>
@@ -452,7 +462,9 @@ namespace Proto.Utils
         }
     }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public struct ValueLinkedQueueZeroGC<T> : IEnumerable<T>
     {
         public struct Enumerator : IEnumerator<T>
@@ -589,7 +601,9 @@ namespace Proto.Utils
     /// <summary>
     /// Generic Array enumerator. Use this instead of the default <see cref="Array.GetEnumerator"/> for passing it around as an <see cref="IEnumerator{T}"/>.
     /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public struct ArrayEnumerator<T> : IEnumerator<T>
     {
         private readonly T[] _collection;
@@ -626,7 +640,9 @@ namespace Proto.Utils
         }
     }
 
+#if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
+#endif
     public static class ArrayExtensions
     {
         /// <summary>


### PR DESCRIPTION
- Fixed PromiseMethodBuilders in non-IL2CPP builds when the TStateMachine is a struct.
- Removed DebuggerHiddenAttributes in the PromiseMethodBuilders  since the type is marked with DebuggerNonUserAttribute.
- Added #if !PROTO_PROMISE_DEVELOPER_MODE around all [System.Diagnostics.DebuggerNonUserCode] usages to make it easier to debug the library.
- Fixed a Promise.Progress callback subscribed to a promise chain where the chain is broken by a cancelation token and continued with Promise.ContinueWith reports incorrect progress (introduced in v 0.9 with Promise.ContinueWith).
- Fixed progress subscribed to a promise that was created from a deferred with a cancelation token.
- Fixed various progress bugs with multi promises (All/Merge/Race/First).
- Added more progress tests.
- Fixed CancelationToken.Equals(object).
- Added a temporary optimization in Promise.HandleBranches until background tasks are added.
- Added thread checks to make sure the library is only used with one thread.
- Removed class restriction on PromiseYielder.WaitFor.