### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: timcassell

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/timcassell/1e655c18-d443-4aa0-b9f5-f2877c886d50/4aa189f0-a23d-43f2-8a9f-8a5e7a1ed9f5/_apis/work/boardbadge/5c5a34b3-e330-4a86-a1e2-ed316c0281eb)](https://dev.azure.com/timcassell/1e655c18-d443-4aa0-b9f5-f2877c886d50/_boards/board/t/4aa189f0-a23d-43f2-8a9f-8a5e7a1ed9f5/Microsoft.RequirementCategory)
 # ProtoPromise
 <a href="https://promisesaplus.com/">
     <img src="https://promisesaplus.com/assets/logo-small.png" alt="Promises/A+ logo"


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/timcassell/1e655c18-d443-4aa0-b9f5-f2877c886d50/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.