### PR TITLE
Remove Cancelation Reasons

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
@@ -35,6 +35,17 @@ namespace Proto.Promises
         }
 
         /// <summary>
+        /// Get the <see cref="CancelationToken"/> associated with this <see cref="CancelationRegistration"/>.
+        /// </summary>
+        public CancelationToken Token
+        {
+            get
+            {
+                return new CancelationToken(_ref, _id);
+            }
+        }
+
+        /// <summary>
         /// Get whether the callback is registered and the associated <see cref="CancelationToken"/> has not been canceled and the associated <see cref="CancelationSource"/> has not been disposed.
         /// </summary>
         public bool IsRegistered
@@ -48,7 +59,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Get whether this is registered and whether the associated <see cref="CancelationToken"/> is requesting cancelation.
+        /// Get whether this is registered and whether the associated <see cref="CancelationToken"/> is requesting cancelation as an atomic operation.
         /// </summary>
         /// <param name="isRegistered">true if this is registered, false otherwise</param>
         /// <param name="isTokenCancelationRequested">true if the associated <see cref="CancelationToken"/> is requesting cancelation, false otherwise</param>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
@@ -18,7 +18,7 @@ namespace Proto.Promises
 #if CSHARP_7_3_OR_NEWER
         readonly
 #endif
-        struct CancelationSource : ICancelableAny, IDisposable, IEquatable<CancelationSource>
+        struct CancelationSource : ICancelable, IDisposable, IEquatable<CancelationSource>
     {
         private readonly Internal.CancelationRef _ref;
         private readonly short _sourceId;
@@ -119,7 +119,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Try to communicate a request for cancelation without providing a reason, and invoke all callbacks that are registered to the associated <see cref="Token"/>. Returns true if successful, false otherwise.
+        /// Try to communicate a request for cancelation, and invoke all callbacks that are registered to the associated <see cref="Token"/>. Returns true if successful, false otherwise.
         /// </summary>
         /// <returns>True if this is valid and was not already canceled, false otherwise.</returns>
         public bool TryCancel()
@@ -128,33 +128,12 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Try to communicate a request for cancelation with the provided reason, and invoke all callbacks that are registered to the associated <see cref="Token"/>.
-        /// </summary>
-        /// <returns>True if this is valid and was not already canceled, false otherwise.</returns>
-        public bool TryCancel<TCancel>(TCancel reason)
-        {
-            return Internal.CancelationRef.TrySetCanceled(reason, _ref, _sourceId);
-        }
-
-        /// <summary>
-        /// Communicate a request for cancelation without providing a reason, and invoke all callbacks that are registered to the associated <see cref="Token"/>.
+        /// Communicate a request for cancelation, and invoke all callbacks that are registered to the associated <see cref="Token"/>.
         /// </summary>
         /// <exception cref="InvalidOperationException"/>
         public void Cancel()
         {
             if (!TryCancel())
-            {
-                throw new InvalidOperationException("CancelationSource.Cancel: source is not valid or was already canceled.", Internal.GetFormattedStacktrace(1));
-            }
-        }
-
-        /// <summary>
-        /// Communicate a request for cancelation with the provided reason, and invoke all callbacks that are registered to the associated <see cref="Token"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException"/>
-        public void Cancel<TCancel>(TCancel reason)
-        {
-            if (!TryCancel(reason))
             {
                 throw new InvalidOperationException("CancelationSource.Cancel: source is not valid or was already canceled.", Internal.GetFormattedStacktrace(1));
             }
@@ -208,6 +187,18 @@ namespace Proto.Promises
         public static bool operator !=(CancelationSource c1, CancelationSource c2)
         {
             return !(c1 == c2);
+        }
+
+        [Obsolete("Cancelation reasons are no longer supported. Use TryCancel() instead.", true)]
+        public bool TryCancel<TCancel>(TCancel reason)
+        {
+            throw new InvalidOperationException("Cancelation reasons are no longer supported. Use TryCancel() instead.", Internal.GetFormattedStacktrace(1));
+        }
+
+        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
+        public void Cancel<TCancel>(TCancel reason)
+        {
+            throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Cancel() instead.", Internal.GetFormattedStacktrace(1));
         }
     }
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
@@ -91,7 +91,7 @@ namespace Proto.Promises
         {
             get
             {
-                return new CancelationToken(_ref, _tokenId);
+                return new CancelationToken(_ref, _tokenId, false);
             }
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
@@ -47,11 +47,7 @@ namespace Proto.Promises
         /// </summary>
         internal void MaybeLinkSourceInternal(Internal.CancelationRef cancelationRef)
         {
-            // No need to copy values for thread-safety here, as this is only called from the `New(CancetionToken)` functions.
-            if (_ref != null)
-            {
-                _ref.MaybeAddLinkedCancelation(cancelationRef, _id);
-            }
+            Internal.CancelationRef.MaybeAddLinkedCancelation(cancelationRef, _ref, _id, _isCanceled);
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -490,6 +490,19 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
+            internal static void MaybeAddLinkedCancelation(CancelationRef listener, CancelationRef _this, short tokenId, bool isCanceled)
+            {
+                if (isCanceled)
+                {
+                    listener.TryInvokeCallbacks();
+                }
+                else if (_this != null)
+                {
+                    _this.MaybeAddLinkedCancelation(listener, tokenId);
+                }
+            }
+
+            [MethodImpl(InlineOption)]
             internal void MaybeAddLinkedCancelation(CancelationRef listener, short tokenId)
             {
                 // Retain for thread safety.
@@ -740,7 +753,7 @@ namespace Proto.Promises
                     return false;
                 }
                 // Wait for a callback currently being added/removed in another thread.
-                // When other threads enter the lock, they will see the _valueContainer was already set, so we don't need any further callback synchronization.
+                // When other threads enter the lock, they will see the _state was already set, so we don't need any further callback synchronization.
                 lock (_registeredCallbacks) { }
                 Unlink();
                 List<Exception> exceptions = null;
@@ -786,7 +799,7 @@ namespace Proto.Promises
                 if (Interlocked.CompareExchange(ref _state, (int) State.Disposed, (int) State.Pending) == (int) State.Pending)
                 {
                     // Wait for a callback currently being added/removed in another thread.
-                    // When other threads enter the lock, they will see the _valueContainer was already set, so we don't need any further callback synchronization.
+                    // When other threads enter the lock, they will see the _state was already set, so we don't need any further callback synchronization.
                     lock (_registeredCallbacks) { }
                     Unlink();
                     for (int i = 0, max = _registeredCallbacks.Count; i < max; ++i)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -22,119 +22,145 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
 #endif
-        internal sealed class CancelationRef : ICancelDelegate, ILinked<CancelationRef>, ITraceable
+        internal abstract class CancelableBase
+        {
+            internal abstract void Invoke();
+            internal abstract void Dispose();
+        }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode]
+#endif
+        internal struct CancelDelegateTokenVoid : ICancelable
+        {
+            private readonly Action _callback;
+
+            [MethodImpl(InlineOption)]
+            internal CancelDelegateTokenVoid(Action callback)
+            {
+                _callback = callback;
+            }
+
+            [MethodImpl(InlineOption)]
+            public void Cancel()
+            {
+                _callback.Invoke();
+            }
+        }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode]
+#endif
+        internal struct CancelDelegateToken<TCapture> : ICancelable
+        {
+            private readonly TCapture _capturedValue;
+            private readonly Action<TCapture> _callback;
+
+            [MethodImpl(InlineOption)]
+            internal CancelDelegateToken(
+#if CSHARP_7_3_OR_NEWER
+                    in
+#endif
+                    TCapture capturedValue, Action<TCapture> callback)
+            {
+                _capturedValue = capturedValue;
+                _callback = callback;
+            }
+
+            [MethodImpl(InlineOption)]
+            public void Cancel()
+            {
+                _callback.Invoke(_capturedValue);
+            }
+        }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode]
+#endif
+        internal sealed class CancelationRef : CancelableBase, ILinked<CancelationRef>, ITraceable
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode]
 #endif
-            private struct CancelDelegateTokenVoid : IDelegateSimple
-            {
-                private readonly Promise.CanceledAction _callback;
-
-                [MethodImpl(InlineOption)]
-                internal CancelDelegateTokenVoid(Promise.CanceledAction callback)
-                {
-                    _callback = callback;
-                }
-
-                [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer)
-                {
-                    _callback.Invoke(new ReasonContainer(valueContainer, InvokeId));
-                }
-            }
-
-#if !PROTO_PROMISE_DEVELOPER_MODE
-            [DebuggerNonUserCode]
-#endif
-            private struct CancelDelegateToken<TCapture> : IDelegateSimple
-            {
-                private readonly TCapture _capturedValue;
-                private readonly Promise.CanceledAction<TCapture> _callback;
-
-                [MethodImpl(InlineOption)]
-                internal CancelDelegateToken(
-#if CSHARP_7_3_OR_NEWER
-                    in
-#endif
-                    TCapture capturedValue, Promise.CanceledAction<TCapture> callback)
-                {
-                    _capturedValue = capturedValue;
-                    _callback = callback;
-                }
-
-                [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer)
-                {
-                    _callback.Invoke(_capturedValue, new ReasonContainer(valueContainer, InvokeId));
-                }
-            }
-
-#if !PROTO_PROMISE_DEVELOPER_MODE
-            [DebuggerNonUserCode]
-#endif
-            private sealed class CancelDelegate<TCanceler> : ICancelDelegate, ITraceable, ILinked<CancelDelegate<TCanceler>>
-                where TCanceler : IDelegateSimple
+            private sealed class CancelableWrappe<TCancelable> : CancelableBase, ITraceable, ILinked<CancelableWrappe<TCancelable>>
+                where TCancelable : ICancelable
             {
 #if PROMISE_DEBUG
                 CausalityTrace ITraceable.Trace { get; set; }
 #endif
-                CancelDelegate<TCanceler> ILinked<CancelDelegate<TCanceler>>.Next { get; set; }
+                CancelableWrappe<TCancelable> ILinked<CancelableWrappe<TCancelable>>.Next { get; set; }
 
-                private TCanceler _canceler;
+                private TCancelable _cancelable;
 
-                private CancelDelegate() { }
+                private CancelableWrappe() { }
+
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                volatile private bool _disposed;
+
+                ~CancelableWrappe()
+                {
+                    if (!_disposed)
+                    {
+                        // For debugging. This should never happen.
+                        string message = "A " + GetType() + " was garbage collected without it being disposed.";
+                        AddRejectionToUnhandledStack(new UnreleasedObjectException(message), this);
+                    }
+                }
+#endif
 
                 [MethodImpl(InlineOption)]
-                internal static CancelDelegate<TCanceler> GetOrCreate(TCanceler canceler)
+                internal static CancelableWrappe<TCancelable> GetOrCreate(TCancelable cancelable)
                 {
-                    var del = ObjectPool<CancelDelegate<TCanceler>>.TryTake<CancelDelegate<TCanceler>>()
-                        ?? new CancelDelegate<TCanceler>();
-                    del._canceler = canceler;
+                    var del = ObjectPool<CancelableWrappe<TCancelable>>.TryTake<CancelableWrappe<TCancelable>>()
+                        ?? new CancelableWrappe<TCancelable>();
+                    del._cancelable = cancelable;
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    del._disposed = false;
+#endif
                     SetCreatedStacktrace(del, 2);
                     return del;
                 }
 
-                void ICancelDelegate.Invoke(ICancelValueContainer valueContainer)
+                internal override void Invoke()
                 {
                     ThrowIfInPool(this);
+                    var canceler = _cancelable;
+#if PROMISE_DEBUG
                     SetCurrentInvoker(this);
-                    var canceler = _canceler;
-                    Dispose();
                     try
                     {
-                        // Canceler may dispose this.
-                        canceler.Invoke(valueContainer);
+                        canceler.Cancel();
                     }
                     finally
                     {
                         ClearCurrentInvoker();
+                        Dispose();
                     }
+#else
+                    Dispose();
+                    canceler.Cancel();
+#endif
                 }
 
                 [MethodImpl(InlineOption)]
-                private void Dispose()
-                {
-                    _canceler = default(TCanceler);
-                    ObjectPool<CancelDelegate<TCanceler>>.MaybeRepool(this);
-                }
-
-                void ICancelDelegate.Dispose()
+                internal override void Dispose()
                 {
                     ThrowIfInPool(this);
-                    Dispose();
+                    _cancelable = default(TCancelable);
+                    _disposed = true;
+                    ObjectPool<CancelableWrappe<TCancelable>>.MaybeRepool(this);
                 }
             }
 
             private struct RegisteredDelegate : IComparable<RegisteredDelegate>
             {
-                internal readonly ICancelDelegate callback;
+                internal readonly CancelableBase cancelable;
                 internal readonly uint order;
 
                 [MethodImpl(InlineOption)]
-                internal RegisteredDelegate(uint order, ICancelDelegate callback)
+                internal RegisteredDelegate(uint order, CancelableBase cancelable)
                 {
-                    this.callback = callback;
+                    this.cancelable = cancelable;
                     this.order = order;
                 }
 
@@ -146,24 +172,6 @@ namespace Proto.Promises
                 {
                     return order.CompareTo(other.order);
                 }
-            }
-
-            // Used as a reference holder for _valueContainer for thread safety purposes and to let the finalizer know that the source was disposed.
-            private class DisposedRef : ICancelValueContainer
-            {
-                internal static readonly DisposedRef instance = new DisposedRef();
-
-                private DisposedRef() { }
-
-                void IValueContainer.Retain() { }
-                void IValueContainer.Release() { }
-
-                Type IValueContainer.ValueType { get { throw new System.InvalidOperationException(); } }
-                object IValueContainer.Value { get { throw new System.InvalidOperationException(); } }
-                Exception IThrowable.GetException() { throw new System.InvalidOperationException(); }
-                Promise.State IValueContainer.GetState() { throw new System.InvalidOperationException(); }
-                void IValueContainer.ReleaseAndMaybeAddToUnhandledStack(bool shouldAdd) { throw new System.InvalidOperationException(); }
-
             }
 
             [StructLayout(LayoutKind.Explicit)]
@@ -375,6 +383,13 @@ namespace Proto.Promises
                     } while (Interlocked.CompareExchange(ref _longValue, newValue._longValue, initialValue._longValue) != initialValue._longValue);
                     return true;
                 }
+            } // IdsAndRetains
+
+            private enum State : int
+            {
+                Pending,
+                Canceled,
+                Disposed
             }
 
 #if PROMISE_DEBUG
@@ -383,17 +398,13 @@ namespace Proto.Promises
 
             ~CancelationRef()
             {
-                if (ValueContainer != null)
-                {
-                    ValueContainer.Release();
-                }
                 if (_idsAndRetains._userRetains > 0)
                 {
                     // CancelationToken wasn't released.
                     string message = "A CancelationToken's resources were garbage collected without being released. You must release all IRetainable objects that you have retained.";
                     AddRejectionToUnhandledStack(new UnreleasedObjectException(message), this);
                 }
-                if (_valueContainer != DisposedRef.instance)
+                if (_state != (int) State.Disposed)
                 {
                     // CancelationSource wasn't disposed.
                     AddRejectionToUnhandledStack(new UnreleasedObjectException("CancelationSource's resources were garbage collected without being disposed."), this);
@@ -406,15 +417,10 @@ namespace Proto.Promises
             // TODO: create a custom SortedDictionary with pooled nodes instead.
             private readonly List<RegisteredDelegate> _registeredCallbacks = new List<RegisteredDelegate>();
             private ValueLinkedStackZeroGC<CancelationRegistration> _links = ValueLinkedStackZeroGC<CancelationRegistration>.Create();
-            volatile private ICancelValueContainer _valueContainer;
+            volatile private int _state; // State as int for Interlocked.
             private uint _registeredCount;
             private IdsAndRetains _idsAndRetains = new IdsAndRetains(1); // Start with Id 1 instead of 0 to reduce risk of false positives.
 
-            internal ICancelValueContainer ValueContainer
-            {
-                [MethodImpl(InlineOption)]
-                get { return _valueContainer; }
-            }
             internal short SourceId
             {
                 [MethodImpl(InlineOption)]
@@ -431,7 +437,7 @@ namespace Proto.Promises
                 var cancelRef = ObjectPool<CancelationRef>.TryTake<CancelationRef>()
                     ?? new CancelationRef();
                 cancelRef._idsAndRetains.SetInternalRetain(1); // 1 retain for Dispose.
-                cancelRef._valueContainer = null;
+                cancelRef._state = (int) State.Pending;
                 SetCreatedStacktrace(cancelRef, 2);
                 return cancelRef;
             }
@@ -451,8 +457,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             private bool IsSourceCanceled(short sourceId)
             {
-                var temp = _valueContainer;
-                return sourceId == SourceId & temp != null & temp != DisposedRef.instance;
+                return sourceId == SourceId & _state == (int) State.Canceled;
             }
 
             [MethodImpl(InlineOption)]
@@ -470,8 +475,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             private bool IsTokenCanceled(short tokenId)
             {
-                var temp = _valueContainer;
-                return tokenId == TokenId & temp != null & temp != DisposedRef.instance;
+                return tokenId == TokenId & _state == (int) State.Canceled;
             }
 
             [MethodImpl(InlineOption)]
@@ -486,109 +490,10 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             private void ThrowIfCanceled(short tokenId)
             {
-                // Retain for thread safety.
-                if (!TryRetainInternal(tokenId))
+                if (IsTokenCanceled(tokenId))
                 {
-                    return;
+                    throw CanceledExceptionInternal.GetOrCreate();
                 }
-                try
-                {
-                    var temp = _valueContainer;
-                    if (temp != null & temp != DisposedRef.instance)
-                    {
-                        throw temp.GetException();
-                    }
-                }
-                finally
-                {
-                    ReleaseAfterRetainInternal();
-                }
-            }
-
-            [MethodImpl(InlineOption)]
-            internal static Type GetCanceledType(CancelationRef _this, short tokenId)
-            {
-                Type type;
-                if (_this != null && _this.TryGetCanceledType(tokenId, out type))
-                {
-                    return type;
-                }
-                throw new InvalidOperationException("CancelationToken.CancelationValueType: token has not been canceled.", GetFormattedStacktrace(2));
-            }
-
-            [MethodImpl(InlineOption)]
-            private bool TryGetCanceledType(short tokenId, out Type type)
-            {
-                // Retain for thread safety.
-                if (!TryRetainInternal(tokenId))
-                {
-                    type = null;
-                    return false;
-                }
-                var temp = _valueContainer;
-                bool isCanceled = temp != null & temp != DisposedRef.instance;
-                type = isCanceled ? temp.ValueType : null;
-                ReleaseAfterRetainInternal();
-                return isCanceled;
-            }
-
-            [MethodImpl(InlineOption)]
-            internal static object GetCanceledValue(CancelationRef _this, short tokenId)
-            {
-                object value;
-                if (_this != null && _this.TryGetCanceledValue(tokenId, out value))
-                {
-                    return value;
-                }
-                throw new InvalidOperationException("CancelationToken.CancelationValue: token has not been canceled.", GetFormattedStacktrace(2));
-            }
-
-            [MethodImpl(InlineOption)]
-            private bool TryGetCanceledValue(short tokenId, out object value)
-            {
-                // Retain for thread safety.
-                if (!TryRetainInternal(tokenId))
-                {
-                    value = null;
-                    return false;
-                }
-                var temp = _valueContainer;
-                bool isCanceled = temp != null & temp != DisposedRef.instance;
-                value = isCanceled ? temp.Value : null;
-                ReleaseAfterRetainInternal();
-                return isCanceled;
-            }
-
-            [MethodImpl(InlineOption)]
-            internal static bool TryGetCanceledValueAs<T>(CancelationRef _this, short tokenId, out T value)
-            {
-                bool didConvert;
-                if (_this != null && _this.TryGetCanceledValueAs(tokenId, out didConvert, out value))
-                {
-                    return didConvert;
-                }
-                throw new InvalidOperationException("CancelationToken.TryGetCancelationValueAs: token has not been canceled.", GetFormattedStacktrace(2));
-            }
-
-            [MethodImpl(InlineOption)]
-            private bool TryGetCanceledValueAs<T>(short tokenId, out bool didConvert, out T value)
-            {
-                // Retain for thread safety.
-                if (!TryRetainInternal(tokenId))
-                {
-                    value = default(T);
-                    return didConvert = false;
-                }
-                var temp = _valueContainer;
-                if (temp == null | temp == DisposedRef.instance)
-                {
-                    value = default(T);
-                    ReleaseAfterRetainInternal();
-                    return didConvert = false;
-                }
-                didConvert = TryGetValue(ValueContainer, out value);
-                ReleaseAfterRetainInternal();
-                return true;
             }
 
             [MethodImpl(InlineOption)]
@@ -599,22 +504,22 @@ namespace Proto.Promises
                 {
                     return;
                 }
-                var temp = _valueContainer;
-                if (temp != null)
+                State state = (State) _state;
+                if (state != State.Pending)
                 {
                     goto MaybeInvokeAndReturn;
                 }
                 lock (listener._registeredCallbacks)
                 {
-                    if (listener._valueContainer != null) // Make sure listener wasn't canceled from another token on another thread.
+                    if (listener._state != (int) State.Pending) // Make sure listener wasn't canceled from another token on another thread.
                     {
                         goto Return;
                     }
                     uint order;
                     lock (_registeredCallbacks)
                     {
-                        temp = _valueContainer;
-                        if (temp != null) // Double-checked locking! In this case it works because we're not writing back to the field.
+                        state = (State) _state;
+                        if (state != State.Pending) // Double-checked locking! In this case it works because we're not writing back to the field.
                         {
                             goto MaybeInvokeAndReturn;
                         }
@@ -630,37 +535,73 @@ namespace Proto.Promises
                 goto Return;
 
             MaybeInvokeAndReturn:
-                if (temp != DisposedRef.instance)
+                if (state == State.Canceled)
                 {
-                    listener.TryInvokeCallbacks(temp);
+                    listener.TryInvokeCallbacks();
                 }
             Return:
                 ReleaseAfterRetainInternal();
             }
 
-
             [MethodImpl(InlineOption)]
-            internal static bool TryRegisterInternal(CancelationRef _this, short tokenId, ICancelDelegate listener, out CancelationRegistration cancelationRegistration)
+            internal static bool TryRegister<TCancelable>(CancelationRef _this, short tokenId,
+#if CSHARP_7_3_OR_NEWER
+                    in
+#endif
+                    TCancelable cancelable, out CancelationRegistration registration) where TCancelable : ICancelable
             {
-                // Retain for thread safety.
-                if (_this == null || !_this.TryRetainInternal(tokenId))
+                if (_this == null)
                 {
-                    cancelationRegistration = default(CancelationRegistration);
+                    registration = default(CancelationRegistration);
                     return false;
                 }
-                bool success = _this.TryRegister(listener, out cancelationRegistration);
-                _this.ReleaseAfterRetainInternal();
-                return success;
+                return _this.TryRegister(cancelable, tokenId, out registration);
             }
 
-            private bool TryRegister(ICancelDelegate callback, out CancelationRegistration registration)
+            [MethodImpl(InlineOption)]
+            private bool TryRegister<TCancelable>(
+#if CSHARP_7_3_OR_NEWER
+                    in
+#endif
+                    TCancelable cancelable, short tokenId, out CancelationRegistration registration) where TCancelable : ICancelable
+            {
+                // Retain for thread safety.
+                if (!TryRetainInternal(tokenId))
+                {
+                    registration = default(CancelationRegistration);
+                    return false;
+                }
+                try
+                {
+                    State state = (State) _state;
+                    if (state != State.Pending)
+                    {
+                        if (state == State.Canceled)
+                        {
+                            registration = new CancelationRegistration(this, TokenId, 0);
+                            cancelable.Cancel();
+                            return true;
+                        }
+                        registration = default(CancelationRegistration);
+                        return false;
+                    }
+                    return TryRegister(CancelableWrappe<TCancelable>.GetOrCreate(cancelable), out registration);
+                }
+                finally
+                {
+                    ReleaseAfterRetainInternal();
+                }
+            }
+
+            [MethodImpl(InlineOption)]
+            private bool TryRegister(CancelableBase callback, out CancelationRegistration registration)
             {
                 uint order;
-                ICancelValueContainer temp;
+                State state;
                 lock (_registeredCallbacks)
                 {
-                    temp = _valueContainer;
-                    if (temp != null)
+                    state = (State) _state;
+                    if (state != State.Pending)
                     {
                         goto MaybeInvoke;
                     }
@@ -674,110 +615,15 @@ namespace Proto.Promises
                 return true;
 
             MaybeInvoke:
-                if (temp != DisposedRef.instance)
+                if (state == State.Canceled)
                 {
                     registration = new CancelationRegistration(this, TokenId, 0);
-                    callback.Invoke(temp);
+                    callback.Invoke();
                     return true;
                 }
+                callback.Dispose();
                 registration = default(CancelationRegistration);
                 return false;
-            }
-
-            [MethodImpl(InlineOption)]
-            internal static bool TryRegister(CancelationRef _this, short tokenId, Promise.CanceledAction callback, out CancelationRegistration registration)
-            {
-                if (_this == null)
-                {
-                    registration = default(CancelationRegistration);
-                    return false;
-                }
-                return _this.TryRegister(callback, tokenId, out registration);
-            }
-
-            [MethodImpl(InlineOption)]
-            private bool TryRegister(Promise.CanceledAction callback, short tokenId, out CancelationRegistration registration)
-            {
-                // Retain for thread safety.
-                if (!TryRetainInternal(tokenId))
-                {
-                    registration = default(CancelationRegistration);
-                    return false;
-                }
-                try
-                {
-                    var temp = _valueContainer;
-                    if (temp != null)
-                    {
-                        if (temp != DisposedRef.instance)
-                        {
-                            registration = new CancelationRegistration(this, TokenId, 0);
-                            callback.Invoke(new ReasonContainer(temp, InvokeId));
-                            return true;
-                        }
-                        registration = default(CancelationRegistration);
-                        return false;
-                    }
-                    var cancelDelegate = CancelDelegate<CancelDelegateTokenVoid>.GetOrCreate(new CancelDelegateTokenVoid(callback));
-                    return TryRegister(cancelDelegate, out registration);
-                }
-                finally
-                {
-                    ReleaseAfterRetainInternal();
-                }
-            }
-
-            [MethodImpl(InlineOption)]
-            internal static bool TryRegister<TCapture>(CancelationRef _this, short tokenId,
-#if CSHARP_7_3_OR_NEWER
-                    in
-#endif
-                    TCapture capturedValue,
-                    Promise.CanceledAction<TCapture> callback,
-                    out CancelationRegistration registration)
-            {
-                if (_this == null)
-                {
-                    registration = default(CancelationRegistration);
-                    return false;
-                }
-                return _this.TryRegister(capturedValue, callback, tokenId, out registration);
-            }
-
-            [MethodImpl(InlineOption)]
-            private bool TryRegister<TCapture>(
-#if CSHARP_7_3_OR_NEWER
-                    in
-#endif
-                    TCapture capturedValue, Promise.CanceledAction<TCapture> callback, short tokenId, out CancelationRegistration registration)
-            {
-                // Retain for thread safety.
-                if (!TryRetainInternal(tokenId))
-                {
-                    registration = default(CancelationRegistration);
-                    return false;
-                }
-                try
-                {
-                    var temp = _valueContainer;
-                    if (temp != null)
-                    {
-                        if (temp != DisposedRef.instance)
-                        {
-                            registration = new CancelationRegistration(this, TokenId, 0);
-                            callback.Invoke(capturedValue, new ReasonContainer(temp, InvokeId));
-                            return true;
-                        }
-                        registration = default(CancelationRegistration);
-                        return false;
-                    }
-                    var cancelDelegate = CancelDelegate<CancelDelegateToken<TCapture>>.GetOrCreate(new CancelDelegateToken<TCapture>(capturedValue, callback));
-                    return TryRegister(cancelDelegate, out registration);
-                }
-                finally
-                {
-                    ReleaseAfterRetainInternal();
-                }
             }
 
             [MethodImpl(InlineOption)]
@@ -796,21 +642,20 @@ namespace Proto.Promises
                     return isCanceled = false;
                 }
                 bool validOrder;
-                var temp = _valueContainer;
-                if (temp != null)
+                State state = (State) _state;
+                isCanceled = state == State.Canceled;
+                if (state != State.Pending)
                 {
-                    isCanceled = temp != DisposedRef.instance;
                     validOrder = false;
                 }
                 else
                 {
                     lock (_registeredCallbacks)
                     {
-                        temp = _valueContainer;
-                        isCanceled = temp != null;
+                        state = (State) _state;
+                        isCanceled = state == State.Canceled;
                         validOrder = !isCanceled && IndexOf(order) >= 0;
                     }
-                    isCanceled &= temp != DisposedRef.instance;
                 }
                 ReleaseAfterRetainInternal();
                 return validOrder;
@@ -835,25 +680,24 @@ namespace Proto.Promises
                     return isCanceled = false;
                 }
                 bool unregistered = false;
-                ICancelDelegate del;
+                CancelableBase cancelable;
                 lock (_registeredCallbacks)
                 {
-                    var temp = _valueContainer;
-                    if (temp != null)
+                    State state = (State) _state;
+                    isCanceled = state == State.Canceled;
+                    if (state != State.Pending)
                     {
-                        isCanceled = temp != DisposedRef.instance;
                         goto ReleaseAndReturn;
                     }
-                    isCanceled = false;
                     int index = IndexOf(order);
                     if (index < 0)
                     {
                         goto ReleaseAndReturn;
                     }
-                    del = _registeredCallbacks[index].callback;
+                    cancelable = _registeredCallbacks[index].cancelable;
                     _registeredCallbacks.RemoveAt(index);
                 }
-                del.Dispose();
+                cancelable.Dispose();
                 unregistered = true;
             ReleaseAndReturn:
                 ReleaseAfterRetainInternal();
@@ -882,7 +726,7 @@ namespace Proto.Promises
                 }
                 try
                 {
-                    return _valueContainer == null && TryInvokeCallbacks(CancelContainerVoid.GetOrCreate(0));
+                    return TryInvokeCallbacks();
                 }
                 finally
                 {
@@ -890,45 +734,10 @@ namespace Proto.Promises
                 }
             }
 
