### PR TITLE
Fix causality trace from uncaught rejections from await.

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ExceptionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ExceptionsInternal.cs
@@ -16,8 +16,8 @@ namespace Proto.Promises
 #endif
         internal sealed class UnhandledExceptionInternal : UnhandledException, IRejectionToContainer, ICantHandleException
         {
-            internal UnhandledExceptionInternal(object value, Type valueType, string message, string stackTrace, Exception innerException) :
-                base(value, valueType, message, stackTrace, innerException)
+            internal UnhandledExceptionInternal(object value, string message, string stackTrace, Exception innerException) :
+                base(value, message, stackTrace, innerException)
             { }
 
             void ICantHandleException.AddToUnhandledStack(ITraceable traceable)
@@ -27,11 +27,7 @@ namespace Proto.Promises
 
             ValueContainer IRejectionToContainer.ToContainer(ITraceable traceable)
             {
-                var rejection = CreateRejectContainer(Value, int.MinValue, traceable);
-#if PROMISE_DEBUG
-                ((IRejectValueContainer) rejection).SetCreatedAndRejectedStacktrace(new StackTrace(this, true), traceable.Trace);
-#endif
-                return rejection;
+                return RethrownRejectionContainer.GetOrCreate(this);
             }
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
@@ -364,7 +364,7 @@ namespace Proto.Promises
             Exception innerException = unhandledValue as Exception;
             string message = innerException != null ? "An exception was not handled." : "A rejected value was not handled, type: " + type + ", value: " + unhandledValue.ToString();
 
-            AddUnhandledException(new UnhandledExceptionInternal(unhandledValue, type, message + CausalityTraceMessage, GetFormattedStacktrace(traceable), innerException));
+            AddUnhandledException(new UnhandledExceptionInternal(unhandledValue, message + CausalityTraceMessage, GetFormattedStacktrace(traceable), innerException));
         }
 
         internal static void MaybeReportUnhandledRejections()

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Exceptions.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Exceptions.cs
@@ -147,25 +147,23 @@ namespace Proto.Promises
         UnhandledException Internal.ILinked<UnhandledException>.Next { get; set; }
 
         private readonly object _value;
-        private readonly Type _type;
         private readonly string _stackTrace;
 
-        internal UnhandledException(object value, Type valueType, string message, string stackTrace, Exception innerException) : base(message, innerException)
+        internal UnhandledException(object value, string message, string stackTrace, Exception innerException) : base(message, innerException)
         {
             _value = value;
-            _type = valueType;
             _stackTrace = stackTrace;
         }
 
         public override string StackTrace { get { return _stackTrace; } }
 
-        public Type ValueType { get { return _type; } }
+        public Type ValueType { get { return _value.GetType(); } }
 
         public object Value { get { return _value; } }
 
         public bool TryGetValueAs<T>(out T value)
         {
-            if (typeof(T).IsAssignableFrom(_type))
+            if (typeof(T).IsAssignableFrom(ValueType))
             {
                 value = (T) _value;
                 return true;


### PR DESCRIPTION
Fixes stacktrace from `Deferred.Reject(reason)` being lost when the promise is awaited.

Independent from #47, which will need to solve the problem differently.