### PR TITLE
Throw original exception when awaiting a promise

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/InterfacesInternal.cs
@@ -53,12 +53,14 @@ namespace Proto.Promises
             void AddToUnhandledStack(ITraceable traceable);
         }
 
-        internal interface IThrowable
+        internal partial interface IRejectValueContainer
         {
+#if CSHARP_7_3_OR_NEWER
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo GetExceptionDispatchInfo();
+#else
             Exception GetException();
+#endif
         }
-
-        internal partial interface IRejectValueContainer : IThrowable { }
 
         internal interface IDelegateSimple
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
@@ -282,17 +282,8 @@ namespace Proto.Promises
             {
                 // Spin until we successfully get lock.
                 SpinWait spinner = new SpinWait();
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                Stopwatch stopwatch = Stopwatch.StartNew();
-#endif
                 while (Interlocked.Exchange(ref _locker, 1) == 1)
                 {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    if (stopwatch.Elapsed.TotalSeconds > 10)
-                    {
-                        throw new TimeoutException();
-                    }
-#endif
                     spinner.SpinOnce();
                 }
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueContainersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueContainersInternal.cs
@@ -284,11 +284,19 @@ namespace Proto.Promises
                 return _exception;
             }
 
-            Exception IThrowable.GetException()
+#if CSHARP_7_3_OR_NEWER
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo IRejectValueContainer.GetExceptionDispatchInfo()
+            {
+                ThrowIfInPool(this);
+                return System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(value as Exception ?? ToException());
+            }
+#else
+            Exception IRejectValueContainer.GetException()
             {
                 ThrowIfInPool(this);
                 return ToException();
             }
