### PR TITLE
Struct thread safety

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
@@ -41,8 +41,9 @@ namespace Proto.Promises
         {
             get
             {
+                CancelationRegistration _this = this;
                 bool _;
-                return _ref != null && _ref.IsRegistered(_id, _order, out _);
+                return _this._ref != null && _this._ref.IsRegistered(_this._id, _this._order, out _);
             }
         }
 
@@ -53,13 +54,14 @@ namespace Proto.Promises
         /// <param name="isTokenCancelationRequested">true if the associated <see cref="CancelationToken"/> is requesting cancelation, false otherwise</param>
         public void GetIsRegisteredAndIsCancelationRequested(out bool isRegistered, out bool isTokenCancelationRequested)
         {
-            if (_ref == null)
+            CancelationRegistration _this = this;
+            if (_this._ref == null)
             {
                 isRegistered = isTokenCancelationRequested = false;
             }
             else
             {
-                isRegistered = _ref.IsRegistered(_id, _order, out isTokenCancelationRequested);
+                isRegistered = _this._ref.IsRegistered(_this._id, _this._order, out isTokenCancelationRequested);
             }
         }
 
@@ -82,7 +84,7 @@ namespace Proto.Promises
         public bool TryUnregister()
         {
             bool _;
-            return _ref != null && _ref.TryUnregister(_id, _order, out _);
+            return TryUnregister(out _);
         }
 
         /// <summary>
@@ -93,11 +95,12 @@ namespace Proto.Promises
         /// <returns>true if the callback was previously registered and the associated <see cref="CancelationSource"/> not yet canceled or disposed, false otherwise</returns>
         public bool TryUnregister(out bool isTokenCancelationRequested)
         {
-            if (_ref == null)
+            CancelationRegistration _this = this;
+            if (_this._ref == null)
             {
                 return isTokenCancelationRequested = false;
             }
-            return _ref.TryUnregister(_id, _order, out isTokenCancelationRequested);
+            return _this._ref.TryUnregister(_this._id, _this._order, out isTokenCancelationRequested);
         }
 
         public bool Equals(CancelationRegistration other)