-
-            [MethodImpl(InlineOption)]
-            internal static bool TrySetCanceled<T>(
-#if CSHARP_7_3_OR_NEWER
-                in
-#endif
-                T reason, CancelationRef _this, short sourceId)
+            private bool TryInvokeCallbacks()
             {
-                return _this != null && _this.TrySetCanceled(reason, sourceId);
-            }
-
-            [MethodImpl(InlineOption)]
-            private bool TrySetCanceled<T>(
-#if CSHARP_7_3_OR_NEWER
-                in
-#endif
-                T reason, short sourceId)
-            {
-                // Retain for thread safety and recursive calls.
-                if (!TryRetainInternal(sourceId))
+                if (Interlocked.CompareExchange(ref _state, (int) State.Canceled, (int) State.Pending) != (int) State.Pending)
                 {
-                    return false;
-                }
-                try
-                {
-                    return _valueContainer == null && TryInvokeCallbacks(CreateCancelContainer(reason));
-                }
-                finally
-                {
-                    ReleaseAfterRetainInternal();
-                }
-            }
-
-            private bool TryInvokeCallbacks(ICancelValueContainer valueContainer)
-            {
-                valueContainer.Retain();
-                if (Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) != null)
-                {
-                    valueContainer.Release();
                     return false;
                 }
                 // Wait for a callback currently being added/removed in another thread.
@@ -940,7 +749,7 @@ namespace Proto.Promises
                 {
                     try
                     {
-                        _registeredCallbacks[i].callback.Invoke(valueContainer);
+                        _registeredCallbacks[i].cancelable.Invoke();
                     }
                     catch (Exception e)
                     {
@@ -975,16 +784,15 @@ namespace Proto.Promises
                 }
                 ThrowIfInPool(this);
                 // In case Dispose is called concurrently with Cancel.
-                if (Interlocked.CompareExchange(ref _valueContainer, DisposedRef.instance, null) == null)
+                if (Interlocked.CompareExchange(ref _state, (int) State.Disposed, (int) State.Pending) == (int) State.Pending)
                 {
                     // Wait for a callback currently being added/removed in another thread.
                     // When other threads enter the lock, they will see the _valueContainer was already set, so we don't need any further callback synchronization.
                     lock (_registeredCallbacks) { }
                     Unlink();
-                    // No need to lock on _registeredCallbacks since it won't be modified after WaitForCallbacks().
                     for (int i = 0, max = _registeredCallbacks.Count; i < max; ++i)
                     {
-                        _registeredCallbacks[i].callback.Dispose();
+                        _registeredCallbacks[i].cancelable.Dispose();
                     }
                     _registeredCallbacks.Clear();
                 }
@@ -1074,20 +882,22 @@ namespace Proto.Promises
             private void ResetAndRepool()
             {
                 ThrowIfInPool(this);
-                var oldContainer = Interlocked.Exchange(ref _valueContainer, DisposedRef.instance);
-                if (oldContainer != null)
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                if (_registeredCallbacks.Count != 0)
                 {
-                    oldContainer.Release();
+                    throw new System.InvalidOperationException("CancelationToken callbacks have not been unregistered.");
                 }
+#endif
+                _state = (int) State.Disposed;
                 ObjectPool<CancelationRef>.MaybeRepool(this);
             }
 
-            void ICancelDelegate.Invoke(ICancelValueContainer valueContainer)
+            internal override void Invoke()
             {
                 ThrowIfInPool(this);
                 try
                 {
-                    TryInvokeCallbacks(valueContainer);
+                    TryInvokeCallbacks();
                 }
                 finally
                 {
@@ -1095,7 +905,7 @@ namespace Proto.Promises
                 }
             }
 
-            void ICancelDelegate.Dispose()
+            internal override void Dispose()
             {
                 ThrowIfInPool(this);
                 ReleaseAfterRetainInternal();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Interfaces.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Interfaces.cs
@@ -3,7 +3,7 @@
     public interface ICancelable
     {
         /// <summary>
-        /// Cancel this instance without a reason.
+        /// Cancel this instance.
         /// </summary>
         void Cancel();
     }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Interfaces.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Interfaces.cs
@@ -8,14 +8,6 @@
         void Cancel();
     }
 
-    public interface ICancelableAny : ICancelable
-    {
-        /// <summary>
-        /// Cancel this instance with <paramref name="reason"/>.
-        /// </summary>
-        void Cancel<TCancel>(TCancel reason);
-    }
-
     public interface IRetainable
     {
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ExceptionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ExceptionsInternal.cs
@@ -67,7 +67,7 @@ namespace Proto.Promises
         internal sealed class CanceledExceptionInternal : CanceledException
         {
 #if !PROMISE_DEBUG
-            private static readonly CanceledExceptionInternalVoid _instance = new CanceledExceptionInternalVoid("Operation was canceled.");
+            private static readonly CanceledExceptionInternal _instance = new CanceledExceptionInternal("Operation was canceled.");
 #endif
 
             internal static CanceledExceptionInternal GetOrCreate()

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ExceptionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ExceptionsInternal.cs
@@ -64,104 +64,22 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
 #endif
-        internal sealed class CanceledExceptionInternal<T> : CanceledException, ICancelValueContainer, ICancelationToContainer
-        {
-            private readonly T _value;
-
-            internal CanceledExceptionInternal(T value, string message) : base(message)
-            {
-                _value = value;
-            }
-
-            public override Type ValueType { get { return typeof(T).IsValueType ? typeof(T) : _value.GetType(); } }
-
-            public override object Value { get { return _value; } }
-
-            public override bool TryGetValueAs<TConvert>(out TConvert value)
-            {
-                CanceledExceptionInternal<TConvert> casted = this as CanceledExceptionInternal<TConvert>;
-                if (casted != null)
-                {
-                    value = casted._value;
-                    return true;
-                }
-                if (!typeof(T).IsValueType && typeof(TConvert).IsAssignableFrom(_value.GetType()))
-                {
-                    value = (TConvert) (object) _value;
-                    return true;
-                }
-                value = default(TConvert);
-                return false;
-            }
-
-            Promise.State IValueContainer.GetState()
-            {
-                return Promise.State.Canceled;
-            }
-
-            void IValueContainer.Retain() { }
-            void IValueContainer.Release() { }
-            void IValueContainer.ReleaseAndMaybeAddToUnhandledStack(bool shouldAdd) { }
-
-            Exception IThrowable.GetException()
-            {
-                return this;
-            }
-
-            ICancelValueContainer ICancelationToContainer.ToContainer()
-            {
-                return this;
-            }
-        }
-
-#if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
-#endif
-        internal sealed class CanceledExceptionInternalVoid : CanceledException, ICancelValueContainer, ICancelationToContainer
+        internal sealed class CanceledExceptionInternal : CanceledException
         {
 #if !PROMISE_DEBUG
-            private static readonly CanceledExceptionInternalVoid _instance = new CanceledExceptionInternalVoid("Operation was canceled without a reason.");
+            private static readonly CanceledExceptionInternalVoid _instance = new CanceledExceptionInternalVoid("Operation was canceled.");
 #endif
 
-            internal static CanceledExceptionInternalVoid GetOrCreate()
+            internal static CanceledExceptionInternal GetOrCreate()
             {
 #if PROMISE_DEBUG
-                return new CanceledExceptionInternalVoid("Operation was canceled without a reason."); // Don't re-use instance in DEBUG mode so users can read its stacktrace on any thread.
+                return new CanceledExceptionInternal("Operation was canceled."); // Don't re-use instance in DEBUG mode so users can read its stacktrace on any thread.
 #else
                 return _instance;
 #endif
             }
 
-            private CanceledExceptionInternalVoid(string message) : base(message) { }
-
-            public override Type ValueType { get { return null; } }
-
-            public override object Value { get { return null; } }
-
-            public override bool TryGetValueAs<TConvert>(out TConvert value)
-            {
-                value = default(TConvert);
-                return false;
-            }
-
-            Promise.State IValueContainer.GetState()
-            {
-                return Promise.State.Canceled;
-            }
-
-            void IValueContainer.Retain() { }
-            void IValueContainer.Release() { }
-            void IValueContainer.ReleaseAndMaybeAddToUnhandledStack(bool shouldAdd) { }
-
-            Exception IThrowable.GetException()
-            {
-                return this;
-            }
-
-            ICancelValueContainer ICancelationToContainer.ToContainer()
-            {
-                return this;
-            }
+            private CanceledExceptionInternal(string message) : base(message) { }
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
@@ -331,44 +331,6 @@ namespace Proto.Promises
             return valueContainer;
         }
 
-        internal static ICancelValueContainer CreateCancelContainer<TCancel>(
-#if CSHARP_7_3_OR_NEWER
-                in
-#endif
-                TCancel reason)
-        {
-            ICancelValueContainer cancelValue;
-            if (typeof(TCancel).IsValueType)
-            {
-                cancelValue = CancelContainer<TCancel>.GetOrCreate(reason, 0);
-            }
-            else
-            {
-#if CSHARP_7_3_OR_NEWER
-                if (reason is ICancelationToContainer internalCancelation)
-#else
-                ICancelationToContainer internalCancelation = reason as ICancelationToContainer;
-                if (internalCancelation != null)
-#endif
-                {
-                    // reason is an internal cancelation object, get its container instead of wrapping it.
-                    cancelValue = internalCancelation.ToContainer();
-                }
-                else if (reason == null || reason is OperationCanceledException)
-                {
-                    // Use void container instead of wrapping OperationCanceledException, or if reason is null.
-                    cancelValue = CancelContainerVoid.GetOrCreate(0);
-                }
-                else
-                {
-                    // Only need to create one object pool for reference types.
-                    object o = reason;
-                    cancelValue = CancelContainer<object>.GetOrCreate(o, 0);
-                }
-            }
-            return cancelValue;
-        }
-
         // Handle uncaught errors. These must not be readonly.
         private static ValueLinkedStack<UnhandledException> _unhandledExceptions = new ValueLinkedStack<UnhandledException>();
         private static SpinLocker _unhandledExceptionsLocker;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
@@ -440,17 +440,22 @@ namespace Proto.Promises
 
         internal static int BuildHashCode(object _ref, int hashcode1, int hashcode2)
         {
-            if (_ref == null)
-            {
-                return 0;
-            }
+            int hashcode0 = _ref == null ? 0 : _ref.GetHashCode();
             unchecked
             {
                 int hash = 17;
-                hash = hash * 31 + _ref.GetHashCode();
+                hash = hash * 31 + hashcode0;
                 hash = hash * 31 + hashcode1;
                 hash = hash * 31 + hashcode2;
                 return hash;
+            }
+        }
+
+        internal static int BuildHashCode(object _ref, int hashcode1, int hashcode2, int hashcode3)
+        {
+            unchecked
+            {
+                return BuildHashCode(_ref, hashcode1, hashcode2) * 31 + hashcode3;
             }
         }
     } // class Internal

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/InterfacesInternal.cs
@@ -43,11 +43,6 @@ namespace Proto.Promises
             IRejectValueContainer ToContainer(ITraceable traceable);
         }
 
-        internal interface ICancelationToContainer
-        {
-            ICancelValueContainer ToContainer();
-        }
-
         internal interface ICantHandleException
         {
             void AddToUnhandledStack(ITraceable traceable);
@@ -62,15 +57,9 @@ namespace Proto.Promises
 
         internal interface ICancelValueContainer : IValueContainer, IThrowable { }
 
-        internal interface ICancelDelegate
-        {
-            void Invoke(ICancelValueContainer valueContainer);
-            void Dispose();
-        }
-
         internal interface IDelegateSimple
         {
-            void Invoke(IValueContainer valueContainer);
+            void Invoke();
         }
     }
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
@@ -282,8 +282,17 @@ namespace Proto.Promises
             {
                 // Spin until we successfully get lock.
                 SpinWait spinner = new SpinWait();
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                Stopwatch stopwatch = Stopwatch.StartNew();
+#endif
                 while (Interlocked.Exchange(ref _locker, 1) == 1)
                 {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    if (stopwatch.Elapsed.TotalSeconds > 10)
+                    {
+                        throw new TimeoutException();
+                    }
+#endif
                     spinner.SpinOnce();
                 }
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
@@ -159,7 +159,7 @@ namespace Proto.Promises
             }
 
             /// <summary>
-            /// Cancel the linked <see cref="Promise"/> without a reason.
+            /// Cancel the linked <see cref="Promise"/>.
             /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
             /// </summary>
             /// <exception cref="InvalidOperationException"/>
@@ -173,7 +173,7 @@ namespace Proto.Promises
             }
 
             /// <summary>
-            /// Try to cancel the linked <see cref="Promise"/> with <paramref name="reason"/>.
+            /// Try to cancel the linked <see cref="Promise"/>.
             /// <para/> Returns true if successful, false otherwise.
             /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
             /// </summary>
@@ -353,7 +353,7 @@ namespace Proto.Promises
 
             /// <summary>
             /// Returns a new <see cref="Deferred"/> instance that is linked to and controls the state of a new <see cref="Promises.Promise"/>.
-            /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Deferred"/> is pending, it and the <see cref="Promises.Promise"/> will be canceled with its reason.
+            /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Deferred"/> is pending, it and the <see cref="Promises.Promise"/> will be canceled.
             /// </summary>
             [MethodImpl(Internal.InlineOption)]
             public static Deferred New(CancelationToken cancelationToken = default(CancelationToken))
@@ -402,7 +402,7 @@ namespace Proto.Promises
             }
 
             /// <summary>
-            /// Cancel the linked <see cref="Promise"/> without a reason.
+            /// Cancel the linked <see cref="Promise"/>.
             /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
             /// </summary>
             /// <exception cref="InvalidOperationException"/>
@@ -413,7 +413,7 @@ namespace Proto.Promises
             }
 
             /// <summary>
-            /// Try to cancel the linked <see cref="Promise"/> with <paramref name="reason"/>.
+            /// Try to cancel the linked <see cref="Promise"/>.
             /// <para/> Returns true if successful, false otherwise.
             /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
             /// </summary>
@@ -607,7 +607,7 @@ namespace Proto.Promises
 
             /// <summary>
             /// Returns a new <see cref="Deferred"/> instance that is linked to and controls the state of a new <see cref="Promises.Promise"/>.
-            /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Deferred"/> is pending, it and the <see cref="Promises.Promise"/> will be canceled with its reason.
+            /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Deferred"/> is pending, it and the <see cref="Promises.Promise"/> will be canceled.
             /// </summary>
             public static Deferred New(CancelationToken cancelationToken = default(CancelationToken))
             {
@@ -664,7 +664,7 @@ namespace Proto.Promises
             }
 
             /// <summary>
-            /// Cancel the linked <see cref="Promise"/> without a reason.
+            /// Cancel the linked <see cref="Promise"/>.
             /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
             /// </summary>
             /// <exception cref="InvalidOperationException"/>
@@ -678,7 +678,7 @@ namespace Proto.Promises
             }
 
             /// <summary>
-            /// Try to cancel the linked <see cref="Promise"/> with <paramref name="reason"/>.
+            /// Try to cancel the linked <see cref="Promise"/>.
             /// <para/> Returns true if successful, false otherwise.
             /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
             /// </summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
@@ -25,7 +25,7 @@ namespace Proto.Promises
 #if CSHARP_7_3_OR_NEWER
             readonly
 #endif
-            struct DeferredBase : IProgress<float>, IEquatable<DeferredBase>
+            struct DeferredBase : ICancelable, IProgress<float>, IEquatable<DeferredBase>
         {
             private readonly Internal.PromiseRef.DeferredPromiseBase _ref;
             private readonly short _promiseId;
@@ -159,31 +159,6 @@ namespace Proto.Promises
             }
 
             /// <summary>
-            /// Cancel the linked <see cref="Promise"/> with <paramref name="reason"/>.
-            /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
-            /// </summary>
-            /// <exception cref="InvalidOperationException"/>
-            [MethodImpl(Internal.InlineOption)]
-            public void Cancel<TCancel>(TCancel reason)
-            {
-                if (!TryCancel(reason))
-                {
-                    throw new InvalidOperationException("Deferred.Reject: instance is not valid.", Internal.GetFormattedStacktrace(1));
-                }
-            }
-
-            /// <summary>
-            /// Try to cancel the linked <see cref="Promise"/> with <paramref name="reason"/>.
-            /// <para/> Returns true if successful, false otherwise.
-            /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
-            /// </summary>
-            [MethodImpl(Internal.InlineOption)]
-            public bool TryCancel<TCancel>(TCancel reason)
-            {
-                return Internal.PromiseRef.DeferredPromiseBase.TryCancel(_ref, _deferredId, reason);
-            }
-
-            /// <summary>
             /// Cancel the linked <see cref="Promise"/> without a reason.
             /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
             /// </summary>
@@ -205,7 +180,7 @@ namespace Proto.Promises
             [MethodImpl(Internal.InlineOption)]
             public bool TryCancel()
             {
-                return Internal.PromiseRef.DeferredPromiseBase.TryCancelVoid(_ref, _deferredId);
+                return Internal.PromiseRef.DeferredPromiseBase.TryCancel(_ref, _deferredId);
             }
 
             /// <summary>
@@ -274,6 +249,18 @@ namespace Proto.Promises
                 return !(lhs == rhs);
             }
 
+            [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
+            public void Cancel<TCancel>(TCancel reason)
+            {
+                throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Cancel() instead.", Internal.GetFormattedStacktrace(1));
+            }
+
+            [Obsolete("Cancelation reasons are no longer supported. Use TryCancel() instead.", true)]
+            public bool TryCancel<TCancel>(TCancel reason)
+            {
+                throw new InvalidOperationException("Cancelation reasons are no longer supported. Use TryCancel() instead.", Internal.GetFormattedStacktrace(1));
+            }
+
             [Obsolete("DeferredBase.State is no longer valid. Use IsValidAndPending.", true)]
             public State State
             {
@@ -306,7 +293,7 @@ namespace Proto.Promises
 #if CSHARP_7_3_OR_NEWER
             readonly
 #endif
-            struct Deferred : IProgress<float>, IEquatable<Deferred>
+            struct Deferred : ICancelable, IProgress<float>, IEquatable<Deferred>
         {
             private readonly Promise<Internal.VoidResult>.Deferred _target;
 
@@ -415,28 +402,6 @@ namespace Proto.Promises
             }
 
             /// <summary>
-            /// Cancel the linked <see cref="Promise"/> with <paramref name="reason"/>.
-            /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
-            /// </summary>
-            /// <exception cref="InvalidOperationException"/>
-            [MethodImpl(Internal.InlineOption)]
-            public void Cancel<TCancel>(TCancel reason)
-            {
-                _target.Cancel(reason);
-            }
-
-            /// <summary>
-            /// Try to cancel the linked <see cref="Promise"/> with <paramref name="reason"/>.
-            /// <para/> Returns true if successful, false otherwise.
-            /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
-            /// </summary>
-            [MethodImpl(Internal.InlineOption)]
-            public bool TryCancel<TCancel>(TCancel reason)
-            {
-                return _target.TryCancel(reason);
-            }
-
-            /// <summary>
             /// Cancel the linked <see cref="Promise"/> without a reason.
             /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
             /// </summary>
@@ -537,6 +502,18 @@ namespace Proto.Promises
                 return !(lhs == rhs);
             }
 
+            [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
+            public void Cancel<TCancel>(TCancel reason)
+            {
+                throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Cancel() instead.", Internal.GetFormattedStacktrace(1));
+            }
+
+            [Obsolete("Cancelation reasons are no longer supported. Use TryCancel() instead.", true)]
+            public bool TryCancel<TCancel>(TCancel reason)
+            {
+                throw new InvalidOperationException("Cancelation reasons are no longer supported. Use TryCancel() instead.", Internal.GetFormattedStacktrace(1));
+            }
+
             [Obsolete("Deferred.State is no longer valid. Use IsValidAndPending.", true)]
             public State State
             {
@@ -572,7 +549,7 @@ namespace Proto.Promises
 #if CSHARP_7_3_OR_NEWER
             readonly
 #endif
-            struct Deferred : IProgress<float>, IEquatable<Deferred>
+            struct Deferred : ICancelable, IProgress<float>, IEquatable<Deferred>
         {
             internal readonly Internal.PromiseRef.DeferredPromise<T> _ref;
             internal readonly short _promiseId;
@@ -687,31 +664,6 @@ namespace Proto.Promises
             }
 
             /// <summary>
-            /// Cancel the linked <see cref="Promise"/> with <paramref name="reason"/>.
-            /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
-            /// </summary>
-            /// <exception cref="InvalidOperationException"/>
-            [MethodImpl(Internal.InlineOption)]
-            public void Cancel<TCancel>(TCancel reason)
-            {
-                if (!TryCancel(reason))
-                {
-                    throw new InvalidOperationException("Deferred.Reject: instance is not valid.", Internal.GetFormattedStacktrace(1));
-                }
-            }
-
-            /// <summary>
-            /// Try to cancel the linked <see cref="Promise"/> with <paramref name="reason"/>.
-            /// <para/> Returns true if successful, false otherwise.
-            /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
-            /// </summary>
-            [MethodImpl(Internal.InlineOption)]
-            public bool TryCancel<TCancel>(TCancel reason)
-            {
-                return Internal.PromiseRef.DeferredPromiseBase.TryCancel(_ref, _deferredId, reason);
-            }
-
-            /// <summary>
             /// Cancel the linked <see cref="Promise"/> without a reason.
             /// <para/>Note: This is not recommended. Instead, you should pass a <see cref="CancelationToken"/> into <see cref="New(CancelationToken)"/>.
             /// </summary>
@@ -733,7 +685,7 @@ namespace Proto.Promises
             [MethodImpl(Internal.InlineOption)]
             public bool TryCancel()
             {
-                return Internal.PromiseRef.DeferredPromiseBase.TryCancelVoid(_ref, _deferredId);
+                return Internal.PromiseRef.DeferredPromiseBase.TryCancel(_ref, _deferredId);
             }
 
             /// <summary>
@@ -818,6 +770,18 @@ namespace Proto.Promises
             public static bool operator !=(Deferred lhs, Deferred rhs)
             {
                 return !(lhs == rhs);
+            }
+
+            [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
+            public void Cancel<TCancel>(TCancel reason)
+            {
+                throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Cancel() instead.", Internal.GetFormattedStacktrace(1));
+            }
+
+            [Obsolete("Cancelation reasons are no longer supported. Use TryCancel() instead.", true)]
+            public bool TryCancel<TCancel>(TCancel reason)
+            {
+                throw new InvalidOperationException("Cancelation reasons are no longer supported. Use TryCancel() instead.", Internal.GetFormattedStacktrace(1));
             }
 
             [Obsolete("Deferred.State is no longer valid. Use IsValidAndPending.", true)]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/EnumsAndDelegates.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/EnumsAndDelegates.cs
@@ -22,9 +22,6 @@
         public delegate void ContinueAction<TCapture>(TCapture capturedValue, ResultContainer resultContainer);
         public delegate TResult ContinueFunc<TResult>(ResultContainer resultContainer);
         public delegate TResult ContinueFunc<TCapture, TResult>(TCapture capturedValue, ResultContainer resultContainer);
-        // Same for ReasonContainer.
-        public delegate void CanceledAction(ReasonContainer resultContainer);
-        public delegate void CanceledAction<TCapture>(TCapture capturedValue, ReasonContainer resultContainer);
     }
 
     partial struct Promise<T>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Exceptions.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Exceptions.cs
@@ -190,11 +190,30 @@ namespace Proto.Promises
     {
         internal CanceledException(string message) : base(message) { }
 
-        public abstract Type ValueType { get; }
 
-        public abstract object Value { get; }
+        [Obsolete("Cancelation reasons are no longer supported.", true)]
+        public Type ValueType
+        {
+            get
+            {
+                throw new InvalidOperationException("Cancelation reasons are no longer supported.", Internal.GetFormattedStacktrace(1));
+            }
+        }
 
-        public abstract bool TryGetValueAs<T>(out T value);
+        [Obsolete("Cancelation reasons are no longer supported.", true)]
+        public object Value
+        {
+            get
+            {
+                throw new InvalidOperationException("Cancelation reasons are no longer supported.", Internal.GetFormattedStacktrace(1));
+            }
+        }
+
+        [Obsolete("Cancelation reasons are no longer supported.", true)]
+        public bool TryGetValueAs<T>(out T value)
+        {
+            throw new InvalidOperationException("Cancelation reasons are no longer supported.", Internal.GetFormattedStacktrace(1));
+        }
     }
 
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -380,7 +380,7 @@ namespace Proto.Promises
             {
                 if (exception is OperationCanceledException)
                 {
-                    CancelDirect(exception);
+                    CancelDirect();
                 }
                 else
                 {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -42,9 +42,9 @@ namespace Proto.Promises
                         TResult result = resolver.Invoke(resolved.Result);
                         return new Promise<TResult>(null, ValidIdFromApi, resolved.Depth, result);
                     }
-                    catch (OperationCanceledException e)
+                    catch (OperationCanceledException)
                     {
-                        var promise = Promise<TResult>.Canceled(e);
+                        var promise = Promise<TResult>.Canceled();
                         return new Promise<TResult>(promise._ref, promise.Id, resolved.Depth, promise.Result);
                     }
                     catch (Exception e)
@@ -62,9 +62,9 @@ namespace Proto.Promises
                         TResult result = resolver.Invoke(resolved.Result);
                         return new Promise<TResult>(null, ValidIdFromApi, resolved.Depth, result);
                     }
-                    catch (OperationCanceledException e)
+                    catch (OperationCanceledException)
                     {
-                        var promise = Promise<TResult>.Canceled(e);
+                        var promise = Promise<TResult>.Canceled();
                         return new Promise<TResult>(promise._ref, promise.Id, resolved.Depth, promise.Result);
                     }
                     catch (Exception e)
@@ -81,9 +81,9 @@ namespace Proto.Promises
                     {
                         return CallbackHelper.AdoptDirect(resolver.Invoke(resolved.Result), resolved.Depth);
                     }
-                    catch (OperationCanceledException e)
+                    catch (OperationCanceledException)
                     {
-                        var promise = Promise<TResult>.Canceled(e);
+                        var promise = Promise<TResult>.Canceled();
                         return new Promise<TResult>(promise._ref, promise.Id, resolved.Depth + 1, promise.Result);
                     }
                     catch (Exception e)
@@ -100,9 +100,9 @@ namespace Proto.Promises
                     {
                         return CallbackHelper.AdoptDirect(resolver.Invoke(resolved.Result), resolved.Depth);
                     }
-                    catch (OperationCanceledException e)
+                    catch (OperationCanceledException)
                     {
-                        var promise = Promise<TResult>.Canceled(e);
+                        var promise = Promise<TResult>.Canceled();
                         return new Promise<TResult>(promise._ref, promise.Id, resolved.Depth + 1, promise.Result);
                     }
                     catch (Exception e)
@@ -120,9 +120,9 @@ namespace Proto.Promises
                         TResult result = resolver.Invoke(resolved.Result);
                         return new Promise<TResult>(null, ValidIdFromApi, resolved.Depth, result);
                     }
-                    catch (OperationCanceledException e)
+                    catch (OperationCanceledException)
                     {
-                        var promise = Promise<TResult>.Canceled(e);
+                        var promise = Promise<TResult>.Canceled();
                         return new Promise<TResult>(promise._ref, promise.Id, resolved.Depth, promise.Result);
                     }
                     catch (Exception e)
@@ -140,9 +140,9 @@ namespace Proto.Promises
                         TResult result = resolver.Invoke(resolved.Result);
                         return new Promise<TResult>(null, ValidIdFromApi, resolved.Depth, result);
                     }
-                    catch (OperationCanceledException e)
+                    catch (OperationCanceledException)
                     {
-                        var promise = Promise<TResult>.Canceled(e);
+                        var promise = Promise<TResult>.Canceled();
                         return new Promise<TResult>(promise._ref, promise.Id, resolved.Depth, promise.Result);
                     }
                     catch (Exception e)
@@ -159,9 +159,9 @@ namespace Proto.Promises
                     {
                         return CallbackHelper.AdoptDirect(resolver.Invoke(resolved.Result), resolved.Depth);
                     }
-                    catch (OperationCanceledException e)
+                    catch (OperationCanceledException)
                     {
-                        var promise = Promise<TResult>.Canceled(e);
+                        var promise = Promise<TResult>.Canceled();
                         return new Promise<TResult>(promise._ref, promise.Id, resolved.Depth + 1, promise.Result);
                     }
                     catch (Exception e)
@@ -178,9 +178,9 @@ namespace Proto.Promises
                     {
                         return CallbackHelper.AdoptDirect(resolver.Invoke(resolved.Result), resolved.Depth);
                     }
-                    catch (OperationCanceledException e)
+                    catch (OperationCanceledException)
                     {
-                        var promise = Promise<TResult>.Canceled(e);
+                        var promise = Promise<TResult>.Canceled();
                         return new Promise<TResult>(promise._ref, promise.Id, resolved.Depth + 1, promise.Result);
                     }
                     catch (Exception e)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
@@ -799,7 +799,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer)
+                public void Invoke()
                 {
                     _callback.Invoke();
                 }
@@ -810,18 +810,18 @@ namespace Proto.Promises
 #endif
             internal struct DelegateCancel : IDelegateSimple
             {
-                private readonly Promise.CanceledAction _callback;
+                private readonly Action _callback;
 
                 [MethodImpl(InlineOption)]
-                public DelegateCancel(Promise.CanceledAction callback)
+                public DelegateCancel(Action callback)
                 {
                     _callback = callback;
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer)
+                public void Invoke()
                 {
-                    _callback.Invoke(new ReasonContainer(valueContainer, InvokeId));
+                    _callback.Invoke();
                 }
             }
 
@@ -1347,7 +1347,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer)
+                public void Invoke()
                 {
                     _callback.Invoke(_capturedValue);
                 }
@@ -1358,7 +1358,7 @@ namespace Proto.Promises
 #endif
             internal struct DelegateCaptureCancel<TCapture> : IDelegateSimple
             {
-                private readonly Promise.CanceledAction<TCapture> _callback;
+                private readonly Action<TCapture> _callback;
                 private readonly TCapture _capturedValue;
 
                 [MethodImpl(InlineOption)]
@@ -1366,16 +1366,16 @@ namespace Proto.Promises
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
-                    TCapture capturedValue, Promise.CanceledAction<TCapture> callback)
+                    TCapture capturedValue, Action<TCapture> callback)
                 {
                     _capturedValue = capturedValue;
                     _callback = callback;
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer)
+                public void Invoke()
                 {
-                    _callback.Invoke(_capturedValue, new ReasonContainer(valueContainer, InvokeId));
+                    _callback.Invoke(_capturedValue);
                 }
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -329,10 +329,10 @@ namespace Proto.Promises
                             RejectOrCancelInternal(CreateRejectContainer(e, int.MinValue, this), ref executionScheduler);
                         }
                     }