+#endif
 
             ValueContainer IRejectionToContainer.ToContainer(ITraceable traceable)
             {
@@ -361,7 +369,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [System.Diagnostics.DebuggerNonUserCode]
 #endif
-        internal sealed class CancelContainerVoid : SingletonValueContainer<CancelContainerVoid, CancelContainerVoid.Constructor>, IThrowable
+        internal sealed class CancelContainerVoid : SingletonValueContainer<CancelContainerVoid, CancelContainerVoid.Constructor>
         {
             internal struct Constructor : IConstructor<CancelContainerVoid>
             {
@@ -381,11 +389,6 @@ namespace Proto.Promises
             internal override Promise.State GetState()
             {
                 return Promise.State.Canceled;
-            }
-
-            Exception IThrowable.GetException()
-            {
-                return CanceledExceptionInternal.GetOrCreate();
             }
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueContainersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueContainersInternal.cs
@@ -9,6 +9,7 @@
 #pragma warning disable IDE0034 // Simplify 'default' expression
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Proto.Promises
@@ -16,7 +17,7 @@ namespace Proto.Promises
     internal static partial class Internal
     {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode]
 #endif
         internal abstract class ValueContainer<T> : ValueContainer, ITraceable
         {
@@ -101,18 +102,18 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode]
 #endif
         internal sealed class RejectionContainer<T> : ValueContainer<T>, ILinked<RejectionContainer<T>>, IRejectValueContainer, IRejectionToContainer, ICantHandleException
         {
             RejectionContainer<T> ILinked<RejectionContainer<T>>.Next { get; set; }
 
 #if PROMISE_DEBUG
-            System.Diagnostics.StackTrace _rejectedStackTrace;
+            private StackTrace _rejectedStackTrace;
             // Stack traces of recursive callbacks.
             private CausalityTrace _stackTraces;
 
-            public void SetCreatedAndRejectedStacktrace(System.Diagnostics.StackTrace rejectedStacktrace, CausalityTrace createdStacktraces)
+            public void SetCreatedAndRejectedStacktrace(StackTrace rejectedStacktrace, CausalityTrace createdStacktraces)
             {
                 ThrowIfInPool(this);
                 _rejectedStackTrace = rejectedStacktrace;
@@ -172,40 +173,33 @@ namespace Proto.Promises
             {
                 ThrowIfInPool(this);
 #if PROMISE_DEBUG
-                string innerStacktrace = _rejectedStackTrace == null ? null : FormatStackTrace(new System.Diagnostics.StackTrace[1] { _rejectedStackTrace });
+                string innerStacktrace = _rejectedStackTrace == null ? null : FormatStackTrace(new StackTrace[1] { _rejectedStackTrace });
 #else
                 string innerStacktrace = null;
 #endif
-                string message = null;
-                Exception innerException = value as Exception;
-                if (innerException != null)
-                {
-#if PROMISE_DEBUG
-                    if (_rejectedStackTrace != null)
-                    {
-                        innerException = new RejectionException(message, innerStacktrace, innerException);
-                    }
-#endif
-                    message = "An exception was not handled.";
-                }
-                else
-                {
-                    message = "A rejected value was not handled, type: " + value.GetType() + ", value: " + value.ToString();
-                    innerException = new RejectionException(message, innerStacktrace, null);
-                }
+                string message = "A rejected value was not handled, type: " + value.GetType() + ", value: " + value.ToString();
+                Exception innerException = new RejectionException(message, innerStacktrace, null);
 #if PROMISE_DEBUG
                 string outerStacktrace = _stackTraces.ToString();
 #else
                 string outerStacktrace = null;
 #endif
-                return new UnhandledExceptionInternal(Value, message + CausalityTraceMessage, outerStacktrace, innerException);
+                return new UnhandledExceptionInternal(value, message + CausalityTraceMessage, outerStacktrace, innerException);
             }
 
-            Exception IThrowable.GetException()
+#if CSHARP_7_3_OR_NEWER
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo IRejectValueContainer.GetExceptionDispatchInfo()
+            {
+                ThrowIfInPool(this);
+                return System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ToException());
+            }
+#else
+            Exception IRejectValueContainer.GetException()
             {
                 ThrowIfInPool(this);
                 return ToException();
             }
+#endif
 
             ValueContainer IRejectionToContainer.ToContainer(ITraceable traceable)
             {
@@ -221,7 +215,133 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode]
+#endif
+        internal sealed class RejectionContainerException : ValueContainer<Exception>, ILinked<RejectionContainerException>, IRejectValueContainer, IRejectionToContainer, ICantHandleException
+        {
+#if PROMISE_DEBUG && CSHARP_7_3_OR_NEWER
+            // This is used to reconstruct the rejection causality trace when the original exception is rethrown from await in an async function, and this container is lost.
+            private static readonly ConditionalWeakTable<Exception, RejectionException> _rejectExceptionsForTrace = new ConditionalWeakTable<Exception, RejectionException>();
+#endif
+
+            RejectionContainerException ILinked<RejectionContainerException>.Next { get; set; }
+
+#if CSHARP_7_3_OR_NEWER
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo _capturedInfo;
+#endif
+#if PROMISE_DEBUG
+            RejectionException _rejectException;
+            // Stack traces of recursive callbacks.
+            private CausalityTrace _stackTraces;
+
+            public void SetCreatedAndRejectedStacktrace(StackTrace rejectedStacktrace, CausalityTrace createdStacktraces)
+            {
+                ThrowIfInPool(this);
+                _stackTraces = createdStacktraces;
+                // rejectedStacktrace will only be non-null when this is created from Deferred.Reject and causality traces are enabled.
+                // Otherwise, _rejectException will have been gotten from _rejectExceptionsForTrace in GetOrCreate.
+                if (rejectedStacktrace != null)
+                {
+                    _rejectException = new RejectionException("This exception contains the stacktrace of the Deferred.Reject for the uncaught exception.", FormatStackTrace(new StackTrace[1] { rejectedStacktrace }), value);
+#if CSHARP_7_3_OR_NEWER
+                    _rejectExceptionsForTrace.Add(value, _rejectException);
+#endif
+                }
+            }
+#endif
+
+                    private RejectionContainerException() { }
+
+            internal static RejectionContainerException GetOrCreate(Exception value)
+            {
+                var container = ObjectPool<RejectionContainerException>.TryTake<RejectionContainerException>()
+                    ?? new RejectionContainerException();
+                container.value = value;
+#if CSHARP_7_3_OR_NEWER
+                container._capturedInfo = System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(value);
+#if PROMISE_DEBUG
+                _rejectExceptionsForTrace.TryGetValue(value, out container._rejectException);
+#endif
+#endif
+                container.Reset();
+                return container;
+            }
+
+            internal override Promise.State GetState()
+            {
+                return Promise.State.Rejected;
+            }
+
+            internal override void Release()
+            {
+                ThrowIfInPool(this);
+                if (TryReleaseComplete())
+                {
+                    Dispose();
+                }
+            }
+
+            internal override void ReleaseAndMaybeAddToUnhandledStack(bool shouldAdd)
+            {
+                if (shouldAdd)
+                {
+                    AddUnhandledException(ToException());
+                }
+                Release();
+            }
+
+            private void Dispose()
+            {
+#if PROMISE_DEBUG
+                _rejectException = null;
+                _stackTraces = null;
+#if CSHARP_7_3_OR_NEWER
+                _rejectExceptionsForTrace.Remove(value);
+#endif
+#endif
+                value = null;
+                ObjectPool<RejectionContainerException>.MaybeRepool(this);
+            }
+
+            private UnhandledException ToException()
+            {
+                ThrowIfInPool(this);
+#if PROMISE_DEBUG
+                return new UnhandledExceptionInternal(Value, "An exception was not handled." + CausalityTraceMessage, _stackTraces.ToString(), _rejectException ?? value);
+#else
+                return new UnhandledExceptionInternal(Value, "An exception was not handled." + CausalityTraceMessage, null, value);
+#endif
+            }
+
+#if CSHARP_7_3_OR_NEWER
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo IRejectValueContainer.GetExceptionDispatchInfo()
+            {
+                ThrowIfInPool(this);
+                return _capturedInfo;
+            }
+#else
+            Exception IRejectValueContainer.GetException()
+            {
+                ThrowIfInPool(this);
+                return ToException();
+            }
+#endif
+
+            ValueContainer IRejectionToContainer.ToContainer(ITraceable traceable)
+            {
+                ThrowIfInPool(this);
+                return this;
+            }
+
+            void ICantHandleException.AddToUnhandledStack(ITraceable traceable)
+            {
+                ThrowIfInPool(this);
+                AddUnhandledException(ToException());
+            }
+        }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode]
 #endif
         internal sealed class RethrownRejectionContainer : ValueContainer<object>, ILinked<RethrownRejectionContainer>, IRejectValueContainer, IRejectionToContainer, ICantHandleException
         {
@@ -230,7 +350,7 @@ namespace Proto.Promises
             private UnhandledExceptionInternal _exception;
 
 #if PROMISE_DEBUG
-            public void SetCreatedAndRejectedStacktrace(System.Diagnostics.StackTrace rejectedStacktrace, CausalityTrace createdStacktraces)
+            public void SetCreatedAndRejectedStacktrace(StackTrace rejectedStacktrace, CausalityTrace createdStacktraces)
             {
                 ThrowIfInPool(this);
             }
@@ -317,7 +437,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode]
 #endif
         internal abstract class SingletonValueContainer<TValueContainer, TConstructor> : ValueContainer<VoidResult>
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
@@ -367,7 +487,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode]
 #endif
         internal sealed class CancelContainerVoid : SingletonValueContainer<CancelContainerVoid, CancelContainerVoid.Constructor>
         {
@@ -393,7 +513,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode]
 #endif
         internal sealed class ResolveContainer<T> : ValueContainer<T>, ILinked<ResolveContainer<T>>
         {
@@ -441,7 +561,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode]
 #endif
         internal sealed class ResolveContainerVoid : SingletonValueContainer<ResolveContainerVoid, ResolveContainerVoid.Constructor>
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Exceptions.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Exceptions.cs
@@ -240,8 +240,8 @@ namespace Proto.Promises
 #else
             string stacktrace = new StackTrace(this, true).ToString();
 #endif
-            object exception = new InvalidOperationException("RethrowException is only valid in promise onRejected callbacks.", stacktrace);
-            return Internal.RejectionContainer<object>.GetOrCreate(exception);
+            Exception exception = new InvalidOperationException("RethrowException is only valid in promise onRejected callbacks.", stacktrace);
+            return Internal.RejectionContainerException.GetOrCreate(exception);
         }
     }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -384,15 +384,6 @@ namespace Proto.Promises
                 }
                 else
                 {
-                    if (exception is RethrowException)
-                    {
-#if PROMISE_DEBUG
-                        string stacktrace = FormatStackTrace(new StackTrace[1] { new StackTrace(exception, true) });
-#else
-                        string stacktrace = new StackTrace(exception, true).ToString();
-#endif
-                        exception = new InvalidOperationException("RethrowException is only valid in promise onRejected callbacks.", stacktrace);
-                    }
                     RejectDirect(exception, int.MinValue);
                 }
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -167,7 +167,7 @@ namespace Proto.Promises
             CausalityTrace ITraceable.Trace { get; set; }
 #endif
 