@@ -116,16 +119,17 @@ namespace Proto.Promises
 
         public override int GetHashCode()
         {
-            if (_ref == null)
+            CancelationRegistration _this = this;
+            if (_this._ref == null)
             {
                 return 0;
             }
             unchecked
             {
                 int hash = 17;
-                hash = hash * 31 + _ref.GetHashCode();
-                hash = hash * 31 + _order.GetHashCode();
-                hash = hash * 31 + _id.GetHashCode();
+                hash = hash * 31 + _this._ref.GetHashCode();
+                hash = hash * 31 + _this._order.GetHashCode();
+                hash = hash * 31 + _this._id.GetHashCode();
                 return hash;
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
@@ -103,7 +103,8 @@ namespace Proto.Promises
         {
             get
             {
-                return _ref != null && _ref.SourceId == _sourceId;
+                CancelationSource _this = this;
+                return _this._ref != null && _this._ref.SourceId == _this._sourceId;
             }
         }
 
@@ -114,7 +115,8 @@ namespace Proto.Promises
         {
             get
             {
-                return _ref != null && _ref.IsSourceCanceled(_sourceId);
+                CancelationSource _this = this;
+                return _this._ref != null && _this._ref.IsSourceCanceled(_this._sourceId);
             }
         }
 
@@ -124,7 +126,8 @@ namespace Proto.Promises
         /// <returns>True if this is valid and was not already canceled, false otherwise.</returns>
         public bool TryCancel()
         {
-            return _ref != null && _ref.TrySetCanceled(_sourceId);
+            CancelationSource _this = this;
+            return _this._ref != null && _this._ref.TrySetCanceled(_this._sourceId);
         }
 
         /// <summary>
@@ -133,7 +136,8 @@ namespace Proto.Promises
         /// <returns>True if this is valid and was not already canceled, false otherwise.</returns>
         public bool TryCancel<TCancel>(TCancel reason)
         {
-            return _ref != null && _ref.TrySetCanceled(ref reason, _sourceId);
+            CancelationSource _this = this;
+            return _this._ref != null && _this._ref.TrySetCanceled(ref reason, _this._sourceId);
         }
 
         /// <summary>
@@ -166,7 +170,8 @@ namespace Proto.Promises
         /// <returns>True if this is valid and was not already disposed, false otherwise.</returns>
         public bool TryDispose()
         {
-            return _ref != null && _ref.TryDispose(_sourceId);
+            CancelationSource _this = this;
+            return _this._ref != null && _this._ref.TryDispose(_this._sourceId);
         }
 
         /// <summary>
@@ -197,15 +202,17 @@ namespace Proto.Promises
 
         public override int GetHashCode()
         {
-            if (_ref == null)
+            CancelationSource _this = this;
+            if (_this._ref == null)
             {
                 return 0;
             }
             unchecked
             {
                 int hash = 17;
-                hash = hash * 31 + _sourceId.GetHashCode();
-                hash = hash * 31 + _ref.GetHashCode();
+                hash = hash * 31 + _this._tokenId.GetHashCode();
+                hash = hash * 31 + _this._sourceId.GetHashCode();
+                hash = hash * 31 + _this._ref.GetHashCode();
                 return hash;
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
@@ -45,9 +45,10 @@ namespace Proto.Promises
         /// </summary>
         internal void MaybeLinkSourceInternal(Internal.CancelationRef cancelationRef)
         {
-            if (_ref != null)
+            CancelationToken _this = this;
+            if (_this._ref != null)
             {
-                _ref.MaybeAddLinkedCancelation(cancelationRef, _id);
+                _this._ref.MaybeAddLinkedCancelation(cancelationRef, _this._id);
             }
         }
 
@@ -58,13 +59,14 @@ namespace Proto.Promises
         internal bool TryRegisterInternal(Internal.ICancelDelegate listener, out CancelationRegistration cancelationRegistration)
         {
             // Retain for thread safety.
-            if (_ref == null || !_ref.TryRetainInternal(_id))
+            CancelationToken _this = this;
+            if (_this._ref == null || !_this._ref.TryRetainInternal(_this._id))
             {
                 cancelationRegistration = default(CancelationRegistration);
                 return false;
             }
-            bool success = _ref.TryRegister(listener, out cancelationRegistration);
-            _ref.ReleaseAfterRetainInternal();
+            bool success = _this._ref.TryRegister(listener, out cancelationRegistration);
+            _this._ref.ReleaseAfterRetainInternal();
             return success;
         }
 
@@ -76,7 +78,8 @@ namespace Proto.Promises
         {
             get
             {
-                return _ref != null && _ref.TokenId == _id;
+                CancelationToken _this = this;
+                return _this._ref != null && _this._ref.TokenId == _this._id;
             }
         }
 
@@ -87,7 +90,8 @@ namespace Proto.Promises
         {
             get
             {
-                return _ref != null && _ref.IsTokenCanceled(_id);
+                CancelationToken _this = this;
+                return _this._ref != null && _this._ref.IsTokenCanceled(_this._id);
             }
         }
 
@@ -97,9 +101,10 @@ namespace Proto.Promises
         /// <exception cref="CancelException"/>
         public void ThrowIfCancelationRequested()
         {
-            if (_ref != null)
+            CancelationToken _this = this;
+            if (_this._ref != null)
             {
-                _ref.ThrowIfCanceled(_id);
+                _this._ref.ThrowIfCanceled(_this._id);
             }
         }
 
@@ -112,8 +117,9 @@ namespace Proto.Promises
         {
             get
             {
+                CancelationToken _this = this;
                 Type type;
-                if (_ref != null && _ref.TryGetCanceledType(_id, out type))
+                if (_this._ref != null && _this._ref.TryGetCanceledType(_this._id, out type))
                 {
                     return type;
                 }
@@ -130,8 +136,9 @@ namespace Proto.Promises
         {
             get
             {
+                CancelationToken _this = this;
                 object value;
-                if (_ref != null && _ref.TryGetCanceledValue(_id, out value))
+                if (_this._ref != null && _this._ref.TryGetCanceledValue(_this._id, out value))
                 {
                     return value;
                 }
@@ -146,8 +153,9 @@ namespace Proto.Promises
         /// <exception cref="InvalidOperationException"/>
         public bool TryGetCancelationValueAs<T>(out T value)
         {
+            CancelationToken _this = this;
             bool didConvert;
-            if (_ref != null && _ref.TryGetCanceledValueAs(_id, out didConvert, out value))
+            if (_this._ref != null && _this._ref.TryGetCanceledValueAs(_this._id, out didConvert, out value))
             {
                 return didConvert;
             }
@@ -164,12 +172,13 @@ namespace Proto.Promises
         public bool TryRegister(Promise.CanceledAction callback, out CancelationRegistration cancelationRegistration)
         {
             ValidateArgument(callback, "callback", 1);
-            if (_ref == null)
+            CancelationToken _this = this;
+            if (_this._ref == null)
             {
                 cancelationRegistration = default(CancelationRegistration);
                 return false;
             }
-            return _ref.TryRegister(callback, _id, out cancelationRegistration);
+            return _this._ref.TryRegister(callback, _this._id, out cancelationRegistration);
         }
 
         /// <summary>
@@ -183,12 +192,13 @@ namespace Proto.Promises
         public bool TryRegister<TCapture>(TCapture captureValue, Promise.CanceledAction<TCapture> callback, out CancelationRegistration cancelationRegistration)
         {
             ValidateArgument(callback, "callback", 1);
-            if (_ref == null)
+            CancelationToken _this = this;
+            if (_this._ref == null)
             {
                 cancelationRegistration = default(CancelationRegistration);
                 return false;
             }
-            return _ref.TryRegister(ref captureValue, callback, _id, out cancelationRegistration);
+            return _this._ref.TryRegister(ref captureValue, callback, _this._id, out cancelationRegistration);
         }
 
         /// <summary>
@@ -200,7 +210,6 @@ namespace Proto.Promises
         /// <exception cref="InvalidOperationException"/>
         public CancelationRegistration Register(Promise.CanceledAction callback)
         {
-            ValidateArgument(callback, "callback", 1);
             CancelationRegistration registration;
             if (TryRegister(callback, out registration))
             {
@@ -218,7 +227,6 @@ namespace Proto.Promises
         /// <exception cref="InvalidOperationException"/>
         public CancelationRegistration Register<TCapture>(TCapture captureValue, Promise.CanceledAction<TCapture> callback)
         {
-            ValidateArgument(callback, "callback", 1);
             CancelationRegistration registration;
             if (TryRegister(captureValue, callback, out registration))
             {
@@ -234,7 +242,8 @@ namespace Proto.Promises
         /// </summary>
         public bool TryRetain()
         {
-            return _ref != null && _ref.TryRetainUser(_id);
+            CancelationToken _this = this;
+            return _this._ref != null && _this._ref.TryRetainUser(_this._id);
         }
 
         /// <summary>
@@ -257,7 +266,8 @@ namespace Proto.Promises
         /// <exception cref="InvalidOperationException"/>
         public void Release()
         {
-            if (_ref == null || !_ref.TryReleaseUser(_id))
+            CancelationToken _this = this;
+            if (_this._ref == null || !_this._ref.TryReleaseUser(_this._id))
             {
                 throw new InvalidOperationException("CancelationToken.Release: you must call Retain before you call Release.", Internal.GetFormattedStacktrace(1));
             }
@@ -279,15 +289,16 @@ namespace Proto.Promises
 
         public override int GetHashCode()
         {
-            if (_ref == null)
+            CancelationToken _this = this;
+            if (_this._ref == null)
             {
                 return 0;
             }
             unchecked
             {
                 int hash = 17;
-                hash = hash * 31 + _id.GetHashCode();
-                hash = hash * 31 + _ref.GetHashCode();
+                hash = hash * 31 + _this._id.GetHashCode();
+                hash = hash * 31 + _this._ref.GetHashCode();
                 return hash;
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
@@ -36,7 +36,8 @@ namespace Proto.Promises
             {
                 get
                 {
-                    return _ref != null && _deferredId == _ref.DeferredId;
+                    DeferredInternal<TDeferredRef> _this = this;
+                    return _this._ref != null && _this._deferredId == _this._ref.DeferredId;
                 }
             }
 
@@ -58,7 +59,8 @@ namespace Proto.Promises
 
             public bool TryResolveVoid()
             {
-                return _ref != null && _ref.TryResolveVoid(_deferredId);
+                DeferredInternal<TDeferredRef> _this = this;
+                return _this._ref != null && _this._ref.TryResolveVoid(_this._deferredId);
             }
 
             public void Resolve<T>(ref T value)
@@ -71,7 +73,8 @@ namespace Proto.Promises
 
             public bool TryResolve<T>(ref T value)
             {
-                return _ref != null && _ref.TryResolve(ref value, _deferredId);
+                DeferredInternal<TDeferredRef> _this = this;
+                return _this._ref != null && _this._ref.TryResolve(ref value, _this._deferredId);
             }
 
             public void Reject<TReject>(ref TReject reason)
@@ -84,7 +87,8 @@ namespace Proto.Promises
 
             public bool TryReject<TReject>(ref TReject reason)
             {
-                return _ref != null && _ref.TryReject(ref reason, _deferredId, 1);
+                DeferredInternal<TDeferredRef> _this = this;
+                return _this._ref != null && _this._ref.TryReject(ref reason, _this._deferredId, 1);
             }
 
             public void Cancel<TCancel>(ref TCancel reason)
@@ -97,7 +101,8 @@ namespace Proto.Promises
 
             public bool TryCancel<TCancel>(ref TCancel reason)
             {
-                return _ref != null && _ref.TryCancel(ref reason, _deferredId);
+                DeferredInternal<TDeferredRef> _this = this;
+                return _this._ref != null && _this._ref.TryCancel(ref reason, _this._deferredId);
             }
 
             public void Cancel()
@@ -110,14 +115,15 @@ namespace Proto.Promises
 
             public bool TryCancel()
             {
-                return _ref != null && _ref.TryCancelVoid(_deferredId);
+                DeferredInternal<TDeferredRef> _this = this;
+                return _this._ref != null && _this._ref.TryCancelVoid(_this._deferredId);
             }
 
             // TODO: don't error if progress is disabled, just do nothing.
             public void ReportProgress(float progress)
             {
 #if !PROMISE_PROGRESS
-                Internal.ThrowProgressException(1);
+                ThrowProgressException(1);
 #else
                 if (!TryReportProgress(progress))
                 {
@@ -133,23 +139,24 @@ namespace Proto.Promises
 #else
                 ValidateProgress(progress, 1);
 
-                return _ref != null && _ref.TryReportProgress(progress, _deferredId);
+                DeferredInternal<TDeferredRef> _this = this;
+                return _this._ref != null && _this._ref.TryReportProgress(progress, _this._deferredId);
 #endif
             }
 
             public override int GetHashCode()
             {
-                var temp = _ref;
-                if (temp == null)
+                DeferredInternal<TDeferredRef> _this = this;
+                if (_this._ref == null)
                 {
                     return 0;
                 }
                 unchecked
                 {
                     int hash = 17;
-                    hash = hash * 31 + _deferredId.GetHashCode();
-                    hash = hash * 31 + _promiseId.GetHashCode();
-                    hash = hash * 31 + temp.GetHashCode();
+                    hash = hash * 31 + _this._deferredId.GetHashCode();
+                    hash = hash * 31 + _this._promiseId.GetHashCode();
+                    hash = hash * 31 + _this._ref.GetHashCode();
                     return hash;
                 }
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -34,7 +34,8 @@ namespace Proto.Promises
         {
             get
             {
-                return _id == (_ref == null ? Internal.ValidIdFromApi : _ref.Id);
+                var _this = GetVoidCopy();
+                return _this._id == (_this._ref == null ? Internal.ValidIdFromApi : _this._ref.Id);
             }
         }
 
@@ -57,9 +58,10 @@ namespace Proto.Promises
 
         public override string ToString()
         {
+            var _this = GetVoidCopy();
             string state =
-                !IsValid ? "Invalid"
-                : _ref != null ? _ref.State.ToString()
+                !_this.IsValid ? "Invalid"
+                : _this._ref != null ? _this._ref.State.ToString()
                 : Promise.State.Resolved.ToString();
             return string.Format("Type: Promise<{0}>, State: {1}", typeof(T), state);
         }
@@ -72,9 +74,10 @@ namespace Proto.Promises
         public Promise<T> Preserve()
         {
             ValidateOperation(1);
-            if (_ref != null)
+            var _this = GetVoidCopy();
+            if (_this._ref != null)
             {
-                var newPromise = _ref.GetPreserved(_id);
+                var newPromise = _this._ref.GetPreserved(_this._id);
                 return new Promise<T>(newPromise, newPromise.Id);
             }
             return this;
@@ -87,9 +90,10 @@ namespace Proto.Promises
         public void Forget()
         {
             ValidateOperation(1);
-            if (_ref != null)
+            var _this = GetVoidCopy();
+            if (_this._ref != null)
             {
-                _ref.Forget(_id);
+                _this._ref.Forget(_this._id);
             }
         }
 
@@ -102,9 +106,10 @@ namespace Proto.Promises
         public Promise<T> Duplicate()
         {
             ValidateOperation(1);
+            var _this = GetVoidCopy();
             if (_ref != null)
             {
-                var newPromise = _ref.GetDuplicate(_id);
+                var newPromise = _this._ref.GetDuplicate(_this._id);
                 return new Promise<T>(newPromise, newPromise.Id);
             }
             return this;
@@ -3571,15 +3576,16 @@ namespace Proto.Promises
         {
             unchecked
             {
+                Promise<T> _this = this;
                 int hash = 17;
                 hash = hash * 31 + _id.GetHashCode();
-                if (_ref != null)
+                if (_this._ref != null)
                 {
-                    hash = hash * 31 + _ref.GetHashCode();
+                    hash = hash * 31 + _this._ref.GetHashCode();
                 }
-                else if (_result != null)
+                else if (_this._result != null)
                 {
-                    hash = hash * 31 + EqualityComparer<T>.Default.GetHashCode(_result);
+                    hash = hash * 31 + EqualityComparer<T>.Default.GetHashCode(_this._result);
                 }
                 hash = hash * 31 + typeof(T).TypeHandle.GetHashCode(); // Hashcode variance for different T types.
                 return hash;
@@ -3597,6 +3603,13 @@ namespace Proto.Promises
         public static bool operator !=(Promise<T> lhs, Promise<T> rhs)
         {
             return !(lhs == rhs);
+        }
+
+        // Defensive copy for thread safety purposes.
+        [MethodImpl(Internal.InlineOption)]
+        private Promise<Internal.VoidResult> GetVoidCopy()
+        {
+            return new Promise<Internal.VoidResult>(_ref, _id);
         }
     }
 }


### PR DESCRIPTION
Copy public structs before operating on them to prevent null refs from torn values due to thread race conditions.