-                    catch (OperationCanceledException e)
+                    catch (OperationCanceledException)
                     {
                         valueContainer.ReleaseAndMaybeAddToUnhandledStack(!suppressRejection);
-                        RejectOrCancelInternal(CreateCancelContainer(e), ref executionScheduler);
+                        RejectOrCancelInternal(CancelContainerVoid.GetOrCreate(0), ref executionScheduler);
                     }
                     catch (Exception e)
                     {
@@ -724,16 +724,6 @@ namespace Proto.Promises
                     RejectOrCancelInternal(CancelContainerVoid.GetOrCreate(0));
                 }
 
-                protected void CancelDirect<TCancel>(
-#if CSHARP_7_3_OR_NEWER
-                    in
-#endif
-                    TCancel reason)
-                {
-                    ThrowIfInPool(this);
-                    RejectOrCancelInternal(CreateCancelContainer(reason));
-                }
-
                 public sealed override void Handle(ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
             }
 
@@ -1077,7 +1067,7 @@ namespace Proto.Promises
                 {
                     var callback = _finalizer;
                     _finalizer = default(TFinalizer);
-                    callback.Invoke(valueContainer);
+                    callback.Invoke();
                     HandleSelf(valueContainer, ref executionScheduler);
                 }
             }
@@ -1122,7 +1112,7 @@ namespace Proto.Promises
                     SetCurrentInvoker(this);
                     try
                     {
-                        callback.Invoke(valueContainer);
+                        callback.Invoke();
                     }
                     catch (Exception e)
                     {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
@@ -190,7 +190,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onCanceled"/> will not be invoked.
         /// </summary>
-        public Promise CatchCancelation(CanceledAction onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        public Promise CatchCancelation(Action onCanceled, CancelationToken cancelationToken = default(CancelationToken))
         {
             ValidateOperation(1);
             ValidateArgument(onCanceled, "onCanceled", 1);
@@ -795,7 +795,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onCanceled"/> will not be invoked.
         /// </summary>
-        public Promise CatchCancelation<TCaptureCancel>(TCaptureCancel cancelCaptureValue, CanceledAction<TCaptureCancel> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        public Promise CatchCancelation<TCaptureCancel>(TCaptureCancel cancelCaptureValue, Action<TCaptureCancel> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
         {
             ValidateOperation(1);
             ValidateArgument(onCanceled, "onCanceled", 1);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
@@ -23,8 +23,8 @@ namespace Proto.Promises
 {
     /// <summary>
     /// A <see cref="Promise"/> represents the eventual result of an asynchronous operation.
-    /// The primary way of interacting with a <see cref="Promise"/> is through its then method,
-    /// which registers callbacks to be invoked when the <see cref="Promise"/> is resolved,
+    /// The primary ways of interacting with a <see cref="Promise"/> are via the `await` keyword in an async function,
+    /// or through its then method, which registers callbacks to be invoked when the <see cref="Promise"/> is resolved,
     /// or the reason why the <see cref="Promise"/> cannot be resolved.
     /// </summary>
     public
@@ -110,7 +110,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, progress will stop being reported.
         /// </summary>
@@ -130,7 +130,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
@@ -150,7 +150,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, progress will stop being reported.
         /// </summary>
@@ -171,7 +171,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
@@ -186,7 +186,7 @@ namespace Proto.Promises
 
         /// <summary>
         /// Add a cancel callback. Returns a new <see cref="Promise"/> that inherits the state of <see cref="this"/> and can be awaited once.
-        /// <para/>If/when this instance is canceled, <paramref name="onCanceled"/> will be invoked with the cancelation reason.
+        /// <para/>If/when this instance is canceled, <paramref name="onCanceled"/> will be invoked.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onCanceled"/> will not be invoked.
         /// </summary>
@@ -216,9 +216,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise Then(Action onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -233,9 +233,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult>(Func<TResult> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -250,9 +250,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise Then(Func<Promise> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -267,9 +267,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult>(Func<Promise<TResult>> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -286,9 +286,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Catch(Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -305,9 +305,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Catch<TReject>(Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -323,9 +323,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Catch(Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -342,9 +342,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Catch<TReject>(Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -363,9 +363,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then(Action onResolved, Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -384,9 +384,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TReject>(Action onResolved, Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -404,9 +404,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult>(Func<TResult> onResolved, Func<TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -425,9 +425,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult, TReject>(Func<TResult> onResolved, Func<TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -445,9 +445,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then(Func<Promise> onResolved, Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -466,9 +466,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TReject>(Func<Promise> onResolved, Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -486,9 +486,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult>(Func<Promise<TResult>> onResolved, Func<Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -507,9 +507,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult, TReject>(Func<Promise<TResult>> onResolved, Func<TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -527,9 +527,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then(Action onResolved, Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -548,9 +548,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TReject>(Action onResolved, Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -568,9 +568,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult>(Func<TResult> onResolved, Func<Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -589,9 +589,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult, TReject>(Func<TResult> onResolved, Func<TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -609,9 +609,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then(Func<Promise> onResolved, Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -630,9 +630,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TReject>(Func<Promise> onResolved, Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -650,9 +650,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult>(Func<Promise<TResult>> onResolved, Func<TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -671,9 +671,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult, TReject>(Func<Promise<TResult>> onResolved, Func<TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -692,7 +692,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise ContinueWith(ContinueAction onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -707,7 +707,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise<TResult> ContinueWith<TResult>(ContinueFunc<TResult> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -722,7 +722,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise ContinueWith(ContinueFunc<Promise> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -737,7 +737,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise<TResult> ContinueWith<TResult>(ContinueFunc<Promise<TResult>> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -756,7 +756,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
@@ -776,7 +776,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
@@ -791,7 +791,7 @@ namespace Proto.Promises
 
         /// <summary>
         /// Capture a value and add a cancel callback. Returns a new <see cref="Promise"/> that inherits the state of <see cref="this"/> and can be awaited once.
-        /// <para/>If/when this instance is canceled, <paramref name="onCanceled"/> will be invoked with <paramref name="cancelCaptureValue"/> and the cancelation reason.
+        /// <para/>If/when this instance is canceled, <paramref name="onCanceled"/> will be invoked with <paramref name="cancelCaptureValue"/>.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onCanceled"/> will not be invoked.
         /// </summary>
@@ -821,9 +821,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with <paramref name="resolveCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -838,9 +838,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with <paramref name="resolveCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -855,9 +855,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with <paramref name="resolveCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -872,9 +872,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with <paramref name="resolveCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -891,9 +891,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Catch<TCaptureReject>(TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -912,9 +912,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Catch<TCaptureReject, TReject>(TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -932,9 +932,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Catch<TCaptureReject>(TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -953,9 +953,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Catch<TCaptureReject, TReject>(TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -976,9 +976,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -998,9 +998,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject>(Action onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1020,9 +1020,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1043,9 +1043,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1066,9 +1066,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject, TReject>(Action onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1089,9 +1089,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject, TReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1111,9 +1111,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, Func<TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1133,9 +1133,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult>(Func<TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1155,9 +1155,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1178,9 +1178,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, Func<TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1201,9 +1201,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult, TReject>(Func<TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1224,9 +1224,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1246,9 +1246,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1268,9 +1268,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject>(Func<Promise> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1290,9 +1290,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1313,9 +1313,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1336,9 +1336,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject, TReject>(Func<Promise> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1359,9 +1359,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1381,9 +1381,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, Func<Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1403,9 +1403,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult>(Func<Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1425,9 +1425,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1448,9 +1448,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, Func<TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1471,9 +1471,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult, TReject>(Func<Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1494,9 +1494,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1516,9 +1516,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1538,9 +1538,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject>(Action onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1560,9 +1560,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1583,9 +1583,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1606,9 +1606,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject, TReject>(Action onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1629,9 +1629,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject, TReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1651,9 +1651,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, Func<Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1673,9 +1673,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult>(Func<TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1695,9 +1695,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1718,9 +1718,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, Func<TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1741,9 +1741,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult, TReject>(Func<TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1764,9 +1764,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1786,9 +1786,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1808,9 +1808,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject>(Func<Promise> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1830,9 +1830,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1853,9 +1853,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1876,9 +1876,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject, TReject>(Func<Promise> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1899,9 +1899,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1921,9 +1921,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, Func<TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1943,9 +1943,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult>(Func<Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1965,9 +1965,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1988,9 +1988,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, Func<TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2011,9 +2011,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult, TReject>(Func<Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2034,9 +2034,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2057,7 +2057,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise ContinueWith<TCapture>(TCapture continueCaptureValue, ContinueAction<TCapture> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2072,7 +2072,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise<TResult> ContinueWith<TCapture, TResult>(TCapture continueCaptureValue, ContinueFunc<TCapture, TResult> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2087,7 +2087,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise ContinueWith<TCapture>(TCapture continueCaptureValue, ContinueFunc<TCapture, Promise> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2102,7 +2102,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise<TResult> ContinueWith<TCapture, TResult>(TCapture continueCaptureValue, ContinueFunc<TCapture, Promise<TResult>> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
@@ -1256,9 +1256,9 @@ namespace Proto.Promises
                 {
                     cv.Item2.Invoke(def);
                 }
-                catch (OperationCanceledException e)
+                catch (OperationCanceledException)
                 {
-                    def.TryCancel(e); // Don't rethrow cancelation.
+                    def.TryCancel(); // Don't rethrow cancelation.
                 }
                 catch (Exception e)
                 {
@@ -1286,9 +1286,9 @@ namespace Proto.Promises
                 {
                     cv.Item2.Invoke(def);
                 }
-                catch (OperationCanceledException e)
+                catch (OperationCanceledException)
                 {
-                    def.TryCancel(e); // Don't rethrow cancelation.
+                    def.TryCancel(); // Don't rethrow cancelation.
                 }
                 catch (Exception e)
                 {
@@ -1329,9 +1329,9 @@ namespace Proto.Promises
                 {
                     cv.Item2.Invoke(cv.Item3, def);
                 }
-                catch (OperationCanceledException e)
+                catch (OperationCanceledException)
                 {
-                    def.TryCancel(e); // Don't rethrow cancelation.
+                    def.TryCancel(); // Don't rethrow cancelation.
                 }
                 catch (Exception e)
                 {
@@ -1359,9 +1359,9 @@ namespace Proto.Promises
                 {
                     cv.Item2.Invoke(cv.Item3, def);
                 }
-                catch (OperationCanceledException e)
+                catch (OperationCanceledException)
                 {
-                    def.TryCancel(e); // Don't rethrow cancelation.
+                    def.TryCancel(); // Don't rethrow cancelation.
                 }
                 catch (Exception e)
                 {
@@ -1634,14 +1634,10 @@ namespace Proto.Promises
             return deferred.Promise;
         }
 
-        /// <summary>
-        /// Returns a <see cref="Promise"/> that is already canceled with <paramref name="reason"/>.
-        /// </summary>
+        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
         public static Promise Canceled<TCancel>(TCancel reason)
         {
-            var deferred = NewDeferred();
-            deferred.Cancel(reason);
-            return deferred.Promise;
+            throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Canceled() instead.", Internal.GetFormattedStacktrace(1));
         }
 
         /// <summary>
@@ -1652,7 +1648,7 @@ namespace Proto.Promises
             return Promise<T>.Canceled();
         }
 
-        [Obsolete("Prefer Promise<T>.Canceled<TCancel>(TCancel reason)")]
+        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
         public static Promise<T> Canceled<T, TCancel>(TCancel reason)
         {
             return Promise<T>.Canceled(reason);
@@ -1695,18 +1691,17 @@ namespace Proto.Promises
         /// </summary>
         public static CanceledException CancelException()
         {
-            return Internal.CanceledExceptionInternalVoid.GetOrCreate();
+            return Internal.CanceledExceptionInternal.GetOrCreate();
         }
 
         /// <summary>
         /// Get a <see cref="Promises.CancelException"/> that can be thrown to cancel the promise with the provided reason from an onResolved or onRejected callback, or in an async Promise function.
         /// This should be used as "throw Promise.CancelException(value);"
         /// </summary>
+        [Obsolete("Cancelation reasons are no longer supported. Use CancelException() instead.", true)]
         public static CanceledException CancelException<T>(T value)
         {
-            Type type = typeof(T).IsValueType ? typeof(T) : value.GetType();
-            string message = "Operation was canceled with a reason, type: " + type + ", value: " + value.ToString();
-            return new Internal.CanceledExceptionInternal<T>(value, message);
+            throw new InvalidOperationException("Cancelation reasons are no longer supported. Use CancelException() instead.", Internal.GetFormattedStacktrace(1));
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
@@ -1625,7 +1625,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Returns a <see cref="Promise"/> that is already canceled without a reason.
+        /// Returns a <see cref="Promise"/> that is already canceled.
         /// </summary>
         public static Promise Canceled()
         {
@@ -1641,7 +1641,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Returns a <see cref="Promise{T}"/> that is already canceled without a reason.
+        /// Returns a <see cref="Promise{T}"/> that is already canceled.
         /// </summary>
         public static Promise<T> Canceled<T>()
         {
@@ -1656,7 +1656,7 @@ namespace Proto.Promises
 
         /// <summary>
         /// Returns a new <see cref="Deferred"/> instance that is linked to and controls the state of a new <see cref="Promise"/>.
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Deferred"/> is pending, it and the <see cref="Promise"/> will be canceled with its reason.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Deferred"/> is pending, it and the <see cref="Promise"/> will be canceled.
         /// </summary>
         public static Deferred NewDeferred(CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1665,7 +1665,7 @@ namespace Proto.Promises
 
         /// <summary>
         /// Returns a <see cref="Promise{T}.Deferred"/> object that is linked to and controls the state of a new <see cref="Promise{T}"/>.
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Promise{T}.Deferred"/> is pending, it and the <see cref="Promise{T}"/> will be canceled with its reason.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Promise{T}.Deferred"/> is pending, it and the <see cref="Promise{T}"/> will be canceled.
         /// </summary>
         public static Promise<T>.Deferred NewDeferred<T>(CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1686,7 +1686,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Get a <see cref="CancelException"/> that can be thrown to cancel the promise without a reason from an onResolved or onRejected callback, or in an async Promise function.
+        /// Get a <see cref="CancelException"/> that can be thrown to cancel the promise from an onResolved or onRejected callback, or in an async Promise function.
         /// This should be used as "throw Promise.CancelException();"
         /// </summary>
         public static CanceledException CancelException()
@@ -1694,10 +1694,6 @@ namespace Proto.Promises
             return Internal.CanceledExceptionInternal.GetOrCreate();
         }
 
-        /// <summary>
-        /// Get a <see cref="Promises.CancelException"/> that can be thrown to cancel the promise with the provided reason from an onResolved or onRejected callback, or in an async Promise function.
-        /// This should be used as "throw Promise.CancelException(value);"
-        /// </summary>
         [Obsolete("Cancelation reasons are no longer supported. Use CancelException() instead.", true)]
         public static CanceledException CancelException<T>(T value)
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -233,7 +233,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onCanceled"/> will not be invoked.
         /// </summary>
-        public Promise<T> CatchCancelation(Promise.CanceledAction onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        public Promise<T> CatchCancelation(Action onCanceled, CancelationToken cancelationToken = default(CancelationToken))
         {
             ValidateOperation(1);
             ValidateArgument(onCanceled, "onCanceled", 1);
@@ -844,7 +844,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onCanceled"/> will not be invoked.
         /// </summary>
-        public Promise<T> CatchCancelation<TCaptureCancel>(TCaptureCancel cancelCaptureValue, Promise.CanceledAction<TCaptureCancel> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        public Promise<T> CatchCancelation<TCaptureCancel>(TCaptureCancel cancelCaptureValue, Action<TCaptureCancel> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
         {
             ValidateOperation(1);
             ValidateArgument(onCanceled, "onCanceled", 1);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -21,8 +21,8 @@ namespace Proto.Promises
 {
     /// <summary>
     /// A <see cref="Promise{T}"/> represents the eventual result of an asynchronous operation.
-    /// The primary way of interacting with a <see cref="Promise{T}"/> is through its then method,
-    /// which registers callbacks to be invoked with its resolve value when the <see cref="Promise{T}"/> is resolved,
+    /// The primary ways of interacting with a <see cref="Promise{T}"/> are via the `await` keyword in an async function,
+    /// or its then method, which registers callbacks to be invoked with its resolve value when the <see cref="Promise{T}"/> is resolved,
     /// or the reason why the <see cref="Promise{T}"/> cannot be resolved.
     /// </summary>
     public
@@ -135,7 +135,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, progress will stop being reported.
         /// </summary>
@@ -162,7 +162,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
@@ -184,7 +184,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, progress will stop being reported.
         /// </summary>
@@ -212,7 +212,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
@@ -229,7 +229,7 @@ namespace Proto.Promises
 
         /// <summary>
         /// Add a cancel callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/> that inherits the state of <see cref="this"/> and can be awaited once.
-        /// <para/>If/when this instance is canceled, <paramref name="onCanceled"/> will be invoked with the cancelation reason.
+        /// <para/>If/when this instance is canceled, <paramref name="onCanceled"/> will be invoked.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onCanceled"/> will not be invoked.
         /// </summary>
@@ -261,9 +261,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with the resolve value, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise Then(Action<T> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -278,9 +278,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with the resolve value, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult>(Func<T, TResult> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -295,9 +295,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with the resolve value, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise Then(Func<T, Promise> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -312,9 +312,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with the resolve value, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult>(Func<T, Promise<TResult>> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -331,9 +331,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise{T}"/> will be resolved with the resolve value.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<T> Catch(Func<T> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -350,9 +350,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<T> Catch<TReject>(Func<TReject, T> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -368,9 +368,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise{T}"/> will be resolved with the resolve value.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<T> Catch(Func<Promise<T>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -388,7 +388,7 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise{T}"/> will be resolved with the resolve value.
         /// <para/>If/when this is canceled or rejected with any other reason or no reason, the new <see cref="Promise{T}"/> will be canceled or rejected with the same reason.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<T> Catch<TReject>(Func<TReject, Promise<T>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -407,9 +407,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then(Action<T> onResolved, Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -428,9 +428,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TReject>(Action<T> onResolved, Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -448,9 +448,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult>(Func<T, TResult> onResolved, Func<TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -469,9 +469,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult, TReject>(Func<T, TResult> onResolved, Func<TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -489,9 +489,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then(Func<T, Promise> onResolved, Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -510,9 +510,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TReject>(Func<T, Promise> onResolved, Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -530,9 +530,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult>(Func<T, Promise<TResult>> onResolved, Func<Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -551,9 +551,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult, TReject>(Func<T, Promise<TResult>> onResolved, Func<TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -571,9 +571,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then(Action<T> onResolved, Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -592,9 +592,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TReject>(Action<T> onResolved, Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -612,9 +612,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult>(Func<T, TResult> onResolved, Func<Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -633,9 +633,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult, TReject>(Func<T, TResult> onResolved, Func<TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -653,9 +653,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then(Func<T, Promise> onResolved, Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -674,9 +674,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TReject>(Func<T, Promise> onResolved, Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -694,9 +694,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult>(Func<T, Promise<TResult>> onResolved, Func<TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -715,9 +715,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TResult, TReject>(Func<T, Promise<TResult>> onResolved, Func<TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -736,7 +736,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise ContinueWith(ContinueAction onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -751,7 +751,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise<TResult> ContinueWith<TResult>(ContinueFunc<TResult> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -767,7 +767,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise ContinueWith(ContinueFunc<Promise> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -782,7 +782,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise<TResult> ContinueWith<TResult>(ContinueFunc<Promise<TResult>> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -801,7 +801,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="PromisePromise{T}"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
@@ -823,7 +823,7 @@ namespace Proto.Promises
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="PromisePromise{T}"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
@@ -840,7 +840,7 @@ namespace Proto.Promises
 
         /// <summary>
         /// Capture a value and add a cancel callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/> that inherits the state of <see cref="this"/> and can be awaited once.
-        /// <para/>If/when this instance is canceled, <paramref name="onCanceled"/> will be invoked with <paramref name="cancelCaptureValue"/> and the cancelation reason.
+        /// <para/>If/when this instance is canceled, <paramref name="onCanceled"/> will be invoked with <paramref name="cancelCaptureValue"/>.
         /// 
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onCanceled"/> will not be invoked.
         /// </summary>
@@ -872,9 +872,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with <paramref name="resolveCaptureValue"/> and the resolve value, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve, T> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -889,9 +889,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with <paramref name="resolveCaptureValue"/> and the resolve value, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, TResult> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -906,9 +906,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with <paramref name="resolveCaptureValue"/> and the resolve value, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -923,9 +923,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with <paramref name="resolveCaptureValue"/> and the resolve value, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise<TResult>> onResolved, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -942,9 +942,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise{T}"/> will be resolved with the resolve value.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<T> Catch<TCaptureReject>(TCaptureReject rejectCaptureValue, Func<TCaptureReject, T> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -963,9 +963,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<T> Catch<TCaptureReject, TReject>(TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, T> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -983,9 +983,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise{T}"/> will be resolved with the resolve value.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<T> Catch<TCaptureReject>(TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<T>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1004,9 +1004,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<T> Catch<TCaptureReject, TReject>(TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<T>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1027,9 +1027,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve, T> onResolved, Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1049,9 +1049,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject>(Action<T> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1071,9 +1071,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve, T> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1094,9 +1094,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve, T> onResolved, Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1117,9 +1117,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject, TReject>(Action<T> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1140,9 +1140,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject, TReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve, T> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1163,9 +1163,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, TResult> onResolved, Func<TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1185,9 +1185,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult>(Func<T, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1207,9 +1207,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1230,9 +1230,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, TResult> onResolved, Func<TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1253,9 +1253,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult, TReject>(Func<T, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1276,9 +1276,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1298,9 +1298,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise> onResolved, Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1320,9 +1320,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject>(Func<T, Promise> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1342,9 +1342,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1365,9 +1365,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise> onResolved, Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1388,9 +1388,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject, TReject>(Func<T, Promise> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1411,9 +1411,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1433,9 +1433,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise<TResult>> onResolved, Func<Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1455,9 +1455,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult>(Func<T, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1477,9 +1477,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1500,9 +1500,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise<TResult>> onResolved, Func<TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1523,9 +1523,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult, TReject>(Func<T, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1546,9 +1546,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1568,9 +1568,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve, T> onResolved, Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1590,9 +1590,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject>(Action<T> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1612,9 +1612,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve, T> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1635,9 +1635,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve, T> onResolved, Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1658,9 +1658,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject, TReject>(Action<T> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1681,9 +1681,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject, TReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve, T> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1704,9 +1704,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, TResult> onResolved, Func<Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1726,9 +1726,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult>(Func<T, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1748,9 +1748,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1771,9 +1771,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, TResult> onResolved, Func<TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1794,9 +1794,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult, TReject>(Func<T, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1817,9 +1817,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1839,9 +1839,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise> onResolved, Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1861,9 +1861,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject>(Func<T, Promise> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1883,9 +1883,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1906,9 +1906,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise> onResolved, Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1929,9 +1929,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureReject, TReject>(Func<T, Promise> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1952,9 +1952,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise Then<TCaptureResolve, TCaptureReject, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1974,9 +1974,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise<TResult>> onResolved, Func<TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -1996,9 +1996,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult>(Func<T, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2018,9 +2018,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2041,9 +2041,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise<TResult>> onResolved, Func<TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2064,9 +2064,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureReject, TResult, TReject>(Func<T, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2087,9 +2087,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, T, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2110,7 +2110,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise ContinueWith<TCapture>(TCapture continueCaptureValue, ContinueAction<TCapture> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2125,7 +2125,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise<TResult> ContinueWith<TCapture, TResult>(TCapture continueCaptureValue, ContinueFunc<TCapture, TResult> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2140,7 +2140,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise ContinueWith<TCapture>(TCapture continueCaptureValue, ContinueFunc<TCapture, Promise> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2155,7 +2155,7 @@ namespace Proto.Promises
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onContinue"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
         public Promise<TResult> ContinueWith<TCapture, TResult>(TCapture continueCaptureValue, ContinueFunc<TCapture, Promise<TResult>> onContinue, CancelationToken cancelationToken = default(CancelationToken))
         {
@@ -2189,9 +2189,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then(Action onResolved, CancelationToken cancelationToken = default(CancelationToken))
@@ -2204,9 +2204,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TResult>(Func<TResult> onResolved, CancelationToken cancelationToken = default(CancelationToken))
@@ -2219,9 +2219,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then(Func<Promise> onResolved, CancelationToken cancelationToken = default(CancelationToken))
@@ -2234,9 +2234,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TResult>(Func<Promise<TResult>> onResolved, CancelationToken cancelationToken = default(CancelationToken))
@@ -2251,9 +2251,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Catch(Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2267,9 +2267,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Catch<TReject>(Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2282,9 +2282,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Catch(Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2298,9 +2298,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Catch<TReject>(Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2316,9 +2316,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then(Action onResolved, Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2333,9 +2333,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TReject>(Action onResolved, Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2349,9 +2349,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TResult>(Func<TResult> onResolved, Func<TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2366,9 +2366,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TResult, TReject>(Func<TResult> onResolved, Func<TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2382,9 +2382,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then(Func<Promise> onResolved, Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2399,9 +2399,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TReject>(Func<Promise> onResolved, Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2415,9 +2415,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TResult>(Func<Promise<TResult>> onResolved, Func<Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2432,9 +2432,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TResult, TReject>(Func<Promise<TResult>> onResolved, Func<TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2448,9 +2448,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then(Action onResolved, Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2465,9 +2465,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TReject>(Action onResolved, Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2481,9 +2481,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TResult>(Func<TResult> onResolved, Func<Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2498,9 +2498,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TResult, TReject>(Func<TResult> onResolved, Func<TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2514,9 +2514,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then(Func<Promise> onResolved, Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2531,9 +2531,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TReject>(Func<Promise> onResolved, Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2547,9 +2547,9 @@ namespace Proto.Promises
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TResult>(Func<Promise<TResult>> onResolved, Func<TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2564,9 +2564,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TResult, TReject>(Func<Promise<TResult>> onResolved, Func<TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2583,9 +2583,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with <paramref name="resolveCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, CancelationToken cancelationToken = default(CancelationToken))
@@ -2598,9 +2598,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with <paramref name="resolveCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, CancelationToken cancelationToken = default(CancelationToken))
@@ -2613,9 +2613,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with <paramref name="resolveCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, CancelationToken cancelationToken = default(CancelationToken))
@@ -2628,9 +2628,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, <paramref name="onResolved"/> will be invoked with <paramref name="resolveCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, CancelationToken cancelationToken = default(CancelationToken))
@@ -2645,9 +2645,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Catch<TCaptureReject>(TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2661,9 +2661,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Catch<TCaptureReject, TReject>(TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2676,9 +2676,9 @@ namespace Proto.Promises
         /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Catch<TCaptureReject>(TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2692,9 +2692,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Catch<TCaptureReject, TReject>(TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2710,9 +2710,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2726,9 +2726,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureReject>(Action onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2742,9 +2742,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve, TCaptureReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2759,9 +2759,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve, TReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2776,9 +2776,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureReject, TReject>(Action onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2793,9 +2793,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve, TCaptureReject, TReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2809,9 +2809,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, Func<TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2825,9 +2825,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureReject, TResult>(Func<TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2841,9 +2841,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2858,9 +2858,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, Func<TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2875,9 +2875,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureReject, TResult, TReject>(Func<TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2892,9 +2892,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2908,9 +2908,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2924,9 +2924,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureReject>(Func<Promise> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2940,9 +2940,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve, TCaptureReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2957,9 +2957,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2974,9 +2974,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureReject, TReject>(Func<Promise> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -2991,9 +2991,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve, TCaptureReject, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3007,9 +3007,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, Func<Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3023,9 +3023,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureReject, TResult>(Func<Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3039,9 +3039,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3056,9 +3056,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, Func<TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3073,9 +3073,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureReject, TResult, TReject>(Func<Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3090,9 +3090,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3106,9 +3106,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, Func<Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3122,9 +3122,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureReject>(Action onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3138,9 +3138,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve, TCaptureReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3155,9 +3155,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve, TReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, Func<TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3172,9 +3172,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureReject, TReject>(Action onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3189,9 +3189,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve, TCaptureReject, TReject>(TCaptureResolve resolveCaptureValue, Action<TCaptureResolve> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3205,9 +3205,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, Func<Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3221,9 +3221,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureReject, TResult>(Func<TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3237,9 +3237,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3254,9 +3254,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, Func<TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3271,9 +3271,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureReject, TResult, TReject>(Func<TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3288,9 +3288,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, TResult> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, Promise<TResult>> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3304,9 +3304,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, Action onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3320,9 +3320,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureReject>(Func<Promise> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3336,9 +3336,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve, TCaptureReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3353,9 +3353,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, Action<TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3370,9 +3370,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureReject, TReject>(Func<Promise> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3387,9 +3387,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise Then<TCaptureResolve, TCaptureReject, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise> onResolved, TCaptureReject rejectCaptureValue, Action<TCaptureReject, TReject> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3403,9 +3403,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, Func<TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3419,9 +3419,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureReject, TResult>(Func<Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3435,9 +3435,9 @@ namespace Proto.Promises
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// <para/>If/when this is rejected with any reason, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3452,9 +3452,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, Func<TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3469,9 +3469,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureReject, TResult, TReject>(Func<Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))
@@ -3486,9 +3486,9 @@ namespace Proto.Promises
         /// <para/>If/when this is rejected with any reason that is convertible to <typeparamref name="TReject"/>, <paramref name="onRejected"/> will be invoked with <paramref name="rejectCaptureValue"/> and that reason, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
         /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>.
         /// If this is rejected with any other reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
-        /// <para/>If/when this is canceled with any reason or no reason, the new <see cref="Promise{T}"/> will be canceled with the same reason.
+        /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
         ///
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled with its reason, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onResolved"/> and <paramref name="onRejected"/> will not be invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<TResult> Then<TCaptureResolve, TCaptureReject, TResult, TReject>(TCaptureResolve resolveCaptureValue, Func<TCaptureResolve, Promise<TResult>> onResolved, TCaptureReject rejectCaptureValue, Func<TCaptureReject, TReject, TResult> onRejected, CancelationToken cancelationToken = default(CancelationToken))

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
@@ -647,9 +647,9 @@ namespace Proto.Promises
                 {
                     cv.Item2.Invoke(def);
                 }
-                catch (OperationCanceledException e)
+                catch (OperationCanceledException)
                 {
-                    def.TryCancel(e); // Don't rethrow cancelation.
+                    def.TryCancel(); // Don't rethrow cancelation.
                 }
                 catch (Exception e)
                 {
@@ -678,9 +678,9 @@ namespace Proto.Promises
                 {
                     cv.Item2.Invoke(cv.Item3, def);
                 }
-                catch (OperationCanceledException e)
+                catch (OperationCanceledException)
                 {
-                    def.TryCancel(e); // Don't rethrow cancelation.
+                    def.TryCancel(); // Don't rethrow cancelation.
                 }
                 catch (Exception e)
                 {
@@ -708,9 +708,9 @@ namespace Proto.Promises
                 {
                     cv.Item2.Invoke(def);
                 }
-                catch (OperationCanceledException e)
+                catch (OperationCanceledException)
                 {
-                    def.TryCancel(e); // Don't rethrow cancelation.
+                    def.TryCancel(); // Don't rethrow cancelation.
                 }
                 catch (Exception e)
                 {
@@ -738,9 +738,9 @@ namespace Proto.Promises
                 {
                     cv.Item2.Invoke(cv.Item3, def);
                 }
-                catch (OperationCanceledException e)
+                catch (OperationCanceledException)
                 {
-                    def.TryCancel(e); // Don't rethrow cancelation.
+                    def.TryCancel(); // Don't rethrow cancelation.
                 }
                 catch (Exception e)
                 {
@@ -779,14 +779,10 @@ namespace Proto.Promises
             return deferred.Promise;
         }
 
-        /// <summary>
-        /// Returns a <see cref="Promise{T}"/> that is already canceled with <paramref name="reason"/>.
-        /// </summary>
+        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
         public static Promise<T> Canceled<TCancel>(TCancel reason)
         {
-            var deferred = NewDeferred();
-            deferred.Cancel(reason);
-            return deferred.Promise;
+            throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Canceled() instead.", Internal.GetFormattedStacktrace(1));
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
@@ -770,7 +770,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Returns a <see cref="Promise{T}"/> that is already canceled without a reason.
+        /// Returns a <see cref="Promise{T}"/> that is already canceled.
         /// </summary>
         public static Promise<T> Canceled()
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
@@ -165,12 +165,9 @@ namespace Proto.Promises
                 get { return _target.RejectContainer; }
             }
 
-            /// <summary>
-            /// If the <see cref="Promise"/> is canceled, get a container of the reason.
-            /// </summary>
+            [Obsolete("Cancelation reasons are no longer supported.", true)]
             public ReasonContainer CancelContainer
             {
-                [MethodImpl(Internal.InlineOption)]
                 get { return _target.CancelContainer; }
             }
         }
@@ -318,20 +315,6 @@ namespace Proto.Promises
                 }
             }
 
-            /// <summary>
-            /// If the <see cref="Promise{T}"/> is canceled, get a container of the reason.
-            /// </summary>
-            public ReasonContainer CancelContainer
-            {
-                [MethodImpl(Internal.InlineOption)]
-                get
-                {
-                    ValidateCall();
-                    ValidateCanceled();
-                    return new ReasonContainer(_valueContainer, Id);
-                }
-            }
-
             [MethodImpl(Internal.InlineOption)]
             public static implicit operator Promise.ResultContainer(ResultContainer rhs)
             {
@@ -376,6 +359,16 @@ namespace Proto.Promises
                 }
             }
 #endif
+
+            [Obsolete("Cancelation reasons are no longer supported.", true)]
+            public ReasonContainer CancelContainer
+            {
+                [MethodImpl(Internal.InlineOption)]
+                get
+                {
+                    throw new InvalidOperationException("Cancelation reasons are no longer supported.", Internal.GetFormattedStacktrace(1));
+                }
+            }
         }
     }
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/AllTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/AllTests.cs
@@ -375,10 +375,10 @@ namespace ProtoPromiseTests.APIs
 
             Promise.All(deferred1.Promise, deferred2.Promise)
                 .Then(() => Assert.Fail("Promise was resolved when it should have been canceled."))
-                .CatchCancelation(e => { canceled = true; })
+                .CatchCancelation(() => { canceled = true; })
                 .Forget();
 
-            cancelationSource.Cancel("Cancel!");
+            cancelationSource.Cancel();
 
             Assert.IsTrue(canceled);
 
@@ -401,10 +401,10 @@ namespace ProtoPromiseTests.APIs
 
             Promise<int>.All(deferred1.Promise, deferred2.Promise)
                 .Then(v => Assert.Fail("Promise was resolved when it should have been canceled."))
-                .CatchCancelation(e => { canceled = true; })
+                .CatchCancelation(() => { canceled = true; })
                 .Forget();
 
-            cancelationSource.Cancel("Cancel!");
+            cancelationSource.Cancel();
 
             Assert.IsTrue(canceled);
 
@@ -426,14 +426,14 @@ namespace ProtoPromiseTests.APIs
 
             Promise.All(deferred1.Promise, deferred2.Promise)
                 .Then(() => Assert.Fail("Promise was resolved when it should have been canceled."))
-                .CatchCancelation(e => { canceled = true; })
+                .CatchCancelation(() => { canceled = true; })
                 .Forget();
 
             deferred1.Resolve();
 
             Assert.IsFalse(canceled);
 
-            cancelationSource.Cancel("Cancel!");
+            cancelationSource.Cancel();
 
             Assert.IsTrue(canceled);
 
@@ -451,14 +451,14 @@ namespace ProtoPromiseTests.APIs
 
             Promise<int>.All(deferred1.Promise, deferred2.Promise)
                 .Then(v => Assert.Fail("Promise was resolved when it should have been canceled."))
-                .CatchCancelation(e => { canceled = true; })
+                .CatchCancelation(() => { canceled = true; })
                 .Forget();
 
             deferred1.Resolve(2);
 
             Assert.IsFalse(canceled);
 
-            cancelationSource.Cancel("Cancel!");
+            cancelationSource.Cancel();
 
             Assert.IsTrue(canceled);
 
@@ -478,14 +478,14 @@ namespace ProtoPromiseTests.APIs
 
             Promise.All(deferred1.Promise, deferred2.Promise)
                 .Then(() => Assert.Fail("Promise was resolved when it should have been canceled."))
-                .CatchCancelation(e => { canceled = true; })
+                .CatchCancelation(() => { canceled = true; })
                 .Forget();
 
-            cancelationSource1.Cancel("Cancel!");
+            cancelationSource1.Cancel();
 
             Assert.IsTrue(canceled);
 
-            cancelationSource2.Cancel("Cancel!");
+            cancelationSource2.Cancel();
 
             Assert.IsTrue(canceled);
 
@@ -506,14 +506,14 @@ namespace ProtoPromiseTests.APIs
 
             Promise<int>.All(deferred1.Promise, deferred2.Promise)
                 .Then(v => Assert.Fail("Promise was resolved when it should have been canceled."))
-                .CatchCancelation(e => { canceled = true; })
+                .CatchCancelation(() => { canceled = true; })
                 .Forget();
 
-            cancelationSource1.Cancel("Cancel!");
+            cancelationSource1.Cancel();
 
             Assert.IsTrue(canceled);
 
-            cancelationSource2.Cancel("Cancel!");
+            cancelationSource2.Cancel();
 
             Assert.IsTrue(canceled);
 
@@ -525,26 +525,23 @@ namespace ProtoPromiseTests.APIs
         public void AllPromiseIsCancelededWhenAnyPromiseIsAlreadyCanceled_void()
         {
             int cancelCount = 0;
-            string cancelation = "Cancel!";
 
             var deferred = Promise.NewDeferred();
             var promise1 = deferred.Promise.Preserve();
-            var promise2 = Promise.Canceled(cancelation).Preserve();
+            var promise2 = Promise.Canceled().Preserve();
 
             Promise.All(promise1, promise2)
                 .Then(() => Assert.Fail("Promise was resolved when it should have been canceled."))
-                .CatchCancelation(ex =>
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(cancelation, ex.Value);
                     ++cancelCount;
                 })
                 .Forget();
 
             Promise.All(promise2, promise1)
                 .Then(() => Assert.Fail("Promise was resolved when it should have been canceled."))
-                .CatchCancelation(ex =>
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(cancelation, ex.Value);
                     ++cancelCount;
                 })
                 .Forget();
@@ -561,26 +558,23 @@ namespace ProtoPromiseTests.APIs
         public void AllPromiseIsCancelededWhenAnyPromiseIsAlreadyCanceled_T()
         {
             int cancelCount = 0;
-            string cancelation = "Cancel!";
 
             var deferred = Promise.NewDeferred<int>();
             var promise1 = deferred.Promise.Preserve();
-            var promise2 = Promise<int>.Canceled(cancelation).Preserve();
+            var promise2 = Promise<int>.Canceled().Preserve();
 
             Promise<int>.All(promise1, promise2)
                 .Then(v => Assert.Fail("Promise was resolved when it should have been canceled."))
-                .CatchCancelation(ex =>
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(cancelation, ex.Value);
                     ++cancelCount;
                 })
                 .Forget();
 
             Promise<int>.All(promise2, promise1)
                 .Then(v => Assert.Fail("Promise was resolved when it should have been canceled."))
-                .CatchCancelation(ex =>
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(cancelation, ex.Value);
                     ++cancelCount;
                 })
                 .Forget();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/AsyncTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/AsyncTests.cs
@@ -270,7 +270,7 @@ namespace ProtoPromiseTests.APIs
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
 
-            string expected = "Cancel";
+            //System.Diagnostics.Debugger.Launch();
             bool canceled = false;
 
             async Promise Func()
@@ -279,15 +279,14 @@ namespace ProtoPromiseTests.APIs
             }
 
             Func()
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(expected, e.Value);
                     canceled = true;
                 })
                 .Forget();
 
             Assert.IsFalse(canceled);
-            cancelationSource.Cancel(expected);
+            cancelationSource.Cancel();
             Assert.IsTrue(canceled);
 
             cancelationSource.Dispose();
@@ -299,7 +298,6 @@ namespace ProtoPromiseTests.APIs
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
 
-            string expected = "Cancel";
             bool canceled = false;
 
             async Promise<int> Func()
@@ -308,15 +306,14 @@ namespace ProtoPromiseTests.APIs
             }
 
             Func()
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(expected, e.Value);
                     canceled = true;
                 })
                 .Forget();
 
             Assert.IsFalse(canceled);
-            cancelationSource.Cancel(expected);
+            cancelationSource.Cancel();
             Assert.IsTrue(canceled);
 
             cancelationSource.Dispose();
@@ -335,9 +332,8 @@ namespace ProtoPromiseTests.APIs
             }
 
             Func()
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(e.ValueType);
                     canceled = true;
                 })
                 .Forget();
@@ -358,9 +354,8 @@ namespace ProtoPromiseTests.APIs
             }
 
             Func()
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(e.ValueType);
                     canceled = true;
                 })
                 .Forget();
@@ -371,20 +366,18 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void AsyncPromiseIsCanceledFromThrow3()
         {
-            string expected = "Cancel";
             bool canceled = false;
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
             async Promise Func()
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
             {
-                throw Promise.CancelException(expected);
+                throw Promise.CancelException();
             }
 
             Func()
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(expected, e.Value);
                     canceled = true;
                 })
                 .Forget();
@@ -395,20 +388,18 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void AsyncPromiseIsCanceledFromThrow4()
         {
-            string expected = "Cancel";
             bool canceled = false;
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
             async Promise<int> Func()
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
             {
-                throw Promise.CancelException(expected);
+                throw Promise.CancelException();
             }
 
             Func()
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(expected, e.Value);
                     canceled = true;
                 })
                 .Forget();
@@ -428,9 +419,8 @@ namespace ProtoPromiseTests.APIs
             }
 
             Func()
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(e.ValueType);
                     canceled = true;
                 })
                 .Forget();
@@ -450,9 +440,8 @@ namespace ProtoPromiseTests.APIs
             }
 
             Func()
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(e.ValueType);
                     canceled = true;
                 })
                 .Forget();
@@ -463,19 +452,17 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void AsyncPromiseIsCanceledFromThrow7()
         {
-            string expected = "Cancel";
             bool canceled = false;
 
             async Promise Func()
             {
                 await Promise.Resolved();
-                throw Promise.CancelException(expected);
+                throw Promise.CancelException();
             }
 
             Func()
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(expected, e.Value);
                     canceled = true;
                 })
                 .Forget();
@@ -486,19 +473,17 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void AsyncPromiseIsCanceledFromThrow8()
         {
-            string expected = "Cancel";
             bool canceled = false;
 
             async Promise<int> Func()
             {
                 await Promise.Resolved();
-                throw Promise.CancelException(expected);
+                throw Promise.CancelException();
             }
 
             Func()
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(expected, e.Value);
                     canceled = true;
                 })
                 .Forget();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/AwaitTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/AwaitTests.cs
@@ -214,13 +214,12 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void CancelAwaitedPromiseThrowsOperationCanceled1()
+        public void CancelAwaitedPromiseThrowsOperationCanceled_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
 
             bool continued = false;
-            string cancelValue = "Cancel";
 
             async void Func()
             {
@@ -228,9 +227,8 @@ namespace ProtoPromiseTests.APIs
                 {
                     await deferred.Promise;
                 }
-                catch (CanceledException e)
+                catch (CanceledException)
                 {
-                    Assert.AreEqual(cancelValue, e.Value);
                     continued = true;
                 }
             }
@@ -238,19 +236,18 @@ namespace ProtoPromiseTests.APIs
             Func();
             Assert.IsFalse(continued);
 
-            cancelationSource.Cancel(cancelValue);
+            cancelationSource.Cancel();
             Assert.IsTrue(continued);
 
             cancelationSource.Dispose();
         }
 
         [Test]
-        public void CancelAwaitedPromiseThrowsOperationCanceled2()
+        public void CancelAwaitedPromiseThrowsOperationCanceled_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
 
-            string cancelValue = "Cancel";
             bool continued = false;
 
             async void Func()
@@ -259,9 +256,8 @@ namespace ProtoPromiseTests.APIs
                 {
                     int value = await deferred.Promise;
                 }
-                catch (CanceledException e)
+                catch (CanceledException)
                 {
-                    Assert.AreEqual(cancelValue, e.Value);
                     continued = true;
                 }
             }
@@ -269,27 +265,25 @@ namespace ProtoPromiseTests.APIs
             Func();
             Assert.IsFalse(continued);
 
-            cancelationSource.Cancel(cancelValue);
+            cancelationSource.Cancel();
             Assert.IsTrue(continued);
 
             cancelationSource.Dispose();
         }
 
         [Test]
-        public void AwaitAlreadyCanceledPromiseThrowsOperationCanceled1()
+        public void AwaitAlreadyCanceledPromiseThrowsOperationCanceled_void()
         {
-            string cancelValue = "Cancel";
             bool continued = false;
 
             async void Func()
             {
                 try
                 {
-                    await Promise.Canceled(cancelValue);
+                    await Promise.Canceled();
                 }
-                catch (CanceledException e)
+                catch (CanceledException)
                 {
-                    Assert.AreEqual(cancelValue, e.Value);
                     continued = true;
                 }
             }
@@ -302,20 +296,18 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void AwaitAlreadyCanceledPromiseThrowsOperationCanceled2()
+        public void AwaitAlreadyCanceledPromiseThrowsOperationCanceled_T()
         {
-            string cancelValue = "Cancel";
             bool continued = false;
 
             async void Func()
             {
                 try
                 {
-                    int value = await Promise<int>.Canceled(cancelValue);
+                    int value = await Promise<int>.Canceled();
                 }
-                catch (CanceledException e)
+                catch (CanceledException)
                 {
-                    Assert.AreEqual(cancelValue, e.Value);
                     continued = true;
                 }
             }
@@ -546,7 +538,6 @@ namespace ProtoPromiseTests.APIs
             var deferred = Promise.NewDeferred(cancelationSource.Token);
             var promise = deferred.Promise.Preserve();
 
-            string cancelValue = "Cancel";
             int continuedCount = 0;
 
             async void Func()
@@ -555,9 +546,8 @@ namespace ProtoPromiseTests.APIs
                 {
                     await promise;
                 }
-                catch (CanceledException e)
+                catch (CanceledException)
                 {
-                    Assert.AreEqual(cancelValue, e.Value);
                     ++continuedCount;
                 }
             }
@@ -567,7 +557,7 @@ namespace ProtoPromiseTests.APIs
             promise.Forget();
             Assert.AreEqual(0, continuedCount);
 
-            cancelationSource.Cancel(cancelValue);
+            cancelationSource.Cancel();
             Assert.AreEqual(2, continuedCount);
 
             cancelationSource.Dispose();
@@ -580,7 +570,6 @@ namespace ProtoPromiseTests.APIs
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
             var promise = deferred.Promise.Preserve();
 
-            string cancelValue = "Cancel";
             int continuedCount = 0;
 
             async void Func()
@@ -589,9 +578,8 @@ namespace ProtoPromiseTests.APIs
                 {
                     int value = await promise;
                 }
-                catch (CanceledException e)
+                catch (CanceledException)
                 {
-                    Assert.AreEqual(cancelValue, e.Value);
                     ++continuedCount;
                 }
             }
@@ -601,7 +589,7 @@ namespace ProtoPromiseTests.APIs
             promise.Forget();
             Assert.AreEqual(0, continuedCount);
 
-            cancelationSource.Cancel(cancelValue);
+            cancelationSource.Cancel();
             Assert.AreEqual(2, continuedCount);
 
             cancelationSource.Dispose();
@@ -610,8 +598,7 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void DoubleAwaitAlreadyCanceledPromiseThrowsOperationCanceled_void()
         {
-            string cancelValue = "Cancel";
-            var promise = Promise.Canceled(cancelValue).Preserve();
+            var promise = Promise.Canceled().Preserve();
             int continuedCount = 0;
 
             async void Func()
@@ -620,9 +607,8 @@ namespace ProtoPromiseTests.APIs
                 {
                     await promise;
                 }
-                catch (CanceledException e)
+                catch (CanceledException)
                 {
-                    Assert.AreEqual(cancelValue, e.Value);
                     ++continuedCount;
                 }
             }
@@ -639,8 +625,7 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void DoubleAwaitAlreadyCanceledPromiseThrowsOperationCanceled_T()
         {
-            string cancelValue = "Cancel";
-            var promise = Promise<int>.Canceled(cancelValue).Preserve();
+            var promise = Promise<int>.Canceled().Preserve();
             int continuedCount = 0;
 
             async void Func()
@@ -649,9 +634,8 @@ namespace ProtoPromiseTests.APIs
                 {
                     int value = await promise;
                 }
-                catch (CanceledException e)
+                catch (CanceledException)
                 {
-                    Assert.AreEqual(cancelValue, e.Value);
                     ++continuedCount;
                 }
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/CancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/CancelationTests.cs
@@ -41,7 +41,6 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource cancelationSource = new CancelationSource();
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => { cancelationSource.Cancel(); });
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => { cancelationSource.Cancel("Cancel"); });
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => { cancelationSource.Dispose(); });
             }
 
@@ -62,19 +61,10 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationSourceIsValidAfterCancel_0()
+            public void CancelationSourceIsValidAfterCancel()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
-                Assert.IsTrue(cancelationSource.IsValid);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationSourceIsValidAfterCancel_1()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                cancelationSource.Cancel("Canceled");
                 Assert.IsTrue(cancelationSource.IsValid);
                 cancelationSource.Dispose();
             }
@@ -92,15 +82,6 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
-                Assert.IsTrue(cancelationSource.IsCancelationRequested);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationSourceCancelationRequestedAfterCanceled_1()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                cancelationSource.Cancel("Canceled");
                 Assert.IsTrue(cancelationSource.IsCancelationRequested);
                 cancelationSource.Dispose();
             }
@@ -139,34 +120,30 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationSource2CanceledWithSameValueAsToken1_0()
+            public void CancelationSource2IsCanceledWhenToken1IsCanceled_0()
             {
-                string cancelValue = "CancelValue";
                 bool invoked = false;
                 CancelationSource cancelationSource1 = CancelationSource.New();
                 CancelationSource cancelationSource2 = CancelationSource.New(cancelationSource1.Token);
-                cancelationSource2.Token.Register(reason =>
+                cancelationSource2.Token.Register(() =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 });
-                cancelationSource1.Cancel(cancelValue);
+                cancelationSource1.Cancel();
                 Assert.IsTrue(invoked);
                 cancelationSource1.Dispose();
                 cancelationSource2.Dispose();
             }
 
             [Test]
-            public void CancelationSource2CanceledWithSameValueAsToken1_1()
+            public void CancelationSource2IsCanceledWhenToken1IsCanceled_1()
             {
-                string cancelValue = "CancelValue";
                 bool invoked = false;
                 CancelationSource cancelationSource1 = CancelationSource.New();
-                cancelationSource1.Cancel(cancelValue);
+                cancelationSource1.Cancel();
                 CancelationSource cancelationSource2 = CancelationSource.New(cancelationSource1.Token);
-                cancelationSource2.Token.Register(reason =>
+                cancelationSource2.Token.Register(() =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 });
                 Assert.IsTrue(invoked);
@@ -254,22 +231,20 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationSource3CanceledWithSameValueAsToken1_0()
+            public void CancelationSource3IsCanceledWhenToken1IsCanceled_0()
             {
-                string cancelValue = "CancelValue";
                 bool invoked = false;
                 CancelationSource cancelationSource1 = CancelationSource.New();
                 CancelationSource cancelationSource2 = CancelationSource.New();
                 CancelationSource cancelationSource3 = CancelationSource.New(cancelationSource1.Token, cancelationSource2.Token);
-                cancelationSource3.Token.Register(reason =>
+                cancelationSource3.Token.Register(() =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 });
-                cancelationSource1.Cancel(cancelValue);
+                cancelationSource1.Cancel();
                 Assert.IsTrue(invoked);
                 invoked = false;
-                cancelationSource2.Cancel("Different value");
+                cancelationSource2.Cancel();
                 Assert.IsFalse(invoked);
                 cancelationSource1.Dispose();
                 cancelationSource2.Dispose();
@@ -277,22 +252,20 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationSource3CanceledWithSameValueAsToken1_1()
+            public void CancelationSource3IsCanceledWhenToken1IsCanceled_1()
             {
-                string cancelValue = "CancelValue";
                 bool invoked = false;
                 CancelationSource cancelationSource1 = CancelationSource.New();
                 CancelationSource cancelationSource2 = CancelationSource.New();
-                cancelationSource1.Cancel(cancelValue);
+                cancelationSource1.Cancel();
                 CancelationSource cancelationSource3 = CancelationSource.New(cancelationSource1.Token, cancelationSource2.Token);
-                cancelationSource3.Token.Register(reason =>
+                cancelationSource3.Token.Register(() =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 });
                 Assert.IsTrue(invoked);
                 invoked = false;
-                cancelationSource2.Cancel("Different value");
+                cancelationSource2.Cancel();
                 Assert.IsFalse(invoked);
                 cancelationSource1.Dispose();
                 cancelationSource2.Dispose();
@@ -300,22 +273,20 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationSource3CanceledWithSameValueAsToken2_0()
+            public void CancelationSource3IsCanceledWhenToken2IsCanceled_0()
             {
-                string cancelValue = "CancelValue";
                 bool invoked = false;
                 CancelationSource cancelationSource1 = CancelationSource.New();
                 CancelationSource cancelationSource2 = CancelationSource.New();
                 CancelationSource cancelationSource3 = CancelationSource.New(cancelationSource1.Token, cancelationSource2.Token);
-                cancelationSource3.Token.Register(reason =>
+                cancelationSource3.Token.Register(() =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 });
-                cancelationSource2.Cancel(cancelValue);
+                cancelationSource2.Cancel();
                 Assert.IsTrue(invoked);
                 invoked = false;
-                cancelationSource1.Cancel("Different value");
+                cancelationSource1.Cancel();
                 Assert.IsFalse(invoked);
                 cancelationSource1.Dispose();
                 cancelationSource2.Dispose();
@@ -323,22 +294,20 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationSource3CanceledWithSameValueAsToken2_1()
+            public void CancelationSource3IsCanceledWhenToken2IsCanceled_1()
             {
-                string cancelValue = "CancelValue";
                 bool invoked = false;
                 CancelationSource cancelationSource1 = CancelationSource.New();
                 CancelationSource cancelationSource2 = CancelationSource.New();
-                cancelationSource2.Cancel(cancelValue);
+                cancelationSource2.Cancel();
                 CancelationSource cancelationSource3 = CancelationSource.New(cancelationSource1.Token, cancelationSource2.Token);
-                cancelationSource3.Token.Register(reason =>
+                cancelationSource3.Token.Register(() =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 });
                 Assert.IsTrue(invoked);
                 invoked = false;
-                cancelationSource1.Cancel("Different value");
+                cancelationSource1.Cancel();
                 Assert.IsFalse(invoked);
                 cancelationSource1.Dispose();
                 cancelationSource2.Dispose();
@@ -425,22 +394,20 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationSource3CanceledWithSameValueAsToken1_2()
+            public void CancelationSource3IsCanceledWhenToken1IsCanceled_2()
             {
-                string cancelValue = "CancelValue";
                 bool invoked = false;
                 CancelationSource cancelationSource1 = CancelationSource.New();
                 CancelationSource cancelationSource2 = CancelationSource.New();
                 CancelationSource cancelationSource3 = CancelationSource.New(new CancelationToken[] { cancelationSource1.Token, cancelationSource2.Token });
-                cancelationSource3.Token.Register(reason =>
+                cancelationSource3.Token.Register(() =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 });
-                cancelationSource1.Cancel(cancelValue);
+                cancelationSource1.Cancel();
                 Assert.IsTrue(invoked);
                 invoked = false;
-                cancelationSource2.Cancel("Different value");
+                cancelationSource2.Cancel();
                 Assert.IsFalse(invoked);
                 cancelationSource1.Dispose();
                 cancelationSource2.Dispose();
@@ -448,22 +415,20 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationSource3CanceledWithSameValueAsToken1_3()
+            public void CancelationSource3IsCanceledWhenToken1IsCanceled_3()
             {
-                string cancelValue = "CancelValue";
                 bool invoked = false;
                 CancelationSource cancelationSource1 = CancelationSource.New();
                 CancelationSource cancelationSource2 = CancelationSource.New();
-                cancelationSource1.Cancel(cancelValue);
+                cancelationSource1.Cancel();
                 CancelationSource cancelationSource3 = CancelationSource.New(new CancelationToken[] { cancelationSource1.Token, cancelationSource2.Token });
-                cancelationSource3.Token.Register(reason =>
+                cancelationSource3.Token.Register(() =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 });
                 Assert.IsTrue(invoked);
                 invoked = false;
-                cancelationSource2.Cancel("Different value");
+                cancelationSource2.Cancel();
                 Assert.IsFalse(invoked);
                 cancelationSource1.Dispose();
                 cancelationSource2.Dispose();
@@ -471,22 +436,20 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationSource3CanceledWithSameValueAsToken2_2()
+            public void CancelationSource3IsCanceledWhenToken2IsCanceled_2()
             {
-                string cancelValue = "CancelValue";
                 bool invoked = false;
                 CancelationSource cancelationSource1 = CancelationSource.New();
                 CancelationSource cancelationSource2 = CancelationSource.New();
                 CancelationSource cancelationSource3 = CancelationSource.New(new CancelationToken[] { cancelationSource1.Token, cancelationSource2.Token });
-                cancelationSource3.Token.Register(reason =>
+                cancelationSource3.Token.Register(() =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 });
-                cancelationSource2.Cancel(cancelValue);
+                cancelationSource2.Cancel();
                 Assert.IsTrue(invoked);
                 invoked = false;
-                cancelationSource1.Cancel("Different value");
+                cancelationSource1.Cancel();
                 Assert.IsFalse(invoked);
                 cancelationSource1.Dispose();
                 cancelationSource2.Dispose();
@@ -494,22 +457,20 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationSource3CanceledWithSameValueAsToken2_3()
+            public void CancelationSource3IsCanceledWhenToken2IsCanceled_3()
             {
-                string cancelValue = "CancelValue";
                 bool invoked = false;
                 CancelationSource cancelationSource1 = CancelationSource.New();
                 CancelationSource cancelationSource2 = CancelationSource.New();
-                cancelationSource2.Cancel(cancelValue);
+                cancelationSource2.Cancel();
                 CancelationSource cancelationSource3 = CancelationSource.New(new CancelationToken[] { cancelationSource1.Token, cancelationSource2.Token });
-                cancelationSource3.Token.Register(reason =>
+                cancelationSource3.Token.Register(()  =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 });
                 Assert.IsTrue(invoked);
                 invoked = false;
-                cancelationSource1.Cancel("Different value");
+                cancelationSource1.Cancel();
                 Assert.IsFalse(invoked);
                 cancelationSource1.Dispose();
                 cancelationSource2.Dispose();
@@ -517,39 +478,35 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationSourceLinkedToToken1TwiceIsCanceledWithSameValueAsToken1()
+            public void CancelationSourceLinkedToToken1TwiceIsCanceledWhenToken1Iscanceled()
             {
                 CancelationSource cancelationSource1 = CancelationSource.New();
                 CancelationSource cancelationSource2 = CancelationSource.New(cancelationSource1.Token, cancelationSource1.Token);
-                string cancelValue = "CancelValue";
                 bool invoked = false;
-                cancelationSource2.Token.Register(reason =>
+                cancelationSource2.Token.Register(() =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 });
-                cancelationSource1.Cancel(cancelValue);
+                cancelationSource1.Cancel();
                 Assert.IsTrue(invoked);
                 cancelationSource1.Dispose();
                 cancelationSource2.Dispose();
             }
 
             [Test]
-            public void CancelationSourceLinkedToToken1TwiceIsCanceledWithDifferentValueAsToken1()
+            public void CancelationSourceLinkedToToken1TwiceIsNotCanceledWhenToken1Iscanceled()
             {
                 CancelationSource cancelationSource1 = CancelationSource.New();
                 CancelationSource cancelationSource2 = CancelationSource.New(cancelationSource1.Token, cancelationSource1.Token);
-                string cancelValue = "CancelValue";
                 bool invoked = false;
-                cancelationSource2.Token.Register(reason =>
+                cancelationSource2.Token.Register(() =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 });
-                cancelationSource2.Cancel(cancelValue);
+                cancelationSource2.Cancel();
                 Assert.IsTrue(invoked);
                 invoked = false;
-                cancelationSource1.Cancel("Different value");
+                cancelationSource1.Cancel();
                 Assert.IsFalse(invoked);
                 cancelationSource1.Dispose();
                 cancelationSource2.Dispose();
@@ -612,7 +569,7 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationTokenCancelationRequestedAfterCanceled0()
+            public void CancelationTokenCancelationRequestedAfterCanceled()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
@@ -622,24 +579,11 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationTokenCancelationRequestedAfterCanceled1()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel("Canceled");
-                Assert.IsTrue(cancelationToken.IsCancelationRequested);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
             public void CancelationTokenInvalidOperations()
             {
                 CancelationToken cancelationToken = new CancelationToken();
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => { var _ = cancelationToken.CancelationValue; });
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => { var _ = cancelationToken.CancelationValueType; });
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => { cancelationToken.Register(_ => { }); });
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => { cancelationToken.Register(1, (i, _) => { }); });
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => { string _; cancelationToken.TryGetCancelationValueAs(out _); });
+                Assert.Throws<Proto.Promises.InvalidOperationException>(() => { cancelationToken.Register(() => { }); });
+                Assert.Throws<Proto.Promises.InvalidOperationException>(() => { cancelationToken.Register(1, i => { }); });
                 Assert.Throws<Proto.Promises.InvalidOperationException>(cancelationToken.Retain);
                 Assert.Throws<Proto.Promises.InvalidOperationException>(cancelationToken.Release);
             }
@@ -663,7 +607,7 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationTokenFromSourceCancelationIsRequested0()
+            public void CancelationTokenFromSourceCancelationIsRequested()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
@@ -673,127 +617,13 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationTokenFromSourceCancelationIsRequested1()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel("Cancel");
-                Assert.IsTrue(cancelationToken.IsCancelationRequested);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationTokenFromSourceCancelationIsNotRequestedAfterSourceIsDisposed0()
+            public void CancelationTokenFromSourceCancelationIsNotRequestedAfterSourceIsDisposed()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 cancelationSource.Cancel();
                 cancelationSource.Dispose();
                 Assert.IsFalse(cancelationToken.IsCancelationRequested);
-            }
-
-            [Test]
-            public void CancelationTokenFromSourceCancelationIsNotRequestedAfterSourceIsDisposed1()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel("Cancel");
-                cancelationSource.Dispose();
-                Assert.IsFalse(cancelationToken.IsCancelationRequested);
-            }
-
-            [Test]
-            public void CancelationTokenValueTypeIsNull0()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel();
-                Assert.IsNull(cancelationToken.CancelationValueType);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationTokenValueTypeIsNull1()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel(default(string));
-                Assert.IsNull(cancelationToken.CancelationValueType);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationTokenValueTypeIsString()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel("Cancel");
-                Assert.IsTrue(cancelationToken.CancelationValueType == typeof(string));
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationTokenValueIsNull0()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel();
-                Assert.IsNull(cancelationToken.CancelationValue);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationTokenValueIsNull1()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel(default(string));
-                Assert.IsNull(cancelationToken.CancelationValue);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationTokenValueMatchesCancelValue()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                string cancelValue = "Cancel";
-                cancelationSource.Cancel(cancelValue);
-                Assert.AreEqual(cancelValue, cancelationToken.CancelationValue);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationTokenNullValueCannotBeGottenAsString0()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel();
-                string val;
-                Assert.IsFalse(cancelationToken.TryGetCancelationValueAs(out val));
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationTokenNullValueCannotBeGottenAsString1()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel(default(string));
-                string val;
-                Assert.IsFalse(cancelationToken.TryGetCancelationValueAs(out val));
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationTokenStringValueCanBeGottenAsString()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel("Cancel");
-                string val;
-                Assert.IsTrue(cancelationToken.TryGetCancelationValueAs(out val));
-                cancelationSource.Dispose();
             }
 
             [Test]
@@ -819,7 +649,7 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void RetainedCancelationTokenFromSourceCancelationIsRequestedAfterSourceIsDisposed0()
+            public void RetainedCancelationTokenFromSourceCancelationIsRequestedAfterSourceIsDisposed()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
@@ -831,19 +661,7 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void RetainedCancelationTokenFromSourceCancelationIsRequestedAfterSourceIsDisposed1()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel("Cancel");
-                cancelationToken.Retain();
-                cancelationSource.Dispose();
-                Assert.IsTrue(cancelationToken.IsCancelationRequested);
-                cancelationToken.Release();
-            }
-
-            [Test]
-            public void ReleasedCancelationTokenFromSourceCancelationIsNotRequestedAfterSourceIsDisposed0()
+            public void ReleasedCancelationTokenFromSourceCancelationIsNotRequestedAfterSourceIsDisposed()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
@@ -855,42 +673,11 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void ReleasedCancelationTokenFromSourceCancelationIsNotRequestedAfterSourceIsDisposed1()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel("Cancel");
-                cancelationToken.Retain();
-                cancelationSource.Dispose();
-                cancelationToken.Release();
-                Assert.IsFalse(cancelationToken.IsCancelationRequested);
-            }
-
-            [Test]
-            public void CancelationTokenThrowIfCancelationRequested0()
+            public void CancelationTokenThrowIfCancelationRequested()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 cancelationSource.Cancel();
-                bool caughtException = false;
-                try
-                {
-                    cancelationToken.ThrowIfCancelationRequested();
-                }
-                catch (CanceledException)
-                {
-                    caughtException = true;
-                }
-                cancelationSource.Dispose();
-                Assert.IsTrue(caughtException);
-            }
-
-            [Test]
-            public void CancelationTokenThrowIfCancelationRequested1()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationSource.Cancel("Cancel");
                 bool caughtException = false;
                 try
                 {
@@ -931,7 +718,7 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
-                CancelationRegistration cancelationRegistration = cancelationToken.Register(_ => { });
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(() => { });
                 Assert.IsTrue(cancelationRegistration.IsRegistered);
                 cancelationSource.Dispose();
             }
@@ -941,7 +728,7 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
-                CancelationRegistration cancelationRegistration = cancelationToken.Register(0, (i, _) => { });
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(0, i => { });
                 Assert.IsTrue(cancelationRegistration.IsRegistered);
                 cancelationSource.Dispose();
             }
@@ -951,7 +738,7 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
-                CancelationRegistration cancelationRegistration = cancelationToken.Register(_ => { });
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(() => { });
                 cancelationSource.Cancel();
                 Assert.IsFalse(cancelationRegistration.IsRegistered);
                 cancelationSource.Dispose();
@@ -962,7 +749,7 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
-                CancelationRegistration cancelationRegistration = cancelationToken.Register(0, (i, _) => { });
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(0, i => { });
                 cancelationSource.Cancel();
                 Assert.IsFalse(cancelationRegistration.IsRegistered);
                 cancelationSource.Dispose();
@@ -974,7 +761,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 CancelationRegistration cancelationRegistration = new CancelationRegistration();
-                cancelationRegistration = cancelationToken.Register(_ => Assert.IsFalse(cancelationRegistration.IsRegistered));
+                cancelationRegistration = cancelationToken.Register(() => Assert.IsFalse(cancelationRegistration.IsRegistered));
                 cancelationSource.Cancel();
                 cancelationSource.Dispose();
             }
@@ -985,7 +772,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 CancelationRegistration cancelationRegistration = new CancelationRegistration();
-                cancelationRegistration = cancelationToken.Register(0, (i, _) => Assert.IsFalse(cancelationRegistration.IsRegistered));
+                cancelationRegistration = cancelationToken.Register(0, i => Assert.IsFalse(cancelationRegistration.IsRegistered));
                 cancelationSource.Cancel();
                 cancelationSource.Dispose();
             }
@@ -995,7 +782,7 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
-                CancelationRegistration cancelationRegistration = cancelationToken.Register(_ => { });
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(() => { });
                 cancelationSource.Dispose();
                 Assert.IsFalse(cancelationRegistration.IsRegistered);
             }
@@ -1005,7 +792,7 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
-                CancelationRegistration cancelationRegistration = cancelationToken.Register(0, (i, _) => { });
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(0, i => { });
                 cancelationSource.Dispose();
                 Assert.IsFalse(cancelationRegistration.IsRegistered);
             }
@@ -1016,7 +803,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 bool invoked = false;
-                cancelationToken.Register(_ => invoked = true);
+                cancelationToken.Register(() => invoked = true);
                 cancelationSource.Cancel();
                 Assert.IsTrue(invoked);
                 cancelationSource.Dispose();
@@ -1028,32 +815,8 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 bool invoked = false;
-                cancelationToken.Register(0, (i, _) => invoked = true);
+                cancelationToken.Register(0, i => invoked = true);
                 cancelationSource.Cancel();
-                Assert.IsTrue(invoked);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationTokenRegisterCallbackIsInvoked2()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                bool invoked = false;
-                cancelationToken.Register(_ => invoked = true);
-                cancelationSource.Cancel("Cancel");
-                Assert.IsTrue(invoked);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationTokenRegisterCallbackIsInvoked3()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                bool invoked = false;
-                cancelationToken.Register(0, (i, _) => invoked = true);
-                cancelationSource.Cancel("Cancel");
                 Assert.IsTrue(invoked);
                 cancelationSource.Dispose();
             }
@@ -1066,8 +829,8 @@ namespace ProtoPromiseTests.APIs
                 bool invoked = false;
                 CancelationRegistration cancelationRegistration = new CancelationRegistration();
                 // Can't unregister cancelation after token is canceled.
-                cancelationToken.Register(_ => Assert.IsFalse(cancelationRegistration.TryUnregister()));
-                cancelationRegistration = cancelationToken.Register(_ => invoked = true);
+                cancelationToken.Register(() => Assert.IsFalse(cancelationRegistration.TryUnregister()));
+                cancelationRegistration = cancelationToken.Register(() => invoked = true);
                 cancelationSource.Cancel();
                 Assert.IsTrue(invoked);
                 cancelationSource.Dispose();
@@ -1081,8 +844,8 @@ namespace ProtoPromiseTests.APIs
                 bool invoked = false;
                 CancelationRegistration cancelationRegistration = new CancelationRegistration();
                 // Can't unregister cancelation after token is canceled.
-                cancelationToken.Register(_ => Assert.IsFalse(cancelationRegistration.TryUnregister()));
-                cancelationRegistration = cancelationToken.Register(0, (i, _) => invoked = true);
+                cancelationToken.Register(() => Assert.IsFalse(cancelationRegistration.TryUnregister()));
+                cancelationRegistration = cancelationToken.Register(0, i => invoked = true);
                 cancelationSource.Cancel();
                 Assert.IsTrue(invoked);
                 cancelationSource.Dispose();
@@ -1094,7 +857,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 bool invoked = false;
-                CancelationRegistration cancelationRegistration = cancelationToken.Register(_ => invoked = true);
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(() => invoked = true);
                 cancelationRegistration.Unregister();
                 cancelationSource.Cancel();
                 Assert.IsFalse(invoked);
@@ -1107,7 +870,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 bool invoked = false;
-                CancelationRegistration cancelationRegistration = cancelationToken.Register(0, (i, _) => invoked = true);
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(0, i => invoked = true);
                 cancelationRegistration.Unregister();
                 cancelationSource.Cancel();
                 Assert.IsFalse(invoked);
@@ -1120,7 +883,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 string expected = "Captured";
-                cancelationToken.Register(expected, (cv, _) => Assert.AreEqual(expected, cv));
+                cancelationToken.Register(expected, cv => Assert.AreEqual(expected, cv));
                 cancelationSource.Cancel();
                 cancelationSource.Dispose();
             }
@@ -1132,8 +895,8 @@ namespace ProtoPromiseTests.APIs
                 CancelationToken cancelationToken = cancelationSource.Token;
                 bool invoked = false;
                 // This should never be done in practice!
-                cancelationToken.Register(_ => cancelationSource.Dispose());
-                cancelationToken.Register(_ => invoked = true);
+                cancelationToken.Register(() => cancelationSource.Dispose());
+                cancelationToken.Register(() => invoked = true);
                 cancelationSource.Cancel();
                 Assert.IsTrue(invoked);
             }
@@ -1144,8 +907,8 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 CancelationRegistration cancelationRegistration = new CancelationRegistration();
-                cancelationToken.Register(_ => Assert.IsFalse(cancelationRegistration.IsRegistered));
-                cancelationRegistration = cancelationToken.Register(_ => { });
+                cancelationToken.Register(() => Assert.IsFalse(cancelationRegistration.IsRegistered));
+                cancelationRegistration = cancelationToken.Register(() => { });
                 cancelationSource.Cancel();
                     cancelationSource.Dispose();
             }
@@ -1155,7 +918,7 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationToken.Register(_ =>
+                cancelationToken.Register(() =>
                 {
                     throw new Exception();
                 });
@@ -1169,13 +932,13 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 int callbackCount = 0;
-                cancelationToken.Register(_ => ++callbackCount);
-                cancelationToken.Register(_ =>
+                cancelationToken.Register(() => ++callbackCount);
+                cancelationToken.Register(() =>
                 {
                     ++callbackCount;
                     throw new Exception();
                 });
-                cancelationToken.Register(_ => ++callbackCount);
+                cancelationToken.Register(() => ++callbackCount);
                 try
                 {
                     cancelationSource.Cancel();
@@ -1193,11 +956,11 @@ namespace ProtoPromiseTests.APIs
                 cancelationToken.Retain();
                 cancelationSource.Cancel();
                 cancelationSource.Dispose();
-                cancelationToken.Register(_ => { });
-                cancelationToken.Register(1, (cv, _) => { });
+                cancelationToken.Register(() => { });
+                cancelationToken.Register(1, cv => { });
                 CancelationRegistration cancelationRegistration;
-                Assert.IsTrue(cancelationToken.TryRegister(_ => { }, out cancelationRegistration));
-                Assert.IsTrue(cancelationToken.TryRegister(1, (cv, _) => { }, out cancelationRegistration));
+                Assert.IsTrue(cancelationToken.TryRegister(() => { }, out cancelationRegistration));
+                Assert.IsTrue(cancelationToken.TryRegister(1, cv => { }, out cancelationRegistration));
                 cancelationToken.Release();
             }
 
@@ -1209,10 +972,10 @@ namespace ProtoPromiseTests.APIs
                 cancelationToken.Retain();
                 cancelationSource.Dispose();
                 CancelationRegistration cancelationRegistration;
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => cancelationToken.Register(_ => { }));
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => cancelationToken.Register(1, (cv, _) => { }));
-                Assert.IsFalse(cancelationToken.TryRegister(_ => { }, out cancelationRegistration));
-                Assert.IsFalse(cancelationToken.TryRegister(1, (cv, _) => { }, out cancelationRegistration));
+                Assert.Throws<Proto.Promises.InvalidOperationException>(() => cancelationToken.Register(() => { }));
+                Assert.Throws<Proto.Promises.InvalidOperationException>(() => cancelationToken.Register(1, cv => { }));
+                Assert.IsFalse(cancelationToken.TryRegister(() => { }, out cancelationRegistration));
+                Assert.IsFalse(cancelationToken.TryRegister(1, cv => { }, out cancelationRegistration));
                 cancelationToken.Release();
             }
 
@@ -1222,7 +985,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 CancelationRegistration cancelationRegistration = default(CancelationRegistration);
-                cancelationRegistration = cancelationToken.Register(_ =>
+                cancelationRegistration = cancelationToken.Register(() =>
                 {
                     bool isRegistered, isCancelationRequested;
                     cancelationRegistration.GetIsRegisteredAndIsCancelationRequested(out isRegistered, out isCancelationRequested);
@@ -1239,7 +1002,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 CancelationRegistration cancelationRegistration = default(CancelationRegistration);
-                cancelationRegistration = cancelationToken.Register(1, (cv, _) =>
+                cancelationRegistration = cancelationToken.Register(1, cv =>
                 {
                     bool isRegistered, isCancelationRequested;
                     cancelationRegistration.GetIsRegisteredAndIsCancelationRequested(out isRegistered, out isCancelationRequested);
@@ -1256,7 +1019,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 CancelationRegistration cancelationRegistration = default(CancelationRegistration);
-                cancelationRegistration = cancelationToken.Register(_ =>
+                cancelationRegistration = cancelationToken.Register(() =>
                 {
                     bool isCancelationRequested;
                     Assert.IsFalse(cancelationRegistration.TryUnregister(out isCancelationRequested));
@@ -1272,7 +1035,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 CancelationRegistration cancelationRegistration = default(CancelationRegistration);
-                cancelationRegistration = cancelationToken.Register(1, (cv, _) =>
+                cancelationRegistration = cancelationToken.Register(1, cv =>
                 {
                     bool isCancelationRequested;
                     Assert.IsFalse(cancelationRegistration.TryUnregister(out isCancelationRequested));

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/CancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/CancelationTests.cs
@@ -546,10 +546,24 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
+            public void CancelationTokenCanceledCanBeCanceled()
+            {
+                CancelationToken cancelationToken = CancelationToken.Canceled();
+                Assert.IsTrue(cancelationToken.CanBeCanceled);
+            }
+
+            [Test]
             public void NewCancelationTokenCannotBeCanceled()
             {
                 CancelationToken cancelationToken = new CancelationToken();
                 Assert.IsFalse(cancelationToken.CanBeCanceled);
+            }
+
+            [Test]
+            public void CancelationTokenCanceledCancelationIsRequested()
+            {
+                CancelationToken cancelationToken = CancelationToken.Canceled();
+                Assert.IsTrue(cancelationToken.IsCancelationRequested);
             }
 
             [Test]
@@ -673,7 +687,23 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationTokenThrowIfCancelationRequested()
+            public void CancelationTokenCanceledThrowIfCancelationRequested()
+            {
+                CancelationToken cancelationToken = CancelationToken.Canceled();
+                bool caughtException = false;
+                try
+                {
+                    cancelationToken.ThrowIfCancelationRequested();
+                }
+                catch (CanceledException)
+                {
+                    caughtException = true;
+                }
+                Assert.IsTrue(caughtException);
+            }
+
+            [Test]
+            public void CancelationTokenFromSourceThrowIfCancelationRequested()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
@@ -778,6 +808,22 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
+            public void RegistrationFromCancelationTokenCanceledIsNotRegisteredAfterInvoked0()
+            {
+                CancelationToken cancelationToken = CancelationToken.Canceled();
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(() => { });
+                Assert.IsFalse(cancelationRegistration.IsRegistered);
+            }
+
+            [Test]
+            public void RegistrationFromCancelationTokenCanceledIsNotRegisteredAfterInvoked1()
+            {
+                CancelationToken cancelationToken = CancelationToken.Canceled();
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(0, i => { });
+                Assert.IsFalse(cancelationRegistration.IsRegistered);
+            }
+
+            [Test]
             public void RegistrationFromCancelationTokenIsNotRegisteredAfterSourceIsDisposed0()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
@@ -819,6 +865,22 @@ namespace ProtoPromiseTests.APIs
                 cancelationSource.Cancel();
                 Assert.IsTrue(invoked);
                 cancelationSource.Dispose();
+            }
+
+            [Test]
+            public void CancelationTokenRegisterCallbackIsInvoked2()
+            {
+                bool invoked = false;
+                CancelationToken.Canceled().Register(() => invoked = true);
+                Assert.IsTrue(invoked);
+            }
+
+            [Test]
+            public void CancelationTokenRegisterCallbackIsInvoked3()
+            {
+                bool invoked = false;
+                CancelationToken.Canceled().Register(0, i => invoked = true);
+                Assert.IsTrue(invoked);
             }
 
             [Test]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/CaptureTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/CaptureTests.cs
@@ -72,7 +72,7 @@ namespace ProtoPromiseTests.APIs
 
             Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
             {
-                promise.CatchCancelation(100, default(Promise.CanceledAction<int>));
+                promise.CatchCancelation(100, default(Action<int>));
             });
 
             deferred.Resolve();
@@ -87,7 +87,7 @@ namespace ProtoPromiseTests.APIs
 
             Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
             {
-                promise.CatchCancelation(100, default(Promise.CanceledAction<int>));
+                promise.CatchCancelation(100, default(Action<int>));
             });
 
             deferred.Resolve(1);
@@ -662,7 +662,7 @@ namespace ProtoPromiseTests.APIs
 #endif
 
         [Test]
-        public void OnCanceledWillBeInvokedWithCapturedValue_void0()
+        public void OnCanceledWillBeInvokedWithCapturedValue_void()
         {
             string expected = "expected";
             bool invoked = false;
@@ -671,10 +671,9 @@ namespace ProtoPromiseTests.APIs
             var deferred = Promise.NewDeferred(cancelationSource.Token);
 
             deferred.Promise
-                .CatchCancelation(expected, (cv, reason) =>
+                .CatchCancelation(expected, cv =>
                 {
                     Assert.AreEqual(expected, cv);
-                    Assert.IsNull(reason.ValueType);
                     invoked = true;
                 })
                 .Forget();
@@ -687,33 +686,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void OnCanceledWillBeInvokedWithCapturedValue_void1()
-        {
-            string expected = "expected";
-            int cancelValue = 50;
-            bool invoked = false;
-
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
-
-            deferred.Promise
-                .CatchCancelation(expected, (cv, reason) =>
-                {
-                    Assert.AreEqual(expected, cv);
-                    Assert.AreEqual(cancelValue, reason.Value);
-                    invoked = true;
-                })
-                .Forget();
-
-            cancelationSource.Cancel(cancelValue);
-
-            Assert.IsTrue(invoked);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void OnCanceledWillBeInvokedWithCapturedValue_T0()
+        public void OnCanceledWillBeInvokedWithCapturedValue_T()
         {
             string expected = "expected";
             bool invoked = false;
@@ -722,41 +695,14 @@ namespace ProtoPromiseTests.APIs
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
 
             deferred.Promise
-                .CatchCancelation(expected, (cv, reason) =>
+                .CatchCancelation(expected, cv =>
                 {
                     Assert.AreEqual(expected, cv);
-                    Assert.IsNull(reason.ValueType);
                     invoked = true;
                 })
                 .Forget();
 
             cancelationSource.Cancel();
-
-            Assert.IsTrue(invoked);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void OnCanceledWillBeInvokedWithCapturedValue_T1()
-        {
-            string expected = "expected";
-            int cancelValue = 50;
-            bool invoked = false;
-
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-
-            deferred.Promise
-                .CatchCancelation(expected, (cv, reason) =>
-                {
-                    Assert.AreEqual(expected, cv);
-                    Assert.AreEqual(cancelValue, reason.Value);
-                    invoked = true;
-                })
-                .Forget();
-
-            cancelationSource.Cancel(cancelValue);
 
             Assert.IsTrue(invoked);
 
@@ -855,8 +801,6 @@ namespace ProtoPromiseTests.APIs
         public void OnFinallyWillBeInvokedWithCapturedValue_canceled_void()
         {
             string expected = "expected";
-            bool repeat = true;
-        Repeat:
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
 
@@ -870,30 +814,16 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            if (repeat)
-            {
-                cancelationSource.Cancel();
-            }
-            else
-            {
-                cancelationSource.Cancel("Cancel");
-            }
+            cancelationSource.Cancel();
             Assert.IsTrue(invoked);
 
             cancelationSource.Dispose();
-            if (repeat)
-            {
-                repeat = false;
-                goto Repeat;
-            }
         }
 
         [Test]
         public void OnFinallyWillBeInvokedWithCapturedValue_canceled_T()
         {
             string expected = "expected";
-            bool repeat = true;
-        Repeat:
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
 
@@ -907,22 +837,10 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            if (repeat)
-            {
-                cancelationSource.Cancel();
-            }
-            else
-            {
-                cancelationSource.Cancel("Cancel");
-            }
+            cancelationSource.Cancel();
             Assert.IsTrue(invoked);
 
             cancelationSource.Dispose();
-            if (repeat)
-            {
-                repeat = false;
-                goto Repeat;
-            }
         }
 
         [Test]
@@ -1042,9 +960,7 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void PromiseIsRejectedWithThrownExceptionWhenOnFinallyWithCapturedValueThrows_cancel_void()
         {
-            bool repeat = true;
             Exception expected = new Exception();
-        Repeat:
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
 
@@ -1059,32 +975,16 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            if (repeat)
-            {
-                cancelationSource.Cancel();
-            }
-            else
-            {
-                cancelationSource.Cancel("Cancel");
-            }
-
+            cancelationSource.Cancel();
             Assert.IsTrue(invoked);
 
             cancelationSource.Dispose();
-
-            if (repeat)
-            {
-                repeat = false;
-                goto Repeat;
-            }
         }
 
         [Test]
         public void PromiseIsRejectedWithThrownExceptionWhenOnFinallyWithCapturedValueThrows_cancel_T()
         {
-            bool repeat = true;
             Exception expected = new Exception();
-        Repeat:
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
 
@@ -1099,24 +999,10 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            if (repeat)
-            {
-                cancelationSource.Cancel();
-            }
-            else
-            {
-                cancelationSource.Cancel("Cancel");
-            }
-
+            cancelationSource.Cancel();
             Assert.IsTrue(invoked);
 
             cancelationSource.Dispose();
-
-            if (repeat)
-            {
-                repeat = false;
-                goto Repeat;
-            }
         }
 
         [Test]
@@ -1223,8 +1109,6 @@ namespace ProtoPromiseTests.APIs
         public void OnContinueWillBeInvokedWithCapturedValue_canceled_void()
         {
             string expected = "expected";
-            bool repeat = true;
-        Repeat:
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
             var promise = deferred.Promise.Preserve();
@@ -1240,31 +1124,16 @@ namespace ProtoPromiseTests.APIs
                 }
             );
 
-            if (repeat)
-            {
-                cancelationSource.Cancel();
-            }
-            else
-            {
-                cancelationSource.Cancel("Cancel");
-            }
-
+            cancelationSource.Cancel();
             Assert.IsTrue(invoked);
 
             cancelationSource.Dispose();
             promise.Forget();
-            if (repeat)
-            {
-                repeat = false;
-                goto Repeat;
-            }
         }
 
         [Test]
         public void OnContinueWillBeInvokedWithCapturedValue_canceled_T()
         {
-            bool repeat = true;
-        Repeat:
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
             var promise = deferred.Promise.Preserve();
@@ -1281,24 +1150,11 @@ namespace ProtoPromiseTests.APIs
                 }
             );
 
-            if (repeat)
-            {
-                cancelationSource.Cancel();
-            }
-            else
-            {
-                cancelationSource.Cancel("Cancel");
-            }
-
+            cancelationSource.Cancel();
             Assert.IsTrue(invoked);
 
             cancelationSource.Dispose();
             promise.Forget();
-            if (repeat)
-            {
-                repeat = false;
-                goto Repeat;
-            }
         }
 
         [Test]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/ContinuewithTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/ContinuewithTests.cs
@@ -282,8 +282,6 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void OnContinueIsInvokedWhenPromiseIsCanceled_void()
         {
-            bool repeat = true;
-        Repeat:
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
             var promise = deferred.Promise.Preserve();
@@ -294,32 +292,16 @@ namespace ProtoPromiseTests.APIs
                 onContinue: r => ++finallyCount
             );
 
-            if (repeat)
-            {
-                cancelationSource.Cancel();
-            }
-            else
-            {
-                cancelationSource.Cancel("Cancel");
-            }
-
+            cancelationSource.Cancel();
             Assert.AreEqual(TestHelper.continueVoidCallbacks * 2, finallyCount);
 
             cancelationSource.Dispose();
             promise.Forget();
-
-            if (repeat)
-            {
-                repeat = false;
-                goto Repeat;
-            }
         }
 
         [Test]
         public void OnContinueIsInvokedWhenPromiseIsCanceled_T()
         {
-            bool repeat = true;
-        Repeat:
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
             var promise = deferred.Promise.Preserve();
@@ -330,25 +312,11 @@ namespace ProtoPromiseTests.APIs
                 onContinue: r => ++finallyCount
             );
 
-            if (repeat)
-            {
-                cancelationSource.Cancel();
-            }
-            else
-            {
-                cancelationSource.Cancel("Cancel");
-            }
-
+            cancelationSource.Cancel();
             Assert.AreEqual(TestHelper.continueTCallbacks * 2, finallyCount);
 
             cancelationSource.Dispose();
             promise.Forget();
-
-            if (repeat)
-            {
-                repeat = false;
-                goto Repeat;
-            }
         }
 
         [Test]
@@ -362,33 +330,10 @@ namespace ProtoPromiseTests.APIs
                 onContinue: r =>
                 {
                     Assert.AreEqual(r.State, Promise.State.Canceled);
-                    Assert.IsNull(r.CancelContainer.ValueType);
                 }
             );
 
             cancelationSource.Cancel();
-
-            cancelationSource.Dispose();
-            promise.Forget();
-        }
-
-        [Test]
-        public void OnContinueCancelReasonWhenPromiseIsCanceled_void()
-        {
-            string cancelation = "Cancel";
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
-            var promise = deferred.Promise.Preserve();
-
-            TestHelper.AddContinueCallbacks<int, string>(promise,
-                onContinue: r =>
-                {
-                    Assert.AreEqual(r.State, Promise.State.Canceled);
-                    Assert.AreEqual(cancelation, r.CancelContainer.Value);
-                }
-            );
-
-            cancelationSource.Cancel(cancelation);
 
             cancelationSource.Dispose();
             promise.Forget();
@@ -405,7 +350,6 @@ namespace ProtoPromiseTests.APIs
                 onContinue: r =>
                 {
                     Assert.AreEqual(r.State, Promise.State.Canceled);
-                    Assert.IsNull(r.CancelContainer.ValueType);
                 }
             );
 
@@ -416,29 +360,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void OnContinueCancelReasonWhenPromiseIsCanceled_T()
-        {
-            string cancelation = "Cancel";
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-            var promise = deferred.Promise.Preserve();
-
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
-                onContinue: r =>
-                {
-                    Assert.AreEqual(r.State, Promise.State.Canceled);
-                    Assert.AreEqual(cancelation, r.CancelContainer.Value);
-                }
-            );
-
-            cancelationSource.Cancel(cancelation);
-
-            cancelationSource.Dispose();
-            promise.Forget();
-        }
-
-        [Test]
-        public void OnContinueRethrowCancelReasonWhenPromiseIsCanceled_void0()
+        public void OnContinueRethrowCancelWhenPromiseIsCanceled_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
@@ -448,7 +370,7 @@ namespace ProtoPromiseTests.APIs
 
             TestHelper.AddContinueCallbacks<int, string>(promise,
                 onContinue: r => r.RethrowIfCanceled(),
-                onCancel: e => { Assert.IsNull(e.ValueType); ++cancelCount; }
+                onCancel: () => { ++cancelCount; }
             );
 
             cancelationSource.Cancel();
@@ -463,33 +385,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void OnContinueRethrowCancelReasonWhenPromiseIsCanceled_void1()
-        {
-            string cancelation = "Cancel";
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
-            var promise = deferred.Promise.Preserve();
-
-            int cancelCount = 0;
-
-            TestHelper.AddContinueCallbacks<int, string>(promise,
-                onContinue: r => r.RethrowIfCanceled(),
-                onCancel: e => { Assert.AreEqual(cancelation, e.Value); ++cancelCount; }
-            );
-
-            cancelationSource.Cancel(cancelation);
-
-            Assert.AreEqual(
-                TestHelper.continueVoidCallbacks * 2,
-                cancelCount
-            );
-
-            cancelationSource.Dispose();
-            promise.Forget();
-        }
-
-        [Test]
-        public void OnContinueRethrowCancelReasonWhenPromiseIsCanceled_T0()
+        public void OnContinueRethrowCancelReasonWhenPromiseIsCanceled_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
@@ -499,36 +395,10 @@ namespace ProtoPromiseTests.APIs
 
             TestHelper.AddContinueCallbacks<int, int, string>(promise,
                 onContinue: r => r.RethrowIfCanceled(),
-                onCancel: e => { Assert.IsNull(e.ValueType); ++cancelCount; }
+                onCancel: () => { ++cancelCount; }
             );
 
             cancelationSource.Cancel();
-
-            Assert.AreEqual(
-                TestHelper.continueTCallbacks * 2,
-                cancelCount
-            );
-
-            cancelationSource.Dispose();
-            promise.Forget();
-        }
-
-        [Test]
-        public void OnContinueRethrowCancelReasonWhenPromiseIsCanceled_T1()
-        {
-            string cancelation = "Cancel";
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-            var promise = deferred.Promise.Preserve();
-
-            int cancelCount = 0;
-
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
-                onContinue: r => r.RethrowIfCanceled(),
-                onCancel: e => { Assert.AreEqual(cancelation, e.Value); ++cancelCount; }
-            );
-
-            cancelationSource.Cancel(cancelation);
 
             Assert.AreEqual(
                 TestHelper.continueTCallbacks * 2,

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/FinallyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/FinallyTests.cs
@@ -129,8 +129,6 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void OnFinallyIsInvokedWhenPromiseIsCanceled_void()
         {
-            bool repeat = true;
-        Repeat:
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
 
@@ -140,31 +138,15 @@ namespace ProtoPromiseTests.APIs
                 .Finally(() => invoked = true)
                 .Forget();
 
-            if (repeat)
-            {
-                cancelationSource.Cancel();
-            }
-            else
-            {
-                cancelationSource.Cancel("Cancel");
-            }
-
+            cancelationSource.Cancel();
             Assert.IsTrue(invoked);
 
             cancelationSource.Dispose();
-
-            if (repeat)
-            {
-                repeat = false;
-                goto Repeat;
-            }
         }
 
         [Test]
         public void OnFinallyIsInvokedWhenPromiseIsCanceled_T()
         {
-            bool repeat = true;
-        Repeat:
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
 
@@ -174,24 +156,10 @@ namespace ProtoPromiseTests.APIs
                 .Finally(() => invoked = true)
                 .Forget();
 
-            if (repeat)
-            {
-                cancelationSource.Cancel();
-            }
-            else
-            {
-                cancelationSource.Cancel("Cancel");
-            }
-
+            cancelationSource.Cancel();
             Assert.IsTrue(invoked);
 
             cancelationSource.Dispose();
-
-            if (repeat)
-            {
-                repeat = false;
-                goto Repeat;
-            }
         }
 
         [Test]
@@ -311,9 +279,7 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void PromiseIsRejectedWithThrownExceptionWhenOnFinallyThrows_canceled_void()
         {
-            bool repeat = true;
             Exception expected = new Exception();
-        Repeat:
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
 
@@ -328,32 +294,16 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            if (repeat)
-            {
-                cancelationSource.Cancel();
-            }
-            else
-            {
-                cancelationSource.Cancel("Cancel");
-            }
-
+            cancelationSource.Cancel();
             Assert.IsTrue(invoked);
 
             cancelationSource.Dispose();
-
-            if (repeat)
-            {
-                repeat = false;
-                goto Repeat;
-            }
         }
 
         [Test]
         public void PromiseIsRejectedWithThrownExceptionWhenOnFinallyThrows_canceled_T()
         {
-            bool repeat = true;
             Exception expected = new Exception();
-        Repeat:
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
 
@@ -368,24 +318,10 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            if (repeat)
-            {
-                cancelationSource.Cancel();
-            }
-            else
-            {
-                cancelationSource.Cancel("Cancel");
-            }
-
+            cancelationSource.Cancel();
             Assert.IsTrue(invoked);
 
             cancelationSource.Dispose();
-
-            if (repeat)
-            {
-                repeat = false;
-                goto Repeat;
-            }
         }
     }
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/FirstTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/FirstTests.cs
@@ -287,7 +287,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            cancelationSource.Cancel("Cancel");
+            cancelationSource.Cancel();
 
             Assert.IsFalse(resolved);
 
@@ -315,7 +315,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            cancelationSource.Cancel("Cancel");
+            cancelationSource.Cancel();
 
             Assert.IsFalse(resolved);
 
@@ -342,7 +342,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            cancelationSource.Cancel("Cancel");
+            cancelationSource.Cancel();
 
             Assert.IsFalse(resolved);
 
@@ -370,7 +370,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            cancelationSource.Cancel("Cancel");
+            cancelationSource.Cancel();
 
             Assert.IsFalse(resolved);
 
@@ -382,69 +382,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void FirstIsCanceledWhenAllPromisesAreCanceled_void0()
-        {
-            CancelationSource cancelationSource1 = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred(cancelationSource1.Token);
-            CancelationSource cancelationSource2 = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource2.Token);
-
-            bool canceled = false;
-            string expected = "Cancel";
-
-            Promise.First(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
-                {
-                    Assert.AreEqual(expected, reason.Value);
-                    canceled = true;
-                })
-                .Forget();
-
-            cancelationSource1.Cancel("Different Cancel");
-
-            Assert.IsFalse(canceled);
-
-            cancelationSource2.Cancel(expected);
-
-            Assert.IsTrue(canceled);
-
-            cancelationSource1.Dispose();
-            cancelationSource2.Dispose();
-        }
-
-        [Test]
-        public void FirstIsCanceledWhenAllPromisesAreCanceled_T0()
-        {
-            CancelationSource cancelationSource1 = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource1.Token);
-            CancelationSource cancelationSource2 = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource2.Token);
-
-            bool canceled = false;
-            string expected = "Cancel";
-
-            Promise<int>.First(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
-                {
-                    Assert.AreEqual(expected, reason.Value);
-                    canceled = true;
-                })
-                .Forget();
-
-            cancelationSource1.Cancel("Different Cancel");
-
-            Assert.IsFalse(canceled);
-
-            cancelationSource2.Cancel(expected);
-
-            Assert.IsTrue(canceled);
-
-            cancelationSource1.Dispose();
-            cancelationSource2.Dispose();
-        }
-
-        [Test]
-        public void FirstIsCanceledWhenAllPromisesAreCanceled_void1()
+        public void FirstIsCanceledWhenAllPromisesAreCanceled_void()
         {
             CancelationSource cancelationSource1 = CancelationSource.New();
             var deferred1 = Promise.NewDeferred(cancelationSource1.Token);
@@ -454,19 +392,16 @@ namespace ProtoPromiseTests.APIs
             bool canceled = false;
 
             Promise.First(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(reason.ValueType);
                     canceled = true;
                 })
                 .Forget();
 
-            cancelationSource1.Cancel("Different Cancel");
-
+            cancelationSource1.Cancel();
             Assert.IsFalse(canceled);
 
             cancelationSource2.Cancel();
-
             Assert.IsTrue(canceled);
 
             cancelationSource1.Dispose();
@@ -474,7 +409,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void FirstIsCanceledWhenAllPromisesAreCanceled_T1()
+        public void FirstIsCanceledWhenAllPromisesAreCanceled_T()
         {
             CancelationSource cancelationSource1 = CancelationSource.New();
             var deferred1 = Promise.NewDeferred<int>(cancelationSource1.Token);
@@ -484,19 +419,16 @@ namespace ProtoPromiseTests.APIs
             bool canceled = false;
 
             Promise<int>.First(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(reason.ValueType);
                     canceled = true;
                 })
                 .Forget();
 
-            cancelationSource1.Cancel("Different Cancel");
-
+            cancelationSource1.Cancel();
             Assert.IsFalse(canceled);
 
             cancelationSource2.Cancel();
-
             Assert.IsTrue(canceled);
 
             cancelationSource1.Dispose();
@@ -521,7 +453,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            cancelationSource.Cancel("Cancel");
+            cancelationSource.Cancel();
 
             Assert.IsFalse(rejected);
 
@@ -550,7 +482,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            cancelationSource.Cancel("Cancel");
+            cancelationSource.Cancel();
 
             Assert.IsFalse(rejected);
 
@@ -579,7 +511,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            cancelationSource.Cancel("Cancel");
+            cancelationSource.Cancel();
 
             Assert.IsFalse(rejected);
 
@@ -608,7 +540,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            cancelationSource.Cancel("Cancel");
+            cancelationSource.Cancel();
 
             Assert.IsFalse(rejected);
 
@@ -620,65 +552,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void FirstIsCancelededWhenFirstPromiseIsRejectedThenSecondPromiseIsCanceled_void0()
-        {
-            var deferred1 = Promise.NewDeferred();
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
-
-            bool canceled = false;
-            string expected = "Cancel";
-
-            Promise.First(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
-                {
-                    Assert.AreEqual(expected, reason.Value);
-                    canceled = true;
-                })
-                .Forget();
-
-            deferred1.Reject("Error");
-
-            Assert.IsFalse(canceled);
-
-            cancelationSource.Cancel(expected);
-
-            Assert.IsTrue(canceled);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void FirstIsCancelededWhenFirstPromiseIsRejectedThenSecondPromiseIsCanceled_T0()
-        {
-            var deferred1 = Promise.NewDeferred<int>();
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource.Token);
-
-            bool canceled = false;
-            string expected = "Cancel";
-
-            Promise<int>.First(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
-                {
-                    Assert.AreEqual(expected, reason.Value);
-                    canceled = true;
-                })
-                .Forget();
-
-            deferred1.Reject("Error");
-
-            Assert.IsFalse(canceled);
-
-            cancelationSource.Cancel(expected);
-
-            Assert.IsTrue(canceled);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void FirstIsCancelededWhenFirstPromiseIsRejectedThenSecondPromiseIsCanceled_void1()
+        public void FirstIsCancelededWhenFirstPromiseIsRejectedThenSecondPromiseIsCanceled_void()
         {
             var deferred1 = Promise.NewDeferred();
             CancelationSource cancelationSource = CancelationSource.New();
@@ -687,9 +561,8 @@ namespace ProtoPromiseTests.APIs
             bool canceled = false;
 
             Promise.First(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(reason.ValueType);
                     canceled = true;
                 })
                 .Forget();
@@ -706,7 +579,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void FirstIsCancelededWhenFirstPromiseIsRejectedThenSecondPromiseIsCanceled_T1()
+        public void FirstIsCancelededWhenFirstPromiseIsRejectedThenSecondPromiseIsCanceled_T()
         {
             var deferred1 = Promise.NewDeferred<int>();
             CancelationSource cancelationSource = CancelationSource.New();
@@ -715,9 +588,8 @@ namespace ProtoPromiseTests.APIs
             bool canceled = false;
 
             Promise<int>.First(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(reason.ValueType);
                     canceled = true;
                 })
                 .Forget();
@@ -734,65 +606,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void FirstIsCancelededWhenSecondPromiseIsRejectedThenFirstPromiseIsCanceled_void0()
-        {
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred(cancelationSource.Token);
-            var deferred2 = Promise.NewDeferred();
-
-            bool canceled = false;
-            string expected = "Cancel";
-
-            Promise.First(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
-                {
-                    Assert.AreEqual(expected, reason.Value);
-                    canceled = true;
-                })
-                .Forget();
-
-            deferred2.Reject("Error");
-
-            Assert.IsFalse(canceled);
-
-            cancelationSource.Cancel(expected);
-
-            Assert.IsTrue(canceled);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void FirstIsCancelededWhenSecondPromiseIsRejectedThenFirstPromiseIsCanceled_T0()
-        {
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource.Token);
-            var deferred2 = Promise.NewDeferred<int>();
-
-            bool canceled = false;
-            string expected = "Cancel";
-
-            Promise<int>.First(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
-                {
-                    Assert.AreEqual(expected, reason.Value);
-                    canceled = true;
-                })
-                .Forget();
-
-            deferred2.Reject("Error");
-
-            Assert.IsFalse(canceled);
-
-            cancelationSource.Cancel(expected);
-
-            Assert.IsTrue(canceled);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void FirstIsCancelededWhenSecondPromiseIsRejectedThenFirstPromiseIsCanceled_void1()
+        public void FirstIsCancelededWhenSecondPromiseIsRejectedThenFirstPromiseIsCanceled_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred1 = Promise.NewDeferred(cancelationSource.Token);
@@ -801,9 +615,8 @@ namespace ProtoPromiseTests.APIs
             bool canceled = false;
 
             Promise.First(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(reason.ValueType);
                     canceled = true;
                 })
                 .Forget();
@@ -820,7 +633,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void FirstIsCancelededWhenSecondPromiseIsRejectedThenFirstPromiseIsCanceled_T1()
+        public void FirstIsCancelededWhenSecondPromiseIsRejectedThenFirstPromiseIsCanceled_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred1 = Promise.NewDeferred<int>(cancelationSource.Token);
@@ -829,9 +642,8 @@ namespace ProtoPromiseTests.APIs
             bool canceled = false;
 
             Promise<int>.First(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(reason.ValueType);
                     canceled = true;
                 })
                 .Forget();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/MergeTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/MergeTests.cs
@@ -168,33 +168,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void MergePromiseIsCanceledWhenFirstPromiseIsCanceled0()
-        {
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource.Token);
-            var deferred2 = Promise.NewDeferred<string>();
-
-            string expected = "Cancel";
-            bool canceled = false;
-
-            Promise.Merge(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(e =>
-                {
-                    Assert.AreEqual(expected, e.Value);
-                    canceled = true;
-                })
-                .Forget();
-
-            cancelationSource.Cancel(expected);
-            deferred2.Resolve("Success");
-
-            Assert.IsTrue(canceled);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void MergePromiseIsCanceledWhenFirstPromiseIsCanceled1()
+        public void MergePromiseIsCanceledWhenFirstPromiseIsCanceled()
         {
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred1 = Promise.NewDeferred<int>(cancelationSource.Token);
@@ -203,9 +177,8 @@ namespace ProtoPromiseTests.APIs
             bool canceled = false;
 
             Promise.Merge(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(e.ValueType);
                     canceled = true;
                 })
                 .Forget();
@@ -219,33 +192,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void MergePromiseIsCanceledWhenSecondPromiseIsCanceled0()
-        {
-            var deferred1 = Promise.NewDeferred<int>();
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<string>(cancelationSource.Token);
-
-            string expected = "Cancel";
-            bool canceled = false;
-
-            Promise.Merge(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(e =>
-                {
-                    Assert.AreEqual(expected, e.Value);
-                    canceled = true;
-                })
-                .Forget();
-
-            deferred1.Resolve(2);
-            cancelationSource.Cancel(expected);
-
-            Assert.IsTrue(canceled);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void MergePromiseIsCanceledWhenSecondPromiseIsCanceled1()
+        public void MergePromiseIsCanceledWhenSecondPromiseIsCanceled()
         {
             var deferred1 = Promise.NewDeferred<int>();
             CancelationSource cancelationSource = CancelationSource.New();
@@ -254,9 +201,8 @@ namespace ProtoPromiseTests.APIs
             bool canceled = false;
 
             Promise.Merge(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(e.ValueType);
                     canceled = true;
                 })
                 .Forget();
@@ -270,35 +216,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void MergePromiseIsCanceledWhenBothPromisesAreCanceled0()
-        {
-            CancelationSource cancelationSource1 = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource1.Token);
-            CancelationSource cancelationSource2 = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<string>(cancelationSource2.Token);
-
-            string expected = "Cancel";
-            bool canceled = false;
-
-            Promise.Merge(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(e =>
-                {
-                    Assert.AreEqual(expected, e.Value);
-                    canceled = true;
-                })
-                .Forget();
-
-            cancelationSource1.Cancel(expected);
-            cancelationSource2.Cancel("Different Cancel");
-
-            Assert.IsTrue(canceled);
-
-            cancelationSource1.Dispose();
-            cancelationSource2.Dispose();
-        }
-
-        [Test]
-        public void MergePromiseIsCanceledWhenBothPromisesAreCanceled1()
+        public void MergePromiseIsCanceledWhenBothPromisesAreCanceled()
         {
             CancelationSource cancelationSource1 = CancelationSource.New();
             var deferred1 = Promise.NewDeferred<int>(cancelationSource1.Token);
@@ -308,15 +226,14 @@ namespace ProtoPromiseTests.APIs
             bool canceled = false;
 
             Promise.Merge(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(e =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(e.ValueType);
                     canceled = true;
                 })
                 .Forget();
 
             cancelationSource1.Cancel();
-            cancelationSource2.Cancel("Different Cancel");
+            cancelationSource2.Cancel();
 
             Assert.IsTrue(canceled);
 
@@ -328,14 +245,12 @@ namespace ProtoPromiseTests.APIs
         public void MergePromiseIsCanceledWhenAnyPromiseIsAlreadyCanceled()
         {
             bool canceled = false;
-            string expected = "Cancel";
 
             var deferred = Promise.NewDeferred<int>();
 
-            Promise.Merge(deferred.Promise, Promise<int>.Canceled(expected))
-                .CatchCancelation(reason =>
+            Promise.Merge(deferred.Promise, Promise<int>.Canceled())
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(expected, reason.Value);
                     canceled = true;
                 })
                 .Forget();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/MiscellaneousTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/MiscellaneousTests.cs
@@ -48,8 +48,8 @@ namespace ProtoPromiseTests.APIs
             Assert.Throws<InvalidOperationException>(() => promise.Progress(v => { }));
             Assert.Throws<InvalidOperationException>(() => promise.Progress(1, (cv, v) => { }));
 #endif
-            Assert.Throws<InvalidOperationException>(() => promise.CatchCancelation(r => { }));
-            Assert.Throws<InvalidOperationException>(() => promise.CatchCancelation(1, (cv, r) => { }));
+            Assert.Throws<InvalidOperationException>(() => promise.CatchCancelation(() => { }));
+            Assert.Throws<InvalidOperationException>(() => promise.CatchCancelation(1, cv => { }));
 
             Assert.Throws<InvalidOperationException>(() => promise.Finally(() => { }));
             Assert.Throws<InvalidOperationException>(() => promise.Finally(1, cv => { }));
@@ -179,8 +179,8 @@ namespace ProtoPromiseTests.APIs
             Assert.Throws<InvalidOperationException>(() => promise.Progress(v => { }));
             Assert.Throws<InvalidOperationException>(() => promise.Progress(1, (cv, v) => { }));
 #endif
-            Assert.Throws<InvalidOperationException>(() => promise.CatchCancelation(r => { }));
-            Assert.Throws<InvalidOperationException>(() => promise.CatchCancelation(1, (cv, r) => { }));
+            Assert.Throws<InvalidOperationException>(() => promise.CatchCancelation(() => { }));
+            Assert.Throws<InvalidOperationException>(() => promise.CatchCancelation(1, cv => { }));
 
             Assert.Throws<InvalidOperationException>(() => promise.Finally(() => { }));
             Assert.Throws<InvalidOperationException>(() => promise.Finally(1, cv => { }));
@@ -468,24 +468,22 @@ namespace ProtoPromiseTests.APIs
             var promise = Promise.Resolved().Preserve();
 
             int cancelCount = 0;
-            string expected = "Cancel!";
 
-            Promise.CanceledAction onCancel = reason =>
+            System.Action onCancel = () =>
             {
-                Assert.AreEqual(expected, reason.Value);
                 ++cancelCount;
             };
 
             TestHelper.AddResolveCallbacks<int, string>(promise,
-                onResolve: () => { throw Promise.CancelException(expected); },
+                onResolve: () => { throw Promise.CancelException(); },
                 onCancel: onCancel
             );
             TestHelper.AddCallbacks<int, object, string>(promise,
-                onResolve: () => { throw Promise.CancelException(expected); },
+                onResolve: () => { throw Promise.CancelException(); },
                 onCancel: onCancel
             );
             TestHelper.AddContinueCallbacks<int, string>(promise,
-                onContinue: _ => { throw Promise.CancelException(expected); },
+                onContinue: _ => { throw Promise.CancelException(); },
                 onCancel: onCancel
             );
 
@@ -503,24 +501,22 @@ namespace ProtoPromiseTests.APIs
             var promise = Promise.Resolved(100).Preserve();
 
             int cancelCount = 0;
-            string expected = "Cancel!";
 
-            Promise.CanceledAction onCancel = reason =>
+            System.Action onCancel = () =>
             {
-                Assert.AreEqual(expected, reason.Value);
                 ++cancelCount;
             };
 
             TestHelper.AddResolveCallbacks<int, bool, string>(promise,
-                onResolve: v => { throw Promise.CancelException(expected); },
+                onResolve: v => { throw Promise.CancelException(); },
                 onCancel: onCancel
             );
             TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                onResolve: v => { throw Promise.CancelException(expected); },
+                onResolve: v => { throw Promise.CancelException(); },
                 onCancel: onCancel
             );
             TestHelper.AddContinueCallbacks<int, bool, string>(promise,
-                onContinue: _ => { throw Promise.CancelException(expected); },
+                onContinue: _ => { throw Promise.CancelException(); },
                 onCancel: onCancel
             );
 
@@ -538,21 +534,19 @@ namespace ProtoPromiseTests.APIs
             var promise = Promise.Rejected("Rejected").Preserve();
 
             int cancelCount = 0;
-            string expected = "Cancel!";
 
-            Promise.CanceledAction onCancel = reason =>
+            System.Action onCancel = () =>
             {
-                Assert.AreEqual(expected, reason.Value);
                 ++cancelCount;
             };
 
             TestHelper.AddCallbacks<int, object, string>(promise,
-                onReject: v => { throw Promise.CancelException(expected); },
-                onUnknownRejection: () => { throw Promise.CancelException(expected); },
+                onReject: v => { throw Promise.CancelException(); },
+                onUnknownRejection: () => { throw Promise.CancelException(); },
                 onCancel: onCancel
             );
             TestHelper.AddContinueCallbacks<int, string>(promise,
-                onContinue: _ => { throw Promise.CancelException(expected); },
+                onContinue: _ => { throw Promise.CancelException(); },
                 onCancel: onCancel
             );
 
@@ -570,21 +564,19 @@ namespace ProtoPromiseTests.APIs
             var promise = Promise<int>.Rejected("Rejected").Preserve();
 
             int cancelCount = 0;
-            string expected = "Cancel!";
 
-            Promise.CanceledAction onCancel = reason =>
+            System.Action onCancel = () =>
             {
-                Assert.AreEqual(expected, reason.Value);
                 ++cancelCount;
             };
 
             TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                onReject: v => { throw Promise.CancelException(expected); },
-                onUnknownRejection: () => { throw Promise.CancelException(expected); },
+                onReject: v => { throw Promise.CancelException(); },
+                onUnknownRejection: () => { throw Promise.CancelException(); },
                 onCancel: onCancel
             );
             TestHelper.AddContinueCallbacks<int, int, string>(promise,
-                onContinue: _ => { throw Promise.CancelException(expected); },
+                onContinue: _ => { throw Promise.CancelException(); },
                 onCancel: onCancel
             );
 
@@ -765,7 +757,7 @@ namespace ProtoPromiseTests.APIs
             bool resolved = false;
 
             Promise.Resolved()
-                .CatchCancelation(r => Assert.Fail("Promise was canceled when it should have been resolved"))
+                .CatchCancelation(() => Assert.Fail("Promise was canceled when it should have been resolved"))
                 .Then(() => resolved = true, () => Assert.Fail("Promise was rejected when it should have been resolved"))
                 .Forget();
 
@@ -779,7 +771,7 @@ namespace ProtoPromiseTests.APIs
             bool resolved = false;
 
             Promise.Resolved(expected)
-                .CatchCancelation(r => Assert.Fail("Promise was canceled when it should have been resolved"))
+                .CatchCancelation(() => Assert.Fail("Promise was canceled when it should have been resolved"))
                 .Then(val =>
                 {
                     Assert.AreEqual(expected, val);
@@ -797,7 +789,7 @@ namespace ProtoPromiseTests.APIs
             bool rejected = false;
 
             Promise.Rejected(expected)
-                .CatchCancelation(r => Assert.Fail("Promise was canceled when it should have been rejected"))
+                .CatchCancelation(() => Assert.Fail("Promise was canceled when it should have been rejected"))
                 .Then(() => Assert.Fail("Promise was resolved when it should have been rejected"),
                 (object reason) =>
                 {
@@ -816,7 +808,7 @@ namespace ProtoPromiseTests.APIs
             bool rejected = false;
 
             Promise<int>.Rejected(expected)
-                .CatchCancelation(r => Assert.Fail("Promise was canceled when it should have been rejected"))
+                .CatchCancelation(() => Assert.Fail("Promise was canceled when it should have been rejected"))
                 .Then(() => Assert.Fail("Promise was resolved when it should have been rejected"),
                 (object reason) =>
                 {
@@ -829,15 +821,13 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void PromiseCanceledIsCanceledWithTheGivenReason_void()
+        public void PromiseCanceledIsCanceled_void()
         {
-            string expected = "Cancel";
             bool canceled = false;
 
-            Promise.Canceled(expected)
-                .CatchCancelation(reason =>
+            Promise.Canceled()
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(expected, reason.Value);
                     canceled = true;
                 })
                 .Then(() => Assert.Fail("Promise was resolved when it should have been canceled"), () => Assert.Fail("Promise was rejected when it should have been canceled"))
@@ -847,15 +837,13 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void PromiseCanceledIsCanceledWithTheGivenReason_T()
+        public void PromiseCanceledIsCanceled_T()
         {
-            string expected = "Cancel";
             bool canceled = false;
 
-            Promise<int>.Canceled(expected)
-                .CatchCancelation(reason =>
+            Promise<int>.Canceled()
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(expected, reason.Value);
                     canceled = true;
                 })
                 .Then(() => Assert.Fail("Promise was resolved when it should have been canceled"), () => Assert.Fail("Promise was rejected when it should have been canceled"))

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/PromiseCancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/PromiseCancelationTests.cs
@@ -48,7 +48,7 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
-                    .CatchCancelation(_ => state = Canceled)
+                    .CatchCancelation(() => state = Canceled)
                     .Then(() => state = Resolved, () => state = Rejected)
                     .Forget();
                 Assert.IsNull(state);
@@ -63,7 +63,7 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
-                    .CatchCancelation(_ => state = Canceled)
+                    .CatchCancelation(() => state = Canceled)
                     .Then(() => state = Resolved, () => state = Rejected)
                     .Forget();
                 Assert.IsNull(state);
@@ -77,7 +77,7 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
-                    .CatchCancelation(_ => state = Canceled)
+                    .CatchCancelation(() => state = Canceled)
                     .Then(() => state = Resolved, () => state = Rejected)
                     .Forget();
                 Assert.IsNull(state);
@@ -94,12 +94,12 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
-                    .CatchCancelation(_ => state = Canceled)
+                    .CatchCancelation(() => state = Canceled)
                     .Then(() => state = Resolved, () => state = Rejected)
                     .Forget();
                 Assert.IsNull(state);
 
-                cancelationSource.Cancel("Cancel Value");
+                cancelationSource.Cancel();
                 Assert.IsFalse(deferred.IsValidAndPending);
 
                 Assert.AreEqual(Canceled, state);
@@ -116,7 +116,7 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
-                    .CatchCancelation(_ => state = Canceled)
+                    .CatchCancelation(() => state = Canceled)
                     .Then(v => state = Resolved, () => state = Rejected)
                     .Forget();
                 Assert.IsNull(state);
@@ -131,7 +131,7 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
-                    .CatchCancelation(_ => state = Canceled)
+                    .CatchCancelation(() => state = Canceled)
                     .Then(v => state = Resolved, () => state = Rejected)
                     .Forget();
                 Assert.IsNull(state);
@@ -145,7 +145,7 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
-                    .CatchCancelation(_ => state = Canceled)
+                    .CatchCancelation(() => state = Canceled)
                     .Then(v => state = Resolved, () => state = Rejected)
                     .Forget();
                 Assert.IsNull(state);
@@ -162,12 +162,12 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
-                    .CatchCancelation(_ => state = Canceled)
+                    .CatchCancelation(() => state = Canceled)
                     .Then(v => state = Resolved, () => state = Rejected)
                     .Forget();
                 Assert.IsNull(state);
 
-                cancelationSource.Cancel("Cancel Value");
+                cancelationSource.Cancel();
                 Assert.IsFalse(deferred.IsValidAndPending);
 
                 Assert.AreEqual(Canceled, state);
@@ -200,7 +200,7 @@ namespace ProtoPromiseTests.APIs
                 deferred.Promise
                     .Then(() => { resolved = true; })
                     .Catch(() => Assert.Fail("Promise was rejected when it was already resolved."))
-                    .CatchCancelation(e => Assert.Fail("Promise was canceled when it was already resolved."))
+                    .CatchCancelation(() => Assert.Fail("Promise was canceled when it was already resolved."))
                     .Forget();
 
                 deferred.Resolve();
@@ -228,7 +228,7 @@ namespace ProtoPromiseTests.APIs
                 deferred.Promise
                     .Then(v => { resolved = true; })
                     .Catch(() => Assert.Fail("Promise was rejected when it was already resolved."))
-                    .CatchCancelation(e => Assert.Fail("Promise was canceled when it was already resolved."))
+                    .CatchCancelation(() => Assert.Fail("Promise was canceled when it was already resolved."))
                     .Forget();
 
                 deferred.Resolve(1);
@@ -271,7 +271,7 @@ namespace ProtoPromiseTests.APIs
                 deferred.Promise
                     .Then(() => Assert.Fail("Promise was resolved when it was already rejected."))
                     .Catch(() => { rejected = true; })
-                    .CatchCancelation(e => Assert.Fail("Promise was canceled when it was already rejected."))
+                    .CatchCancelation(() => Assert.Fail("Promise was canceled when it was already rejected."))
                     .Forget();
 
                 deferred.Reject("Fail Value");
@@ -299,7 +299,7 @@ namespace ProtoPromiseTests.APIs
                 deferred.Promise
                     .Then(() => Assert.Fail("Promise was resolved when it was already rejected."))
                     .Catch(() => { rejected = true; })
-                    .CatchCancelation(e => Assert.Fail("Promise was canceled when it was already rejected."))
+                    .CatchCancelation(() => Assert.Fail("Promise was canceled when it was already rejected."))
                     .Forget();
 
                 deferred.Reject("Fail Value");
@@ -342,7 +342,7 @@ namespace ProtoPromiseTests.APIs
                 deferred.Promise
                     .Then(() => Assert.Fail("Promise was resolved when it was already canceled."))
                     .Catch(() => Assert.Fail("Promise was rejected when it was already canceled."))
-                    .CatchCancelation(e => { canceled = true; })
+                    .CatchCancelation(() => { canceled = true; })
                     .Forget();
 
                 cancelationSource.Cancel();
@@ -369,7 +369,7 @@ namespace ProtoPromiseTests.APIs
                 deferred.Promise
                     .Then(v => Assert.Fail("Promise was resolved when it was already canceled."))
                     .Catch(() => Assert.Fail("Promise was rejected when it was already canceled."))
-                    .CatchCancelation(e => { canceled = true; })
+                    .CatchCancelation(() => { canceled = true; })
                     .Forget();
 
                 cancelationSource.Cancel();
@@ -384,90 +384,6 @@ namespace ProtoPromiseTests.APIs
 
                 cancelationSource.Dispose();
             }
-
-            [Test]
-            public void MustHaveAReasonWhichMustNotChange_void()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred(cancelationSource.Token);
-                var promise = deferred.Promise.Preserve();
-
-                object cancelation = null;
-                string expected = "Cancel Value";
-
-                Action rejectAssert = () => Assert.Fail("Promise was rejected when it should have been resolved.");
-                Action resolveAssert = () => Assert.Fail("Promise was resolved when it should have been rejected.");
-
-                TestHelper.AddCallbacks<int, object, string>(promise,
-                    onResolve: resolveAssert,
-                    onReject: failValue => rejectAssert(),
-                    onUnknownRejection: rejectAssert);
-                promise
-                    .CatchCancelation(cancelValue => Assert.AreEqual(expected, cancelation = cancelValue.Value))
-                    .Forget();
-                cancelationSource.Cancel(expected);
-
-                Assert.AreEqual(expected, cancelation);
-
-                TestHelper.AddCallbacks<int, object, string>(promise,
-                    onResolve: resolveAssert,
-                    onReject: failValue => rejectAssert(),
-                    onUnknownRejection: rejectAssert);
-                promise
-                    .CatchCancelation(cancelValue => Assert.AreEqual(expected, cancelation = cancelValue.Value))
-                    .Forget();
-
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() =>
-                    cancelationSource.Cancel("Different Cancel Value")
-                );
-
-                Assert.AreEqual(expected, cancelation);
-
-                promise.Forget();
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void MustHaveAReasonWhichMustNotChange_T()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-                var promise = deferred.Promise.Preserve();
-
-                object cancelation = null;
-                string expected = "Cancel Value";
-
-                Action rejectAssert = () => Assert.Fail("Promise was rejected when it should have been resolved.");
-                Action resolveAssert = () => Assert.Fail("Promise was resolved when it should have been rejected.");
-
-                TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                    onResolve: _ => resolveAssert(),
-                    onReject: _ => rejectAssert(),
-                    onUnknownRejection: rejectAssert);
-                promise
-                    .CatchCancelation(cancelValue => Assert.AreEqual(expected, cancelation = cancelValue.Value))
-                    .Forget();
-                cancelationSource.Cancel(expected);
-
-                Assert.AreEqual(expected, cancelation);
-
-                TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                    onResolve: _ => resolveAssert(),
-                    onReject: _ => rejectAssert(),
-                    onUnknownRejection: rejectAssert);
-                promise
-                    .CatchCancelation(cancelValue => Assert.AreEqual(expected, cancelation = cancelValue.Value))
-                    .Forget();
-
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() =>
-                    cancelationSource.Cancel("Different Cancel Value")
-                );
-
-                Assert.AreEqual(expected, cancelation);
-
-                promise.Forget();
-                cancelationSource.Dispose();
-            }
         }
 
 #if PROMISE_DEBUG
@@ -479,7 +395,7 @@ namespace ProtoPromiseTests.APIs
 
             Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
             {
-                deferred.Promise.CatchCancelation(default(Promise.CanceledAction));
+                deferred.Promise.CatchCancelation(default(Action));
             });
 
             cancelationSource.Cancel();
@@ -495,7 +411,7 @@ namespace ProtoPromiseTests.APIs
 
             Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
             {
-                deferred.Promise.CatchCancelation(default(Promise.CanceledAction));
+                deferred.Promise.CatchCancelation(default(Action));
             });
 
             cancelationSource.Cancel();
@@ -519,20 +435,18 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void ItMustBeCalledAfterPromiseIsCanceledWithPromisesReasonAsItsFirstArgument()
+            public void ItMustBeCalledAfterPromiseIsCanceled()
             {
-                string cancelReason = "Cancel value";
                 var canceled = false;
                 CancelationSource cancelationSource = CancelationSource.New();
                 var deferred = Promise.NewDeferred(cancelationSource.Token);
                 deferred.Promise
-                    .CatchCancelation(r =>
+                    .CatchCancelation(() =>
                     {
-                        Assert.AreEqual(cancelReason, r.Value);
                         canceled = true;
                     })
                     .Forget();
-                cancelationSource.Cancel(cancelReason);
+                cancelationSource.Cancel();
 
                 Assert.True(canceled);
 
@@ -542,21 +456,19 @@ namespace ProtoPromiseTests.APIs
             [Test]
             public void ItMustNotBeCalledBeforePromiseIsCanceled()
             {
-                string cancelReason = "Cancel value";
                 var canceled = false;
                 CancelationSource cancelationSource = CancelationSource.New();
                 var deferred = Promise.NewDeferred(cancelationSource.Token);
                 deferred.Promise
-                    .CatchCancelation(r =>
+                    .CatchCancelation(() =>
                     {
-                        Assert.AreEqual(cancelReason, r.Value);
                         canceled = true;
                     })
                     .Forget();
 
                 Assert.False(canceled);
 
-                cancelationSource.Cancel(cancelReason);
+                cancelationSource.Cancel();
 
                 Assert.True(canceled);
 
@@ -570,12 +482,12 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred(cancelationSource.Token);
                 var cancelCount = 0;
                 deferred.Promise
-                    .CatchCancelation(r => ++cancelCount)
+                    .CatchCancelation(() => ++cancelCount)
                     .Forget();
-                cancelationSource.Cancel("Cancel value");
+                cancelationSource.Cancel();
 
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() =>
-                    cancelationSource.Cancel("Cancel value")
+                    cancelationSource.Cancel()
                 );
 
                 Assert.AreEqual(1, cancelCount);
@@ -593,9 +505,9 @@ namespace ProtoPromiseTests.APIs
             bool canceled = false;
             deferred.Promise
                 .WaitAsync(SynchronizationOption.Foreground)
-                .CatchCancelation(e => canceled = true)
+                .CatchCancelation(() => canceled = true)
                 .Forget();
-            cancelationSource.Cancel("Cancel value");
+            cancelationSource.Cancel();
             Assert.False(canceled);
 
             TestHelper.ExecuteForegroundCallbacks();
@@ -627,9 +539,9 @@ namespace ProtoPromiseTests.APIs
 
                 int counter = 0;
 
-                promise.CatchCancelation(e => Assert.AreEqual(0, counter++)).Forget();
-                promise.CatchCancelation(e => Assert.AreEqual(1, counter++)).Forget();
-                promise.CatchCancelation(e => Assert.AreEqual(2, counter++)).Forget();
+                promise.CatchCancelation(() => Assert.AreEqual(0, counter++)).Forget();
+                promise.CatchCancelation(() => Assert.AreEqual(1, counter++)).Forget();
+                promise.CatchCancelation(() => Assert.AreEqual(2, counter++)).Forget();
 
                 cancelationSource.Cancel();
 
@@ -707,7 +619,7 @@ namespace ProtoPromiseTests.APIs
 
             deferred.Promise
                 .Then(() => { })
-                .CatchCancelation(e => invoked = true)
+                .CatchCancelation(() => invoked = true)
                 .Forget();
 
             cancelationSource.Cancel();
@@ -718,26 +630,24 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void IfPromiseIsCanceledAndAPreviousPromiseIsAlsoCanceled_PromiseMustBeCanceledWithTheInitialCancelReason()
+        public void IfPromiseIsCanceledAndAPreviousPromiseIsAlsoCanceled_onCanceledMustBeCalled()
         {
             var deferred = Promise.NewDeferred();
 
             bool invoked = false;
 
-            object cancelValue = "Cancel";
             CancelationSource cancelationSource = CancelationSource.New();
 
             deferred.Promise
                 .Then(() => { }, cancelationSource.Token)
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(cancelValue, reason.Value);
                     invoked = true;
                 })
                 .Finally(cancelationSource.Dispose)
                 .Forget();
 
-            cancelationSource.Cancel(cancelValue);
+            cancelationSource.Cancel();
             deferred.Resolve();
 
             Assert.IsTrue(invoked);
@@ -747,39 +657,40 @@ namespace ProtoPromiseTests.APIs
         public void APromiseMayBeCanceledWhenItIsPending()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            string cancelValue = "Cancel";
             var deferred = Promise.NewDeferred();
 
+            bool canceled = false;
+
             deferred.Promise
-                .Then(() => cancelationSource.Cancel(cancelValue))
+                .Then(() => cancelationSource.Cancel())
                 .Then(() => { }, cancelationSource.Token)
                 .Then(() => Assert.Fail("Promise was resolved when it should have been canceled."),
                     () => Assert.Fail("Promise was rejected when it should have been canceled."))
-                .CatchCancelation(reason => Assert.AreEqual(cancelValue, reason.Value))
+                .CatchCancelation(() => canceled = true)
                 .Finally(cancelationSource.Dispose)
                 .Forget();
 
             deferred.Resolve();
+            Assert.IsTrue(canceled);
         }
 
         [Test]
         public void CatchCancelationCaptureValue()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            string cancelValue = "Cancel";
             int captureValue = 100;
             var deferred = Promise.NewDeferred();
             var promise = deferred.Promise.Preserve();
 
             promise
                 .Then(() => { }, cancelationSource.Token)
-                .CatchCancelation(captureValue, (cv, _) => Assert.AreEqual(captureValue, cv))
+                .CatchCancelation(captureValue, cv => Assert.AreEqual(captureValue, cv))
                 .Forget();
             promise
                 .Then(() => 1f, cancelationSource.Token)
-                .CatchCancelation(captureValue, (cv, _) => Assert.AreEqual(captureValue, cv))
+                .CatchCancelation(captureValue, cv => Assert.AreEqual(captureValue, cv))
                 .Forget();
-            cancelationSource.Cancel(cancelValue);
+            cancelationSource.Cancel();
 
             deferred.Resolve();
 
@@ -804,17 +715,15 @@ namespace ProtoPromiseTests.APIs
             [Test]
             public void DeferredIsCanceledFromAlreadyCanceledToken()
             {
-                string cancelReason = "Cancel value";
                 var canceled = false;
                 CancelationSource cancelationSource = CancelationSource.New();
-                cancelationSource.Cancel(cancelReason);
+                cancelationSource.Cancel();
 
                 var deferred = Promise.NewDeferred(cancelationSource.Token);
 
                 deferred.Promise
-                    .CatchCancelation(r =>
+                    .CatchCancelation(() =>
                     {
-                        Assert.AreEqual(cancelReason, r.Value);
                         canceled = true;
                     })
                     .Forget();
@@ -831,8 +740,8 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred(cancelationSource.Token);
 
                 deferred.Promise
-                    .CatchCancelation(_ => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
-                    .CatchCancelation(1, (cv, _) => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(1, cv => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
                     .Forget();
 
                 cancelationSource.Cancel();
@@ -847,8 +756,8 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
 
                 deferred.Promise
-                    .CatchCancelation(_ => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
-                    .CatchCancelation(1, (cv, _) => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(1, cv => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
                     .Forget();
 
                 cancelationSource.Cancel();
@@ -864,8 +773,8 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred(deferredCancelationSource.Token);
 
                 deferred.Promise
-                    .CatchCancelation(_ => Assert.Fail("OnCanceled was invoked."), catchCancelationSource.Token)
-                    .CatchCancelation(1, (cv, _) => Assert.Fail("OnCanceled was invoked."), catchCancelationSource.Token)
+                    .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), catchCancelationSource.Token)
+                    .CatchCancelation(1, cv => Assert.Fail("OnCanceled was invoked."), catchCancelationSource.Token)
                     .Forget();
 
                 catchCancelationSource.Cancel();
@@ -883,8 +792,8 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred<int>(deferredCancelationSource.Token);
 
                 deferred.Promise
-                    .CatchCancelation(_ => Assert.Fail("OnCanceled was invoked."), catchCancelationSource.Token)
-                    .CatchCancelation(1, (cv, _) => Assert.Fail("OnCanceled was invoked."), catchCancelationSource.Token)
+                    .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), catchCancelationSource.Token)
+                    .CatchCancelation(1, cv => Assert.Fail("OnCanceled was invoked."), catchCancelationSource.Token)
                     .Forget();
 
                 catchCancelationSource.Cancel();
@@ -901,12 +810,12 @@ namespace ProtoPromiseTests.APIs
                 cancelationSource.Cancel();
 
                 Promise.Canceled()
-                    .CatchCancelation(_ => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
-                    .CatchCancelation(1, (cv, _) => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(1, cv => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
                     .Forget();
                 Promise.Canceled<int>()
-                    .CatchCancelation(_ => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
-                    .CatchCancelation(1, (cv, _) => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(1, cv => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
                     .Forget();
 
                 cancelationSource.Dispose();
@@ -919,8 +828,8 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred();
 
                 deferred.Promise
-                    .CatchCancelation(_ => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
-                    .CatchCancelation(1, (cv, _) => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(1, cv => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
                     .Forget();
 
                 deferred.Resolve();
@@ -936,8 +845,8 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred<int>();
 
                 deferred.Promise
-                    .CatchCancelation(_ => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
-                    .CatchCancelation(1, (cv, _) => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(1, cv => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
                     .Forget();
 
                 deferred.Resolve(1);
@@ -953,8 +862,8 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred();
 
                 deferred.Promise
-                    .CatchCancelation(_ => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
-                    .CatchCancelation(1, (cv, _) => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(1, cv => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
                     .Forget();
 
                 deferred.Resolve();
@@ -969,8 +878,8 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred<int>();
 
                 deferred.Promise
-                    .CatchCancelation(_ => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
-                    .CatchCancelation(1, (cv, _) => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
+                    .CatchCancelation(1, cv => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
                     .Forget();
 
                 deferred.Resolve(1);
@@ -1269,20 +1178,20 @@ namespace ProtoPromiseTests.APIs
                 TestHelper.AddResolveCallbacksWithCancelation<float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: _ => ++cancelCallbacks,
-                    onCancelCapture: (_, __) => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks,
+                    onCancelCapture: _ => ++cancelCallbacks
                 );
                 TestHelper.AddCallbacksWithCancelation<float, object, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: _ => ++cancelCallbacks,
-                    onCancelCapture: (_, __) => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks,
+                    onCancelCapture: _ => ++cancelCallbacks
                 );
                 TestHelper.AddContinueCallbacksWithCancelation<float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: _ => ++cancelCallbacks,
-                    onCancelCapture: (_, __) => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks,
+                    onCancelCapture: _ => ++cancelCallbacks
                 );
 
                 cancelationSource.Cancel();
@@ -1310,20 +1219,20 @@ namespace ProtoPromiseTests.APIs
                 TestHelper.AddResolveCallbacksWithCancelation<int, float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: _ => ++cancelCallbacks,
-                    onCancelCapture: (_, __) => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks,
+                    onCancelCapture: _ => ++cancelCallbacks
                 );
                 TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: _ => ++cancelCallbacks,
-                    onCancelCapture: (_, __) => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks,
+                    onCancelCapture: _ => ++cancelCallbacks
                 );
                 TestHelper.AddContinueCallbacksWithCancelation<int, float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: _ => ++cancelCallbacks,
-                    onCancelCapture: (_, __) => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks,
+                    onCancelCapture: _ => ++cancelCallbacks
                 );
 
                 cancelationSource.Cancel();
@@ -1352,20 +1261,20 @@ namespace ProtoPromiseTests.APIs
                 TestHelper.AddResolveCallbacksWithCancelation<float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: _ => ++cancelCallbacks,
-                    onCancelCapture: (_, __) => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks,
+                    onCancelCapture: _ => ++cancelCallbacks
                 );
                 TestHelper.AddCallbacksWithCancelation<float, object, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: _ => ++cancelCallbacks,
-                    onCancelCapture: (_, __) => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks,
+                    onCancelCapture: _ => ++cancelCallbacks
                 );
                 TestHelper.AddContinueCallbacksWithCancelation<float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: _ => ++cancelCallbacks,
-                    onCancelCapture: (_, __) => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks,
+                    onCancelCapture: _ => ++cancelCallbacks
                 );
 
                 deferred.Resolve();
@@ -1393,20 +1302,20 @@ namespace ProtoPromiseTests.APIs
                 TestHelper.AddResolveCallbacksWithCancelation<int, float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: _ => ++cancelCallbacks,
-                    onCancelCapture: (_, __) => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks,
+                    onCancelCapture: _ => ++cancelCallbacks
                 );
                 TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: _ => ++cancelCallbacks,
-                    onCancelCapture: (_, __) => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks,
+                    onCancelCapture: _ => ++cancelCallbacks
                 );
                 TestHelper.AddContinueCallbacksWithCancelation<int, float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: _ => ++cancelCallbacks,
-                    onCancelCapture: (_, __) => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks,
+                    onCancelCapture: _ => ++cancelCallbacks
                 );
 
                 deferred.Resolve(1);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/RaceTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/RaceTests.cs
@@ -226,65 +226,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RaceIsCanceledWhenFirstPromiseIsCanceledFirst_void0()
-        {
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred(cancelationSource.Token);
-            var deferred2 = Promise.NewDeferred();
-
-            bool invoked = false;
-            string expected = "Cancel";
-
-            Promise.Race(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
-                {
-                    Assert.AreEqual(expected, reason.Value);
-                    invoked = true;
-                })
-                .Forget();
-
-            cancelationSource.Cancel(expected);
-
-            Assert.IsTrue(invoked);
-
-            deferred2.Resolve();
-
-            cancelationSource.Dispose();
-
-            Assert.IsTrue(invoked);
-        }
-
-        [Test]
-        public void RaceIsCanceledWhenFirstPromiseIsCanceledFirst_T0()
-        {
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource.Token);
-            var deferred2 = Promise.NewDeferred<int>();
-
-            bool invoked = false;
-            string expected = "Cancel";
-
-            Promise<int>.Race(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
-                {
-                    Assert.AreEqual(expected, reason.Value);
-                    invoked = true;
-                })
-                .Forget();
-
-            cancelationSource.Cancel(expected);
-
-            Assert.IsTrue(invoked);
-
-            deferred2.Resolve(5);
-
-            cancelationSource.Dispose();
-
-            Assert.IsTrue(invoked);
-        }
-
-        [Test]
-        public void RaceIsCanceledWhenFirstPromiseIsCanceledFirst_void1()
+        public void RaceIsCanceledWhenFirstPromiseIsCanceledFirst_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred1 = Promise.NewDeferred(cancelationSource.Token);
@@ -293,9 +235,8 @@ namespace ProtoPromiseTests.APIs
             bool invoked = false;
 
             Promise.Race(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(reason.ValueType);
                     invoked = true;
                 })
                 .Forget();
@@ -312,7 +253,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RaceIsCanceledWhenFirstPromiseIsCanceledFirst_T1()
+        public void RaceIsCanceledWhenFirstPromiseIsCanceledFirst_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred1 = Promise.NewDeferred<int>(cancelationSource.Token);
@@ -321,9 +262,8 @@ namespace ProtoPromiseTests.APIs
             bool invoked = false;
 
             Promise<int>.Race(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(reason.ValueType);
                     invoked = true;
                 })
                 .Forget();
@@ -340,65 +280,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RaceIsCanceledWhenSecondPromiseIsCanceledFirst_void0()
-        {
-            var deferred1 = Promise.NewDeferred();
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
-
-            bool invoked = false;
-            string expected = "Cancel";
-
-            Promise.Race(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
-                {
-                    Assert.AreEqual(expected, reason.Value);
-                    invoked = true;
-                })
-                .Forget();
-
-            cancelationSource.Cancel(expected);
-
-            Assert.IsTrue(invoked);
-
-            deferred1.Resolve();
-
-            cancelationSource.Dispose();
-
-            Assert.IsTrue(invoked);
-        }
-
-        [Test]
-        public void RaceIsCanceledWhenSecondPromiseIsCanceledFirst_T0()
-        {
-            var deferred1 = Promise.NewDeferred<int>();
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource.Token);
-
-            bool invoked = false;
-            string expected = "Cancel";
-
-            Promise<int>.Race(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
-                {
-                    Assert.AreEqual(expected, reason.Value);
-                    invoked = true;
-                })
-                .Forget();
-
-            cancelationSource.Cancel(expected);
-
-            Assert.IsTrue(invoked);
-
-            deferred1.Resolve(5);
-
-            cancelationSource.Dispose();
-
-            Assert.IsTrue(invoked);
-        }
-
-        [Test]
-        public void RaceIsCanceledWhenSecondPromiseIsCanceledFirst_void1()
+        public void RaceIsCanceledWhenSecondPromiseIsCanceledFirst_void()
         {
             var deferred1 = Promise.NewDeferred();
             CancelationSource cancelationSource = CancelationSource.New();
@@ -407,9 +289,8 @@ namespace ProtoPromiseTests.APIs
             bool invoked = false;
 
             Promise.Race(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(reason.ValueType);
                     invoked = true;
                 })
                 .Forget();
@@ -426,7 +307,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RaceIsCanceledWhenSecondPromiseIsCanceledFirst_T1()
+        public void RaceIsCanceledWhenSecondPromiseIsCanceledFirst_T()
         {
             var deferred1 = Promise.NewDeferred<int>();
             CancelationSource cancelationSource = CancelationSource.New();
@@ -435,9 +316,8 @@ namespace ProtoPromiseTests.APIs
             bool invoked = false;
 
             Promise<int>.Race(deferred1.Promise, deferred2.Promise)
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
-                    Assert.IsNull(reason.ValueType);
                     invoked = true;
                 })
                 .Forget();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/SequenceTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/SequenceTests.cs
@@ -179,12 +179,12 @@ namespace ProtoPromiseTests.APIs
             bool invoked = false;
 
             Promise.Sequence(() => deferred1.Promise, () => deferred2.Promise)
-                .CatchCancelation(e => invoked = true)
+                .CatchCancelation(() => invoked = true)
                 .Forget();
 
             Assert.IsFalse(invoked);
 
-            cancelationSource.Cancel("Cancel");
+            cancelationSource.Cancel();
 
             Assert.IsTrue(invoked);
 
@@ -206,7 +206,7 @@ namespace ProtoPromiseTests.APIs
             bool invoked = false;
 
             Promise.Sequence(() => deferred1.Promise, () => deferred2.Promise)
-                .CatchCancelation(e => invoked = true)
+                .CatchCancelation(() => invoked = true)
                 .Forget();
 
             Assert.IsFalse(invoked);
@@ -215,7 +215,7 @@ namespace ProtoPromiseTests.APIs
 
             Assert.IsFalse(invoked);
 
-            cancelationSource.Cancel("Cancel");
+            cancelationSource.Cancel();
 
             Assert.IsTrue(invoked);
 
@@ -239,7 +239,7 @@ namespace ProtoPromiseTests.APIs
 
             Assert.AreEqual(1, invokes);
 
-            cancelationSource.Cancel("Cancel");
+            cancelationSource.Cancel();
 
             Assert.AreEqual(1, invokes);
 
@@ -255,14 +255,12 @@ namespace ProtoPromiseTests.APIs
         public void SequencePromiseIsCanceledWhenAnyPromiseIsAlreadyCanceled()
         {
             bool invoked = false;
-            string cancelation = "Cancel";
 
             var deferred = Promise.NewDeferred<int>();
 
-            Promise.Sequence(() => deferred.Promise, () => Promise<int>.Canceled(cancelation))
-                .CatchCancelation(reason =>
+            Promise.Sequence(() => deferred.Promise, () => Promise<int>.Canceled())
+                .CatchCancelation(() =>
                 {
-                    Assert.AreEqual(cancelation, reason.Value);
                     invoked = true;
                 })
                 .Forget();
@@ -296,7 +294,7 @@ namespace ProtoPromiseTests.APIs
                     return Promise.Resolved();
                 }
             )
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
                     canceled = true;
                 })
@@ -392,7 +390,7 @@ namespace ProtoPromiseTests.APIs
                     return Promise.Resolved();
                 }
             )
-                .CatchCancelation(reason =>
+                .CatchCancelation(() =>
                 {
                     canceled = true;
                 })

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/WaitAsyncTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/WaitAsyncTests.cs
@@ -741,7 +741,7 @@ namespace ProtoPromiseTests.APIs
             {
                 ++expectedInvokes;
                 p.ConfigureAwait((ConfigureAwaitType) waitType)
-                    .CatchCancelation(_ =>
+                    .CatchCancelation(() =>
                     {
                         Interlocked.Increment(ref invokeCounter);
                         TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
@@ -752,7 +752,7 @@ namespace ProtoPromiseTests.APIs
             {
                 ++expectedInvokes;
                 p.ConfigureAwait((ConfigureAwaitType) waitType)
-                    .CatchCancelation(1, (cv, reason) =>
+                    .CatchCancelation(1, cv =>
                     {
                         Interlocked.Increment(ref invokeCounter);
                         TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
@@ -806,7 +806,7 @@ namespace ProtoPromiseTests.APIs
             {
                 ++expectedInvokes;
                 p.ConfigureAwait((ConfigureAwaitType) waitType)
-                    .CatchCancelation(_ =>
+                    .CatchCancelation(() =>
                     {
                         Interlocked.Increment(ref invokeCounter);
                         TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
@@ -817,7 +817,7 @@ namespace ProtoPromiseTests.APIs
             {
                 ++expectedInvokes;
                 p.ConfigureAwait((ConfigureAwaitType) waitType)
-                    .CatchCancelation(1, (cv, reason) =>
+                    .CatchCancelation(1, cv =>
                     {
                         Interlocked.Increment(ref invokeCounter);
                         TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/TestHelper.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/TestHelper.cs
@@ -418,7 +418,7 @@ namespace ProtoPromiseTests
                     }
                     else if (result.State == Promise.State.Canceled)
                     {
-                        d.Cancel(result.CancelContainer.Value);
+                        d.Cancel();
                     }
                     else
                     {
@@ -450,7 +450,7 @@ namespace ProtoPromiseTests
                     }
                     else if (result.State == Promise.State.Canceled)
                     {
-                        d.Cancel(result.CancelContainer.Value);
+                        d.Cancel();
                     }
                     else
                     {
@@ -484,7 +484,7 @@ namespace ProtoPromiseTests
             Action<TCapture> onResolveCapture = null, TCapture captureValue = default(TCapture),
             Func<Promise, Promise> promiseToPromise = null, Func<Promise<TConvert>, Promise<TConvert>> promiseToPromiseConvert = null,
             TestAction<Promise> onCallbackAdded = null, TestAction<Promise<TConvert>> onCallbackAddedConvert = null,
-            Promise.CanceledAction onCancel = null, Promise.CanceledAction<TCapture> onCancelCapture = null,
+            Action onCancel = null, Action<TCapture> onCancelCapture = null,
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None)
         {
@@ -526,7 +526,7 @@ namespace ProtoPromiseTests
             Func<Promise, Promise> promiseToPromise = null, Func<Promise<TConvert>, Promise<TConvert>> promiseToPromiseConvert = null,
             TestAction<Promise> onCallbackAdded = null, TestAction<Promise<TConvert>> onCallbackAddedConvert = null,
             CancelationToken cancelationToken = default(CancelationToken),
-            Promise.CanceledAction onCancel = null, Promise.CanceledAction<TCapture> onCancelCapture = null,
+            Action onCancel = null, Action<TCapture> onCancelCapture = null,
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None)
         {
@@ -560,8 +560,8 @@ namespace ProtoPromiseTests
             {
                 onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
             }
-            onCancel += _ => { };
-            onCancelCapture += (_, __) => { };
+            onCancel += () => { };
+            onCancelCapture += _ => { };
 
             foreach (var p in GetTestablePromises(promise))
             {
@@ -649,7 +649,7 @@ namespace ProtoPromiseTests
             Action<TCapture> onResolveCapture = null, TCapture captureValue = default(TCapture),
             Func<Promise, Promise> promiseToPromise = null, Func<Promise<TConvert>, Promise<TConvert>> promiseToPromiseConvert = null,
             TestAction<Promise> onCallbackAdded = null, TestAction<Promise<TConvert>> onCallbackAddedConvert = null,
-            Promise.CanceledAction onCancel = null, Promise.CanceledAction<TCapture> onCancelCapture = null,
+            Action onCancel = null, Action<TCapture> onCancelCapture = null,
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None)
         {
@@ -691,7 +691,7 @@ namespace ProtoPromiseTests
             Func<Promise, Promise> promiseToPromise = null, Func<Promise<TConvert>, Promise<TConvert>> promiseToPromiseConvert = null,
             TestAction<Promise> onCallbackAdded = null, TestAction<Promise<TConvert>> onCallbackAddedConvert = null,
             CancelationToken cancelationToken = default(CancelationToken),
-            Promise.CanceledAction onCancel = null, Promise.CanceledAction<TCapture> onCancelCapture = null,
+            Action onCancel = null, Action<TCapture> onCancelCapture = null,
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None)
         {
@@ -725,8 +725,8 @@ namespace ProtoPromiseTests
             {
                 onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
             }
-            onCancel += _ => { };
-            onCancelCapture += (_, __) => { };
+            onCancel += () => { };
+            onCancelCapture += _ => { };
 
             foreach (var p in GetTestablePromises(promise))
             {
@@ -814,7 +814,7 @@ namespace ProtoPromiseTests
             Action<TCapture> onResolveCapture = null, Action<TCapture> onRejectCapture = null, Action<TCapture> onUnknownRejectionCapture = null, TCapture captureValue = default(TCapture),
             Func<Promise, Promise> promiseToPromise = null, Func<Promise<TConvert>, Promise<TConvert>> promiseToPromiseConvert = null,
             TestAction<Promise> onCallbackAdded = null, TestAction<Promise<TConvert>> onCallbackAddedConvert = null,
-            Promise.CanceledAction onCancel = null, Promise.CanceledAction<TCapture> onCancelCapture = null,
+            Action onCancel = null, Action<TCapture> onCancelCapture = null,
             TestAction<Promise> onDirectCallbackAdded = null, TestAction<Promise<TConvert>> onDirectCallbackAddedConvert = null, TestAction<Promise> onDirectCallbackAddedCatch = null,
             TestAction<Promise, AdoptLocation> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>, AdoptLocation> onAdoptCallbackAddedConvert = null, TestAction<Promise> onAdoptCallbackAddedCatch = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None)
@@ -859,7 +859,7 @@ namespace ProtoPromiseTests
             Func<Promise, Promise> promiseToPromise = null, Func<Promise<TConvert>, Promise<TConvert>> promiseToPromiseConvert = null,
             TestAction<Promise> onCallbackAdded = null, TestAction<Promise<TConvert>> onCallbackAddedConvert = null,
             CancelationToken cancelationToken = default(CancelationToken),
-            Promise.CanceledAction onCancel = null, Promise.CanceledAction<TCapture> onCancelCapture = null,
+            Action onCancel = null, Action<TCapture> onCancelCapture = null,
             TestAction<Promise> onDirectCallbackAdded = null, TestAction<Promise<TConvert>> onDirectCallbackAddedConvert = null, TestAction<Promise> onDirectCallbackAddedCatch = null,
             TestAction<Promise, AdoptLocation> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>, AdoptLocation> onAdoptCallbackAddedConvert = null, TestAction<Promise> onAdoptCallbackAddedCatch = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None)
@@ -914,8 +914,8 @@ namespace ProtoPromiseTests
             {
                 onAdoptCallbackAddedCatch = (ref Promise p) => { };
             }
-            onCancel += _ => { };
-            onCancelCapture += (_, __) => { };
+            onCancel += () => { };
+            onCancelCapture += _ => { };
 
             foreach (var p in GetTestablePromises(promise))
             {
@@ -1668,7 +1668,7 @@ namespace ProtoPromiseTests
             Action<TCapture> onResolveCapture = null, Action<TCapture> onRejectCapture = null, Action<TCapture> onUnknownRejectionCapture = null, TCapture captureValue = default(TCapture),
             Func<Promise, Promise> promiseToPromise = null, Func<Promise<TConvert>, Promise<TConvert>> promiseToPromiseConvert = null, Func<Promise<T>, Promise<T>> promiseToPromiseT = null,
             TestAction<Promise> onCallbackAdded = null, TestAction<Promise<TConvert>> onCallbackAddedConvert = null, TestAction<Promise<T>> onCallbackAddedT = null,
-            Promise.CanceledAction onCancel = null, Promise.CanceledAction<TCapture> onCancelCapture = null,
+            Action onCancel = null, Action<TCapture> onCancelCapture = null,
             TestAction<Promise> onDirectCallbackAdded = null, TestAction<Promise<TConvert>> onDirectCallbackAddedConvert = null, TestAction<Promise<T>> onDirectCallbackAddedT = null,
             TestAction<Promise, AdoptLocation> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>, AdoptLocation> onAdoptCallbackAddedConvert = null, TestAction<Promise<T>> onAdoptCallbackAddedT = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None)
@@ -1713,7 +1713,7 @@ namespace ProtoPromiseTests
             Func<Promise, Promise> promiseToPromise = null, Func<Promise<TConvert>, Promise<TConvert>> promiseToPromiseConvert = null, Func<Promise<T>, Promise<T>> promiseToPromiseT = null,
             TestAction<Promise> onCallbackAdded = null, TestAction<Promise<TConvert>> onCallbackAddedConvert = null, TestAction<Promise<T>> onCallbackAddedT = null,
             CancelationToken cancelationToken = default(CancelationToken),
-            Promise.CanceledAction onCancel = null, Promise.CanceledAction<TCapture> onCancelCapture = null,
+            Action onCancel = null, Action<TCapture> onCancelCapture = null,
             TestAction<Promise> onDirectCallbackAdded = null, TestAction<Promise<TConvert>> onDirectCallbackAddedConvert = null, TestAction<Promise<T>> onDirectCallbackAddedT = null,
             TestAction<Promise, AdoptLocation> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>, AdoptLocation> onAdoptCallbackAddedConvert = null, TestAction<Promise<T>> onAdoptCallbackAddedT = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None)
@@ -1776,8 +1776,8 @@ namespace ProtoPromiseTests
             {
                 onAdoptCallbackAddedT = (ref Promise<T> p) => { };
             }
-            onCancel += _ => { };
-            onCancelCapture += (_, __) => { };
+            onCancel += () => { };
+            onCancelCapture += _ => { };
 
             foreach (var p in GetTestablePromises(promise))
             {
@@ -2532,7 +2532,7 @@ namespace ProtoPromiseTests
             Promise.ContinueAction<TCapture> onContinueCapture = null, TCapture captureValue = default(TCapture),
             Func<Promise, Promise> promiseToPromise = null, Func<Promise<TConvert>, Promise<TConvert>> promiseToPromiseConvert = null,
             TestAction<Promise> onCallbackAdded = null, TestAction<Promise<TConvert>> onCallbackAddedConvert = null,
-            Promise.CanceledAction onCancel = null, Promise.CanceledAction<TCapture> onCancelCapture = null,
+            Action onCancel = null, Action<TCapture> onCancelCapture = null,
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None)
         {
@@ -2574,7 +2574,7 @@ namespace ProtoPromiseTests
             Func<Promise, Promise> promiseToPromise = null, Func<Promise<TConvert>, Promise<TConvert>> promiseToPromiseConvert = null,
             TestAction<Promise> onCallbackAdded = null, TestAction<Promise<TConvert>> onCallbackAddedConvert = null,
             CancelationToken cancelationToken = default(CancelationToken),
-            Promise.CanceledAction onCancel = null, Promise.CanceledAction<TCapture> onCancelCapture = null,
+            Action onCancel = null, Action<TCapture> onCancelCapture = null,
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None)
         {
@@ -2608,8 +2608,8 @@ namespace ProtoPromiseTests
             {
                 onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
             }
-            onCancel += _ => { };
-            onCancelCapture += (_, __) => { };
+            onCancel += () => { };
+            onCancelCapture += _ => { };
 
             foreach (var p in GetTestablePromises(promise))
             {
@@ -2696,7 +2696,7 @@ namespace ProtoPromiseTests
             Promise<T>.ContinueAction<TCapture> onContinueCapture = null, TCapture captureValue = default(TCapture),
             Func<Promise, Promise> promiseToPromise = null, Func<Promise<TConvert>, Promise<TConvert>> promiseToPromiseConvert = null,
             TestAction<Promise> onCallbackAdded = null, TestAction<Promise<TConvert>> onCallbackAddedConvert = null,
-            Promise.CanceledAction onCancel = null, Promise.CanceledAction<TCapture> onCancelCapture = null,
+            Action onCancel = null, Action<TCapture> onCancelCapture = null,
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None)
         {
@@ -2737,7 +2737,7 @@ namespace ProtoPromiseTests
             Func<Promise, Promise> promiseToPromise = null, Func<Promise<TConvert>, Promise<TConvert>> promiseToPromiseConvert = null,
             TestAction<Promise> onCallbackAdded = null, TestAction<Promise<TConvert>> onCallbackAddedConvert = null,
             CancelationToken cancelationToken = default(CancelationToken),
-            Promise.CanceledAction onCancel = null, Promise.CanceledAction<TCapture> onCancelCapture = null,
+            Action onCancel = null, Action<TCapture> onCancelCapture = null,
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None)
         {
@@ -2771,8 +2771,8 @@ namespace ProtoPromiseTests
             {
                 onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
             }
-            onCancel += _ => { };
-            onCancelCapture += (_, __) => { };
+            onCancel += () => { };
+            onCancelCapture += _ => { };
 
             foreach (var p in GetTestablePromises(promise))
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/ApiWithCancelationTokenConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/ApiWithCancelationTokenConcurrencyTests.cs
@@ -190,8 +190,8 @@ namespace ProtoPromiseTests.Threading
             var threadHelper = new ThreadHelper();
             foreach (var action in new Func<Promise, CancelationToken, Promise>[]
                 {
-                    (promise, token) => promise.CatchCancelation(_ => { }, token),
-                    (promise, token) => promise.CatchCancelation(1, (cv, _) => { }, token),
+                    (promise, token) => promise.CatchCancelation(() => { }, token),
+                    (promise, token) => promise.CatchCancelation(1, cv => { }, token),
                 })
             {
                 threadHelper.ExecuteParallelActionsWithOffsets(false,
@@ -212,7 +212,7 @@ namespace ProtoPromiseTests.Threading
                     },
                     // Parallel actions
                     () => cancelationSource.Cancel(),
-                    () => deferred.Cancel(1)
+                    () => deferred.Cancel()
                 );
             }
         }
@@ -227,8 +227,8 @@ namespace ProtoPromiseTests.Threading
             var threadHelper = new ThreadHelper();
             foreach (var action in new Func<Promise<int>, CancelationToken, Promise<int>>[]
                 {
-                    (promise, token) => promise.CatchCancelation(_ => { }, token),
-                    (promise, token) => promise.CatchCancelation(1, (cv, _) => { }, token),
+                    (promise, token) => promise.CatchCancelation(() => { }, token),
+                    (promise, token) => promise.CatchCancelation(1, cv => { }, token),
                 })
             {
                 threadHelper.ExecuteParallelActionsWithOffsets(false,
@@ -249,7 +249,7 @@ namespace ProtoPromiseTests.Threading
                     },
                     // Parallel actions
                     () => cancelationSource.Cancel(),
-                    () => deferred.Cancel(1)
+                    () => deferred.Cancel()
                 );
             }
         }
@@ -509,8 +509,8 @@ namespace ProtoPromiseTests.Threading
             var threadHelper = new ThreadHelper();
             foreach (var action in new Func<Promise, CancelationToken, Promise>[]
                 {
-                    (p, token) => p.CatchCancelation(_ => { }, token),
-                    (p, token) => p.CatchCancelation(1, (cv, _) => { }, token),
+                    (p, token) => p.CatchCancelation(() => { }, token),
+                    (p, token) => p.CatchCancelation(1, cv => { }, token),
                 })
             {
                 threadHelper.ExecuteParallelActionsWithOffsets(false,
@@ -538,7 +538,7 @@ namespace ProtoPromiseTests.Threading
                     },
                     // Parallel actions
                     () => cancelationSource.Cancel(),
-                    () => deferred.Cancel(1),
+                    () => deferred.Cancel(),
                     () => action(promise.ConfigureAwait(configureAwaitType), cancelationToken)
                         .Finally(() =>
                         {
@@ -568,8 +568,8 @@ namespace ProtoPromiseTests.Threading
             var threadHelper = new ThreadHelper();
             foreach (var action in new Func<Promise<int>, CancelationToken, Promise<int>>[]
                 {
-                    (p, token) => p.CatchCancelation(_ => { }, token),
-                    (p, token) => p.CatchCancelation(1, (cv, _) => { }, token),
+                    (p, token) => p.CatchCancelation(() => { }, token),
+                    (p, token) => p.CatchCancelation(1, cv => { }, token),
                 })
             {
                 threadHelper.ExecuteParallelActionsWithOffsets(false,
@@ -597,7 +597,7 @@ namespace ProtoPromiseTests.Threading
                     },
                     // Parallel actions
                     () => cancelationSource.Cancel(),
-                    () => deferred.Cancel(1),
+                    () => deferred.Cancel(),
                     () => action(promise.ConfigureAwait(configureAwaitType), cancelationToken)
                         .Finally(() =>
                         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/DeferredConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/DeferredConcurrencyTests.cs
@@ -328,56 +328,7 @@ namespace ProtoPromiseTests.Threading
             int invokedCount = 0;
             var deferred = Promise.NewDeferred();
             deferred.Promise
-                .CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); })
-                .Forget();
-            int failedTryResolveCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() =>
-            {
-                if (!deferred.TryCancel("Cancel"))
-                {
-                    Interlocked.Increment(ref failedTryResolveCount);
-                }
-            });
-
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
-            Assert.AreEqual(1, invokedCount);
-        }
-
-        [Test]
-        public void DeferredCancelMayNotBeCalledConcurrently_void1()
-        {
-            int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
-            deferred.Promise
-                .CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); })
-                .Forget();
-            int failedTryResolveCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() =>
-            {
-                if (!deferred.TryCancel("Cancel"))
-                {
-                    Interlocked.Increment(ref failedTryResolveCount);
-                }
-            });
-
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
-            Assert.AreEqual(1, invokedCount);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void DeferredCancelMayNotBeCalledConcurrently_void2()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred();
-            deferred.Promise
-                .CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); })
+                .CatchCancelation(() => { Interlocked.Increment(ref invokedCount); })
                 .Forget();
             int failedTryResolveCount = 0;
 
@@ -395,13 +346,13 @@ namespace ProtoPromiseTests.Threading
         }
 
         [Test]
-        public void DeferredCancelMayNotBeCalledConcurrently_void3()
+        public void DeferredCancelMayNotBeCalledConcurrently_void1()
         {
             int invokedCount = 0;
             var cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
             deferred.Promise
-                .CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); })
+                .CatchCancelation(() => { Interlocked.Increment(ref invokedCount); })
                 .Forget();
             int failedTryResolveCount = 0;
 
@@ -426,56 +377,7 @@ namespace ProtoPromiseTests.Threading
             int invokedCount = 0;
             var deferred = Promise.NewDeferred<int>();
             deferred.Promise
-                .CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); })
-                .Forget();
-            int failedTryResolveCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() =>
-            {
-                if (!deferred.TryCancel("Cancel"))
-                {
-                    Interlocked.Increment(ref failedTryResolveCount);
-                }
-            });
-
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
-            Assert.AreEqual(1, invokedCount);
-        }
-
-        [Test]
-        public void DeferredCancelMayNotBeCalledConcurrently_T1()
-        {
-            int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-            deferred.Promise
-                .CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); })
-                .Forget();
-            int failedTryResolveCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() =>
-            {
-                if (!deferred.TryCancel("Cancel"))
-                {
-                    Interlocked.Increment(ref failedTryResolveCount);
-                }
-            });
-
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
-            Assert.AreEqual(1, invokedCount);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void DeferredCancelMayNotBeCalledConcurrently_T2()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred<int>();
-            deferred.Promise
-                .CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); })
+                .CatchCancelation(() => { Interlocked.Increment(ref invokedCount); })
                 .Forget();
             int failedTryResolveCount = 0;
 
@@ -493,13 +395,13 @@ namespace ProtoPromiseTests.Threading
         }
 
         [Test]
-        public void DeferredCancelMayNotBeCalledConcurrently_T3()
+        public void DeferredCancelMayNotBeCalledConcurrently_T1()
         {
             int invokedCount = 0;
             var cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
             deferred.Promise
-                .CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); })
+                .CatchCancelation(() => { Interlocked.Increment(ref invokedCount); })
                 .Forget();
             int failedTryResolveCount = 0;
 
@@ -880,72 +782,13 @@ namespace ProtoPromiseTests.Threading
                     Assert.AreEqual(1, invokedCount);
                 },
                 // Parallel Actions
-                () => cancelationSource.Cancel("Cancel"),
-                () => promise.CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); }).Forget()
+                () => cancelationSource.Cancel(),
+                () => promise.CatchCancelation(() => { Interlocked.Increment(ref invokedCount); }).Forget()
             );
         }
 
         [Test]
         public void DeferredMayBeCanceledAndPromiseAwaitedConcurrently_void1()
-        {
-            var cancelationSource = default(CancelationSource);
-            var deferred = default(Promise.Deferred);
-            var promise = default(Promise);
-
-            int invokedCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteParallelActionsWithOffsets(false,
-                // Setup
-                () =>
-                {
-                    invokedCount = 0;
-                    cancelationSource = CancelationSource.New();
-                    deferred = Promise.NewDeferred(cancelationSource.Token);
-                    promise = deferred.Promise;
-                },
-                // Teardown
-                () =>
-                {
-                    cancelationSource.Dispose();
-                    Assert.AreEqual(1, invokedCount);
-                },
-                // Parallel Actions
-                () => cancelationSource.Cancel(),
-                () => promise.CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); }).Forget()
-            );
-        }
-
-        [Test]
-        public void DeferredMayBeCanceledAndPromiseAwaitedConcurrently_void2()
-        {
-            var deferred = default(Promise.Deferred);
-            var promise = default(Promise);
-
-            int invokedCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteParallelActionsWithOffsets(false,
-                // Setup
-                () =>
-                {
-                    invokedCount = 0;
-                    deferred = Promise.NewDeferred();
-                    promise = deferred.Promise;
-                },
-                // Teardown
-                () =>
-                {
-                    Assert.AreEqual(1, invokedCount);
-                },
-                // Parallel Actions
-                () => deferred.Cancel("Cancel"),
-                () => promise.CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); }).Forget()
-            );
-        }
-
-        [Test]
-        public void DeferredMayBeCanceledAndPromiseAwaitedConcurrently_void3()
         {
             var deferred = default(Promise.Deferred);
             var promise = default(Promise);
@@ -968,7 +811,7 @@ namespace ProtoPromiseTests.Threading
                 },
                 // Parallel Actions
                 () => deferred.Cancel(),
-                () => promise.CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); }).Forget()
+                () => promise.CatchCancelation(() => { Interlocked.Increment(ref invokedCount); }).Forget()
             );
         }
 
@@ -998,39 +841,8 @@ namespace ProtoPromiseTests.Threading
                     Assert.AreEqual(1, invokedCount);
                 },
                 // Parallel Actions
-                () => cancelationSource.Cancel("Cancel"),
-                () => promise.CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); }).Forget()
-            );
-        }
-
-        [Test]
-        public void DeferredMayBeCanceledAndPromiseAwaitedConcurrently_T1()
-        {
-            var cancelationSource = default(CancelationSource);
-            var deferred = default(Promise<int>.Deferred);
-            var promise = default(Promise<int>);
-
-            int invokedCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteParallelActionsWithOffsets(false,
-                // Setup
-                () =>
-                {
-                    invokedCount = 0;
-                    cancelationSource = CancelationSource.New();
-                    deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-                    promise = deferred.Promise;
-                },
-                // Teardown
-                () =>
-                {
-                    cancelationSource.Dispose();
-                    Assert.AreEqual(1, invokedCount);
-                },
-                // Parallel Actions
                 () => cancelationSource.Cancel(),
-                () => promise.CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); }).Forget()
+                () => promise.CatchCancelation(() => { Interlocked.Increment(ref invokedCount); }).Forget()
             );
         }
 
@@ -1057,36 +869,8 @@ namespace ProtoPromiseTests.Threading
                     Assert.AreEqual(1, invokedCount);
                 },
                 // Parallel Actions
-                () => deferred.Cancel("Cancel"),
-                () => promise.CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); }).Forget()
-            );
-        }
-
-        [Test]
-        public void DeferredMayBeCanceledAndPromiseAwaitedConcurrently_T3()
-        {
-            var deferred = default(Promise<int>.Deferred);
-            var promise = default(Promise<int>);
-
-            int invokedCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteParallelActionsWithOffsets(false,
-                // Setup
-                () =>
-                {
-                    invokedCount = 0;
-                    deferred = Promise.NewDeferred<int>();
-                    promise = deferred.Promise;
-                },
-                // Teardown
-                () =>
-                {
-                    Assert.AreEqual(1, invokedCount);
-                },
-                // Parallel Actions
                 () => deferred.Cancel(),
-                () => promise.CatchCancelation(_ => { Interlocked.Increment(ref invokedCount); }).Forget()
+                () => promise.CatchCancelation(() => { Interlocked.Increment(ref invokedCount); }).Forget()
             );
         }
     }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/DeferredThreadTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/DeferredThreadTests.cs
@@ -210,13 +210,13 @@ namespace ProtoPromiseTests.Threading
         }
 
         [Test]
-        public void DeferredMayBeCanceledOnSeparateThread_void0()
+        public void DeferredMayBeCanceledOnSeparateThread_void()
         {
             bool invoked = false;
             var cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
             deferred.Promise
-                .CatchCancelation(_ => { invoked = true; })
+                .CatchCancelation(() => { invoked = true; })
                 .Forget();
 
             var threadHelper = new ThreadHelper();
@@ -227,51 +227,17 @@ namespace ProtoPromiseTests.Threading
         }
 
         [Test]
-        public void DeferredMayBeCanceledOnSeparateThread_void1()
-        {
-            bool invoked = false;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
-            deferred.Promise
-                .CatchCancelation(_ => { invoked = true; })
-                .Forget();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteSingleAction(() => cancelationSource.Cancel("Cancel"));
-
-            Assert.IsTrue(invoked);
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void DeferredMayBeCanceledOnSeparateThread_T0()
+        public void DeferredMayBeCanceledOnSeparateThread_T()
         {
             bool invoked = false;
             var cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
             deferred.Promise
-                .CatchCancelation(_ => { invoked = true; })
+                .CatchCancelation(() => { invoked = true; })
                 .Forget();
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteSingleAction(() => cancelationSource.Cancel());
-
-            Assert.IsTrue(invoked);
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void DeferredMayBeCanceledOnSeparateThread_T1()
-        {
-            bool invoked = false;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-            deferred.Promise
-                .CatchCancelation(_ => { invoked = true; })
-                .Forget();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteSingleAction(() => cancelationSource.Cancel("Cancel"));
 
             Assert.IsTrue(invoked);
             cancelationSource.Dispose();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/PromiseConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/PromiseConcurrencyTests.cs
@@ -292,10 +292,6 @@ namespace ProtoPromiseTests.Threading
                 if (completeType == CompleteType.Resolve && completePlace == ActionPlace.InTeardown)
                 {
                     expectedInvokes += 10;
-                    if (reportPlace == ActionPlace.InTeardown)
-                    {
-                        expectedInvokes += 10;
-                    }
                 }
             }
 
@@ -393,14 +389,7 @@ namespace ProtoPromiseTests.Threading
                     }
                 }
                 progressReporter.Teardown();
-                if (waitForReportTeardown)
-                {
-                    for (int i = 0; i < progressHelpers.Length; ++i)
-                    {
-                        progressHelpers[i].MaybeWaitForInvoke(true, i == 0, TimeSpan.FromSeconds(ThreadHelper.multiExecutionCount)); // Only need to execute foreground the first time.
-                        progressHelpers[i].PrepareForInvoke();
-                    }
-                }
+                // Not checking for report invoke here because of background thread race conditions.
                 promiseCompleter.Teardown();
                 cancelationSource.TryDispose();
                 promise.Forget();
@@ -448,10 +437,6 @@ namespace ProtoPromiseTests.Threading
                 if (completeType == CompleteType.Resolve && completePlace == ActionPlace.InTeardown)
                 {
                     expectedInvokes += 10;
-                    if (reportPlace == ActionPlace.InTeardown)
-                    {
-                        expectedInvokes += 10;
-                    }
                 }
             }
 
@@ -534,9 +519,6 @@ namespace ProtoPromiseTests.Threading
                 promiseCompleter.Setup();
             };
             bool waitForSubscribeTeardown = !waitForSubscribeSetup && completePlace == ActionPlace.InTeardown;
-            bool waitForReportTeardown = !waitForReportSetup && completePlace == ActionPlace.InTeardown
-                && (subscribePlace != ActionPlace.Parallel || reportPlace != ActionPlace.Parallel)
-                && (waitForSubscribeSetup || !waitForSubscribeTeardown || reportPlace == ActionPlace.InTeardown);
             Action teardownAction = () =>
             {
                 progressSubscriber.Teardown();
@@ -549,14 +531,7 @@ namespace ProtoPromiseTests.Threading
                     }
                 }
                 progressReporter.Teardown();
-                if (waitForReportTeardown)
-                {
-                    for (int i = 0; i < progressHelpers.Length; ++i)
-                    {
-                        progressHelpers[i].MaybeWaitForInvoke(true, i == 0, TimeSpan.FromSeconds(ThreadHelper.multiExecutionCount)); // Only need to execute foreground the first time.
-                        progressHelpers[i].PrepareForInvoke();
-                    }
-                }
+                // Not checking for report invoke here because of background thread race conditions.
                 promiseCompleter.Teardown();
                 cancelationSource.TryDispose();
                 promise.Forget();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/PromiseConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/PromiseConcurrencyTests.cs
@@ -855,8 +855,8 @@ namespace ProtoPromiseTests.Threading
             var promise = deferred.Promise.Preserve();
 
             var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(_ => Interlocked.Increment(ref invokedCount)).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, (cv, _) => Interlocked.Increment(ref invokedCount)).Forget());
+            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(() => Interlocked.Increment(ref invokedCount)).Forget());
+            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
             promise.Forget();
             cancelationSource.Cancel();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
@@ -871,8 +871,8 @@ namespace ProtoPromiseTests.Threading
             var promise = Promise.Canceled().Preserve();
 
             var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(_ => Interlocked.Increment(ref invokedCount)).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, (cv, _) => Interlocked.Increment(ref invokedCount)).Forget());
+            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(() => Interlocked.Increment(ref invokedCount)).Forget());
+            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
             promise.Forget();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
         }
@@ -886,8 +886,8 @@ namespace ProtoPromiseTests.Threading
             var promise = deferred.Promise.Preserve();
 
             var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(_ => Interlocked.Increment(ref invokedCount)).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, (cv, _) => Interlocked.Increment(ref invokedCount)).Forget());
+            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(() => Interlocked.Increment(ref invokedCount)).Forget());
+            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
             promise.Forget();
             cancelationSource.Cancel();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
@@ -902,8 +902,8 @@ namespace ProtoPromiseTests.Threading
             var promise = Promise<int>.Canceled().Preserve();
 
             var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(_ => Interlocked.Increment(ref invokedCount)).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, (cv, _) => Interlocked.Increment(ref invokedCount)).Forget());
+            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(() => Interlocked.Increment(ref invokedCount)).Forget());
+            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
             promise.Forget();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/PromiseConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/PromiseConcurrencyTests.cs
@@ -377,8 +377,10 @@ namespace ProtoPromiseTests.Threading
                 }
                 promiseCompleter.Setup();
             };
-            bool waitForSubscribeTeardown = !waitForSubscribeSetup && completePlace == ActionPlace.InTeardown && reportPlace == ActionPlace.InTeardown;
-            bool waitForReportTeardown = !waitForReportSetup && completePlace == ActionPlace.InTeardown;
+            bool waitForSubscribeTeardown = !waitForSubscribeSetup && completePlace == ActionPlace.InTeardown;
+            bool waitForReportTeardown = !waitForReportSetup && completePlace == ActionPlace.InTeardown
+                && (subscribePlace != ActionPlace.Parallel || reportPlace != ActionPlace.Parallel)
+                && (waitForSubscribeSetup || !waitForSubscribeTeardown || reportPlace == ActionPlace.InTeardown);
             Action teardownAction = () =>
             {
                 progressSubscriber.Teardown();
@@ -531,8 +533,10 @@ namespace ProtoPromiseTests.Threading
                 }
                 promiseCompleter.Setup();
             };
-            bool waitForSubscribeTeardown = !waitForSubscribeSetup && completePlace == ActionPlace.InTeardown && reportPlace == ActionPlace.InTeardown;
-            bool waitForReportTeardown = !waitForReportSetup && completePlace == ActionPlace.InTeardown;
+            bool waitForSubscribeTeardown = !waitForSubscribeSetup && completePlace == ActionPlace.InTeardown;
+            bool waitForReportTeardown = !waitForReportSetup && completePlace == ActionPlace.InTeardown
+                && (subscribePlace != ActionPlace.Parallel || reportPlace != ActionPlace.Parallel)
+                && (waitForSubscribeSetup || !waitForSubscribeTeardown || reportPlace == ActionPlace.InTeardown);
             Action teardownAction = () =>
             {
                 progressSubscriber.Teardown();


### PR DESCRIPTION
#13 

Added `CancelationRegistration.Token` property.
Added `CancelationToken.(Try)Register<TCancelable>(TCancelable cancelable) where TCancelable : ICancelable`.
Removed cancelation reasons.
Made `Deferred`s implement `ICancelable`.
Added `CancelationToken.Canceled()` to get a token already in the canceled state without allocating.