### PR TITLE
Optimize virtual calls

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
@@ -82,9 +82,9 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// If cancelation was requested on this token, throws a <see cref="CancelException"/>.
+        /// If cancelation was requested on this token, throws a <see cref="CanceledException"/>.
         /// </summary>
-        /// <exception cref="CancelException"/>
+        /// <exception cref="CanceledException"/>
         public void ThrowIfCancelationRequested()
         {
             Internal.CancelationRef.ThrowIfCanceled(_ref, _id, _isCanceled);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
@@ -286,8 +286,7 @@ namespace Proto.Promises
                 {
                     if (prev == this)
                     {
-                        _ref.MarkAwaited(other._target.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
-                        _ref.MaybeDispose();
+                        _ref.MarkAwaitedAndMaybeDispose(other._target.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         while (passThroughs.Count > 0)
                         {
                             passThroughs.Pop().Release();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -221,8 +221,10 @@ namespace Proto.Promises
 //                    }
 //#endif
                     // Normalize progress. Passing a default resolver makes the Execute method adopt the promise's state without attempting to invoke.
-                    var newRef = PromiseResolvePromise<DelegateResolvePassthrough>.GetOrCreate(default(DelegateResolvePassthrough), currentDepth + 1);
-                    newRef.WaitForWithProgress(promise);
+                    var newRef = PromiseResolvePromise<DelegateResolvePassthrough>.GetOrCreate(null, default(DelegateResolvePassthrough), currentDepth + 1);
+                    ExecutionScheduler executionScheduler = new ExecutionScheduler(true);
+                    promise._ref.HookupWaitPromise(newRef, promise.Id, promise.Depth, ref executionScheduler);
+                    executionScheduler.Execute();
                     return new Promise<TResult>(newRef, newRef.Id, currentDepth + 1);
 #endif
                 }
@@ -294,17 +296,15 @@ namespace Proto.Promises
                     // else if (_this._ref.State != Promise.State.Pending) { }
                     else
                     {
-                        // TODO: refactor to reduce this from 2 virtual calls to 1.
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseResolve<Delegate<TArg, TResult>>.GetOrCreate(resolver, cancelationToken);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseResolve<Delegate<TArg, TResult>>.GetOrCreate(resolver);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseResolve<Delegate<TArg, TResult>>.GetOrCreate(_this._ref, resolver);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
@@ -329,16 +329,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseResolvePromise<DelegatePromise<TArg, TResult>>.GetOrCreate(resolver, cancelationToken, nextDepth);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseResolvePromise<DelegatePromise<TArg, TResult>>.GetOrCreate(resolver, nextDepth);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseResolvePromise<DelegatePromise<TArg, TResult>>.GetOrCreate(_this._ref, resolver, nextDepth);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
@@ -366,17 +365,15 @@ namespace Proto.Promises
                     // else if (_this._ref.State != Promise.State.Pending) { }
                     else
                     {
-                        // TODO: refactor to reduce this from 2 virtual calls to 1.
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseResolve<DelegateCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, cancelationToken);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseResolve<DelegateCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseResolve<DelegateCapture<TCapture, TArg, TResult>>.GetOrCreate(_this._ref, resolver);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
@@ -401,16 +398,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseResolvePromise<DelegatePromiseCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, cancelationToken, nextDepth);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseResolvePromise<DelegatePromiseCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, nextDepth);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseResolvePromise<DelegatePromiseCapture<TCapture, TArg, TResult>>.GetOrCreate(_this._ref, resolver, nextDepth);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
@@ -438,16 +434,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseResolveReject<Delegate<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseResolveReject<Delegate<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseResolveReject<Delegate<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(_this._ref, resolver, rejecter);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
@@ -475,16 +470,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseResolveReject<DelegateCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseResolveReject<DelegateCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseResolveReject<DelegateCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(_this._ref, resolver, rejecter);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
@@ -513,16 +507,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseResolveRejectPromise<Delegate<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseResolveRejectPromise<Delegate<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseResolveRejectPromise<Delegate<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(_this._ref, resolver, rejecter, nextDepth);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
@@ -551,16 +544,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseResolveRejectPromise<DelegateCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseResolveRejectPromise<DelegateCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseResolveRejectPromise<DelegateCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(_this._ref, resolver, rejecter, nextDepth);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
@@ -589,16 +581,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseResolveRejectPromise<DelegatePromise<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseResolveRejectPromise<DelegatePromise<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseResolveRejectPromise<DelegatePromise<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(_this._ref, resolver, rejecter, nextDepth);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
@@ -627,16 +618,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseResolveRejectPromise<DelegatePromiseCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseResolveRejectPromise<DelegatePromiseCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseResolveRejectPromise<DelegatePromiseCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(_this._ref, resolver, rejecter, nextDepth);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
@@ -664,16 +654,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseResolveReject<DelegateResolvePassthrough, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseResolveReject<DelegateResolvePassthrough, TDelegateReject>.GetOrCreate(resolver, rejecter);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseResolveReject<DelegateResolvePassthrough, TDelegateReject>.GetOrCreate(_this._ref, resolver, rejecter);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
@@ -702,16 +691,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseResolveRejectPromise<DelegateResolvePassthrough, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseResolveRejectPromise<DelegateResolvePassthrough, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseResolveRejectPromise<DelegateResolvePassthrough, TDelegateReject>.GetOrCreate(_this._ref, resolver, rejecter, nextDepth);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
@@ -735,16 +723,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseContinue<DelegateContinue<TArg, TResult>>.GetOrCreate(resolver, cancelationToken);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseContinue<DelegateContinue<TArg, TResult>>.GetOrCreate(resolver);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseContinue<DelegateContinue<TArg, TResult>>.GetOrCreate(_this._ref, resolver);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
@@ -769,16 +756,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseContinuePromise<DelegateContinuePromise<TArg, TResult>>.GetOrCreate(resolver, cancelationToken, nextDepth);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseContinuePromise<DelegateContinuePromise<TArg, TResult>>.GetOrCreate(resolver, nextDepth);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseContinuePromise<DelegateContinuePromise<TArg, TResult>>.GetOrCreate(_this._ref, resolver, nextDepth);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
@@ -802,16 +788,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseContinue<DelegateContinueCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, cancelationToken);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseContinue<DelegateContinueCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseContinue<DelegateContinueCapture<TCapture, TArg, TResult>>.GetOrCreate(_this._ref, resolver);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
@@ -836,16 +821,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseContinuePromise<DelegateContinuePromiseCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, cancelationToken, nextDepth);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseContinuePromise<DelegateContinuePromiseCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, nextDepth);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseContinuePromise<DelegateContinuePromiseCapture<TCapture, TArg, TResult>>.GetOrCreate(_this._ref, resolver, nextDepth);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
@@ -859,9 +843,8 @@ namespace Proto.Promises
                         var p = Invoker<VoidResult, VoidResult>.InvokeCallbackDirect(DelegateWrapper.Create(onFinally), _this.AsPromise()._target);
                         return new Promise<TResult>(p._ref, p.Id, p.Depth, _this.Result);
                     }
