### PR TITLE
CatchCancelation Behavior

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -68,12 +68,14 @@ jobs:
           sed -i "{s/$ApiOriginal/$ApiReplace/g}" ProtoPromise_Unity/ProjectSettings/ProjectSettings.asset
 
       - name: Run tests
+        id: tests
         uses: game-ci/unity-test-runner@v2 #timcassell/unity-test-runner@targetPlatform
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE_2018_4_36F1_UBUNTU }}
         with:
           projectPath: ProtoPromise_Unity
           testMode: ${{ matrix.testMode }}
+          artifactsPath: artifacts/unity-test-results/${{ matrix.buildTarget }}-${{ matrix.scriptingRuntime }}-${{ matrix.mode }}-${{ matrix.progress }}-${{ matrix.pooling }}
         timeout-minutes: 90
 
       # Workaround for NUnit XML (see https://github.com/dorny/test-reporter/issues/98#issuecomment-867106931)
@@ -91,7 +93,7 @@ jobs:
       - name: Transform NUnit3 to JUnit
         if: always()
         run: |
-          Get-ChildItem . -Filter artifacts/*.xml | Foreach-Object {
+          Get-ChildItem . -Filter ${{ steps.tests.outputs.artifactsPath }}/*.xml | Foreach-Object {
             $xml = Resolve-Path $_.FullName
             $output = Join-Path ($pwd) ($_.BaseName + '_junit.xml')
             $xslt = New-Object System.Xml.Xsl.XslCompiledTransform;
@@ -111,4 +113,4 @@ jobs:
         if: always()
         with:
           name: Test results
-          path: artifacts
+          path: ${{ steps.tests.outputs.artifactsPath }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           projectPath: ProtoPromise_Unity
           testMode: ${{ matrix.testMode }}
+        timeout-minutes: 90
 
       # Workaround for NUnit XML (see https://github.com/dorny/test-reporter/issues/98#issuecomment-867106931)
       - name: Install NUnit

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -75,7 +75,6 @@ jobs:
         with:
           projectPath: ProtoPromise_Unity
           testMode: ${{ matrix.testMode }}
-          artifactsPath: artifacts/unity-test-results/${{ matrix.buildTarget }}-${{ matrix.scriptingRuntime }}-${{ matrix.mode }}-${{ matrix.progress }}-${{ matrix.pooling }}
         timeout-minutes: 90
 
       # Workaround for NUnit XML (see https://github.com/dorny/test-reporter/issues/98#issuecomment-867106931)
@@ -93,7 +92,7 @@ jobs:
       - name: Transform NUnit3 to JUnit
         if: always()
         run: |
-          Get-ChildItem . -Filter ${{ steps.tests.outputs.artifactsPath }}/*.xml | Foreach-Object {
+          Get-ChildItem . -Filter artifacts/*.xml | Foreach-Object {
             $xml = Resolve-Path $_.FullName
             $output = Join-Path ($pwd) ($_.BaseName + '_junit.xml')
             $xslt = New-Object System.Xml.Xsl.XslCompiledTransform;
@@ -112,5 +111,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: Test results
-          path: ${{ steps.tests.outputs.artifactsPath }}
+          name: unity-test-results-${{ matrix.buildTarget }}-${{ matrix.scriptingRuntime }}-${{ matrix.mode }}-${{ matrix.progress }}-${{ matrix.pooling }}
+          path: artifacts

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
@@ -183,13 +183,13 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Try to retain this instance. Return true if successful, false otherwise.
+        /// Try to retain this instance. Returns true if successful, false otherwise.
         /// <para/>If successful, allows continued use of this instance, even after the associated <see cref="CancelationSource"/> has been disposed, until this is released.
         /// If successful, this should be paired with a call to <see cref="Release"/>.
         /// </summary>
         public bool TryRetain()
         {
-            return Internal.CancelationRef.TryRetainUser(_ref, _id);
+            return Internal.CancelationRef.TryRetainUser(_ref, _id, _isCanceled);
         }
 
         /// <summary>
@@ -212,7 +212,7 @@ namespace Proto.Promises
         /// <exception cref="InvalidOperationException"/>
         public void Release()
         {
-            if (!Internal.CancelationRef.TryReleaseUser(_ref, _id))
+            if (!Internal.CancelationRef.TryReleaseUser(_ref, _id, _isCanceled))
             {
                 throw new InvalidOperationException("CancelationToken.Release: you must call Retain before you call Release.", Internal.GetFormattedStacktrace(1));
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -822,9 +822,9 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static bool TryRetainUser(CancelationRef _this, short tokenId)
+            internal static bool TryRetainUser(CancelationRef _this, short tokenId, bool isCanceled)
             {
-                return _this != null && _this.TryRetainUser(tokenId);
+                return isCanceled | (_this != null && _this.TryRetainUser(tokenId));
             }
 
             [MethodImpl(InlineOption)]
@@ -839,9 +839,9 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static bool TryReleaseUser(CancelationRef _this, short tokenId)
+            internal static bool TryReleaseUser(CancelationRef _this, short tokenId, bool isCanceled)
             {
-                return _this != null && _this.TryReleaseUser(tokenId);
+                return isCanceled | (_this != null && _this.TryReleaseUser(tokenId));
             }
 
             [MethodImpl(InlineOption)]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -655,9 +655,9 @@ namespace Proto.Promises
                 }
                 bool validOrder;
                 State state = (State) _state;
-                isCanceled = state == State.Canceled;
                 if (state != State.Pending)
                 {
+                    isCanceled = state == State.Canceled;
                     validOrder = false;
                 }
                 else
@@ -666,7 +666,7 @@ namespace Proto.Promises
                     {
                         state = (State) _state;
                         isCanceled = state == State.Canceled;
-                        validOrder = !isCanceled && IndexOf(order) >= 0;
+                        validOrder = state == State.Pending && IndexOf(order) >= 0;
                     }
                 }
                 ReleaseAfterRetainInternal();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
@@ -289,7 +289,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal struct DelegateResolvePassthrough : IDelegateResolve, IDelegateResolvePromise
+            internal struct DelegateResolvePassthrough : IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise
             {
                 private readonly bool _isActive;
 
@@ -306,14 +306,14 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolve.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     owner.ResolveInternal(valueContainer, ref executionScheduler);
                     valueContainer.Release();
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolve.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
@@ -322,13 +322,13 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateResolvePromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     owner.ResolveInternal(valueContainer, ref executionScheduler);
                     valueContainer.Release();
                 }
 
-                void IDelegateResolvePromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
@@ -344,7 +344,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal struct Delegate<TArg, TResult> : IDelegateResolve, IDelegateResolvePromise, IDelegateReject, IDelegateRejectPromise
+            internal struct Delegate<TArg, TResult> : IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
             {
                 internal readonly Delegate _callback;
 
@@ -386,7 +386,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolve.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     TResult result = Invoke(valueContainer.GetValue<TArg>());
                     valueContainer.Release();
@@ -394,7 +394,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolve.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -406,7 +406,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolvePromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TResult result = Invoke(valueContainer.GetValue<TArg>());
                     owner.WaitFor(CreateResolved(result), ref executionScheduler);
@@ -414,7 +414,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolvePromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -499,7 +499,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal struct DelegatePromise<TArg, TResult> : IDelegateResolvePromise, IDelegateRejectPromise
+            internal struct DelegatePromise<TArg, TResult> : IDelegateResolveOrCancelPromise, IDelegateRejectPromise
             {
                 internal readonly Delegate _callback;
 
@@ -542,7 +542,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolvePromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     Promise<TResult> result = Invoke(valueContainer.GetValue<TArg>());
                     owner.WaitFor(result, ref executionScheduler);
@@ -550,7 +550,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolvePromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -850,7 +850,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal struct DelegateCapture<TCapture, TArg, TResult> : IDelegateResolve, IDelegateResolvePromise, IDelegateReject, IDelegateRejectPromise
+            internal struct DelegateCapture<TCapture, TArg, TResult> : IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
             {
                 private readonly Delegate _callback;
                 private readonly TCapture _capturedValue;
@@ -904,7 +904,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolve.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     TResult result = Invoke(valueContainer.GetValue<TArg>());
                     valueContainer.Release();
@@ -912,7 +912,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolve.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -924,7 +924,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolvePromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TResult result = Invoke(valueContainer.GetValue<TArg>());
                     owner.WaitFor(CreateResolved(result), ref executionScheduler);
@@ -932,7 +932,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolvePromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -1017,7 +1017,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal struct DelegatePromiseCapture<TCapture, TArg, TResult> : IDelegateResolvePromise, IDelegateRejectPromise
+            internal struct DelegatePromiseCapture<TCapture, TArg, TResult> : IDelegateResolveOrCancelPromise, IDelegateRejectPromise
             {
                 private readonly Delegate _callback;
                 private readonly TCapture _capturedValue;
@@ -1072,7 +1072,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolvePromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     Promise<TResult> result = Invoke(valueContainer.GetValue<TArg>());
                     owner.WaitFor(result, ref executionScheduler);
@@ -1080,7 +1080,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolvePromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
@@ -9,13 +9,13 @@
                 void Handle(PromiseRef owner, IValueContainer valueContainer, PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler);
             }
 
-            internal interface IDelegateResolve
+            internal interface IDelegateResolveOrCancel
             {
                 void InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
                 void InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
-            internal interface IDelegateResolvePromise
+            internal interface IDelegateResolveOrCancelPromise
             {
                 void InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
                 void InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -971,7 +971,7 @@ namespace Proto.Promises
                     IProgressListener progressListener = Interlocked.Exchange(ref _progressListener, null);
                     if (progressListener != null)
                     {
-                        WaitWhileProgressFlags(PromiseFlags.Reporting | PromiseFlags.SettingInitial);
+                        WaitWhileProgressFlags(PromiseFlags.ReportingPriority | PromiseFlags.ReportingInitial | PromiseFlags.SettingInitial);
                         if (state == Promise.State.Resolved)
                         {
                             progressListener.ResolveOrSetProgress(this, progress, ref executionScheduler);
@@ -988,7 +988,7 @@ namespace Proto.Promises
                     PromiseSingleAwaitWithProgress setter = this;
                     do
                     {
-                        PromiseFlags setFlag = progress.IsPriority ? PromiseFlags.Reporting : PromiseFlags.SettingInitial;
+                        PromiseFlags setFlag = progress.IsPriority ? PromiseFlags.ReportingPriority : PromiseFlags.ReportingInitial;
                         if ((setter._smallFields.InterlockedSetFlags(setFlag) & setFlag) != 0)
                         {
                             break;
@@ -1082,7 +1082,7 @@ namespace Proto.Promises
                     {
                         return;
                     }
-                    WaitWhileProgressFlags(PromiseFlags.Reporting | PromiseFlags.SettingInitial);
+                    WaitWhileProgressFlags(PromiseFlags.ReportingPriority | PromiseFlags.ReportingInitial | PromiseFlags.SettingInitial);
 
                     Fixed32 progress = _progressAndLocker._depthAndProgress.GetIncrementedWholeTruncatedForResolve();
                     if (state == Promise.State.Resolved)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -1104,7 +1104,7 @@ namespace Proto.Promises
                 {
                     // If this is coming from hookup progress, we can possibly report without updating the progress.
                     // This is to handle race condition on separate threads.
-                    if ((_progressAndLocker._currentProgress.InterlockedTrySet(progress) | !progress.HasReported)
+                    if ((_progressAndLocker._currentProgress.InterlockedTrySet(progress) | !progress.IsPriority)
                         && (_smallFields.InterlockedSetFlags(PromiseFlags.InProgressQueue) & PromiseFlags.InProgressQueue) == 0) // Was not already in progress queue?
                     {
                         InterlockedRetainDisregardId();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -146,8 +146,9 @@ namespace Proto.Promises
             InProgressQueue = 1 << 2,
             Subscribing = 1 << 3,
             SettingInitial = 1 << 4,
-            Reporting = 1 << 5,
-            Subscribed = 1 << 6,
+            ReportingPriority = 1 << 5,
+            ReportingInitial = 1 << 6,
+            Subscribed = 1 << 7,
 
             All = byte.MaxValue
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -272,19 +272,19 @@ namespace Proto.Promises
 
             #region Non-cancelable Promises
             partial class PromiseResolve<TResolver> : PromiseSingleAwait
-                where TResolver : IDelegateResolve
+                where TResolver : IDelegateResolveOrCancel
             {
                 private TResolver _resolver;
             }
 
             partial class PromiseResolvePromise<TResolver> : PromiseWaitPromise
-                where TResolver : IDelegateResolvePromise
+                where TResolver : IDelegateResolveOrCancelPromise
             {
                 private TResolver _resolver;
             }
 
             partial class PromiseResolveReject<TResolver, TRejecter> : PromiseSingleAwait
-                where TResolver : IDelegateResolve
+                where TResolver : IDelegateResolveOrCancel
                 where TRejecter : IDelegateReject
             {
                 private TResolver _resolver;
@@ -292,7 +292,7 @@ namespace Proto.Promises
             }
 
             partial class PromiseResolveRejectPromise<TResolver, TRejecter> : PromiseWaitPromise
-                where TResolver : IDelegateResolvePromise
+                where TResolver : IDelegateResolveOrCancelPromise
                 where TRejecter : IDelegateRejectPromise
             {
                 private TResolver _resolver;
@@ -318,7 +318,13 @@ namespace Proto.Promises
             }
 
             partial class PromiseCancel<TCanceler> : PromiseSingleAwait
-                where TCanceler : IDelegateSimple
+                where TCanceler : IDelegateResolveOrCancel
+            {
+                private TCanceler _canceler;
+            }
+
+            partial class PromiseCancelPromise<TCanceler> : PromiseWaitPromise
+                where TCanceler : IDelegateResolveOrCancelPromise
             {
                 private TCanceler _canceler;
             }
@@ -337,21 +343,21 @@ namespace Proto.Promises
             }
 
             partial class CancelablePromiseResolve<TResolver> : PromiseSingleAwait
-                where TResolver : IDelegateResolve
+                where TResolver : IDelegateResolveOrCancel
             {
                 private CancelationHelper _cancelationHelper;
                 private TResolver _resolver;
             }
 
             partial class CancelablePromiseResolvePromise<TResolver> : PromiseWaitPromise
-                where TResolver : IDelegateResolvePromise
+                where TResolver : IDelegateResolveOrCancelPromise
             {
                 private CancelationHelper _cancelationHelper;
                 private TResolver _resolver;
             }
 
             partial class CancelablePromiseResolveReject<TResolver, TRejecter> : PromiseSingleAwait
-                where TResolver : IDelegateResolve
+                where TResolver : IDelegateResolveOrCancel
                 where TRejecter : IDelegateReject
             {
                 private CancelationHelper _cancelationHelper;
@@ -360,7 +366,7 @@ namespace Proto.Promises
             }
 
             partial class CancelablePromiseResolveRejectPromise<TResolver, TRejecter> : PromiseWaitPromise
-                where TResolver : IDelegateResolvePromise
+                where TResolver : IDelegateResolveOrCancelPromise
                 where TRejecter : IDelegateRejectPromise
             {
                 private CancelationHelper _cancelationHelper;
@@ -383,7 +389,14 @@ namespace Proto.Promises
             }
 
             partial class CancelablePromiseCancel<TCanceler> : PromiseSingleAwait
-                where TCanceler : IDelegateSimple
+                where TCanceler : IDelegateResolveOrCancel
+            {
+                private CancelationHelper _cancelationHelper;
+                private TCanceler _canceler;
+            }
+
+            partial class CancelablePromiseCancelPromise<TCanceler> : PromiseWaitPromise
+                where TCanceler : IDelegateResolveOrCancelPromise
             {
                 private CancelationHelper _cancelationHelper;
                 private TCanceler _canceler;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
@@ -185,20 +185,6 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Add a cancel callback. Returns a new <see cref="Promise"/> that inherits the state of <see cref="this"/> and can be awaited once.
-        /// <para/>If/when this instance is canceled, <paramref name="onCanceled"/> will be invoked.
-        /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onCanceled"/> will not be invoked.
-        /// </summary>
-        public Promise CatchCancelation(Action onCanceled, CancelationToken cancelationToken = default(CancelationToken))
-        {
-            ValidateOperation(1);
-            ValidateArgument(onCanceled, "onCanceled", 1);
-
-            return Internal.PromiseRef.CallbackHelper.AddCancel(_target, new Internal.PromiseRef.DelegateCancel(onCanceled), cancelationToken);
-        }
-
-        /// <summary>
         /// Add a finally callback. Returns a new <see cref="Promise"/>.
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onFinally"/> will be invoked.
         /// <para/>If <paramref name="onFinally"/> throws an exception, the new <see cref="Promise"/> will be rejected with that exception,
@@ -208,6 +194,40 @@ namespace Proto.Promises
         public Promise Finally(Action onFinally)
         {
             return _target.Finally(onFinally);
+        }
+
+        /// <summary>
+        /// Add a cancel callback. Returns a new <see cref="Promise"/>.
+        /// <para/>If/when this is canceled, <paramref name="onCanceled"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
+        /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onCanceled"/> will not be invoked.
+        /// </summary>
+        public Promise CatchCancelation(Action onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        {
+            ValidateOperation(1);
+            ValidateArgument(onCanceled, "onCanceled", 1);
+
+            return Internal.PromiseRef.CallbackHelper.AddCancel(_target, Internal.PromiseRef.DelegateWrapper.Create(onCanceled), cancelationToken);
+        }
+
+        /// <summary>
+        /// Add a cancel callback. Returns a new <see cref="Promise"/>.
+        /// <para/>If/when this is canceled, <paramref name="onCanceled"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
+        /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onCanceled"/> will not be invoked.
+        /// </summary>
+        public Promise CatchCancelation(Func<Promise> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        {
+            ValidateOperation(1);
+            ValidateArgument(onCanceled, "onCanceled", 1);
+
+            return Internal.PromiseRef.CallbackHelper.AddCancelWait(_target, Internal.PromiseRef.DelegateWrapper.Create(onCanceled), cancelationToken);
         }
 
         #region Resolve Callbacks
@@ -790,20 +810,6 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Capture a value and add a cancel callback. Returns a new <see cref="Promise"/> that inherits the state of <see cref="this"/> and can be awaited once.
-        /// <para/>If/when this instance is canceled, <paramref name="onCanceled"/> will be invoked with <paramref name="cancelCaptureValue"/>.
-        /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onCanceled"/> will not be invoked.
-        /// </summary>
-        public Promise CatchCancelation<TCaptureCancel>(TCaptureCancel cancelCaptureValue, Action<TCaptureCancel> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
-        {
-            ValidateOperation(1);
-            ValidateArgument(onCanceled, "onCanceled", 1);
-
-            return Internal.PromiseRef.CallbackHelper.AddCancel(_target, new Internal.PromiseRef.DelegateCaptureCancel<TCaptureCancel>(cancelCaptureValue, onCanceled), cancelationToken);
-        }
-
-        /// <summary>
         /// Capture a value and add a finally callback. Returns a new <see cref="Promise"/>.
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onFinally"/> will be invoked with <paramref name="finallyCaptureValue"/>.
         /// <para/>If <paramref name="onFinally"/> throws an exception, the new <see cref="Promise"/> will be rejected with that exception,
@@ -813,6 +819,40 @@ namespace Proto.Promises
         public Promise Finally<TCaptureFinally>(TCaptureFinally finallyCaptureValue, Action<TCaptureFinally> onFinally)
         {
             return _target.Finally(finallyCaptureValue, onFinally);
+        }
+
+        /// <summary>
+        /// Capture a value and add a cancel callback. Returns a new <see cref="Promise"/>.
+        /// <para/>If/when this is canceled, <paramref name="onCanceled"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
+        /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onCanceled"/> will not be invoked.
+        /// </summary>
+        public Promise CatchCancelation<TCaptureCancel>(TCaptureCancel cancelCaptureValue, Action<TCaptureCancel> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        {
+            ValidateOperation(1);
+            ValidateArgument(onCanceled, "onCanceled", 1);
+
+            return Internal.PromiseRef.CallbackHelper.AddCancel(_target, Internal.PromiseRef.DelegateWrapper.Create(cancelCaptureValue, onCanceled), cancelationToken);
+        }
+
+        /// <summary>
+        /// Capture a value and add a cancel callback. Returns a new <see cref="Promise"/>.
+        /// <para/>If/when this is canceled, <paramref name="onCanceled"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
+        /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onCanceled"/> will not be invoked.
+        /// </summary>
+        public Promise CatchCancelation<TCaptureCancel>(TCaptureCancel cancelCaptureValue, Func<TCaptureCancel, Promise> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        {
+            ValidateOperation(1);
+            ValidateArgument(onCanceled, "onCanceled", 1);
+
+            return Internal.PromiseRef.CallbackHelper.AddCancelWait(_target, Internal.PromiseRef.DelegateWrapper.Create(cancelCaptureValue, onCanceled), cancelationToken);
         }
 
         #region Resolve Callbacks

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -228,20 +228,6 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Add a cancel callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/> that inherits the state of <see cref="this"/> and can be awaited once.
-        /// <para/>If/when this instance is canceled, <paramref name="onCanceled"/> will be invoked.
-        /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onCanceled"/> will not be invoked.
-        /// </summary>
-        public Promise<T> CatchCancelation(Action onCanceled, CancelationToken cancelationToken = default(CancelationToken))
-        {
-            ValidateOperation(1);
-            ValidateArgument(onCanceled, "onCanceled", 1);
-
-            return Internal.PromiseRef.CallbackHelper.AddCancel(this, new Internal.PromiseRef.DelegateCancel(onCanceled), cancelationToken);
-        }
-
-        /// <summary>
         /// Add a finally callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/>.
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onFinally"/> will be invoked.
         /// <para/>If <paramref name="onFinally"/> throws an exception, the new <see cref="Promise{T}"/> will be rejected with that exception,
@@ -253,6 +239,40 @@ namespace Proto.Promises
             ValidateArgument(onFinally, "onFinally", 1);
 
             return Internal.PromiseRef.CallbackHelper.AddFinally(this, onFinally);
+        }
+
+        /// <summary>
+        /// Add a cancel callback. Returns a new <see cref="Promise{T}"/>.
+        /// <para/>If/when this is canceled, <paramref name="onCanceled"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
+        /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// <para/>If/when this is resolved, the new <see cref="Promise{T}"/> will be resolved with the same value.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onCanceled"/> will not be invoked.
+        /// </summary>
+        public Promise<T> CatchCancelation(Func<T> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        {
+            ValidateOperation(1);
+            ValidateArgument(onCanceled, "onCanceled", 1);
+
+            return Internal.PromiseRef.CallbackHelper.AddCancel(this, Internal.PromiseRef.DelegateWrapper.Create(onCanceled), cancelationToken);
+        }
+
+        /// <summary>
+        /// Add a cancel callback. Returns a new <see cref="Promise{T}"/>.
+        /// <para/>If/when this is canceled, <paramref name="onCanceled"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
+        /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// <para/>If/when this is resolved, the new <see cref="Promise{T}"/> will be resolved with the same value.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onCanceled"/> will not be invoked.
+        /// </summary>
+        public Promise<T> CatchCancelation(Func<Promise<T>> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        {
+            ValidateOperation(1);
+            ValidateArgument(onCanceled, "onCanceled", 1);
+
+            return Internal.PromiseRef.CallbackHelper.AddCancelWait(this, Internal.PromiseRef.DelegateWrapper.Create(onCanceled), cancelationToken);
         }
 
         #region Resolve Callbacks
@@ -839,20 +859,6 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Capture a value and add a cancel callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/> that inherits the state of <see cref="this"/> and can be awaited once.
-        /// <para/>If/when this instance is canceled, <paramref name="onCanceled"/> will be invoked with <paramref name="cancelCaptureValue"/>.
-        /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onCanceled"/> will not be invoked.
-        /// </summary>
-        public Promise<T> CatchCancelation<TCaptureCancel>(TCaptureCancel cancelCaptureValue, Action<TCaptureCancel> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
-        {
-            ValidateOperation(1);
-            ValidateArgument(onCanceled, "onCanceled", 1);
-
-            return Internal.PromiseRef.CallbackHelper.AddCancel(this, new Internal.PromiseRef.DelegateCaptureCancel<TCaptureCancel>(cancelCaptureValue, onCanceled), cancelationToken);
-        }
-
-        /// <summary>
         /// Capture a value and add a finally callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/>.
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onFinally"/> will be invoked with <paramref name="finallyCaptureValue"/>.
         /// <para/>If <paramref name="onFinally"/> throws an exception, the new <see cref="Promise{T}"/> will be rejected with that exception,
@@ -864,6 +870,40 @@ namespace Proto.Promises
             ValidateArgument(onFinally, "onFinally", 1);
 
             return Internal.PromiseRef.CallbackHelper.AddFinally(this, finallyCaptureValue, onFinally);
+        }
+
+        /// <summary>
+        /// Capture a value and add a cancel callback. Returns a new <see cref="Promise{T}"/>.
+        /// <para/>If/when this is canceled, <paramref name="onCanceled"/> will be invoked, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
+        /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// <para/>If/when this is resolved, the new <see cref="Promise{T}"/> will be resolved with the same value.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise{T}"/> will be canceled, and <paramref name="onCanceled"/> will not be invoked.
+        /// </summary>
+        public Promise<T> CatchCancelation<TCaptureCancel>(TCaptureCancel cancelCaptureValue, Func<TCaptureCancel, T> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        {
+            ValidateOperation(1);
+            ValidateArgument(onCanceled, "onCanceled", 1);
+
+            return Internal.PromiseRef.CallbackHelper.AddCancel(this, Internal.PromiseRef.DelegateWrapper.Create(cancelCaptureValue, onCanceled), cancelationToken);
+        }
+
+        /// <summary>
+        /// Capture a value and add a cancel callback. Returns a new <see cref="Promise{T}"/>.
+        /// <para/>If/when this is canceled, <paramref name="onCanceled"/> will be invoked, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
+        /// If it throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// <para/>If/when this is resolved, the new <see cref="Promise{T}"/> will be resolved with the same value.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onCanceled"/> will not be invoked.
+        /// </summary>
+        public Promise<T> CatchCancelation<TCaptureCancel>(TCaptureCancel cancelCaptureValue, Func<TCaptureCancel, Promise<T>> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        {
+            ValidateOperation(1);
+            ValidateArgument(onCanceled, "onCanceled", 1);
+
+            return Internal.PromiseRef.CallbackHelper.AddCancelWait(this, Internal.PromiseRef.DelegateWrapper.Create(cancelCaptureValue, onCanceled), cancelationToken);
         }
 
         #region Resolve Callbacks
@@ -2180,9 +2220,39 @@ namespace Proto.Promises
     }
 
     // Inherited from Promise (must copy since structs cannot inherit).
-    // Did not copy Progress, CatchCancelation, Finally, or ContinueWith.
+    // Did not copy Progress, Finally, or ContinueWith.
     partial struct Promise<T>
     {
+        /// <summary>
+        /// Add a cancel callback. Returns a new <see cref="Promise"/>.
+        /// <para/>If/when this is canceled, <paramref name="onCanceled"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
+        /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onCanceled"/> will not be invoked.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise CatchCancelation(Action onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        {
+            return AsPromise().CatchCancelation(onCanceled, cancelationToken);
+        }
+
+        /// <summary>
+        /// Add a cancel callback. Returns a new <see cref="Promise"/>.
+        /// <para/>If/when this is canceled, <paramref name="onCanceled"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
+        /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onCanceled"/> will not be invoked.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise CatchCancelation(Func<Promise> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        {
+            return AsPromise().CatchCancelation(onCanceled, cancelationToken);
+        }
+
         #region Resolve Callbacks
         /// <summary>
         /// Add a resolve callback. Returns a new <see cref="Promise"/>.
@@ -2576,6 +2646,36 @@ namespace Proto.Promises
         #endregion
 
         // Capture values below.
+
+        /// <summary>
+        /// Capture a value and add a cancel callback. Returns a new <see cref="Promise"/>.
+        /// <para/>If/when this is canceled, <paramref name="onCanceled"/> will be invoked, and the new <see cref="Promise"/> will be resolved when it returns.
+        /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onCanceled"/> will not be invoked.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise CatchCancelation<TCaptureCancel>(TCaptureCancel cancelCaptureValue, Action<TCaptureCancel> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        {
+            return AsPromise().CatchCancelation(cancelCaptureValue, onCanceled, cancelationToken);
+        }
+
+        /// <summary>
+        /// Capture a value and add a cancel callback. Returns a new <see cref="Promise"/>.
+        /// <para/>If/when this is canceled, <paramref name="onCanceled"/> will be invoked, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
+        /// If it throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// <para/>If/when this is resolved, the new <see cref="Promise"/> will be resolved.
+        /// <para/>If/when this is rejected with any reason, the new <see cref="Promise"/> will be rejected with the same reason.
+        /// 
+        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onCanceled"/> will not be invoked.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise CatchCancelation<TCaptureCancel>(TCaptureCancel cancelCaptureValue, Func<TCaptureCancel, Promise> onCanceled, CancelationToken cancelationToken = default(CancelationToken))
+        {
+            return AsPromise().CatchCancelation(cancelCaptureValue, onCanceled, cancelationToken);
+        }
 
         #region Resolve Callbacks
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/APlus_2_2_TheThenMethod.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/APlus_2_2_TheThenMethod.cs
@@ -751,16 +751,16 @@ namespace ProtoPromiseTests.APIs
         {
             bool resolved = false;
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise
-                .WaitAsync(SynchronizationOption.Foreground)
-                .Preserve();
+            var promise = deferred.Promise.Preserve();
 
             TestHelper.AddResolveCallbacks<bool, string>(promise,
-                () => resolved = true
+                () => resolved = true,
+                configureAwaitType: ConfigureAwaitType.Foreground
             );
             TestHelper.AddCallbacks<bool, object, string>(promise,
                 () => resolved = true,
-                s => Assert.Fail("Promise was rejected when it should have been resolved.")
+                s => Assert.Fail("Promise was rejected when it should have been resolved."),
+                configureAwaitType: ConfigureAwaitType.Foreground
             );
             deferred.Resolve();
             Assert.False(resolved);
@@ -776,16 +776,16 @@ namespace ProtoPromiseTests.APIs
         {
             bool resolved = false;
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise
-                .WaitAsync(SynchronizationOption.Foreground)
-                .Preserve();
+            var promise = deferred.Promise.Preserve();
 
             TestHelper.AddResolveCallbacks<int, bool, string>(promise,
-                v => resolved = true
+                v => resolved = true,
+                configureAwaitType: ConfigureAwaitType.Foreground
             );
             TestHelper.AddCallbacks<int, bool, object, string>(promise,
                 v => resolved = true,
-                s => Assert.Fail("Promise was rejected when it should have been resolved.")
+                s => Assert.Fail("Promise was rejected when it should have been resolved."),
+                configureAwaitType: ConfigureAwaitType.Foreground
             );
             deferred.Resolve(1);
             Assert.False(resolved);
@@ -802,9 +802,10 @@ namespace ProtoPromiseTests.APIs
             bool errored = false;
             var deferred = Promise.NewDeferred();
 
-            TestHelper.AddCallbacks<bool, object, string>(deferred.Promise.WaitAsync(SynchronizationOption.Foreground),
+            TestHelper.AddCallbacks<bool, object, string>(deferred.Promise,
                 () => Assert.Fail("Promise was resolved when it should have been rejected."),
-                s => errored = true
+                s => errored = true,
+                configureAwaitType: ConfigureAwaitType.Foreground
             );
             deferred.Reject("Fail value");
             Assert.False(errored);
@@ -819,9 +820,10 @@ namespace ProtoPromiseTests.APIs
             bool errored = false;
             var deferred = Promise.NewDeferred<int>();
 
-            TestHelper.AddCallbacks<int, bool, object, string>(deferred.Promise.WaitAsync(SynchronizationOption.Foreground),
+            TestHelper.AddCallbacks<int, bool, object, string>(deferred.Promise,
                 v => Assert.Fail("Promise was resolved when it should have been rejected."),
-                s => errored = true
+                s => errored = true,
+                configureAwaitType: ConfigureAwaitType.Foreground
             );
             deferred.Reject("Fail value");
             Assert.False(errored);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/CancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/CancelationTests.cs
@@ -641,6 +641,22 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
+            public void CancelationTokenCanceledMaybeBeRetainedAndReleased0()
+            {
+                CancelationToken cancelationToken = CancelationToken.Canceled();
+                cancelationToken.Retain();
+                cancelationToken.Release();
+            }
+
+            [Test]
+            public void CancelationTokenCanceledMaybeBeRetainedAndReleased1()
+            {
+                CancelationToken cancelationToken = CancelationToken.Canceled();
+                Assert.IsTrue(cancelationToken.TryRetain());
+                cancelationToken.Release();
+            }
+
+            [Test]
             public void RetainedCancelationTokenFromSourceCanBeCanceledAfterSourceIsDisposed()
             {
                 CancelationSource cancelationSource = CancelationSource.New();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/MiscellaneousTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/MiscellaneousTests.cs
@@ -771,12 +771,12 @@ namespace ProtoPromiseTests.APIs
             bool resolved = false;
 
             Promise.Resolved(expected)
-                .CatchCancelation(() => Assert.Fail("Promise was canceled when it should have been resolved"))
                 .Then(val =>
                 {
                     Assert.AreEqual(expected, val);
                     resolved = true;
                 }, () => Assert.Fail("Promise was rejected when it should have been resolved"))
+                .CatchCancelation(() => Assert.Fail("Promise was canceled when it should have been resolved"))
                 .Forget();
 
             Assert.IsTrue(resolved);
@@ -830,7 +830,6 @@ namespace ProtoPromiseTests.APIs
                 {
                     canceled = true;
                 })
-                .Then(() => Assert.Fail("Promise was resolved when it should have been canceled"), () => Assert.Fail("Promise was rejected when it should have been canceled"))
                 .Forget();
 
             Assert.IsTrue(canceled);
@@ -846,7 +845,6 @@ namespace ProtoPromiseTests.APIs
                 {
                     canceled = true;
                 })
-                .Then(() => Assert.Fail("Promise was resolved when it should have been canceled"), () => Assert.Fail("Promise was rejected when it should have been canceled"))
                 .Forget();
 
             Assert.IsTrue(canceled);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/ProgressTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/ProgressTests.cs
@@ -1106,7 +1106,7 @@ namespace ProtoPromiseTests.APIs
             var promise = deferred.Promise.Preserve();
             ProgressHelper[] progressHelpers = new ProgressHelper[MultiProgressCount];
 
-            TimeSpan timeout = TimeSpan.FromSeconds(MultiProgressCount);
+            TimeSpan timeout = TimeSpan.FromSeconds(20);
 
             for (int i = 0; i < MultiProgressCount; ++i)
             {
@@ -1162,7 +1162,7 @@ namespace ProtoPromiseTests.APIs
             var promise = deferred.Promise.Preserve();
             ProgressHelper[] progressHelpers = new ProgressHelper[MultiProgressCount];
 
-            TimeSpan timeout = TimeSpan.FromSeconds(MultiProgressCount);
+            TimeSpan timeout = TimeSpan.FromSeconds(20);
 
             for (int i = 0; i < MultiProgressCount; ++i)
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/PromiseCancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/PromiseCancelationTests.cs
@@ -116,8 +116,8 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
-                    .CatchCancelation(() => state = Canceled)
                     .Then(v => state = Resolved, () => state = Rejected)
+                    .CatchCancelation(() => state = Canceled)
                     .Forget();
                 Assert.IsNull(state);
 
@@ -131,8 +131,8 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
-                    .CatchCancelation(() => state = Canceled)
                     .Then(v => state = Resolved, () => state = Rejected)
+                    .CatchCancelation(() => state = Canceled)
                     .Forget();
                 Assert.IsNull(state);
 
@@ -145,8 +145,8 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
-                    .CatchCancelation(() => state = Canceled)
                     .Then(v => state = Resolved, () => state = Rejected)
+                    .CatchCancelation(() => state = Canceled)
                     .Forget();
                 Assert.IsNull(state);
 
@@ -162,8 +162,8 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
-                    .CatchCancelation(() => state = Canceled)
                     .Then(v => state = Resolved, () => state = Rejected)
+                    .CatchCancelation(() => state = Canceled)
                     .Forget();
                 Assert.IsNull(state);
 
@@ -439,13 +439,21 @@ namespace ProtoPromiseTests.APIs
             {
                 var canceled = false;
                 CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred(cancelationSource.Token);
-                deferred.Promise
-                    .CatchCancelation(() =>
+                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                var promise = deferred.Promise.Preserve();
+
+                TestHelper.AddCancelCallbacks<float>(promise,
+                    onCancel: () =>
                     {
                         canceled = true;
-                    })
-                    .Forget();
+                    }
+                );
+                TestHelper.AddCancelCallbacks<int, float>(promise,
+                    onCancel: () =>
+                    {
+                        canceled = true;
+                    }
+                );
                 cancelationSource.Cancel();
 
                 Assert.True(canceled);
@@ -454,17 +462,15 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void ItMustNotBeCalledBeforePromiseIsCanceled()
+            public void ItMustNotBeCalledBeforePromiseIsCanceled_void()
             {
                 var canceled = false;
                 CancelationSource cancelationSource = CancelationSource.New();
                 var deferred = Promise.NewDeferred(cancelationSource.Token);
-                deferred.Promise
-                    .CatchCancelation(() =>
-                    {
-                        canceled = true;
-                    })
-                    .Forget();
+
+                TestHelper.AddCancelCallbacks<float>(deferred.Promise,
+                    onCancel: () => canceled = true
+                );
 
                 Assert.False(canceled);
 
@@ -476,37 +482,99 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void ItMustNotBeCalledMoreThanOnce()
+            public void ItMustNotBeCalledBeforePromiseIsCanceled_T()
+            {
+                var canceled = false;
+                CancelationSource cancelationSource = CancelationSource.New();
+                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+
+                TestHelper.AddCancelCallbacks<int, float>(deferred.Promise,
+                    onCancel: () => canceled = true
+                );
+
+                Assert.False(canceled);
+
+                cancelationSource.Cancel();
+
+                Assert.True(canceled);
+
+                cancelationSource.Dispose();
+            }
+
+            [Test]
+            public void ItMustNotBeCalledMoreThanOnce_void()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 var deferred = Promise.NewDeferred(cancelationSource.Token);
                 var cancelCount = 0;
-                deferred.Promise
-                    .CatchCancelation(() => ++cancelCount)
-                    .Forget();
+
+                TestHelper.AddCancelCallbacks<float>(deferred.Promise,
+                    onCancel: () => ++cancelCount
+                );
                 cancelationSource.Cancel();
 
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() =>
                     cancelationSource.Cancel()
                 );
 
-                Assert.AreEqual(1, cancelCount);
+                Assert.AreEqual(TestHelper.onCancelCallbacks * 2, cancelCount);
+
+                cancelationSource.Dispose();
+            }
+
+            [Test]
+            public void ItMustNotBeCalledMoreThanOnce_T()
+            {
+                CancelationSource cancelationSource = CancelationSource.New();
+                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                var cancelCount = 0;
+
+                TestHelper.AddCancelCallbacks<int, float>(deferred.Promise,
+                    onCancel: () => ++cancelCount
+                );
+                cancelationSource.Cancel();
+
+                Assert.Throws<Proto.Promises.InvalidOperationException>(() =>
+                    cancelationSource.Cancel()
+                );
+
+                Assert.AreEqual(TestHelper.onCancelCallbacks * 2, cancelCount);
 
                 cancelationSource.Dispose();
             }
         }
 
         [Test]
-        public void OnCanceledMustNotBeCalledUntilTheExecutionContextStackContainsOnlyPlatformCode()
+        public void OnCanceledMustNotBeCalledUntilTheExecutionContextStackContainsOnlyPlatformCode_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
 
             bool canceled = false;
-            deferred.Promise
-                .WaitAsync(SynchronizationOption.Foreground)
-                .CatchCancelation(() => canceled = true)
-                .Forget();
+            TestHelper.AddCancelCallbacks<float>(deferred.Promise,
+                onCancel: () => canceled = true,
+                configureAwaitType: ConfigureAwaitType.Foreground
+            );
+            cancelationSource.Cancel();
+            Assert.False(canceled);
+
+            TestHelper.ExecuteForegroundCallbacks();
+            Assert.True(canceled);
+
+            cancelationSource.Dispose();
+        }
+
+        [Test]
+        public void OnCanceledMustNotBeCalledUntilTheExecutionContextStackContainsOnlyPlatformCode_T()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+
+            bool canceled = false;
+            TestHelper.AddCancelCallbacks<int, float>(deferred.Promise,
+                onCancel: () => canceled = true,
+                configureAwaitType: ConfigureAwaitType.Foreground
+            );
             cancelationSource.Cancel();
             Assert.False(canceled);
 
@@ -531,17 +599,28 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void IfWhenPromiseCancelationIsCanceled_AllRespectiveOnCanceledCallbacksMustExecuteInTheOrderOfTheirOriginatingCallsToCatchCancelation()
+            public void IfWhenPromiseCancelationIsCanceled_AllRespectiveOnCanceledCallbacksMustExecuteInTheOrderOfTheirOriginatingCallsToCatchCancelation_void()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 var deferred = Promise.NewDeferred(cancelationSource.Token);
                 var promise = deferred.Promise.Preserve();
 
+                int order = 0;
                 int counter = 0;
 
-                promise.CatchCancelation(() => Assert.AreEqual(0, counter++)).Forget();
-                promise.CatchCancelation(() => Assert.AreEqual(1, counter++)).Forget();
-                promise.CatchCancelation(() => Assert.AreEqual(2, counter++)).Forget();
+                Action<int> callback = expected =>
+                {
+                    Assert.AreEqual(expected, order);
+                    if (++counter == TestHelper.onCancelCallbacks * 2)
+                    {
+                        counter = 0;
+                        ++order;
+                    }
+                };
+
+                TestHelper.AddCancelCallbacks<float>(promise, () => callback(0));
+                TestHelper.AddCancelCallbacks<float>(promise, () => callback(1));
+                TestHelper.AddCancelCallbacks<float>(promise, () => callback(2));
 
                 cancelationSource.Cancel();
 
@@ -550,6 +629,855 @@ namespace ProtoPromiseTests.APIs
                 cancelationSource.Dispose();
                 promise.Forget();
             }
+
+            [Test]
+            public void IfWhenPromiseCancelationIsCanceled_AllRespectiveOnCanceledCallbacksMustExecuteInTheOrderOfTheirOriginatingCallsToCatchCancelation_T()
+            {
+                CancelationSource cancelationSource = CancelationSource.New();
+                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                var promise = deferred.Promise.Preserve();
+
+                int order = 0;
+                int counter = 0;
+
+                Action<int> callback = expected =>
+                {
+                    Assert.AreEqual(expected, order);
+                    if (++counter == TestHelper.onCancelCallbacks * 2)
+                    {
+                        counter = 0;
+                        ++order;
+                    }
+                };
+
+                TestHelper.AddCancelCallbacks<int, float>(promise, onCancel: () => callback(0));
+                TestHelper.AddCancelCallbacks<int, float>(promise, onCancel: () => callback(1));
+                TestHelper.AddCancelCallbacks<int, float>(promise, onCancel: () => callback(2));
+
+                cancelationSource.Cancel();
+
+                Assert.AreEqual(3, counter);
+
+                cancelationSource.Dispose();
+                promise.Forget();
+            }
+        }
+
+        [Test]
+        public void IfOnCanceledThrowsAnExceptionE_Promise2MustBeRejectedWithEAsTheReason_void()
+        {
+            var deferred = Promise.NewDeferred();
+
+            int exceptionCount = 0;
+            Exception expected = new Exception("Fail value");
+
+            Action<Promise> catchCallback = p =>
+                p.Catch((Exception e) =>
+                {
+                    Assert.AreEqual(expected, e);
+                    ++exceptionCount;
+                }).Forget();
+
+            TestHelper.AddCancelCallbacks<float>(deferred.Promise,
+                onCancel: () => { throw expected; },
+                onCancelCapture: cv => { throw expected; },
+                onCallbackAdded: (ref Promise p) => catchCallback(p)
+            );
+
+            deferred.Cancel();
+
+            Assert.AreEqual(TestHelper.onCancelCallbacks * 2, exceptionCount);
+        }
+
+        [Test]
+        public void IfOnCanceledThrowsAnExceptionE_Promise2MustBeRejectedWithEAsTheReason_T()
+        {
+            var deferred = Promise.NewDeferred<int>();
+
+            int exceptionCount = 0;
+            Exception expected = new Exception("Fail value");
+
+            Action<Promise> catchCallback = p =>
+                p.Catch((Exception e) =>
+                {
+                    Assert.AreEqual(expected, e);
+                    ++exceptionCount;
+                }).Forget();
+
+            TestHelper.AddCancelCallbacks<int, float>(deferred.Promise,
+                onCancel: () => { throw expected; },
+                onCancelCapture: cv => { throw expected; },
+                onCallbackAdded: (ref Promise<int> p) => catchCallback(p)
+            );
+
+            deferred.Cancel();
+
+            Assert.AreEqual(TestHelper.onCancelCallbacks * 2, exceptionCount);
+        }
+
+        [Test]
+        public void IfPromiseIsResolved_ReturnedPromiseMustBeResolvedWithTheSameValue_void0()
+        {
+            var deferred = Promise.NewDeferred();
+
+            bool resolved = false;
+
+            deferred.Promise
+                .CatchCancelation(() => Assert.Fail("Promise was canceled when it should have been resolved."))
+                .Then(() => resolved = true, () => Assert.Fail("Promise was rejected when it should have been resolved."))
+                .Forget();
+
+            deferred.Resolve();
+
+            Assert.IsTrue(resolved);
+        }
+
+        [Test]
+        public void IfPromiseIsResolved_ReturnedPromiseMustBeResolvedWithTheSameValue_void1()
+        {
+            var deferred = Promise.NewDeferred();
+
+            bool resolved = false;
+
+            deferred.Promise
+                .CatchCancelation(() => { Assert.Fail("Promise was canceled when it should have been resolved."); return Promise.Canceled(); })
+                .Then(() => resolved = true, () => Assert.Fail("Promise was rejected when it should have been resolved."))
+                .Forget();
+
+            deferred.Resolve();
+
+            Assert.IsTrue(resolved);
+        }
+
+        [Test]
+        public void IfPromiseIsResolved_ReturnedPromiseMustBeResolvedWithTheSameValue_T0()
+        {
+            var deferred = Promise.NewDeferred<int>();
+
+            int expected = 10;
+            int actual = -1;
+
+            deferred.Promise
+                .CatchCancelation(() => { Assert.Fail("Promise was canceled when it should have been resolved."); return -10; })
+                .Then(v => { actual = v; }, () => { Assert.Fail("Promise was rejected when it should have been resolved."); })
+                .Forget();
+
+            deferred.Resolve(expected);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void IfPromiseIsResolved_ReturnedPromiseMustBeResolvedWithTheSameValue_T1()
+        {
+            var deferred = Promise.NewDeferred<int>();
+
+            int expected = 10;
+            int actual = -1;
+
+            deferred.Promise
+                .CatchCancelation(() => { Assert.Fail("Promise was canceled when it should have been resolved."); return Promise<int>.Canceled(); })
+                .Then(v => { actual = v; }, () => { Assert.Fail("Promise was rejected when it should have been resolved."); })
+                .Forget();
+
+            deferred.Resolve(expected);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void IfPromiseIsRejected_ReturnedPromiseMustBeRejectedWithTheSameReason_void0()
+        {
+            var deferred = Promise.NewDeferred();
+
+            float expected = 1.5f;
+            float actual = -1f;
+
+            deferred.Promise
+                .CatchCancelation(() => Assert.Fail("Promise was canceled when it should have been rejected."))
+                .Then(() => Assert.Fail("Promise was resolved when it should have been rejected."), (float rejectReason) => { actual = rejectReason; })
+                .Forget();
+
+            deferred.Reject(expected);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void IfPromiseIsRejected_ReturnedPromiseMustBeRejectedWithTheSameReason_void1()
+        {
+            var deferred = Promise.NewDeferred();
+
+            float expected = 1.5f;
+            float actual = -1f;
+
+            deferred.Promise
+                .CatchCancelation(() => { Assert.Fail("Promise was canceled when it should have been rejected."); return Promise.Canceled(); })
+                .Then(() => Assert.Fail("Promise was resolved when it should have been rejected."), (float rejectReason) => { actual = rejectReason; })
+                .Forget();
+
+            deferred.Reject(expected);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void IfPromiseIsRejected_ReturnedPromiseMustBeRejectedWithTheSameReason_T0()
+        {
+            var deferred = Promise.NewDeferred<int>();
+
+            float expected = 1.5f;
+            float actual = -1f;
+
+            deferred.Promise
+                .CatchCancelation(() => { Assert.Fail("Promise was canceled when it should have been rejected."); return -10; })
+                .Then(() => Assert.Fail("Promise was resolved when it should have been rejected."), (float rejectReason) => { actual = rejectReason; })
+                .Forget();
+
+            deferred.Reject(expected);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void IfPromiseIsRejected_ReturnedPromiseMustBeRejectedWithTheSameReason_T1()
+        {
+            var deferred = Promise.NewDeferred<int>();
+
+            float expected = 1.5f;
+            float actual = -1f;
+
+            deferred.Promise
+                .CatchCancelation(() => { Assert.Fail("Promise was canceled when it should have been rejected."); return Promise<int>.Canceled(); })
+                .Then(() => Assert.Fail("Promise was resolved when it should have been rejected."), (float rejectReason) => { actual = rejectReason; })
+                .Forget();
+
+            deferred.Reject(expected);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        public class ThePromiseResolutionProcedure
+        {
+            [SetUp]
+            public void Setup()
+            {
+                TestHelper.Setup();
+            }
+
+            [TearDown]
+            public void Teardown()
+            {
+                TestHelper.Cleanup();
+            }
+
+#if PROMISE_DEBUG
+            [Test]
+            public void IfPromiseAndXReferToTheSameObject_RejectPromiseWithInvalidReturnExceptionAsTheReason_void()
+            {
+                int exceptionCounter = 0;
+
+                var deferred = Promise.NewDeferred();
+                var promise = deferred.Promise.Preserve();
+
+                TestAction<Promise> catchCallback = (ref Promise p) =>
+                {
+                    var preserved = p.Preserve();
+                    p = preserved;
+                    p.Finally(() => preserved.Forget())
+                    .Catch((object e) =>
+                    {
+                        Assert.IsInstanceOf<InvalidReturnException>(e);
+                        ++exceptionCounter;
+                    }).Forget();
+                };
+                TestAction<Promise<int>> catchCallbackConvert = (ref Promise<int> p) =>
+                {
+                    var preserved = p.Preserve();
+                    p = preserved;
+                    p.Finally(() => preserved.Forget())
+                    .Catch((object e) =>
+                    {
+                        Assert.IsInstanceOf<InvalidReturnException>(e);
+                        ++exceptionCounter;
+                    }).Forget();
+                };
+
+                TestHelper.AddCancelCallbacks<float>(promise,
+                    promiseToPromise: p => p,
+                    onCallbackAdded: catchCallback
+                );
+                TestHelper.AddContinueCallbacks<int, float>(promise,
+                    promiseToPromise: p => p,
+                    promiseToPromiseConvert: p => p,
+                    onCallbackAdded: catchCallback,
+                    onCallbackAddedConvert: catchCallbackConvert
+                );
+
+                deferred.Cancel();
+
+                Assert.AreEqual(
+                    (4 + (TestHelper.continueVoidPromiseVoidCallbacks + TestHelper.continueVoidPromiseConvertCallbacks) * 2) * 2,
+                    exceptionCounter
+                );
+
+                promise.Forget();
+            }
+
+            [Test]
+            public void IfPromiseAndXReferToTheSameObject_RejectPromiseWithInvalidReturnExceptionAsTheReason_T()
+            {
+                int exceptionCounter = 0;
+
+                var deferred = Promise.NewDeferred<int>();
+                var promise = deferred.Promise.Preserve();
+
+                TestAction<Promise> catchCallback = (ref Promise p) =>
+                {
+                    var preserved = p.Preserve();
+                    p = preserved;
+                    p.Finally(() => preserved.Forget())
+                    .Catch((object e) =>
+                    {
+                        Assert.IsInstanceOf<InvalidReturnException>(e);
+                        ++exceptionCounter;
+                    }).Forget();
+                };
+                TestAction<Promise<int>> catchCallbackConvert = (ref Promise<int> p) =>
+                {
+                    var preserved = p.Preserve();
+                    p = preserved;
+                    p.Finally(() => preserved.Forget())
+                    .Catch((object e) =>
+                    {
+                        Assert.IsInstanceOf<InvalidReturnException>(e);
+                        ++exceptionCounter;
+                    }).Forget();
+                };
+
+                TestHelper.AddCancelCallbacks<int, float>(promise,
+                    promiseToPromise: p => p,
+                    onCallbackAdded: catchCallbackConvert
+                );
+                TestHelper.AddContinueCallbacks<int, int, float>(promise,
+                    promiseToPromise: p => p,
+                    promiseToPromiseConvert: p => p,
+                    onCallbackAdded: catchCallback,
+                    onCallbackAddedConvert: catchCallbackConvert
+                );
+
+                deferred.Cancel();
+
+                Assert.AreEqual(
+                    (4 + (TestHelper.continueVoidPromiseVoidCallbacks + TestHelper.continueVoidPromiseConvertCallbacks) * 2) * 2,
+                    exceptionCounter
+                );
+
+                promise.Forget();
+            }
+#endif
+
+            public class IfXIsAPromiseAdoptItsState
+            {
+                [SetUp]
+                public void Setup()
+                {
+                    TestHelper.Setup();
+                }
+
+                [TearDown]
+                public void Teardown()
+                {
+                    TestHelper.Cleanup();
+                }
+
+                [Test]
+                public void IfXIsPending_PromiseMustRemainPendingUntilXIsFulfilledOrRejectedOrCanceled_void()
+                {
+                    int expectedCompleteCount = 0;
+                    int completeCounter = 0;
+
+                    var cancelDeferred = Promise.NewDeferred();
+                    var cancelPromise = cancelDeferred.Promise.Preserve();
+
+                    var resolveWaitDeferred = Promise.NewDeferred();
+                    var rejectWaitDeferred = Promise.NewDeferred();
+                    var cancelWaitDeferred = Promise.NewDeferred();
+
+                    var resolveWaitPromise = resolveWaitDeferred.Promise.Preserve();
+                    var rejectWaitPromise = rejectWaitDeferred.Promise.Preserve();
+                    var cancelWaitPromise = rejectWaitDeferred.Promise.Preserve();
+
+                    TestAction<Promise> onCallbackAdded = (ref Promise p) =>
+                    {
+                        var preserved = p = p.Preserve();
+                        preserved
+                            .Catch(() => { })
+                            .Finally(() => preserved.Forget())
+                            .Forget();
+                    };
+
+                    TestHelper.AddCancelCallbacks<float>(cancelPromise,
+                        promiseToPromise: p =>
+                        {
+                            p.Finally(() => ++completeCounter).Forget();
+                            return resolveWaitPromise;
+                        },
+                        onCallbackAdded: onCallbackAdded
+                    );
+                    TestHelper.AddCancelCallbacks<float>(cancelPromise,
+                        promiseToPromise: p =>
+                        {
+                            p.Finally(() => ++completeCounter).Forget();
+                            return rejectWaitPromise;
+                        },
+                        onCallbackAdded: onCallbackAdded
+                    );
+                    TestHelper.AddCancelCallbacks<float>(cancelPromise,
+                        promiseToPromise: p =>
+                        {
+                            p.Finally(() => ++completeCounter).Forget();
+                            return cancelWaitPromise;
+                        },
+                        onCallbackAdded: onCallbackAdded
+                    );
+                    cancelDeferred.Cancel();
+                    Assert.AreEqual(expectedCompleteCount, completeCounter);
+
+                    resolveWaitDeferred.Resolve();
+                    expectedCompleteCount += TestHelper.onCancelCallbacks * 2;
+                    Assert.AreEqual(expectedCompleteCount, completeCounter);
+
+                    rejectWaitDeferred.Reject("Reject");
+                    expectedCompleteCount += TestHelper.onCancelCallbacks * 2;
+                    Assert.AreEqual(expectedCompleteCount, completeCounter);
+
+                    cancelWaitDeferred.Cancel();
+                    expectedCompleteCount += TestHelper.onCancelCallbacks * 2;
+                    Assert.AreEqual(expectedCompleteCount, completeCounter);
+
+                    cancelPromise.Forget();
+                    resolveWaitPromise.Forget();
+                    rejectWaitPromise.Forget();
+                    cancelWaitPromise.Forget();
+                }
+
+                [Test]
+                public void IfXIsPending_PromiseMustRemainPendingUntilXIsFulfilledOrRejectedOrCanceled_T()
+                {
+                    int expectedCompleteCount = 0;
+                    int completeCounter = 0;
+
+                    var cancelDeferred = Promise.NewDeferred<int>();
+                    var cancelPromise = cancelDeferred.Promise.Preserve();
+
+                    var resolveWaitDeferred = Promise.NewDeferred<int>();
+                    var rejectWaitDeferred = Promise.NewDeferred<int>();
+                    var cancelWaitDeferred = Promise.NewDeferred<int>();
+
+                    var resolveWaitPromise = resolveWaitDeferred.Promise.Preserve();
+                    var rejectWaitPromise = rejectWaitDeferred.Promise.Preserve();
+                    var cancelWaitPromise = rejectWaitDeferred.Promise.Preserve();
+
+                    TestAction<Promise<int>> onCallbackAdded = (ref Promise<int> p) =>
+                    {
+                        var preserved = p = p.Preserve();
+                        preserved
+                            .Catch(() => { })
+                            .Finally(() => preserved.Forget())
+                            .Forget();
+                    };
+
+                    TestHelper.AddCancelCallbacks<int, float>(cancelPromise,
+                        promiseToPromise: p =>
+                        {
+                            p.Finally(() => ++completeCounter).Forget();
+                            return resolveWaitPromise;
+                        },
+                        onCallbackAdded: onCallbackAdded
+                    );
+                    TestHelper.AddCancelCallbacks<int, float>(cancelPromise,
+                        promiseToPromise: p =>
+                        {
+                            p.Finally(() => ++completeCounter).Forget();
+                            return rejectWaitPromise;
+                        },
+                        onCallbackAdded: onCallbackAdded
+                    );
+                    TestHelper.AddCancelCallbacks<int, float>(cancelPromise,
+                        promiseToPromise: p =>
+                        {
+                            p.Finally(() => ++completeCounter).Forget();
+                            return cancelWaitPromise;
+                        },
+                        onCallbackAdded: onCallbackAdded
+                    );
+                    cancelDeferred.Cancel();
+                    Assert.AreEqual(expectedCompleteCount, completeCounter);
+
+                    resolveWaitDeferred.Resolve(1);
+                    expectedCompleteCount += TestHelper.onCancelCallbacks * 2;
+                    Assert.AreEqual(expectedCompleteCount, completeCounter);
+
+                    rejectWaitDeferred.Reject("Reject");
+                    expectedCompleteCount += TestHelper.onCancelCallbacks * 2;
+                    Assert.AreEqual(expectedCompleteCount, completeCounter);
+
+                    cancelWaitDeferred.Cancel();
+                    expectedCompleteCount += TestHelper.onCancelCallbacks * 2;
+                    Assert.AreEqual(expectedCompleteCount, completeCounter);
+
+                    cancelPromise.Forget();
+                    resolveWaitPromise.Forget();
+                    rejectWaitPromise.Forget();
+                    cancelWaitPromise.Forget();
+                }
+
+                [Test]
+                public void IfWhenXIsFulfilled_FulfillPromiseWithTheSameValue_void()
+                {
+                    var cancelDeferred = Promise.NewDeferred();
+                    cancelDeferred.Cancel();
+
+                    var cancelPromise = cancelDeferred.Promise.Preserve();
+
+                    int resolveCounter = 0;
+
+                    TestAction<Promise> onAdoptCallbackAdded = (ref Promise p) =>
+                    {
+                        p.Then(() =>
+                        {
+                            ++resolveCounter;
+                        }).Forget();
+                    };
+
+                    var resolveWaitDeferred = Promise.NewDeferred();
+                    var resolveWaitPromise = resolveWaitDeferred.Promise.Preserve();
+
+                    Func<Promise, Promise> promiseToPromise = p => resolveWaitPromise;
+
+                    // Test pending -> resolved and already resolved.
+                    bool firstRun = true;
+                RunAgain:
+                    resolveCounter = 0;
+
+                    TestHelper.AddCancelCallbacks<float>(cancelPromise,
+                        promiseToPromise: promiseToPromise,
+                        onAdoptCallbackAdded: onAdoptCallbackAdded
+                    );
+
+                    if (firstRun)
+                    {
+                        Assert.AreEqual(0, resolveCounter);
+                        resolveWaitDeferred.Resolve();
+                    }
+
+                    Assert.AreEqual(TestHelper.onCancelCallbacks * 2, resolveCounter);
+
+                    if (firstRun)
+                    {
+                        firstRun = false;
+                        goto RunAgain;
+                    }
+
+                    cancelPromise.Forget();
+                    resolveWaitPromise.Forget();
+                }
+
+                [Test]
+                public void IfWhenXIsFulfilled_FulfillPromiseWithTheSameValue_T()
+                {
+                    var cancelDeferred = Promise.NewDeferred<int>();
+                    cancelDeferred.Cancel();
+
+                    var cancelPromise = cancelDeferred.Promise.Preserve();
+
+                    int resolveValue = 100;
+                    int resolveCounter = 0;
+
+                    TestAction<Promise<int>> onAdoptCallbackAdded = (ref Promise<int> p) =>
+                    {
+                        p.Then(v =>
+                        {
+                            Assert.AreEqual(resolveValue, v);
+                            ++resolveCounter;
+                        }).Forget();
+                    };
+
+                    var resolveWaitDeferred = Promise.NewDeferred<int>();
+                    var resolveWaitPromise = resolveWaitDeferred.Promise.Preserve();
+
+                    Func<Promise<int>, Promise<int>> promiseToPromise = p => resolveWaitPromise;
+
+                    // Test pending -> resolved and already resolved.
+                    bool firstRun = true;
+                RunAgain:
+                    resolveCounter = 0;
+
+                    TestHelper.AddCancelCallbacks<int, float>(cancelPromise,
+                        promiseToPromise: promiseToPromise,
+                        onAdoptCallbackAdded: onAdoptCallbackAdded
+                    );
+
+                    if (firstRun)
+                    {
+                        Assert.AreEqual(0, resolveCounter);
+                        resolveWaitDeferred.Resolve(resolveValue);
+                    }
+
+                    Assert.AreEqual(TestHelper.onCancelCallbacks * 2, resolveCounter);
+
+                    if (firstRun)
+                    {
+                        firstRun = false;
+                        goto RunAgain;
+                    }
+
+                    cancelPromise.Forget();
+                    resolveWaitPromise.Forget();
+                }
+
+                [Test]
+                public void IfWhenXIsRejected_RejectPromiseWithTheSameReason_void()
+                {
+                    var cancelDeferred = Promise.NewDeferred();
+                    cancelDeferred.Cancel();
+
+                    var cancelPromise = cancelDeferred.Promise.Preserve();
+
+                    float rejectReason = 1.5f;
+                    int rejectCounter = 0;
+
+                    TestAction<Promise> onAdoptCallbackAdded = (ref Promise p) =>
+                    {
+                        p.Catch((float reason) =>
+                        {
+                            Assert.AreEqual(rejectReason, reason);
+                            ++rejectCounter;
+                        }).Forget();
+                    };
+
+                    var rejectWaitDeferred = Promise.NewDeferred();
+                    var rejectWaitPromise = rejectWaitDeferred.Promise.Preserve();
+
+                    Func<Promise, Promise> promiseToPromise = p => rejectWaitPromise;
+
+                    // Test pending -> rejected and already rejected.
+                    bool firstRun = true;
+                RunAgain:
+                    rejectCounter = 0;
+
+                    TestHelper.AddCancelCallbacks<float>(cancelPromise,
+                        promiseToPromise: promiseToPromise,
+                        onAdoptCallbackAdded: onAdoptCallbackAdded
+                    );
+
+                    if (firstRun)
+                    {
+                        Assert.AreEqual(0, rejectCounter);
+                        rejectWaitDeferred.Reject(rejectReason);
+                    }
+
+                    Assert.AreEqual(TestHelper.onCancelCallbacks * 2, rejectCounter);
+
+                    if (firstRun)
+                    {
+                        firstRun = false;
+                        goto RunAgain;
+                    }
+
+                    cancelPromise.Forget();
+                    rejectWaitPromise.Forget();
+                }
+
+                [Test]
+                public void IfWhenXIsRejected_RejectPromiseWithTheSameReason_T()
+                {
+                    var cancelDeferred = Promise.NewDeferred<int>();
+                    cancelDeferred.Cancel();
+
+                    var cancelPromise = cancelDeferred.Promise.Preserve();
+
+                    float rejectReason = 1.5f;
+                    int rejectCounter = 0;
+
+                    TestAction<Promise<int>> onAdoptCallbackAdded = (ref Promise<int> p) =>
+                    {
+                        p.Catch((float reason) =>
+                        {
+                            Assert.AreEqual(rejectReason, reason);
+                            ++rejectCounter;
+                        }).Forget();
+                    };
+
+                    var rejectWaitDeferred = Promise.NewDeferred<int>();
+                    var rejectWaitPromise = rejectWaitDeferred.Promise.Preserve();
+
+                    Func<Promise<int>, Promise<int>> promiseToPromise = p => rejectWaitPromise;
+
+                    // Test pending -> rejected and already rejected.
+                    bool firstRun = true;
+                RunAgain:
+                    rejectCounter = 0;
+
+                    TestHelper.AddCancelCallbacks<int, float>(cancelPromise,
+                        promiseToPromise: promiseToPromise,
+                        onAdoptCallbackAdded: onAdoptCallbackAdded
+                    );
+
+                    if (firstRun)
+                    {
+                        Assert.AreEqual(0, rejectCounter);
+                        rejectWaitDeferred.Reject(rejectReason);
+                    }
+
+                    Assert.AreEqual(TestHelper.onCancelCallbacks * 2, rejectCounter);
+
+                    if (firstRun)
+                    {
+                        firstRun = false;
+                        goto RunAgain;
+                    }
+
+                    cancelPromise.Forget();
+                    rejectWaitPromise.Forget();
+                }
+            }
+
+            [Test]
+            public void IfOnCanceledReturnsSuccessfully_ResolvePromise_void()
+            {
+                var deferred = Promise.NewDeferred();
+
+                int resolveCounter = 0;
+
+                TestAction<Promise> onCallbackAdded = (ref Promise p) => p.Then(() => ++resolveCounter).Forget();
+
+                TestHelper.AddCancelCallbacks<float>(deferred.Promise,
+                    onCancel: () => { },
+                    onCancelCapture: cv => { },
+                    onCallbackAdded: onCallbackAdded
+                );
+
+                deferred.Cancel();
+
+                Assert.AreEqual(
+                    TestHelper.onCancelCallbacks * 2,
+                    resolveCounter
+                );
+            }
+
+            [Test]
+            public void IfOnResolvedOrOnRejectedReturnsSuccessfully_ResolvePromise_T()
+            {
+                var deferred = Promise.NewDeferred<int>();
+
+                int expected = 100;
+                int resolveCounter = 0;
+
+                TestAction<Promise<int>> onCallbackAdded = (ref Promise<int> p) => p.Then(v =>
+                {
+                    Assert.AreEqual(expected, v);
+                    ++resolveCounter;
+                }).Forget();
+
+                TestHelper.AddCancelCallbacks<int, float>(deferred.Promise,
+                    TValue: expected,
+                    onCancel: () => { },
+                    onCancelCapture: cv => { },
+                    onCallbackAdded: onCallbackAdded
+                );
+
+                deferred.Cancel();
+
+                Assert.AreEqual(
+                    TestHelper.onCancelCallbacks * 2,
+                    resolveCounter
+                );
+            }
+
+            // If a promise is resolved with a thenable that participates in a circular thenable chain, such that the recursive
+            // nature of[[Resolve]](promise, thenable) eventually causes[[Resolve]](promise, thenable) to be
+            // called again, following the above algorithm will lead to infinite recursion.Implementations are encouraged, but
+            // not required, to detect such recursion and reject promise with an informative Exception as the reason.
+
+#if PROMISE_DEBUG
+            [Test]
+            public void IfXIsAPromiseAndItResultsInACircularPromiseChain_RejectPromiseWithInvalidReturnExceptionAsTheReason_void()
+            {
+                var deferred = Promise.NewDeferred();
+
+                int exceptionCounter = 0;
+
+                Action<object> catcher = (object o) =>
+                {
+                    Assert.IsInstanceOf<InvalidReturnException>(o);
+                    ++exceptionCounter;
+                };
+
+                Func<Promise, Promise> promiseToPromise = p =>
+                {
+                    p.Catch(catcher).Forget();
+                    return p.ThenDuplicate().ThenDuplicate().Catch(() => { });
+                };
+
+                TestAction<Promise> onCallbackAdded = (ref Promise p) =>
+                {
+                    var preserved = p = p.Preserve();
+                    preserved
+                        .Catch(() => { })
+                        .Finally(() => preserved.Forget())
+                        .Forget();
+                };
+
+                TestHelper.AddCancelCallbacks<float>(deferred.Promise,
+                    promiseToPromise: promiseToPromise,
+                    onCallbackAdded: onCallbackAdded
+                );
+
+                deferred.Cancel();
+
+                Assert.AreEqual(TestHelper.onCancelCallbacks * 2, exceptionCounter);
+            }
+
+            [Test]
+            public void _2_3_5_IfXIsAPromiseAndItResultsInACircularPromiseChain_RejectPromiseWithInvalidReturnExceptionAsTheReason_T()
+            {
+                var deferred = Promise.NewDeferred<int>();
+
+                int exceptionCounter = 0;
+
+                Action<object> catcher = (object o) =>
+                {
+                    Assert.IsInstanceOf<InvalidReturnException>(o);
+                    ++exceptionCounter;
+                };
+
+                Func<Promise<int>, Promise<int>> promiseToPromise = p =>
+                {
+                    p.Catch(catcher).Forget();
+                    return p.ThenDuplicate().ThenDuplicate().Catch(() => 1);
+                };
+
+                TestAction<Promise<int>> onCallbackAdded = (ref Promise<int> p) =>
+                {
+                    var preserved = p = p.Preserve();
+                    preserved
+                        .Catch(() => { })
+                        .Finally(() => preserved.Forget())
+                        .Forget();
+                };
+
+                TestHelper.AddCancelCallbacks<int, float>(deferred.Promise,
+                    promiseToPromise: promiseToPromise,
+                    onCallbackAdded: onCallbackAdded
+                );
+
+                deferred.Cancel();
+
+                Assert.AreEqual(TestHelper.onCancelCallbacks * 2, exceptionCounter);
+            }
+#endif
         }
 
         [Test]
@@ -713,13 +1641,34 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void DeferredIsCanceledFromAlreadyCanceledToken()
+            public void DeferredIsCanceledFromAlreadyCanceledToken_0()
             {
                 var canceled = false;
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
 
                 var deferred = Promise.NewDeferred(cancelationSource.Token);
+
+                deferred.Promise
+                    .CatchCancelation(() =>
+                    {
+                        canceled = true;
+                    })
+                    .Forget();
+
+                Assert.True(canceled);
+
+                cancelationSource.Dispose();
+            }
+
+            [Test]
+            public void DeferredIsCanceledFromAlreadyCanceledToken_1()
+            {
+                var canceled = false;
+                CancelationSource cancelationSource = CancelationSource.New();
+                cancelationSource.Cancel();
+
+                var deferred = Promise.NewDeferred(Proto.Promises.CancelationToken.Canceled());
 
                 deferred.Promise
                     .CatchCancelation(() =>
@@ -804,7 +1753,7 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void OnCanceledIsNotInvokedIfTokenIsAlreadyCanceled()
+            public void OnCanceledIsNotInvokedIfTokenIsAlreadyCanceled_0()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
@@ -819,6 +1768,19 @@ namespace ProtoPromiseTests.APIs
                     .Forget();
 
                 cancelationSource.Dispose();
+            }
+
+            [Test]
+            public void OnCanceledIsNotInvokedIfTokenIsAlreadyCanceled_1()
+            {
+                Promise.Canceled()
+                    .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), Proto.Promises.CancelationToken.Canceled())
+                    .CatchCancelation(1, cv => Assert.Fail("OnCanceled was invoked."), Proto.Promises.CancelationToken.Canceled())
+                    .Forget();
+                Promise.Canceled<int>()
+                    .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), Proto.Promises.CancelationToken.Canceled())
+                    .CatchCancelation(1, cv => Assert.Fail("OnCanceled was invoked."), Proto.Promises.CancelationToken.Canceled())
+                    .Forget();
             }
 
             [Test]
@@ -942,7 +1904,7 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void OnResolvedIsNotInvokedIfTokenIsAlreadyCanceled_void()
+            public void OnResolvedIsNotInvokedIfTokenIsAlreadyCanceled_void0()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
@@ -970,7 +1932,31 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void OnResolvedIsNotInvokedIfTokenIsAlreadyCanceled_T()
+            public void OnResolvedIsNotInvokedIfTokenIsAlreadyCanceled_void1()
+            {
+                var deferred = Promise.NewDeferred();
+                var promise = deferred.Promise.Preserve();
+
+                TestHelper.AddResolveCallbacksWithCancelation<float, string>(
+                    promise,
+                    onResolve: () => Assert.Fail("OnResolved was invoked."),
+                    onResolveCapture: _ => Assert.Fail("OnResolved was invoked."),
+                    cancelationToken: Proto.Promises.CancelationToken.Canceled()
+                );
+                TestHelper.AddCallbacksWithCancelation<float, object, string>(
+                    promise,
+                    onResolve: () => Assert.Fail("OnResolved was invoked."),
+                    onResolveCapture: _ => Assert.Fail("OnResolved was invoked."),
+                    cancelationToken: Proto.Promises.CancelationToken.Canceled()
+                );
+
+                deferred.Resolve();
+
+                promise.Forget();
+            }
+
+            [Test]
+            public void OnResolvedIsNotInvokedIfTokenIsAlreadyCanceled_T0()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
@@ -994,6 +1980,30 @@ namespace ProtoPromiseTests.APIs
                 deferred.Resolve(1);
 
                 cancelationSource.Dispose();
+                promise.Forget();
+            }
+
+            [Test]
+            public void OnResolvedIsNotInvokedIfTokenIsAlreadyCanceled_T1()
+            {
+                var deferred = Promise.NewDeferred<int>();
+                var promise = deferred.Promise.Preserve();
+
+                TestHelper.AddResolveCallbacksWithCancelation<int, float, string>(
+                    promise,
+                    onResolve: _ => Assert.Fail("OnResolved was invoked."),
+                    onResolveCapture: _ => Assert.Fail("OnResolved was invoked."),
+                    cancelationToken: Proto.Promises.CancelationToken.Canceled()
+                );
+                TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
+                    promise,
+                    onResolve: _ => Assert.Fail("OnResolved was invoked."),
+                    onResolveCapture: _ => Assert.Fail("OnResolved was invoked."),
+                    cancelationToken: Proto.Promises.CancelationToken.Canceled()
+                );
+
+                deferred.Resolve(1);
+
                 promise.Forget();
             }
 
@@ -1042,7 +2052,7 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_void()
+            public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_void0()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
@@ -1064,7 +2074,24 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_T()
+            public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_void1()
+            {
+                var deferred = Promise.NewDeferred();
+
+                TestHelper.AddCallbacksWithCancelation<float, object, string>(
+                    deferred.Promise,
+                    onReject: _ => Assert.Fail("OnRejected was invoked."),
+                    onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
+                    onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
+                    onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
+                    cancelationToken: Proto.Promises.CancelationToken.Canceled()
+                );
+
+                deferred.Reject("Reject");
+            }
+
+            [Test]
+            public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_T0()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
@@ -1083,6 +2110,23 @@ namespace ProtoPromiseTests.APIs
                 deferred.Reject("Reject");
 
                 cancelationSource.Dispose();
+            }
+
+            [Test]
+            public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_T1()
+            {
+                var deferred = Promise.NewDeferred<int>();
+
+                TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
+                    deferred.Promise,
+                    onReject: _ => Assert.Fail("OnRejected was invoked."),
+                    onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
+                    onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
+                    onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
+                    cancelationToken: Proto.Promises.CancelationToken.Canceled()
+                );
+
+                deferred.Reject("Reject");
             }
 
             [Test]
@@ -1126,7 +2170,7 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void OnContinueIsNotInvokedIfTokenIsAlreadyCanceled_void()
+            public void OnContinueIsNotInvokedIfTokenIsAlreadyCanceled_void0()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
@@ -1146,7 +2190,22 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void OnContinueIsNotInvokedIfTokenIsAlreadyCanceled_T()
+            public void OnContinueIsNotInvokedIfTokenIsAlreadyCanceled_void1()
+            {
+                var deferred = Promise.NewDeferred();
+
+                TestHelper.AddContinueCallbacksWithCancelation<float, string>(
+                    deferred.Promise,
+                    onContinue: _ => Assert.Fail("OnContinue was invoked."),
+                    onContinueCapture: (_, __) => Assert.Fail("OnContinue was invoked."),
+                    cancelationToken: Proto.Promises.CancelationToken.Canceled()
+                );
+
+                deferred.Resolve();
+            }
+
+            [Test]
+            public void OnContinueIsNotInvokedIfTokenIsAlreadyCanceled_T0()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
@@ -1166,6 +2225,21 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
+            public void OnContinueIsNotInvokedIfTokenIsAlreadyCanceled_T1()
+            {
+                var deferred = Promise.NewDeferred<int>();
+
+                TestHelper.AddContinueCallbacksWithCancelation<int, float, string>(
+                    deferred.Promise,
+                    onContinue: _ => Assert.Fail("OnContinue was invoked."),
+                    onContinueCapture: (_, __) => Assert.Fail("OnContinue was invoked."),
+                    cancelationToken: Proto.Promises.CancelationToken.Canceled()
+                );
+
+                deferred.Resolve(1);
+            }
+
+            [Test]
             public void PromiseIsCanceledFromToken_void()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
@@ -1178,20 +2252,17 @@ namespace ProtoPromiseTests.APIs
                 TestHelper.AddResolveCallbacksWithCancelation<float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: () => ++cancelCallbacks,
-                    onCancelCapture: _ => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks
                 );
                 TestHelper.AddCallbacksWithCancelation<float, object, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: () => ++cancelCallbacks,
-                    onCancelCapture: _ => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks
                 );
                 TestHelper.AddContinueCallbacksWithCancelation<float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: () => ++cancelCallbacks,
-                    onCancelCapture: _ => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks
                 );
 
                 cancelationSource.Cancel();
@@ -1219,20 +2290,17 @@ namespace ProtoPromiseTests.APIs
                 TestHelper.AddResolveCallbacksWithCancelation<int, float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: () => ++cancelCallbacks,
-                    onCancelCapture: _ => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks
                 );
                 TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: () => ++cancelCallbacks,
-                    onCancelCapture: _ => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks
                 );
                 TestHelper.AddContinueCallbacksWithCancelation<int, float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: () => ++cancelCallbacks,
-                    onCancelCapture: _ => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks
                 );
 
                 cancelationSource.Cancel();
@@ -1261,20 +2329,17 @@ namespace ProtoPromiseTests.APIs
                 TestHelper.AddResolveCallbacksWithCancelation<float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: () => ++cancelCallbacks,
-                    onCancelCapture: _ => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks
                 );
                 TestHelper.AddCallbacksWithCancelation<float, object, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: () => ++cancelCallbacks,
-                    onCancelCapture: _ => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks
                 );
                 TestHelper.AddContinueCallbacksWithCancelation<float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: () => ++cancelCallbacks,
-                    onCancelCapture: _ => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks
                 );
 
                 deferred.Resolve();
@@ -1302,20 +2367,17 @@ namespace ProtoPromiseTests.APIs
                 TestHelper.AddResolveCallbacksWithCancelation<int, float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: () => ++cancelCallbacks,
-                    onCancelCapture: _ => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks
                 );
                 TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: () => ++cancelCallbacks,
-                    onCancelCapture: _ => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks
                 );
                 TestHelper.AddContinueCallbacksWithCancelation<int, float, string>(
                     promise,
                     cancelationToken: cancelationSource.Token,
-                    onCancel: () => ++cancelCallbacks,
-                    onCancelCapture: _ => ++cancelCallbacks
+                    onCancel: () => ++cancelCallbacks
                 );
 
                 deferred.Resolve(1);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/WaitAsyncTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/WaitAsyncTests.cs
@@ -140,7 +140,7 @@ namespace ProtoPromiseTests.APIs
             }
         }
 
-        private readonly TimeSpan timeout = TimeSpan.FromSeconds(1);
+        private readonly TimeSpan timeout = TimeSpan.FromSeconds(20);
 
         // promise
         //     .Then(() => otherPromise.WaitAsync(SynchronizationOption))

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/ApiWithCancelationTokenConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/ApiWithCancelationTokenConcurrencyTests.cs
@@ -192,6 +192,8 @@ namespace ProtoPromiseTests.Threading
                 {
                     (promise, token) => promise.CatchCancelation(() => { }, token),
                     (promise, token) => promise.CatchCancelation(1, cv => { }, token),
+                    (promise, token) => promise.CatchCancelation(() => Promise.Resolved(), token),
+                    (promise, token) => promise.CatchCancelation(1, cv => Promise.Resolved(), token),
                 })
             {
                 threadHelper.ExecuteParallelActionsWithOffsets(false,
@@ -227,8 +229,10 @@ namespace ProtoPromiseTests.Threading
             var threadHelper = new ThreadHelper();
             foreach (var action in new Func<Promise<int>, CancelationToken, Promise<int>>[]
                 {
-                    (promise, token) => promise.CatchCancelation(() => { }, token),
-                    (promise, token) => promise.CatchCancelation(1, cv => { }, token),
+                    (promise, token) => promise.CatchCancelation(() => 1, token),
+                    (promise, token) => promise.CatchCancelation(1, cv => 1, token),
+                    (promise, token) => promise.CatchCancelation(() => Promise.Resolved(1), token),
+                    (promise, token) => promise.CatchCancelation(1, cv => Promise.Resolved(1), token),
                 })
             {
                 threadHelper.ExecuteParallelActionsWithOffsets(false,
@@ -511,6 +515,8 @@ namespace ProtoPromiseTests.Threading
                 {
                     (p, token) => p.CatchCancelation(() => { }, token),
                     (p, token) => p.CatchCancelation(1, cv => { }, token),
+                    (p, token) => p.CatchCancelation(() => Promise.Resolved(), token),
+                    (p, token) => p.CatchCancelation(1, cv => Promise.Resolved(), token),
                 })
             {
                 threadHelper.ExecuteParallelActionsWithOffsets(false,
@@ -568,8 +574,10 @@ namespace ProtoPromiseTests.Threading
             var threadHelper = new ThreadHelper();
             foreach (var action in new Func<Promise<int>, CancelationToken, Promise<int>>[]
                 {
-                    (p, token) => p.CatchCancelation(() => { }, token),
-                    (p, token) => p.CatchCancelation(1, cv => { }, token),
+                    (p, token) => p.CatchCancelation(() => 1, token),
+                    (p, token) => p.CatchCancelation(1, cv => 1, token),
+                    (p, token) => p.CatchCancelation(() => Promise.Resolved(1), token),
+                    (p, token) => p.CatchCancelation(1, cv => Promise.Resolved(1), token),
                 })
             {
                 threadHelper.ExecuteParallelActionsWithOffsets(false,

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/PromiseConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/PromiseConcurrencyTests.cs
@@ -265,7 +265,7 @@ namespace ProtoPromiseTests.Threading
             Assert.AreEqual(ThreadHelper.multiExecutionCount, invokedCount);
         }
 
-        private static readonly TimeSpan progressConcurrencyTimeout = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan progressConcurrencyTimeout = TimeSpan.FromSeconds(20);
 
         [Test]
         public void PromiseProgressMayBeSubscribedWhilePromiseIsCompletedAndProgressIsReportedConcurrently_Pending_void(

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/PromiseConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/PromiseConcurrencyTests.cs
@@ -265,6 +265,8 @@ namespace ProtoPromiseTests.Threading
             Assert.AreEqual(ThreadHelper.multiExecutionCount, invokedCount);
         }
 
+        private static readonly TimeSpan progressConcurrencyTimeout = TimeSpan.FromSeconds(10);
+
         [Test]
         public void PromiseProgressMayBeSubscribedWhilePromiseIsCompletedAndProgressIsReportedConcurrently_Pending_void(
             [Values] ActionPlace subscribePlace,
@@ -381,7 +383,7 @@ namespace ProtoPromiseTests.Threading
                 {
                     for (int i = 0; i < progressHelpers.Length; ++i)
                     {
-                        progressHelpers[i].MaybeWaitForInvoke(true, i == 0, TimeSpan.FromSeconds(ThreadHelper.multiExecutionCount)); // Only need to execute foreground the first time.
+                        progressHelpers[i].MaybeWaitForInvoke(true, i == 0, progressConcurrencyTimeout); // Only need to execute foreground the first time.
                         progressHelpers[i].PrepareForInvoke();
                     }
                 }
@@ -395,7 +397,7 @@ namespace ProtoPromiseTests.Threading
                 {
                     // Progress may have been invoked simultaneously, so we can't know what the progress value is here.
                     // We must only WaitForInvoke instead of AssertCurrentProgress.
-                    progressHelpers[i].MaybeWaitForInvoke(completeType == CompleteType.Resolve, i == 0, TimeSpan.FromSeconds(ThreadHelper.multiExecutionCount)); // Only need to execute foreground the first time.
+                    progressHelpers[i].MaybeWaitForInvoke(completeType == CompleteType.Resolve, i == 0, progressConcurrencyTimeout); // Only need to execute foreground the first time.
                     progressHelpers[i].MaybeExitLock();
                 }
                 AssertInvokes();
@@ -523,7 +525,7 @@ namespace ProtoPromiseTests.Threading
                 {
                     for (int i = 0; i < progressHelpers.Length; ++i)
                     {
-                        progressHelpers[i].MaybeWaitForInvoke(true, i == 0, TimeSpan.FromSeconds(ThreadHelper.multiExecutionCount)); // Only need to execute foreground the first time.
+                        progressHelpers[i].MaybeWaitForInvoke(true, i == 0, progressConcurrencyTimeout); // Only need to execute foreground the first time.
                         progressHelpers[i].PrepareForInvoke();
                     }
                 }
@@ -537,7 +539,7 @@ namespace ProtoPromiseTests.Threading
                 {
                     // Progress may have been invoked simultaneously, so we can't know what the progress value is here.
                     // We must only WaitForInvoke instead of AssertCurrentProgress.
-                    progressHelpers[i].MaybeWaitForInvoke(completeType == CompleteType.Resolve, i == 0, TimeSpan.FromSeconds(ThreadHelper.multiExecutionCount)); // Only need to execute foreground the first time.
+                    progressHelpers[i].MaybeWaitForInvoke(completeType == CompleteType.Resolve, i == 0, progressConcurrencyTimeout); // Only need to execute foreground the first time.
                     progressHelpers[i].MaybeExitLock();
                 }
                 AssertInvokes();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/PromiseConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/PromiseConcurrencyTests.cs
@@ -374,9 +374,6 @@ namespace ProtoPromiseTests.Threading
                 promiseCompleter.Setup();
             };
             bool waitForSubscribeTeardown = !waitForSubscribeSetup && completePlace == ActionPlace.InTeardown;
-            bool waitForReportTeardown = !waitForReportSetup && completePlace == ActionPlace.InTeardown
-                && (subscribePlace != ActionPlace.Parallel || reportPlace != ActionPlace.Parallel)
-                && (waitForSubscribeSetup || !waitForSubscribeTeardown || reportPlace == ActionPlace.InTeardown);
             Action teardownAction = () =>
             {
                 progressSubscriber.Teardown();


### PR DESCRIPTION
closes #13

Changed behavior of `Promise.CatchCancelation` to be more like `Promise.Catch`, where `onCanceled` resolves the returned promise when it returns, or adopts the state of the returned promise.

Follow-up from #29.

I decided not to add `Promise.ObserveCancelation` (which is what the current behavior acts like), as that behavior can already be done by the user just by throwing a `Promise.CancelException()`, or using `ContinueWith` and rethrowing:

```cs
promise.ContinueWith(r =>
{
    if (r.State == Promise.State.Canceled)
    {
        // Observe code...
        r.RethrowIfCanceled();
    }
    r.RethrowIfRejected();
    return r.Result;
}
```

And the need for that behavior is pretty niche, I think.