-            volatile private object _valueOrPrevious;
+            volatile internal object _valueOrPrevious;
             private SmallFields _smallFields = new SmallFields(1); // Start with Id 1 instead of 0 to reduce risk of false positives.
 
             [StructLayout(LayoutKind.Explicit)]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -148,7 +148,7 @@ namespace Proto.Promises
                 SetCreatedStacktrace(this, 3);
             }
 
-            protected void MaybeDispose()
+            internal void MaybeDispose()
             {
                 ThrowIfInPool(this);
                 if (_smallFields.InterlockedTryReleaseComplete())

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Unity/PromiseBehaviour.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Unity/PromiseBehaviour.cs
@@ -151,19 +151,22 @@ namespace Proto.Promises
                     {
                         Debug.LogException(e);
                     }
+                }
+            }
 
-                    // Pop and pass to UnityEngine.Debug here so Unity won't add extra stackframes that we don't care about.
-                    _unhandledExceptionsLocker.Enter();
-                    var unhandledExceptions = _unhandledExceptions;
-                    _unhandledExceptions = new Internal.ValueLinkedStack<UnhandledException>();
-                    _unhandledExceptionsLocker.Exit();
+            private void Update()
+            {
+                // Pop and pass to UnityEngine.Debug here so Unity won't add extra stackframes that we don't care about.
+                _unhandledExceptionsLocker.Enter();
+                var unhandledExceptions = _unhandledExceptions;
+                _unhandledExceptions = new Internal.ValueLinkedStack<UnhandledException>();
+                _unhandledExceptionsLocker.Exit();
 
-                    while (unhandledExceptions.IsNotEmpty)
-                    {
-                        // Unfortunately, Unity does not provide a means to completely eliminate the stack trace at the point of calling `Debug.Log`, so the log will always have at least 1 extra stack frame.
-                        // This implementation minimizes it to 1 extra stack frame always (because `IEnumerator.MoveNext()` is called from Unity's side, and they do not include their own internal stack traces).
-                        Debug.LogException(unhandledExceptions.Pop());
-                    }
+                while (unhandledExceptions.IsNotEmpty)
+                {
+                    // Unfortunately, Unity does not provide a means to completely eliminate the stack trace at the point of calling `Debug.Log`, so the log will always have at least 1 extra stack frame.
+                    // This implementation minimizes it to 1 extra stack frame always (because `Update()` is called from Unity's side, and they do not include their own internal stack traces).
+                    Debug.LogException(unhandledExceptions.Pop());
                 }
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/TestHelper.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/TestHelper.cs
@@ -68,6 +68,8 @@ namespace ProtoPromiseTests
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void Setup()
         {
+            TestContext.Progress.WriteLine("Begin " + TestContext.CurrentContext.Test.FullName);
+
             if (Promise.Config.ForegroundContext != _foregroundContext)
             {
                 // Set the foreground context to execute foreground promise callbacks.
@@ -115,6 +117,8 @@ namespace ProtoPromiseTests
                 throw new AggregateException(exceptions);
 #endif
             }
+
+            TestContext.Progress.WriteLine("Success " + TestContext.CurrentContext.Test.FullName);
         }
 
         public static void ExecuteForegroundCallbacks()


### PR DESCRIPTION
Resolves #44 

Capture and throw original exception when awaiting a promise.
Non-exception rejections still are thrown as `UnhandledException`.