### PR TITLE
Interfaces to abstract classes

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
@@ -334,23 +334,7 @@ namespace Proto.Promises
                 }
             }
 
-            partial class MergePromise
-            {
-                protected override void BorrowPassthroughs(Stack<PromisePassThrough> borrower)
-                {
-                    ExchangePassthroughs(ref _passThroughs, borrower, _locker);
-                }
-            }
-
-            partial class RacePromise
-            {
-                protected override void BorrowPassthroughs(Stack<PromisePassThrough> borrower)
-                {
-                    ExchangePassthroughs(ref _passThroughs, borrower, _locker);
-                }
-            }
-
-            partial class FirstPromise
+            partial class MultiHandleablePromiseBase
             {
                 protected override void BorrowPassthroughs(Stack<PromisePassThrough> borrower)
                 {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Exceptions.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Exceptions.cs
@@ -240,7 +240,7 @@ namespace Proto.Promises
 #endif
         }
 
-        Internal.IRejectValueContainer Internal.IRejectionToContainer.ToContainer(Internal.ITraceable traceable)
+        Internal.ValueContainer Internal.IRejectionToContainer.ToContainer(Internal.ITraceable traceable)
         {
 #if PROMISE_DEBUG
             string stacktrace = Internal.FormatStackTrace(new StackTrace[1] { new StackTrace(this, true) });

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -360,7 +360,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             public static AsyncPromiseRef GetOrCreate()
             {
-                var promise = ObjectPool<ITreeHandleable>.TryTake<AsyncPromiseRef>()
+                var promise = ObjectPool<HandleablePromiseBase>.TryTake<AsyncPromiseRef>()
                     ?? new AsyncPromiseRef();
                 promise.Reset();
                 return promise;
@@ -502,7 +502,7 @@ namespace Proto.Promises
                     _continuer.Dispose();
                     _continuer = null;
                 }
-                ObjectPool<ITreeHandleable>.MaybeRepool(this);
+                ObjectPool<HandleablePromiseBase>.MaybeRepool(this);
             }
         } // class AsyncPromiseRef
 
