### PR TITLE
IL2CPP async optimize

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -4,6 +4,15 @@
 #undef PROMISE_DEBUG
 #endif
 
+// Fix for IL2CPP compile bug. https://issuetracker.unity3d.com/issues/il2cpp-incorrect-results-when-calling-a-method-from-outside-class-in-a-struct
+// Unity fixed in 2020.3.20f1 and 2021.1.24f1, but it's simpler to just check for 2021.2 or newer.
+// Don't use optimized mode in DEBUG mode for causality traces.
+#if (ENABLE_IL2CPP && !UNITY_2021_2_OR_NEWER) || PROMISE_DEBUG
+#define OPTIMIZED_ASYNC_MODE
+#else
+#undef OPTIMIZED_ASYNC_MODE
+#endif
+
 #pragma warning disable IDE0060 // Remove unused parameter
 #pragma warning disable CS0436 // Type conflicts with imported type
 
@@ -194,9 +203,7 @@ namespace Proto.Promises
 #if CSHARP_7_3_OR_NEWER // Custom async builders only available after C# 7.2.
     partial class Internal
     {
-#if PROMISE_DEBUG || ENABLE_IL2CPP
-        // Fix for IL2CPP compile bug. https://issuetracker.unity3d.com/issues/il2cpp-incorrect-results-when-calling-a-method-from-outside-class-in-a-struct
-        // Also use this in DEBUG mode for causality traces.
+#if !OPTIMIZED_ASYNC_MODE
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
 #endif
@@ -264,7 +271,7 @@ namespace Proto.Promises
             public void SetStateMachine(IAsyncStateMachine stateMachine) { }
         }
 
-#else // PROMISE_DEBUG || ENABLE_IL2CPP
+#else // !OPTIMIZED_ASYNC_MODE
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
@@ -389,9 +396,7 @@ namespace Proto.Promises
             }
         }
 
-#if PROMISE_DEBUG || ENABLE_IL2CPP
-        // Fix for IL2CPP compile bug. https://issuetracker.unity3d.com/issues/il2cpp-incorrect-results-when-calling-a-method-from-outside-class-in-a-struct
-        // Also use this in DEBUG mode for causality traces.
+#if !OPTIMIZED_ASYNC_MODE
         sealed partial class AsyncPromiseRef
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
@@ -497,7 +502,7 @@ namespace Proto.Promises
             }
         } // class AsyncPromiseRef
 
-#else // PROMISE_DEBUG || ENABLE_IL2CPP
+#else // !OPTIMIZED_ASYNC_MODE
 
         partial class AsyncPromiseRef
         {


### PR DESCRIPTION
Resolves #45 

Optimize async promise functions from Unity's IL2CPP fix in 2021.2 or newer.