### PR TITLE
Progress Disabled Behavior

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
@@ -3,11 +3,6 @@
 #else
 #undef PROMISE_DEBUG
 #endif
-#if !PROTO_PROMISE_PROGRESS_DISABLE
-#define PROMISE_PROGRESS
-#else
-#undef PROMISE_PROGRESS
-#endif
 
 using System;
 using System.Collections.Generic;
@@ -22,13 +17,6 @@ namespace Proto.Promises
         internal const MethodImplOptions InlineOption = MethodImplOptions.NoInlining;
 #else
         internal const MethodImplOptions InlineOption = (MethodImplOptions) 256; // AggressiveInlining
-#endif
-
-#if !PROMISE_PROGRESS
-        internal static void ThrowProgressException(int skipFrames)
-        {
-            throw new InvalidOperationException("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", GetFormattedStacktrace(skipFrames + 1));
-        }
 #endif
 
         // Calls to these get compiled away in RELEASE mode
@@ -46,7 +34,7 @@ namespace Proto.Promises
 
         partial interface IRejectValueContainer
         {
-            void SetCreatedAndRejectedStacktrace(System.Diagnostics.StackTrace rejectedStacktrace, CausalityTrace createdStacktraces);
+            void SetCreatedAndRejectedStacktrace(StackTrace rejectedStacktrace, CausalityTrace createdStacktraces);
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
@@ -24,9 +24,14 @@ namespace Proto.Promises
 #if CSHARP_7_3_OR_NEWER
             readonly
 #endif
-            struct DeferredBase : IEquatable<DeferredBase>
+            struct DeferredBase : IProgress<float>, IEquatable<DeferredBase>
         {
             private readonly Internal.DeferredInternal<Internal.PromiseRef.DeferredPromiseBase> _target;
+
+            void IProgress<float>.Report(float value)
+            {
+                ReportProgress(value);
+            }
 
             /// <summary>
             /// The attached <see cref="Promises.Promise"/> that this controls.
@@ -179,7 +184,7 @@ namespace Proto.Promises
             /// <exception cref="InvalidOperationException"/>
             /// <exception cref="ArgumentOutOfRangeException"/>
 #if !PROMISE_PROGRESS
-            [System.Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", true)]
+            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
 #endif
             [MethodImpl(Internal.InlineOption)]
             // TODO: don't error if progress is disabled, just do nothing. Set Obsolete attribute to warning.
@@ -194,7 +199,7 @@ namespace Proto.Promises
             /// </summary>
             /// <exception cref="ArgumentOutOfRangeException"/>
 #if !PROMISE_PROGRESS
-            [System.Obsolete("Progress is disabled, this will always return false. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
 #endif
             [MethodImpl(Internal.InlineOption)]
             public bool TryReportProgress(float progress)
@@ -267,9 +272,14 @@ namespace Proto.Promises
 #if CSHARP_7_3_OR_NEWER
             readonly
 #endif
-            struct Deferred : IEquatable<Deferred>
+            struct Deferred : IProgress<float>, IEquatable<Deferred>
         {
             private readonly Internal.DeferredInternal<Internal.PromiseRef.DeferredPromiseVoid> _target;
+
+            void IProgress<float>.Report(float value)
+            {
+                ReportProgress(value);
+            }
 
             /// <summary>
             /// The attached <see cref="Promises.Promise"/> that this controls.
@@ -416,7 +426,7 @@ namespace Proto.Promises
             /// <exception cref="InvalidOperationException"/>
             /// <exception cref="ArgumentOutOfRangeException"/>
 #if !PROMISE_PROGRESS
-            [System.Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", true)]
+            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
 #endif
             [MethodImpl(Internal.InlineOption)]
             public void ReportProgress(float progress)
@@ -430,7 +440,7 @@ namespace Proto.Promises
             /// </summary>
             /// <exception cref="ArgumentOutOfRangeException"/>
 #if !PROMISE_PROGRESS
-            [System.Obsolete("Progress is disabled, this will always return false. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
 #endif
             [MethodImpl(Internal.InlineOption)]
             public bool TryReportProgress(float progress)
@@ -439,12 +449,12 @@ namespace Proto.Promises
             }
 
             /// <summary>
-            /// Cast to <see cref="Promise.DeferredBase"/>.
+            /// Cast to <see cref="DeferredBase"/>.
             /// </summary>
             [MethodImpl(Internal.InlineOption)]
-            public static implicit operator Promise.DeferredBase(Deferred rhs)
+            public static implicit operator DeferredBase(Deferred rhs)
             {
-                return new Promise.DeferredBase(rhs._target._ref, rhs._target._promiseId, rhs._target._deferredId);
+                return new DeferredBase(rhs._target._ref, rhs._target._promiseId, rhs._target._deferredId);
             }
 
             [MethodImpl(Internal.InlineOption)]
@@ -481,7 +491,7 @@ namespace Proto.Promises
             }
 
             [Obsolete("Deferred.State is no longer valid. Use IsValidAndPending.", true)]
-            public Promise.State State
+            public State State
             {
                 get
                 {
@@ -515,9 +525,14 @@ namespace Proto.Promises
 #if CSHARP_7_3_OR_NEWER
             readonly
 #endif
-            struct Deferred : IEquatable<Deferred>
+            struct Deferred : IProgress<float>, IEquatable<Deferred>
         {
             private readonly Internal.DeferredInternal<Internal.PromiseRef.DeferredPromise<T>> _target;
+
+            void IProgress<float>.Report(float value)
+            {
+                ReportProgress(value);
+            }
 
             /// <summary>
             /// The attached <see cref="Promise{T}"/> that this controls.
@@ -664,7 +679,7 @@ namespace Proto.Promises
             /// <exception cref="InvalidOperationException"/>
             /// <exception cref="ArgumentOutOfRangeException"/>
 #if !PROMISE_PROGRESS
-            [System.Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", true)]
+            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
 #endif
             [MethodImpl(Internal.InlineOption)]
             public void ReportProgress(float progress)
@@ -678,7 +693,7 @@ namespace Proto.Promises
             /// </summary>
             /// <exception cref="ArgumentOutOfRangeException"/>
 #if !PROMISE_PROGRESS
-            [System.Obsolete("Progress is disabled, this will always return false. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
 #endif
             [MethodImpl(Internal.InlineOption)]
             public bool TryReportProgress(float progress)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
@@ -4,7 +4,8 @@
 #undef PROMISE_PROGRESS
 #endif
 
-using System;
+#pragma warning disable IDE0034 // Simplify 'default' expression
+
 using System.Runtime.CompilerServices;
 
 namespace Proto.Promises
@@ -53,7 +54,7 @@ namespace Proto.Promises
             {
                 if (!TryResolveVoid())
                 {
-                    throw new InvalidOperationException("Deferred.Resolve: instance is not valid.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("Deferred.Resolve: instance is not valid.", GetFormattedStacktrace(1));
                 }
             }
 
@@ -67,7 +68,7 @@ namespace Proto.Promises
             {
                 if (!TryResolve(ref value))
                 {
-                    throw new InvalidOperationException("Deferred.Resolve: instance is not valid.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("Deferred.Resolve: instance is not valid.", GetFormattedStacktrace(1));
                 }
             }
 
@@ -81,7 +82,7 @@ namespace Proto.Promises
             {
                 if (!TryReject(ref reason))
                 {
-                    throw new InvalidOperationException("Deferred.Reject: instance is not valid.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("Deferred.Reject: instance is not valid.", GetFormattedStacktrace(1));
                 }
             }
 
@@ -95,7 +96,7 @@ namespace Proto.Promises
             {
                 if (!TryCancel(ref reason))
                 {
-                    throw new InvalidOperationException("Deferred.Reject: instance is not valid.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("Deferred.Reject: instance is not valid.", GetFormattedStacktrace(1));
                 }
             }
 
@@ -109,7 +110,7 @@ namespace Proto.Promises
             {
                 if (!TryCancel())
                 {
-                    throw new InvalidOperationException("Deferred.Reject: instance is not valid.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("Deferred.Reject: instance is not valid.", GetFormattedStacktrace(1));
                 }
             }
 
@@ -119,26 +120,20 @@ namespace Proto.Promises
                 return _this._ref != null && _this._ref.TryCancelVoid(_this._deferredId);
             }
 
-            // TODO: don't error if progress is disabled, just do nothing.
             public void ReportProgress(float progress)
             {
-#if !PROMISE_PROGRESS
-                ThrowProgressException(1);
-#else
                 if (!TryReportProgress(progress))
                 {
-                    throw new InvalidOperationException("Deferred.ReportProgress: instance is not valid.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("Deferred.ReportProgress: instance is not valid.", GetFormattedStacktrace(1));
                 }
-#endif
             }
 
             public bool TryReportProgress(float progress)
             {
-#if !PROMISE_PROGRESS
-                return false;
-#else
                 ValidateProgress(progress, 1);
-
+#if !PROMISE_PROGRESS
+                return IsValidAndPending;
+#else
                 DeferredInternal<TDeferredRef> _this = this;
                 return _this._ref != null && _this._ref.TryReportProgress(progress, _this._deferredId);
 #endif

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
@@ -95,6 +95,33 @@ namespace Proto.Promises
 
         /// <summary>
         /// Add a progress listener. Returns a new <see cref="Promise"/>.
+        /// <para/><paramref name="progressListener"/> will be reported with progress that is normalized between 0 and 1 from this and all previous waiting promises in the chain.
+        /// 
+        /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise"/> will be resolved when it returns.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
+        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, progress will stop being reported.
+        /// </summary>
+#if !PROMISE_PROGRESS
+        [Obsolete("Progress is disabled, progress will not be reported. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+#endif
+        [MethodImpl(Internal.InlineOption)]
+        public Promise Progress<TProgress>(TProgress progressListener, CancelationToken cancelationToken = default(CancelationToken)) where TProgress : IProgress<float>
+        {
+            ValidateArgument(progressListener, "progressListener", 1);
+
+#if !PROMISE_PROGRESS
+            return Duplicate();
+#else
+            ValidateOperation(1);
+
+            return Internal.PromiseRef.CallbackHelper.AddProgress(this, progressListener, cancelationToken);
+#endif
+        }
+
+        /// <summary>
+        /// Add a progress listener. Returns a new <see cref="Promise"/>.
         /// <para/><paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and progress that is normalized between 0 and 1 from this and all previous waiting promises in the chain.
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise"/> will be resolved when it returns.
@@ -104,19 +131,14 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", true)]
+        [Obsolete("Progress is disabled, onProgress will not be invoked. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
 #endif
+        [MethodImpl(Internal.InlineOption)]
         public Promise Progress(Action<float> onProgress, CancelationToken cancelationToken = default(CancelationToken))
         {
-#if !PROMISE_PROGRESS
-            Internal.ThrowProgressException(1);
-            return default(Promise);
-#else
-            ValidateOperation(1);
             ValidateArgument(onProgress, "onProgress", 1);
 
-            return Internal.PromiseRef.CallbackHelper.AddProgress(this, new Internal.PromiseRef.DelegateProgress(onProgress), cancelationToken);
-#endif
+            return Progress(new Internal.PromiseRef.DelegateProgress(onProgress), cancelationToken);
         }
 
         /// <summary>
@@ -734,19 +756,14 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", true)]
+        [Obsolete("Progress is disabled, onProgress will not be invoked. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
 #endif
+        [MethodImpl(Internal.InlineOption)]
         public Promise Progress<TCaptureProgress>(TCaptureProgress progressCaptureValue, Action<TCaptureProgress, float> onProgress, CancelationToken cancelationToken = default(CancelationToken))
         {
-#if !PROMISE_PROGRESS
-            Internal.ThrowProgressException(1);
-            return default(Promise);
-#else
-            ValidateOperation(1);
             ValidateArgument(onProgress, "onProgress", 1);
 
-            return Internal.PromiseRef.CallbackHelper.AddProgress(this, new Internal.PromiseRef.DelegateCaptureProgress<TCaptureProgress>(ref progressCaptureValue, onProgress), cancelationToken);
-#endif
+            return Progress(new Internal.PromiseRef.DelegateCaptureProgress<TCaptureProgress>(ref progressCaptureValue, onProgress), cancelationToken);
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -117,6 +117,32 @@ namespace Proto.Promises
 
         /// <summary>
         /// Add a progress listener. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/>.
+        /// <para/><paramref name="progressListener"/> will be reported with progress that is normalized between 0 and 1 from this and all previous waiting promises in the chain.
+        /// 
+        /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise"/> will be resolved when it returns.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
+        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, progress will stop being reported.
+        /// </summary>
+#if !PROMISE_PROGRESS
+        [Obsolete("Progress is disabled, progress will not be reported. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+#endif
+        public Promise<T> Progress<TProgress>(TProgress progressListener, CancelationToken cancelationToken = default(CancelationToken)) where TProgress : IProgress<float>
+        {
+            ValidateArgument(progressListener, "progressListener", 1);
+
+#if !PROMISE_PROGRESS
+            return Duplicate();
+#else
+            ValidateOperation(1);
+
+            return Internal.PromiseRef.CallbackHelper.AddProgress(this, progressListener, cancelationToken);
+#endif
+        }
+
+        /// <summary>
+        /// Add a progress listener. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/>.
         /// <para/><paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and progress that is normalized between 0 and 1 from this and all previous waiting promises in the chain.
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise"/> will be resolved when it returns.
@@ -126,19 +152,14 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", true)]
+        [Obsolete("Progress is disabled, onProgress will not be invoked. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
 #endif
+        [MethodImpl(Internal.InlineOption)]
         public Promise<T> Progress(Action<float> onProgress, CancelationToken cancelationToken = default(CancelationToken))
         {
-#if !PROMISE_PROGRESS
-            Internal.ThrowProgressException(1);
-            return default(Promise<T>);
-#else
-            ValidateOperation(1);
             ValidateArgument(onProgress, "onProgress", 1);
 
-            return Internal.PromiseRef.CallbackHelper.AddProgress(this, new Internal.PromiseRef.DelegateProgress(onProgress), cancelationToken);
-#endif
+            return Progress(new Internal.PromiseRef.DelegateProgress(onProgress), cancelationToken);
         }
 
         /// <summary>
@@ -756,19 +777,14 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", true)]
+        [Obsolete("Progress is disabled, onProgress will not be invoked. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
 #endif
+        [MethodImpl(Internal.InlineOption)]
         public Promise<T> Progress<TCaptureProgress>(TCaptureProgress progressCaptureValue, Action<TCaptureProgress, float> onProgress, CancelationToken cancelationToken = default(CancelationToken))
         {
-#if !PROMISE_PROGRESS
-            Internal.ThrowProgressException(1);
-            return default(Promise<T>);
-#else
-            ValidateOperation(1);
             ValidateArgument(onProgress, "onProgress", 1);
 
-            return Internal.PromiseRef.CallbackHelper.AddProgress(this, new Internal.PromiseRef.DelegateCaptureProgress<TCaptureProgress>(ref progressCaptureValue, onProgress), cancelationToken);
-#endif
+            return Progress(new Internal.PromiseRef.DelegateCaptureProgress<TCaptureProgress>(ref progressCaptureValue, onProgress), cancelationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
- Progress `Obsolete` attributes are now warnings instead of errors when progress is disabled.
- Changed behavior of `Deferred.ReportProgress` to do nothing when progress is disabled.
- Changed behavior of `Promise.Progress` to return Duplicate when progress is disabled.
- Added `Promise(<T>).Progress<TProgress>(TProgress progressListener, CancelationToken cancelationToken = default(CancelationToken)) where TProgress : IProgress<float>)` overload.
- `Promise(T).Deferred(Base)` now implement `IProgress<float>`.
- Added `Promise.Config.IsProgressEnabled`.

These changes are for libraries to be able to have a ProtoPromise dependency without forcing progress enabled/disabled on those libraries' users.
e.g. a library depends on ProtoPromise v2.0.0 or higher, a user of that library could opt to use ProtoPromise v2.0.0.0 (no progress) or v2.0.0.1 (with progress)