-                    _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
-                    PromiseRef promise = PromiseFinally<DelegateFinally>.GetOrCreate(new DelegateFinally(onFinally));
-                    _this._ref.HookupNewPromise(promise);
+                    PromiseRef promise = PromiseFinally<DelegateFinally>.GetOrCreate(_this._ref, new DelegateFinally(onFinally));
+                    _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 
@@ -877,9 +860,8 @@ namespace Proto.Promises
                         var p = Invoker<VoidResult, VoidResult>.InvokeCallbackDirect(DelegateWrapper.Create(capturedValue, onFinally), _this.AsPromise()._target);
                         return new Promise<TResult>(p._ref, p.Id, p.Depth, _this.Result);
                     }
-                    _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
-                    PromiseRef promise = PromiseFinally<DelegateCaptureFinally<TCapture>>.GetOrCreate(new DelegateCaptureFinally<TCapture>(capturedValue, onFinally));
-                    _this._ref.HookupNewPromise(promise);
+                    PromiseRef promise = PromiseFinally<DelegateCaptureFinally<TCapture>>.GetOrCreate(_this._ref, new DelegateCaptureFinally<TCapture>(capturedValue, onFinally));
+                    _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 
@@ -902,16 +884,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseCancel<TDelegateCancel>.GetOrCreate(canceler, cancelationToken);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseCancel<TDelegateCancel>.GetOrCreate(canceler);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseCancel<TDelegateCancel>.GetOrCreate(_this._ref, canceler);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
@@ -937,16 +918,15 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         if (cancelationToken.CanBeCanceled)
                         {
                             promise = CancelablePromiseCancelPromise<TDelegateCancel>.GetOrCreate(canceler, cancelationToken, nextDepth);
-                            _this._ref.HookupNewCancelablePromise(promise);
+                            _this._ref.HookupNewCancelablePromise(promise, _this.Id);
                         }
                         else
                         {
-                            promise = PromiseCancelPromise<TDelegateCancel>.GetOrCreate(canceler, nextDepth);
-                            _this._ref.HookupNewPromise(promise);
+                            promise = PromiseCancelPromise<TDelegateCancel>.GetOrCreate(_this._ref, canceler, nextDepth);
+                            _this._ref.HookupNewWaiter(promise, _this.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         }
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
@@ -1041,8 +1021,7 @@ namespace Proto.Promises
                         {
                             if (_this._ref == null)
                             {
-                                promise = PromiseProgress<TProgress>.GetOrCreate(progress, cancelationToken, _this.Depth, false, synchronizationContext);
-                                promise._valueOrPrevious = CreateResolveContainer(_this.Result, 1);
+                                promise = PromiseProgress<TProgress>.GetOrCreate(CreateResolveContainer(_this.Result, 1), progress, cancelationToken, _this.Depth, false, synchronizationContext);
                                 promise.IsComplete = true;
                                 ExecutionScheduler.ScheduleOnContextStatic(synchronizationContext, promise);
                                 return new Promise<TResult>(promise, promise.Id, _this.Depth);
@@ -1051,9 +1030,8 @@ namespace Proto.Promises
                         }
                     }
 
-                    _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
-                    promise = PromiseProgress<TProgress>.GetOrCreate(progress, cancelationToken, _this.Depth, invokeOption == SynchronizationOption.Synchronous, synchronizationContext);
-                    _this._ref.HookupNewPromiseWithProgress(promise, _this.Depth);
+                    promise = PromiseProgress<TProgress>.GetOrCreate(_this._ref, progress, cancelationToken, _this.Depth, invokeOption == SynchronizationOption.Synchronous, synchronizationContext);
+                    _this._ref.HookupNewWaiterWithProgress(promise, _this.Id, _this.Depth, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 #endif

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
@@ -24,61 +24,61 @@ namespace Proto.Promises
                 // These static functions help with the implementation so we don't need to type the generics in every method.
 
                 [MethodImpl(InlineOption)]
-                public static DelegateResolvePassthrough CreatePassthrough()
+                internal static DelegateResolvePassthrough CreatePassthrough()
                 {
                     return new DelegateResolvePassthrough(true);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static Delegate<VoidResult, VoidResult> Create(Action callback)
+                internal static Delegate<VoidResult, VoidResult> Create(Action callback)
                 {
                     return new Delegate<VoidResult, VoidResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static Delegate<VoidResult, TResult> Create<TResult>(Func<TResult> callback)
+                internal static Delegate<VoidResult, TResult> Create<TResult>(Func<TResult> callback)
                 {
                     return new Delegate<VoidResult, TResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static Delegate<TArg, VoidResult> Create<TArg>(Action<TArg> callback)
+                internal static Delegate<TArg, VoidResult> Create<TArg>(Action<TArg> callback)
                 {
                     return new Delegate<TArg, VoidResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static Delegate<TArg, TResult> Create<TArg, TResult>(Func<TArg, TResult> callback)
+                internal static Delegate<TArg, TResult> Create<TArg, TResult>(Func<TArg, TResult> callback)
                 {
                     return new Delegate<TArg, TResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegatePromise<VoidResult, VoidResult> Create(Func<Promise> callback)
+                internal static DelegatePromise<VoidResult, VoidResult> Create(Func<Promise> callback)
                 {
                     return new DelegatePromise<VoidResult, VoidResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegatePromise<VoidResult, TResult> Create<TResult>(Func<Promise<TResult>> callback)
+                internal static DelegatePromise<VoidResult, TResult> Create<TResult>(Func<Promise<TResult>> callback)
                 {
                     return new DelegatePromise<VoidResult, TResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegatePromise<TArg, VoidResult> Create<TArg>(Func<TArg, Promise> callback)
+                internal static DelegatePromise<TArg, VoidResult> Create<TArg>(Func<TArg, Promise> callback)
                 {
                     return new DelegatePromise<TArg, VoidResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegatePromise<TArg, TResult> Create<TArg, TResult>(Func<TArg, Promise<TResult>> callback)
+                internal static DelegatePromise<TArg, TResult> Create<TArg, TResult>(Func<TArg, Promise<TResult>> callback)
                 {
                     return new DelegatePromise<TArg, TResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateCapture<TCapture, VoidResult, VoidResult> Create<TCapture>(
+                internal static DelegateCapture<TCapture, VoidResult, VoidResult> Create<TCapture>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -88,7 +88,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateCapture<TCapture, VoidResult, TResult> Create<TCapture, TResult>(
+                internal static DelegateCapture<TCapture, VoidResult, TResult> Create<TCapture, TResult>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -98,7 +98,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateCapture<TCapture, TArg, VoidResult> Create<TCapture, TArg>(
+                internal static DelegateCapture<TCapture, TArg, VoidResult> Create<TCapture, TArg>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -108,7 +108,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateCapture<TCapture, TArg, TResult> Create<TCapture, TArg, TResult>(
+                internal static DelegateCapture<TCapture, TArg, TResult> Create<TCapture, TArg, TResult>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -118,7 +118,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegatePromiseCapture<TCapture, VoidResult, VoidResult> Create<TCapture>(
+                internal static DelegatePromiseCapture<TCapture, VoidResult, VoidResult> Create<TCapture>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -128,7 +128,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegatePromiseCapture<TCapture, VoidResult, TResult> Create<TCapture, TResult>(
+                internal static DelegatePromiseCapture<TCapture, VoidResult, TResult> Create<TCapture, TResult>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -138,7 +138,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegatePromiseCapture<TCapture, TArg, VoidResult> Create<TCapture, TArg>(
+                internal static DelegatePromiseCapture<TCapture, TArg, VoidResult> Create<TCapture, TArg>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -148,7 +148,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegatePromiseCapture<TCapture, TArg, TResult> Create<TCapture, TArg, TResult>(
+                internal static DelegatePromiseCapture<TCapture, TArg, TResult> Create<TCapture, TArg, TResult>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -158,31 +158,31 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinue<VoidResult, VoidResult> Create(Promise.ContinueAction callback)
+                internal static DelegateContinue<VoidResult, VoidResult> Create(Promise.ContinueAction callback)
                 {
                     return new DelegateContinue<VoidResult, VoidResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinue<VoidResult, TResult> Create<TResult>(Promise.ContinueFunc<TResult> callback)
+                internal static DelegateContinue<VoidResult, TResult> Create<TResult>(Promise.ContinueFunc<TResult> callback)
                 {
                     return new DelegateContinue<VoidResult, TResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinue<TArg, VoidResult> Create<TArg>(Promise<TArg>.ContinueAction callback)
+                internal static DelegateContinue<TArg, VoidResult> Create<TArg>(Promise<TArg>.ContinueAction callback)
                 {
                     return new DelegateContinue<TArg, VoidResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinue<TArg, TResult> Create<TArg, TResult>(Promise<TArg>.ContinueFunc<TResult> callback)
+                internal static DelegateContinue<TArg, TResult> Create<TArg, TResult>(Promise<TArg>.ContinueFunc<TResult> callback)
                 {
                     return new DelegateContinue<TArg, TResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinueCapture<TCapture, VoidResult, VoidResult> Create<TCapture>(
+                internal static DelegateContinueCapture<TCapture, VoidResult, VoidResult> Create<TCapture>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -192,7 +192,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinueCapture<TCapture, VoidResult, TResult> Create<TCapture, TResult>(
+                internal static DelegateContinueCapture<TCapture, VoidResult, TResult> Create<TCapture, TResult>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -202,7 +202,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinueCapture<TCapture, TArg, VoidResult> Create<TCapture, TArg>(
+                internal static DelegateContinueCapture<TCapture, TArg, VoidResult> Create<TCapture, TArg>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -212,7 +212,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinueCapture<TCapture, TArg, TResult> Create<TCapture, TArg, TResult>(
+                internal static DelegateContinueCapture<TCapture, TArg, TResult> Create<TCapture, TArg, TResult>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -222,31 +222,31 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinuePromise<VoidResult, VoidResult> Create(Promise.ContinueFunc<Promise> callback)
+                internal static DelegateContinuePromise<VoidResult, VoidResult> Create(Promise.ContinueFunc<Promise> callback)
                 {
                     return new DelegateContinuePromise<VoidResult, VoidResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinuePromise<VoidResult, TResult> Create<TResult>(Promise.ContinueFunc<Promise<TResult>> callback)
+                internal static DelegateContinuePromise<VoidResult, TResult> Create<TResult>(Promise.ContinueFunc<Promise<TResult>> callback)
                 {
                     return new DelegateContinuePromise<VoidResult, TResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinuePromise<TArg, VoidResult> Create<TArg>(Promise<TArg>.ContinueFunc<Promise> callback)
+                internal static DelegateContinuePromise<TArg, VoidResult> Create<TArg>(Promise<TArg>.ContinueFunc<Promise> callback)
                 {
                     return new DelegateContinuePromise<TArg, VoidResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinuePromise<TArg, TResult> Create<TArg, TResult>(Promise<TArg>.ContinueFunc<Promise<TResult>> callback)
+                internal static DelegateContinuePromise<TArg, TResult> Create<TArg, TResult>(Promise<TArg>.ContinueFunc<Promise<TResult>> callback)
                 {
                     return new DelegateContinuePromise<TArg, TResult>(callback);
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinuePromiseCapture<TCapture, VoidResult, VoidResult> Create<TCapture>(
+                internal static DelegateContinuePromiseCapture<TCapture, VoidResult, VoidResult> Create<TCapture>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -256,7 +256,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinuePromiseCapture<TCapture, VoidResult, TResult> Create<TCapture, TResult>(
+                internal static DelegateContinuePromiseCapture<TCapture, VoidResult, TResult> Create<TCapture, TResult>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -266,7 +266,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinuePromiseCapture<TCapture, TArg, VoidResult> Create<TCapture, TArg>(
+                internal static DelegateContinuePromiseCapture<TCapture, TArg, VoidResult> Create<TCapture, TArg>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
@@ -276,13 +276,232 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public static DelegateContinuePromiseCapture<TCapture, TArg, TResult> Create<TCapture, TArg, TResult>(
+                internal static DelegateContinuePromiseCapture<TCapture, TArg, TResult> Create<TCapture, TArg, TResult>(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
                     TCapture capturedValue, Promise<TArg>.ContinueFunc<TCapture, Promise<TResult>> callback)
                 {
                     return new DelegateContinuePromiseCapture<TCapture, TArg, TResult>(capturedValue, callback);
+                }
+            }
+
+            partial class PromiseSingleAwait
+            {
+                [MethodImpl(InlineOption)]
+                protected static DelegateHandleResolve<TDelegate> CreateResolveWrapper<TDelegate>(PromiseSingleAwait owner, TDelegate del) where TDelegate : IDelegateResolveOrCancel
+                {
+                    return new DelegateHandleResolve<TDelegate>(owner, del);
+                }
+
+                [MethodImpl(InlineOption)]
+                protected static DelegateHandleReject<TDelegate> CreateRejectWrapper<TDelegate>(PromiseSingleAwait owner, TDelegate del) where TDelegate : IDelegateReject
+                {
+                    return new DelegateHandleReject<TDelegate>(owner, del);
+                }
+
+                [MethodImpl(InlineOption)]
+                protected static DelegateHandleContinue<TDelegate> CreateContinueWrapper<TDelegate>(PromiseSingleAwait owner, TDelegate del) where TDelegate : IDelegateContinue
+                {
+                    return new DelegateHandleContinue<TDelegate>(owner, del);
+                }
+
+                protected struct DelegateHandleResolve<TDelegate> : IDelegateHandle where TDelegate : IDelegateResolveOrCancel
+                {
+                    private readonly PromiseSingleAwait _owner;
+                    private readonly TDelegate _del;
+
+                    [MethodImpl(InlineOption)]
+                    internal DelegateHandleResolve(PromiseSingleAwait owner, TDelegate del)
+                    {
+                        _owner = owner;
+                        _del = del;
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.InvokeResolver(valueContainer, _owner, ref executionScheduler);
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.InvokeResolver(valueContainer, _owner, ref cancelationHelper, ref executionScheduler);
+                    }
+                }
+
+                protected struct DelegateHandleReject<TDelegate> : IDelegateHandle where TDelegate : IDelegateReject
+                {
+                    private readonly PromiseSingleAwait _owner;
+                    private readonly TDelegate _del;
+
+                    [MethodImpl(InlineOption)]
+                    internal DelegateHandleReject(PromiseSingleAwait owner, TDelegate del)
+                    {
+                        _owner = owner;
+                        _del = del;
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.InvokeRejecter(valueContainer, _owner, ref executionScheduler);
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.InvokeRejecter(valueContainer, _owner, ref cancelationHelper, ref executionScheduler);
+                    }
+                }
+
+                protected struct DelegateHandleContinue<TDelegate> : IDelegateHandle where TDelegate : IDelegateContinue
+                {
+                    private readonly PromiseSingleAwait _owner;
+                    private readonly TDelegate _del;
+
+                    [MethodImpl(InlineOption)]
+                    internal DelegateHandleContinue(PromiseSingleAwait owner, TDelegate del)
+                    {
+                        _owner = owner;
+                        _del = del;
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.Invoke(valueContainer, _owner, ref executionScheduler);
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.Invoke(valueContainer, _owner, ref cancelationHelper, ref executionScheduler);
+                    }
+                }
+
+                protected struct DelegateHandleFinally<TDelegate> : IDelegateHandle where TDelegate : IDelegateSimple
+                {
+                    private readonly PromiseSingleAwait _owner;
+                    private readonly TDelegate _del;
+
+                    [MethodImpl(InlineOption)]
+                    internal DelegateHandleFinally(PromiseSingleAwait owner, TDelegate del)
+                    {
+                        _owner = owner;
+                        _del = del;
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.Invoke();
+                        _owner.HandleSelf(valueContainer, ref executionScheduler);
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.Invoke();
+                        _owner.HandleSelf(valueContainer, ref executionScheduler);
+                    }
+                }
+            }
+
+            partial class PromiseWaitPromise
+            {
+                [MethodImpl(InlineOption)]
+                protected static DelegateHandleResolvePromise<TDelegate> CreateResolveWrapper<TDelegate>(PromiseWaitPromise owner, TDelegate del) where TDelegate : IDelegateResolveOrCancelPromise
+                {
+                    return new DelegateHandleResolvePromise<TDelegate>(owner, del);
+                }
+
+                [MethodImpl(InlineOption)]
+                protected static DelegateHandleRejectPromise<TDelegate> CreateRejectWrapper<TDelegate>(PromiseWaitPromise owner, TDelegate del) where TDelegate : IDelegateRejectPromise
+                {
+                    return new DelegateHandleRejectPromise<TDelegate>(owner, del);
+                }
+
+                [MethodImpl(InlineOption)]
+                protected static DelegateHandleContinuePromise<TDelegate> CreateContinueWrapper<TDelegate>(PromiseWaitPromise owner, TDelegate del) where TDelegate : IDelegateContinuePromise
+                {
+                    return new DelegateHandleContinuePromise<TDelegate>(owner, del);
+                }
+
+                protected struct DelegateHandleResolvePromise<TDelegate> : IDelegateHandle where TDelegate : IDelegateResolveOrCancelPromise
+                {
+                    private readonly PromiseWaitPromise _owner;
+                    private readonly TDelegate _del;
+
+                    [MethodImpl(InlineOption)]
+                    internal DelegateHandleResolvePromise(PromiseWaitPromise owner, TDelegate del)
+                    {
+                        _owner = owner;
+                        _del = del;
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.InvokeResolver(valueContainer, _owner, ref executionScheduler);
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.InvokeResolver(valueContainer, _owner, ref cancelationHelper, ref executionScheduler);
+                    }
+                }
+
+                protected struct DelegateHandleRejectPromise<TDelegate> : IDelegateHandle where TDelegate : IDelegateRejectPromise
+                {
+                    private readonly PromiseWaitPromise _owner;
+                    private readonly TDelegate _del;
+
+                    [MethodImpl(InlineOption)]
+                    internal DelegateHandleRejectPromise(PromiseWaitPromise owner, TDelegate del)
+                    {
+                        _owner = owner;
+                        _del = del;
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.InvokeRejecter(valueContainer, _owner, ref executionScheduler);
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.InvokeRejecter(valueContainer, _owner, ref cancelationHelper, ref executionScheduler);
+                    }
+                }
+
+                protected struct DelegateHandleContinuePromise<TDelegate> : IDelegateHandle where TDelegate : IDelegateContinuePromise
+                {
+                    private readonly PromiseWaitPromise _owner;
+                    private readonly TDelegate _del;
+
+                    [MethodImpl(InlineOption)]
+                    internal DelegateHandleContinuePromise(PromiseWaitPromise owner, TDelegate del)
+                    {
+                        _owner = owner;
+                        _del = del;
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.Invoke(valueContainer, _owner, ref executionScheduler);
+                    }
+
+                    [MethodImpl(InlineOption)]
+                    void IDelegateHandle.InvokeAndHandle(ValueContainer valueContainer, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                    {
+                        _del.Invoke(valueContainer, _owner, ref cancelationHelper, ref executionScheduler);
+                    }
                 }
             }
 
@@ -808,26 +1027,6 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal struct DelegateCancel : IDelegateSimple
-            {
-                private readonly Action _callback;
-
-                [MethodImpl(InlineOption)]
-                public DelegateCancel(Action callback)
-                {
-                    _callback = callback;
-                }
-
-                [MethodImpl(InlineOption)]
-                public void Invoke()
-                {
-                    _callback.Invoke();
-                }
-            }
-
-#if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
-#endif
             internal struct DelegateProgress : IProgress<float>
             {
                 private readonly Action<float> _callback;
@@ -1337,32 +1536,6 @@ namespace Proto.Promises
 
                 [MethodImpl(InlineOption)]
                 public DelegateCaptureFinally(
-#if CSHARP_7_3_OR_NEWER
-                    in
-#endif
-                    TCapture capturedValue, Action<TCapture> callback)
-                {
-                    _capturedValue = capturedValue;
-                    _callback = callback;
-                }
-
-                [MethodImpl(InlineOption)]
-                public void Invoke()
-                {
-                    _callback.Invoke(_capturedValue);
-                }
-            }
-
-#if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
-#endif
-            internal struct DelegateCaptureCancel<TCapture> : IDelegateSimple
-            {
-                private readonly Action<TCapture> _callback;
-                private readonly TCapture _capturedValue;
-
-                [MethodImpl(InlineOption)]
-                public DelegateCaptureCancel(
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
@@ -10,6 +10,15 @@
                 internal abstract void Handle(PromiseRef owner, ValueContainer valueContainer, PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler);
             }
 
+            partial class PromiseSingleAwait
+            {
+                internal interface IDelegateHandle
+                {
+                    void InvokeAndHandle(ValueContainer valueContainer, ref ExecutionScheduler executionScheduler);
+                    void InvokeAndHandle(ValueContainer valueContainer, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                }
+            }
+
             internal interface IDelegateResolveOrCancel
             {
                 void InvokeResolver(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -142,6 +142,7 @@ namespace Proto.Promises
 
             SuppressRejection = 1 << 0,
             WasAwaitedOrForgotten = 1 << 1,
+            HadCallback = 1 << 7, // Shares bit with Subscribed, since HadCallback is only used for SingleAwait and Subscribed is only used for MultiAwait.
             // For progress below
             InProgressQueue = 1 << 2,
             Subscribing = 1 << 3,
@@ -478,6 +479,8 @@ namespace Proto.Promises
                 {
                     internal int _index;
                     internal int _retainCounter;
+                    internal short _ownerId;
+                    internal PromiseFlags _ownerSetFlags;
 #if PROMISE_PROGRESS
                     internal Fixed32 _depth;
                     internal Fixed32 _currentProgress;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
@@ -1686,7 +1686,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Get a <see cref="CancelException"/> that can be thrown to cancel the promise from an onResolved or onRejected callback, or in an async Promise function.
+        /// Get a <see cref="CanceledException"/> that can be thrown to cancel the promise from an onResolved or onRejected callback, or in an async Promise function.
         /// This should be used as "throw Promise.CancelException();"
         /// </summary>
         public static CanceledException CancelException()

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/AsyncTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/AsyncTests.cs
@@ -270,7 +270,6 @@ namespace ProtoPromiseTests.APIs
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
 
-            //System.Diagnostics.Debugger.Launch();
             bool canceled = false;
 
             async Promise Func()


### PR DESCRIPTION
Testing out reducing the number of virtual calls.

Current master:

|                  Type |          Method |      N | BaseIsPending |      Mean | Code Size |
|---------------------- |---------------- |------- |-------------- |----------:|----------:|
|          AwaitPending | ProtoPromise_V2 | 100000 |             ? | 202.81 ms |  13,241 B |
|          AsyncPending | ProtoPromise_V2 | 100000 |             ? |  96.68 ms |   7,565 B |
|         AsyncResolved | ProtoPromise_V2 | 100000 |             ? |  17.27 ms |   2,215 B |
|         AwaitResolved | ProtoPromise_V2 | 100000 |             ? |  12.13 ms |   2,845 B |
|   ContinueWithPending | ProtoPromise_V2 | 100000 |         False | 270.02 ms |  13,204 B |
| ContinueWithFromValue | ProtoPromise_V2 | 100000 |         False |  23.91 ms |   8,180 B |
|  ContinueWithResolved | ProtoPromise_V2 | 100000 |         False |  30.81 ms |  10,187 B |
|   ContinueWithPending | ProtoPromise_V2 | 100000 |          True | 272.20 ms |  11,523 B |
| ContinueWithFromValue | ProtoPromise_V2 | 100000 |          True | 125.91 ms |      40 B |
|  ContinueWithResolved | ProtoPromise_V2 | 100000 |          True | 152.35 ms |  10,026 B |

This PR:

|                  Type |          Method |      N | BaseIsPending |      Mean | Code Size |
|---------------------- |---------------- |------- |-------------- |----------:|----------:|
|          AwaitPending | ProtoPromise_V2 | 100000 |             ? | 180.02 ms |  11,540 B |
|          AsyncPending | ProtoPromise_V2 | 100000 |             ? | 101.60 ms |   7,853 B |
|         AsyncResolved | ProtoPromise_V2 | 100000 |             ? |  17.83 ms |   2,677 B |
|         AwaitResolved | ProtoPromise_V2 | 100000 |             ? |  10.45 ms |   1,906 B |
|   ContinueWithPending | ProtoPromise_V2 | 100000 |         False | 278.52 ms |  13,354 B |
| ContinueWithFromValue | ProtoPromise_V2 | 100000 |         False |  25.21 ms |   8,357 B |
|  ContinueWithResolved | ProtoPromise_V2 | 100000 |         False |  29.74 ms |  10,538 B |
|   ContinueWithPending | ProtoPromise_V2 | 100000 |          True | 278.36 ms |  11,925 B |
| ContinueWithFromValue | ProtoPromise_V2 | 100000 |          True | 131.80 ms |  10,043 B |
|  ContinueWithResolved | ProtoPromise_V2 | 100000 |          True | 154.04 ms |  10,227 B |