@@ -523,7 +523,7 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 public static void SetStateMachine(ref TStateMachine stateMachine, ref AsyncPromiseRef _ref)
                 {
-                    var promise = ObjectPool<ITreeHandleable>.TryTake<AsyncPromiseRefMachine<TStateMachine>>()
+                    var promise = ObjectPool<HandleablePromiseBase>.TryTake<AsyncPromiseRefMachine<TStateMachine>>()
                         ?? new AsyncPromiseRefMachine<TStateMachine>();
                     promise.Reset();
                     // ORDER VERY IMPORTANT, Task must be set before copying stateMachine.
@@ -535,7 +535,7 @@ namespace Proto.Promises
                 {
                     SuperDispose();
                     _stateMachine = default;
-                    ObjectPool<ITreeHandleable>.MaybeRepool(this);
+                    ObjectPool<HandleablePromiseBase>.MaybeRepool(this);
                 }
 
                 protected override void ContinueMethod()
@@ -562,7 +562,7 @@ namespace Proto.Promises
             protected override void Dispose()
             {
                 base.Dispose();
-                ObjectPool<ITreeHandleable>.MaybeRepool(this);
+                ObjectPool<HandleablePromiseBase>.MaybeRepool(this);
             }
 
             // Used for child to call base dispose without repooling for both types.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
@@ -106,7 +106,7 @@ namespace Proto.Promises
                 protected override void Dispose()
                 {
                     base.Dispose();
-                    ObjectPool<ITreeHandleable>.MaybeRepool(this);
+                    ObjectPool<HandleablePromiseBase>.MaybeRepool(this);
                 }
 
                 // Used for child to call base dispose without repooling for both types.
@@ -119,7 +119,7 @@ namespace Proto.Promises
 
                 internal static DeferredPromise<T> GetOrCreate()
                 {
-                    var promise = ObjectPool<ITreeHandleable>.TryTake<DeferredPromise<T>>()
+                    var promise = ObjectPool<HandleablePromiseBase>.TryTake<DeferredPromise<T>>()
                         ?? new DeferredPromise<T>();
                     promise.Reset();
                     return promise;
@@ -152,12 +152,12 @@ namespace Proto.Promises
                 {
                     SuperDispose();
                     _cancelationRegistration = default(CancelationRegistration);
-                    ObjectPool<ITreeHandleable>.MaybeRepool(this);
+                    ObjectPool<HandleablePromiseBase>.MaybeRepool(this);
                 }
 
                 internal static DeferredPromiseCancel<T> GetOrCreate(CancelationToken cancelationToken)
                 {
-                    var promise = ObjectPool<ITreeHandleable>.TryTake<DeferredPromiseCancel<T>>()
+                    var promise = ObjectPool<HandleablePromiseBase>.TryTake<DeferredPromiseCancel<T>>()
                         ?? new DeferredPromiseCancel<T>();
                     promise.Reset();
                     cancelationToken.TryRegister(promise, out promise._cancelationRegistration);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
@@ -306,14 +306,14 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancel.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     owner.ResolveInternal(valueContainer, ref executionScheduler);
                     valueContainer.Release();
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancel.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
@@ -322,13 +322,13 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     owner.ResolveInternal(valueContainer, ref executionScheduler);
                     valueContainer.Release();
                 }
 
-                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
@@ -386,7 +386,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancel.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     TResult result = Invoke(valueContainer.GetValue<TArg>());
                     valueContainer.Release();
@@ -394,7 +394,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancel.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -406,7 +406,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TResult result = Invoke(valueContainer.GetValue<TArg>());
                     owner.WaitFor(CreateResolved(result), ref executionScheduler);
@@ -414,7 +414,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -425,7 +425,7 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateReject.InvokeRejecter(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateReject.InvokeRejecter(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -441,7 +441,7 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateReject.InvokeRejecter(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateReject.InvokeRejecter(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -460,7 +460,7 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -476,7 +476,7 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -542,7 +542,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     Promise<TResult> result = Invoke(valueContainer.GetValue<TArg>());
                     owner.WaitFor(result, ref executionScheduler);
@@ -550,7 +550,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -561,7 +561,7 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -577,7 +577,7 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -643,12 +643,12 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     // JIT constant-optimizes these checks away.
                     bool isVoidArg = null != default(TArg) && typeof(TArg) == typeof(VoidResult);
                     bool isVoidResult = null != default(TResult) && typeof(TResult) == typeof(VoidResult);
-                    IValueContainer resolveContainer;
+                    ValueContainer resolveContainer;
                     if (isVoidResult)
                     {
                         if (isVoidArg)
@@ -679,7 +679,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
@@ -734,7 +734,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     // JIT constant-optimizes these checks away.
                     bool isVoidArg = null != default(TArg) && typeof(TArg) == typeof(VoidResult);
@@ -769,7 +769,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
@@ -904,7 +904,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancel.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     TResult result = Invoke(valueContainer.GetValue<TArg>());
                     valueContainer.Release();
@@ -912,7 +912,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancel.InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -924,7 +924,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TResult result = Invoke(valueContainer.GetValue<TArg>());
                     owner.WaitFor(CreateResolved(result), ref executionScheduler);
@@ -932,7 +932,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -943,7 +943,7 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateReject.InvokeRejecter(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateReject.InvokeRejecter(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -959,7 +959,7 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateReject.InvokeRejecter(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateReject.InvokeRejecter(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -978,7 +978,7 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -994,7 +994,7 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -1072,7 +1072,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     Promise<TResult> result = Invoke(valueContainer.GetValue<TArg>());
                     owner.WaitFor(result, ref executionScheduler);
@@ -1080,7 +1080,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -1091,7 +1091,7 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -1107,7 +1107,7 @@ namespace Proto.Promises
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -1179,12 +1179,12 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     // JIT constant-optimizes these checks away.
                     bool isVoidArg = null != default(TArg) && typeof(TArg) == typeof(VoidResult);
                     bool isVoidResult = null != default(TResult) && typeof(TResult) == typeof(VoidResult);
-                    IValueContainer resolveContainer;
+                    ValueContainer resolveContainer;
                     if (isVoidResult)
                     {
                         if (isVoidArg)
@@ -1215,7 +1215,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
@@ -1276,7 +1276,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     // JIT constant-optimizes these checks away.
                     bool isVoidArg = null != default(TArg) && typeof(TArg) == typeof(VoidResult);
@@ -1311,7 +1311,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
@@ -4,46 +4,47 @@
     {
         partial class PromiseRef
         {
-            internal partial interface IMultiTreeHandleable : ITreeHandleable
+            // Abstract classes is used instead of interface, because virtual calls on interfaces are twice as slow as virtual calls on classes.
+            internal abstract partial class MultiHandleablePromiseBase : PromiseSingleAwaitWithProgress
             {
-                void Handle(PromiseRef owner, IValueContainer valueContainer, PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler);
+                internal abstract void Handle(PromiseRef owner, ValueContainer valueContainer, PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateResolveOrCancel
             {
-                void InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
-                void InvokeResolver(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void InvokeResolver(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
+                void InvokeResolver(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateResolveOrCancelPromise
             {
-                void InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
-                void InvokeResolver(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
+                void InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
                 bool IsNull { get; }
             }
 
             internal interface IDelegateReject
             {
-                void InvokeRejecter(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
-                void InvokeRejecter(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void InvokeRejecter(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
+                void InvokeRejecter(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateRejectPromise
             {
-                void InvokeRejecter(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
-                void InvokeRejecter(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void InvokeRejecter(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
+                void InvokeRejecter(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateContinue
             {
-                void Invoke(IValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
-                void Invoke(IValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void Invoke(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
+                void Invoke(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateContinuePromise
             {
-                void Invoke(IValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
-                void Invoke(IValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void Invoke(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
+                void Invoke(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
                 bool IsNull { get; }
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -237,7 +237,7 @@ namespace Proto.Promises
                 }
 
 #if PROTO_PROMISE_DEVELOPER_MODE // Must use a queue instead of a stack in developer mode so that the ExecutionSchedule.ScheduleSynchronous can invoke immediately and still be in proper order.
-                private ValueLinkedQueue<ITreeHandleable> _nextBranches = new ValueLinkedQueue<ITreeHandleable>();
+                private ValueLinkedQueue<HandleablePromiseBase> _nextBranches = new ValueLinkedQueue<HandleablePromiseBase>();
 #else
                 private ValueLinkedStack<HandleablePromiseBase> _nextBranches = new ValueLinkedStack<HandleablePromiseBase>();
 #endif

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
@@ -25,7 +25,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal sealed partial class RacePromise : PromiseSingleAwaitWithProgress, IMultiTreeHandleable
+            internal sealed partial class RacePromise : MultiHandleablePromiseBase
             {
                 private RacePromise() { }
 
@@ -41,12 +41,12 @@ namespace Proto.Promises
                         }
                     }
 #endif
-                    ObjectPool<ITreeHandleable>.MaybeRepool(this);
+                    ObjectPool<HandleablePromiseBase>.MaybeRepool(this);
                 }
 
                 internal static RacePromise GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, uint pendingAwaits)
                 {
-                    var promise = ObjectPool<ITreeHandleable>.TryTake<RacePromise>()
+                    var promise = ObjectPool<HandleablePromiseBase>.TryTake<RacePromise>()
                         ?? new RacePromise();
 
                     checked
@@ -93,9 +93,9 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                public override void Handle(ref ExecutionScheduler executionScheduler)
+                internal override void Handle(ref ExecutionScheduler executionScheduler)
                 {
-                    IValueContainer valueContainer = (IValueContainer) _valueOrPrevious;
+                    ValueContainer valueContainer = (ValueContainer) _valueOrPrevious;
                     Promise.State state = valueContainer.GetState();
                     State = state;
                     HandleWaiter(valueContainer, ref executionScheduler);
@@ -107,7 +107,7 @@ namespace Proto.Promises
                     }
                 }
 
-                public void Handle(PromiseRef owner, IValueContainer valueContainer, PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler) // IMultiTreeHandleable.Handle
+                internal override void Handle(PromiseRef owner, ValueContainer valueContainer, PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler)
                 {
                     ThrowIfInPool(this);
 
@@ -175,7 +175,7 @@ namespace Proto.Promises
                     _raceSmallFields._depthAndProgress = new Fixed32(minWaitDepth);
                 }
 
-                void IMultiTreeHandleable.IncrementProgress(uint amount, Fixed32 senderAmount, Fixed32 ownerAmount, ref ExecutionScheduler executionScheduler)
+                internal override void IncrementProgress(uint amount, Fixed32 senderAmount, Fixed32 ownerAmount, ref ExecutionScheduler executionScheduler)
                 {
                     ThrowIfInPool(this);
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
@@ -24,7 +24,7 @@ namespace Proto.Promises
 #endif
         partial struct ReasonContainer
     {
-        private readonly Internal.IValueContainer _valueContainer;
+        private readonly Internal.ValueContainer _valueContainer;
 #if PROMISE_DEBUG
         private readonly long _id;
 #endif
@@ -32,7 +32,7 @@ namespace Proto.Promises
         /// <summary>
         /// FOR INTERNAL USE ONLY!
         /// </summary>
-        internal ReasonContainer(Internal.IValueContainer valueContainer, long id)
+        internal ReasonContainer(Internal.ValueContainer valueContainer, long id)
         {
             _valueContainer = valueContainer;
 #if PROMISE_DEBUG
@@ -111,7 +111,7 @@ namespace Proto.Promises
             /// FOR INTERNAL USE ONLY!
             /// </summary>
             [MethodImpl(Internal.InlineOption)]
-            internal ResultContainer(Internal.IValueContainer valueContainer)
+            internal ResultContainer(Internal.ValueContainer valueContainer)
             {
                 _target = new Promise<Internal.VoidResult>.ResultContainer(valueContainer);
             }
@@ -191,7 +191,7 @@ namespace Proto.Promises
             /// <summary>
             /// FOR INTERNAL USE ONLY!
             /// </summary>
-            internal readonly Internal.IValueContainer _valueContainer;
+            internal readonly Internal.ValueContainer _valueContainer;
             private readonly T _result;
 #if PROMISE_DEBUG
             private readonly long _id;
@@ -229,7 +229,7 @@ namespace Proto.Promises
             /// FOR INTERNAL USE ONLY!
             /// </summary>
             [MethodImpl(Internal.InlineOption)]
-            internal ResultContainer(Internal.IValueContainer valueContainer)
+            internal ResultContainer(Internal.ValueContainer valueContainer)
             {
                 _valueContainer = valueContainer;
                 _result = default(T);
@@ -239,7 +239,7 @@ namespace Proto.Promises
             }
 
             [MethodImpl(Internal.InlineOption)]
-            private ResultContainer(Internal.IValueContainer valueContainer, long id, T result = default(T))
+            private ResultContainer(Internal.ValueContainer valueContainer, long id, T result = default(T))
             {
                 _valueContainer = valueContainer;
                 _result = result;


### PR DESCRIPTION
#26 

Nets ~5% speedup on average for pending promises, just from changing interfaces to abstract classes.

Current master:

|                  Type |   N | BaseIsPending |       Mean | Code Size |
|---------------------- |---- |-------------- |-----------:|----------:|
|          AwaitPending | 100 |             ? | 424.685 μs |  16,647 B |
|          AsyncPending | 100 |             ? | 107.352 μs |   7,553 B |
|         AsyncResolved | 100 |             ? |  18.702 μs |   2,215 B |
|         AwaitResolved | 100 |             ? |  13.674 μs |   2,845 B |
|   ContinueWithPending | 100 |         False | 487.998 μs |  18,336 B |
| ContinueWithFromValue | 100 |         False |  24.998 μs |   7,238 B |
|  ContinueWithResolved | 100 |         False |  32.014 μs |   9,193 B |
|   ContinueWithPending | 100 |          True | 484.569 μs |  14,874 B |
| ContinueWithFromValue | 100 |          True | 128.037 μs |   9,317 B |
|  ContinueWithResolved | 100 |          True | 137.503 μs |   8,947 B |

This PR:

|                  Type |   N | BaseIsPending |      Mean | Code Size |
|---------------------- |---- |-------------- |----------:|----------:|
|          AwaitPending | 100 |             ? | 402.87 μs |  16,498 B |
|          AsyncPending | 100 |             ? | 101.79 μs |   7,565 B |
|         AsyncResolved | 100 |             ? |  18.13 μs |   2,215 B |
|         AwaitResolved | 100 |             ? |  13.45 μs |   2,845 B |
|   ContinueWithPending | 100 |         False | 465.93 μs |  18,891 B |
| ContinueWithFromValue | 100 |         False |  24.88 μs |   8,180 B |
|  ContinueWithResolved | 100 |         False |  31.76 μs |  10,187 B |
|   ContinueWithPending | 100 |          True | 463.06 μs |  15,416 B |
| ContinueWithFromValue | 100 |          True | 119.73 μs |   9,908 B |
|  ContinueWithResolved | 100 |          True | 138.84 μs |  10,026 B |