### PR TITLE
Reporting progress to async Promise function

### DIFF
--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -9,8 +9,11 @@
     <!--Only for function pointers in await override implementation. All other async/await code should be C# 7.3 compatible, and all other code should be C# 4 compatible for old Unity versions.-->
     <LangVersion>9</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!--Set true to help debug internal promise code-->
+    <!--Set true to help debug internal promise code.-->
     <DeveloperMode>false</DeveloperMode>
+    <!--Set false to not unwind the stack before invoking the next continuation.
+        This can help to debug internal promise code with longer stack traces, but may result in a StackOverflowException if there are many continuations.-->
+    <AllowStackToUnwind>true</AllowStackToUnwind>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +24,10 @@
 
   <PropertyGroup Condition="'$(DeveloperMode)'=='true'">
     <DefineConstants>$(DefineConstants);TRACE;PROTO_PROMISE_DEVELOPER_MODE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(AllowStackToUnwind)'=='false'">
+    <DefineConstants>$(DefineConstants);PROTO_PROMISE_NO_STACK_UNWIND</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoProgress|AnyCPU'">

--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <RootNamespace>ProtoPromise</RootNamespace>
-    <DefineConstants>TRACE;CSHARP_7_3_OR_NEWER</DefineConstants>
+    <DefineConstants>CSHARP_7_3_OR_NEWER</DefineConstants>
     <Configurations>Release;Debug;Release_NoProgress;Debug_NoProgress</Configurations>
     <Version>2.0.0</Version>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -21,29 +20,18 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(DeveloperMode)'=='true'">
-    <DefineConstants>$(DefineConstants);PROTO_PROMISE_DEVELOPER_MODE</DefineConstants>
-  </PropertyGroup>
-
-  <!--Version ending in `.1` is full fat with progress, ending in `.0` is without progress-->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <VersionSuffix>.1</VersionSuffix>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <VersionSuffix>.1</VersionSuffix>
+    <DefineConstants>$(DefineConstants);TRACE;PROTO_PROMISE_DEVELOPER_MODE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoProgress|AnyCPU'">
     <DefineConstants>$(DefineConstants);RELEASE;PROTO_PROMISE_PROGRESS_DISABLE</DefineConstants>
-    <VersionSuffix>.0</VersionSuffix>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_NoProgress|AnyCPU'">
-    <DefineConstants>$(DefineConstants);DEBUG;PROTO_PROMISE_PROGRESS_DISABLE</DefineConstants>
-    <VersionSuffix>.0</VersionSuffix>
+    <DefineConstants>$(DefineConstants);TRACE;DEBUG;PROTO_PROMISE_PROGRESS_DISABLE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -9,7 +9,7 @@
     <!--Only for function pointers in await override implementation. All other async/await code should be C# 7.3 compatible, and all other code should be C# 4 compatible for old Unity versions.-->
     <LangVersion>9</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!--Set true to help debug internal promise code.-->
+    <!--Set true to help debug internal promise code (allows the debugger to step into the code).-->
     <DeveloperMode>false</DeveloperMode>
     <!--Set false to not unwind the stack before invoking the next continuation.
         This can help to debug internal promise code with longer stack traces, but may result in a StackOverflowException if there are many continuations.-->

--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -7,7 +7,9 @@
     <Configurations>Release;Debug;Release_NoProgress;Debug_NoProgress</Configurations>
     <Version>2.0.0</Version>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <LangVersion>7.3</LangVersion>
+    <!--Only for function pointers in await override implementation. All other async/await code should be C# 7.3 compatible, and all other code should be C# 4 compatible for old Unity versions.-->
+    <LangVersion>9</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!--Set true to help debug internal promise code-->
     <DeveloperMode>false</DeveloperMode>
   </PropertyGroup>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
@@ -39,6 +39,15 @@ namespace Proto.Promises
         internal const MethodImplOptions InlineOption = (MethodImplOptions) 256; // AggressiveInlining
 #endif
 
+        internal static void ValidateProgressValue(float value, string argName, int skipFrames)
+        {
+            bool isBetween01 = value >= 0f && value <= 1f;
+            if (!isBetween01)
+            {
+                throw new ArgumentOutOfRangeException(argName, "Must be between 0 and 1.", GetFormattedStacktrace(skipFrames + 1));
+            }
+        }
+
         // Calls to these get compiled away in RELEASE mode
         partial class PromiseRef
         {
@@ -236,16 +245,6 @@ namespace Proto.Promises
             }
         }
 
-        internal static void ValidateProgressValue(float value, int skipFrames)
-        {
-            const string argName = "progress";
-            bool isBetween01 = value >= 0f && value <= 1f;
-            if (!isBetween01)
-            {
-                throw new ArgumentOutOfRangeException(argName, "Must be between 0 and 1.", GetFormattedStacktrace(skipFrames + 1));
-            }
-        }
-
         internal static void ValidateOperation(Promise promise, int skipFrames)
         {
             if (!promise.IsValid)
@@ -346,7 +345,7 @@ namespace Proto.Promises
             {
                 static partial void ValidateProgress(float progress, int skipFrames)
                 {
-                    ValidateProgressValue(progress, skipFrames + 1);
+                    ValidateProgressValue(progress, "progress", skipFrames + 1);
                 }
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
@@ -282,6 +282,8 @@ namespace Proto.Promises
                 // A promise cannot wait on itself.
                 if (other == this)
                 {
+                    other.MarkAwaited(other.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
+                    other.MaybeDispose();
                     if (awaited)
                         throw new InvalidOperationException("A Promise cannot wait on itself.", string.Empty);
                     throw new InvalidReturnException("A Promise cannot wait on itself.", string.Empty);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
@@ -432,7 +432,7 @@ namespace Proto.Promises
         }
 
         [MethodImpl(InlineOption)]
-        private static long InterlockedAddWithOverflowCheck(ref int location, int value, int comparand)
+        private static int InterlockedAddWithOverflowCheck(ref int location, int value, int comparand)
         {
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
             Thread.MemoryBarrier();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
@@ -315,7 +315,7 @@ namespace Proto.Promises
                 }
 
                 // If reason is null, behave the same way .Net behaves if you throw null.
-                object o = reason == null ? new NullReferenceException() : (object) reason;
+                object o = (object) reason ?? new NullReferenceException();
                 Exception e = o as Exception;
                 if (e != null)
                 {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
@@ -280,6 +280,7 @@ namespace Proto.Promises
 
             internal void Enter()
             {
+                Thread.MemoryBarrier();
                 // Spin until we successfully get lock.
                 SpinWait spinner = new SpinWait();
                 while (Interlocked.Exchange(ref _locker, 1) == 1)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueContainersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueContainersInternal.cs
@@ -25,7 +25,7 @@ namespace Proto.Promises
 #if PROMISE_DEBUG
             CausalityTrace ITraceable.Trace { get; set; }
 #endif
-            // This should be nint to be more efficient in 32-bit runtimes, but it's only available in C# 9 and later.
+            // This should be nint to be more efficient in 32-bit runtimes, but it's only available in C# 9 and later, and Interlocked does not have an overload for nint.
             private long _retainCounter;
             public T value;
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Config.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Config.cs
@@ -64,7 +64,7 @@ namespace Proto.Promises
             /// The maximum precision of progress reports.
             /// </summary>
 #if !PROMISE_PROGRESS
-            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+            [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
             public static readonly float ProgressPrecision = (float) (1d / Math.Pow(2d, Internal.PromiseRef.Fixed32.DecimalBits));
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
@@ -189,7 +189,7 @@ namespace Proto.Promises
             /// <exception cref="InvalidOperationException"/>
             /// <exception cref="ArgumentOutOfRangeException"/>
 #if !PROMISE_PROGRESS
-            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+            [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
             [MethodImpl(Internal.InlineOption)]
             public void ReportProgress(float progress)
@@ -206,7 +206,7 @@ namespace Proto.Promises
             /// </summary>
             /// <exception cref="ArgumentOutOfRangeException"/>
 #if !PROMISE_PROGRESS
-            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+            [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
             [MethodImpl(Internal.InlineOption)]
             public bool TryReportProgress(float progress)
@@ -429,7 +429,7 @@ namespace Proto.Promises
             /// <exception cref="InvalidOperationException"/>
             /// <exception cref="ArgumentOutOfRangeException"/>
 #if !PROMISE_PROGRESS
-            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+            [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
             [MethodImpl(Internal.InlineOption)]
             public void ReportProgress(float progress)
@@ -443,7 +443,7 @@ namespace Proto.Promises
             /// </summary>
             /// <exception cref="ArgumentOutOfRangeException"/>
 #if !PROMISE_PROGRESS
-            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+            [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
             [MethodImpl(Internal.InlineOption)]
             public bool TryReportProgress(float progress)
@@ -694,7 +694,7 @@ namespace Proto.Promises
             /// <exception cref="InvalidOperationException"/>
             /// <exception cref="ArgumentOutOfRangeException"/>
 #if !PROMISE_PROGRESS
-            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+            [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
             [MethodImpl(Internal.InlineOption)]
             public void ReportProgress(float progress)
@@ -711,7 +711,7 @@ namespace Proto.Promises
             /// </summary>
             /// <exception cref="ArgumentOutOfRangeException"/>
 #if !PROMISE_PROGRESS
-            [Obsolete("Progress is disabled. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+            [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
             [MethodImpl(Internal.InlineOption)]
             public bool TryReportProgress(float progress)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -408,6 +408,12 @@ namespace Proto.Promises
                 {
                     _valueOrPrevious = other;
                 }
+
+                [MethodImpl(InlineOption)]
+                private void SetAwaitedComplete()
+                {
+                    _valueOrPrevious = null;
+                }
 #endif
 
                 partial void SetPassthroughCompleted();
@@ -553,8 +559,7 @@ namespace Proto.Promises
                 {
                     // TODO: executionScheduler.ScheduleSynchronous and set a flag if this was completed by a promise or an unknown awaiter so that the SetResult or SetException won't have to execute on a new scheduler.
                     ThrowIfInPool(this);
-                    _valueOrPrevious = null;
-                    SetPassthroughCompleted();
+                    SetAwaitedComplete();
                     WaitWhileProgressFlags(PromiseFlags.Subscribing);
                     MoveNext();
                 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -410,6 +410,8 @@ namespace Proto.Promises
                 }
 #endif
 
+                partial void SetPassthroughCompleted();
+
                 [MethodImpl(InlineOption)]
                 public static AsyncPromiseRef GetOrCreate()
                 {
@@ -552,6 +554,7 @@ namespace Proto.Promises
                     // TODO: executionScheduler.ScheduleSynchronous and set a flag if this was completed by a promise or an unknown awaiter so that the SetResult or SetException won't have to execute on a new scheduler.
                     ThrowIfInPool(this);
                     _valueOrPrevious = null;
+                    SetPassthroughCompleted();
                     WaitWhileProgressFlags(PromiseFlags.Subscribing);
                     MoveNext();
                 }
@@ -599,6 +602,7 @@ namespace Proto.Promises
                         // TODO: executionScheduler.ScheduleSynchronous and set a flag if this was completed by a promise or an unknown awaiter so that the SetResult or SetException won't have to execute on a new scheduler.
                         ThrowIfInPool(this);
                         _valueOrPrevious = null;
+                        SetPassthroughCompleted();
                         WaitWhileProgressFlags(PromiseFlags.Subscribing);
                         ContinueMethod();
                     }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -410,7 +410,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                private void SetAwaitedComplete()
+                private void SetAwaitedComplete(ValueContainer valueContainer, ref ExecutionScheduler executionScheduler)
                 {
                     _valueOrPrevious = null;
                 }
@@ -557,7 +557,7 @@ namespace Proto.Promises
                 {
                     // TODO: executionScheduler.ScheduleSynchronous and set a flag if this was completed by a promise or an unknown awaiter so that the SetResult or SetException won't have to execute on a new scheduler.
                     ThrowIfInPool(this);
-                    SetAwaitedComplete();
+                    SetAwaitedComplete(valueContainer, ref executionScheduler);
                     WaitWhileProgressFlags(PromiseFlags.Subscribing);
                     MoveNext();
                 }
@@ -604,7 +604,7 @@ namespace Proto.Promises
                     {
                         // TODO: executionScheduler.ScheduleSynchronous and set a flag if this was completed by a promise or an unknown awaiter so that the SetResult or SetException won't have to execute on a new scheduler.
                         ThrowIfInPool(this);
-                        SetAwaitedComplete();
+                        SetAwaitedComplete(valueContainer, ref executionScheduler);
                         WaitWhileProgressFlags(PromiseFlags.Subscribing);
                         ContinueMethod();
                     }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -416,8 +416,6 @@ namespace Proto.Promises
                 }
 #endif
 
-                partial void SetPassthroughCompleted();
-
                 [MethodImpl(InlineOption)]
                 public static AsyncPromiseRef GetOrCreate()
                 {
@@ -606,8 +604,7 @@ namespace Proto.Promises
                     {
                         // TODO: executionScheduler.ScheduleSynchronous and set a flag if this was completed by a promise or an unknown awaiter so that the SetResult or SetException won't have to execute on a new scheduler.
                         ThrowIfInPool(this);
-                        _valueOrPrevious = null;
-                        SetPassthroughCompleted();
+                        SetAwaitedComplete();
                         WaitWhileProgressFlags(PromiseFlags.Subscribing);
                         ContinueMethod();
                     }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -117,6 +117,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal void AwaitOnCompletedInternal(AsyncPromiseRef asyncPromiseRef, short promiseId)
             {
+                asyncPromiseRef.ValidateReturn(new Promise(this, Id, Depth));
                 MarkAwaited(promiseId, PromiseFlags.None);
                 HookupNewPromise(asyncPromiseRef);
             }
@@ -124,6 +125,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal void AwaitOnCompletedWithProgressInternal(AsyncPromiseRef asyncPromiseRef, short promiseId, ushort depth, float minProgress, float maxProgress)
             {
+                asyncPromiseRef.ValidateReturn(new Promise(this, Id, Depth));
                 MarkAwaited(promiseId, PromiseFlags.None);
                 ExecutionScheduler executionScheduler = new ExecutionScheduler(true);
                 asyncPromiseRef.SetPreviousAndMaybeSubscribeProgress(this, depth, minProgress, maxProgress, ref executionScheduler);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -747,8 +747,8 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Used to support reporting progress to the async Promise function. The progress reported will be scaled from minProgress to maxProgress. Both values must be between 0 and 1 inclusive.
-        /// <para/> Use as `await promise.AwaitWithprogress(min, max);`
+        /// Used to support reporting progress to the async Promise function. The progress reported will be lerped from <paramref name="minProgress"/> to <paramref name="maxProgress"/>. Both values must be between 0 and 1 inclusive.
+        /// <para/> Use as `await promise.AwaitWithProgress(min, max);`
         /// </summary>
         public PromiseProgressAwaiter<T> AwaitWithProgress(float minProgress, float maxProgress)
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -117,7 +117,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal void AwaitOnCompletedInternal(AsyncPromiseRef asyncPromiseRef, short promiseId)
             {
-                asyncPromiseRef.ValidateReturn(new Promise(this, Id, Depth));
+                asyncPromiseRef.ValidateAwait(this, promiseId);
                 MarkAwaited(promiseId, PromiseFlags.None);
                 HookupNewPromise(asyncPromiseRef);
             }
@@ -125,7 +125,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal void AwaitOnCompletedWithProgressInternal(AsyncPromiseRef asyncPromiseRef, short promiseId, ushort depth, float minProgress, float maxProgress)
             {
-                asyncPromiseRef.ValidateReturn(new Promise(this, Id, Depth));
+                asyncPromiseRef.ValidateAwait(this, promiseId);
                 MarkAwaited(promiseId, PromiseFlags.None);
                 ExecutionScheduler executionScheduler = new ExecutionScheduler(true);
                 asyncPromiseRef.SetPreviousAndMaybeSubscribeProgress(this, depth, minProgress, maxProgress, ref executionScheduler);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -712,6 +712,22 @@ namespace Proto.Promises
                 Internal.AwaitOverrider<PromiseAwaiter<T>>.Create<PromiseAwaiter<T>>();
             }
         }
+
+        partial struct PromiseProgressAwaiterVoid
+        {
+            static PromiseProgressAwaiterVoid()
+            {
+                Internal.AwaitOverrider<PromiseProgressAwaiterVoid>.Create<PromiseProgressAwaiterVoid>();
+            }
+        }
+
+        partial struct PromiseProgressAwaiter<T>
+        {
+            static PromiseProgressAwaiter()
+            {
+                Internal.AwaitOverrider<PromiseProgressAwaiter<T>>.Create<PromiseProgressAwaiter<T>>();
+            }
+        }
     } // namespace Async.CompilerServices
 
     partial struct Promise

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -375,11 +375,11 @@ namespace Proto.Promises
 #endif
         } // struct PromiseAwaiterVoid
 
-    /// <summary>
-    /// Used to support the await keyword.
-    /// </summary>
+        /// <summary>
+        /// Used to support the await keyword.
+        /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [DebuggerNonUserCode]
+        [DebuggerNonUserCode]
 #endif
         public
 #if CSHARP_7_3_OR_NEWER

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -279,6 +279,19 @@ namespace Proto.Promises
             }
         }
 #endif // UNITY_2021_2_OR_NEWER || !UNITY_5_5_OR_NEWER
+
+#if PROMISE_DEBUG
+        internal static void ValidateAwaiterOperation(Promise promise, bool checkForIncremented, int skipFrames)
+        {
+            bool isValid = promise.IsValid
+                // Also check for id + 1 since this might be called after OnCompleted is hooked up or the promise is forgotten.
+                || (checkForIncremented && promise._target._ref != null && promise._target.Id + 1 == promise._target._ref.Id);
+            if (!isValid)
+            {
+                throw new InvalidOperationException("Attempted to use PromiseAwaiter incorrectly. You must call IsCompleted, then maybe OnCompleted, then GetResult when it is complete.", GetFormattedStacktrace(skipFrames + 1));
+            }
+        }
+#endif
     }
 
     namespace Async.CompilerServices
@@ -353,23 +366,11 @@ namespace Proto.Promises
                 _awaiter._promise._ref.AwaitOnCompletedInternal(asyncPromiseRef, _awaiter._promise.Id);
             }
 
-            static partial void ValidateGetResult(Promise<Internal.VoidResult> promise, int skipFrames);
-            static partial void ValidateOperation(Promise<Internal.VoidResult> promise, int skipFrames);
+            static partial void ValidateGetResult(Promise promise, int skipFrames);
 #if PROMISE_DEBUG
-            static partial void ValidateGetResult(Promise<Internal.VoidResult> promise, int skipFrames)
+            static partial void ValidateGetResult(Promise promise, int skipFrames)
             {
-                if (promise._ref == null)
-                {
-                    ValidateOperation(promise, skipFrames + 1);
-                }
-            }
-
-            static partial void ValidateOperation(Promise<Internal.VoidResult> promise, int skipFrames)
-            {
-                if (!promise.IsValid)
-                {
-                    throw new InvalidOperationException("Attempted to use PromiseAwaiter incorrectly. You must call IsCompleted, then maybe OnCompleted, then GetResult when it is complete.", Internal.GetFormattedStacktrace(skipFrames + 1));
-                }
+                Internal.ValidateAwaiterOperation(promise, true, skipFrames + 1);
             }
 #endif
         } // struct PromiseAwaiterVoid
@@ -457,28 +458,22 @@ namespace Proto.Promises
             }
 
             static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
-            static partial void ValidateGetResult(Promise<T> promise, int skipFrames);
-            static partial void ValidateOperation(Promise<T> promise, int skipFrames);
+            static partial void ValidateGetResult(Promise promise, int skipFrames);
+            static partial void ValidateOperation(Promise promise, int skipFrames);
 #if PROMISE_DEBUG
             static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames)
             {
                 Internal.ValidateArgument(arg, argName, skipFrames + 1);
             }
 
-            static partial void ValidateGetResult(Promise<T> promise, int skipFrames)
+            static partial void ValidateGetResult(Promise promise, int skipFrames)
             {
-                if (promise._ref == null)
-                {
-                    ValidateOperation(promise, skipFrames + 1);
-                }
+                Internal.ValidateAwaiterOperation(promise, true, skipFrames + 1);
             }
 
-            static partial void ValidateOperation(Promise<T> promise, int skipFrames)
+            static partial void ValidateOperation(Promise promise, int skipFrames)
             {
-                if (!promise.IsValid)
-                {
-                    throw new InvalidOperationException("Attempted to use PromiseAwaiter incorrectly. You must call IsCompleted, then maybe OnCompleted, then GetResult when it is complete.", Internal.GetFormattedStacktrace(skipFrames + 1));
-                }
+                Internal.ValidateAwaiterOperation(promise, false, skipFrames + 1);
             }
 #endif
         } // struct PromiseAwaiter<T>
@@ -559,23 +554,11 @@ namespace Proto.Promises
                 _awaiter._promise._ref.AwaitOnCompletedWithProgressInternal(asyncPromiseRef, _awaiter._promise.Id, _awaiter._promise.Depth, _awaiter._minProgress, _awaiter._maxProgress);
             }
 
-            static partial void ValidateGetResult(Promise<Internal.VoidResult> promise, int skipFrames);
-            static partial void ValidateOperation(Promise<Internal.VoidResult> promise, int skipFrames);
+            static partial void ValidateGetResult(Promise promise, int skipFrames);
 #if PROMISE_DEBUG
-            static partial void ValidateGetResult(Promise<Internal.VoidResult> promise, int skipFrames)
+            static partial void ValidateGetResult(Promise promise, int skipFrames)
             {
-                if (promise._ref == null)
-                {
-                    ValidateOperation(promise, skipFrames + 1);
-                }
-            }
-
-            static partial void ValidateOperation(Promise<Internal.VoidResult> promise, int skipFrames)
-            {
-                if (!promise.IsValid)
-                {
-                    throw new InvalidOperationException("Attempted to use PromiseAwaiter incorrectly. You must call IsCompleted, then maybe OnCompleted, then GetResult when it is complete.", Internal.GetFormattedStacktrace(skipFrames + 1));
-                }
+                Internal.ValidateAwaiterOperation(promise, true, skipFrames + 1);
             }
 #endif
         } // struct PromiseAwaiterVoid
@@ -673,28 +656,22 @@ namespace Proto.Promises
             }
 
             static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
-            static partial void ValidateGetResult(Promise<T> promise, int skipFrames);
-            static partial void ValidateOperation(Promise<T> promise, int skipFrames);
+            static partial void ValidateGetResult(Promise promise, int skipFrames);
+            static partial void ValidateOperation(Promise promise, int skipFrames);
 #if PROMISE_DEBUG
             static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames)
             {
                 Internal.ValidateArgument(arg, argName, skipFrames + 1);
             }
 
-            static partial void ValidateGetResult(Promise<T> promise, int skipFrames)
+            static partial void ValidateGetResult(Promise promise, int skipFrames)
             {
-                if (promise._ref == null)
-                {
-                    ValidateOperation(promise, skipFrames + 1);
-                }
+                Internal.ValidateAwaiterOperation(promise, true, skipFrames + 1);
             }
 
-            static partial void ValidateOperation(Promise<T> promise, int skipFrames)
+            static partial void ValidateOperation(Promise promise, int skipFrames)
             {
-                if (!promise.IsValid)
-                {
-                    throw new InvalidOperationException("Attempted to use PromiseAwaiter incorrectly. You must call IsCompleted, then maybe OnCompleted, then GetResult when it is complete.", Internal.GetFormattedStacktrace(skipFrames + 1));
-                }
+                Internal.ValidateAwaiterOperation(promise, false, skipFrames + 1);
             }
 #endif
         } // struct PromiseAwaiter<T>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -930,7 +930,7 @@ namespace Proto.Promises
                         }
                         else
                         {
-                            return _this;
+                            return new Promise<TResult>(_this._ref, _this.Id, nextDepth, _this.Result);
                         }
                     }
                     else
@@ -947,7 +947,7 @@ namespace Proto.Promises
                             _this._ref.HookupNewPromise(promise);
                         }
                     }
-                    return new Promise<TResult>(promise, promise.Id, _this.Depth);
+                    return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
 
                 [MethodImpl(InlineOption)]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
@@ -48,7 +48,7 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 private bool Release()
                 {
-                    return Interlocked.Decrement(ref _retainAndCanceled) == 0; // If all bits are 0, canceled was set and all calls are complete.
+                    return InterlockedAddWithOverflowCheck(ref _retainAndCanceled, -1, 0) == 0; // If all bits are 0, canceled was set and all calls are complete.
                 }
 
                 internal void SetCanceled(PromiseSingleAwait owner)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -1922,14 +1922,13 @@ namespace Proto.Promises
                 private void SetAwaitedComplete(PromiseRef owner, ValueContainer valueContainer, ref ExecutionScheduler executionScheduler)
                 {
                     ThrowIfInPool(this);
-                    var oldFlags = _progressAndSubscribeFields._previousDepthAndFlags.InterlockedUnsetFlags(ProgressSubscribeFlags.AboutToSetPrevious);
                     var oldPrevious = _valueOrPrevious;
                     _valueOrPrevious = null;
-                    bool wasListeningToProgress = (oldFlags & ProgressSubscribeFlags.AboutToSetPrevious) != 0;
-                    if (wasListeningToProgress)
+                    _progressAndSubscribeFields._previousDepthAndFlags.InterlockedUnsetFlags(ProgressSubscribeFlags.AboutToSetPrevious);
+                    if (oldPrevious is AsyncProgressPassThrough passthrough)
                     {
                         Fixed32 expectedProgress = Fixed32.FromWhole(_progressAndSubscribeFields._previousDepthAndFlags.GetPreviousDepthPlusOne());
-                        ((AsyncProgressPassThrough) oldPrevious).MarkComplete(expectedProgress);
+                        passthrough.MarkComplete(expectedProgress);
                         // Don't report progress if it's 1. That will be reported when the async promise is resolved.
                         // Also don't report if the awaited promise was rejected or canceled.
                         if (valueContainer.GetState() == Promise.State.Resolved & _maxProgress < 1f)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -1881,7 +1881,6 @@ namespace Proto.Promises
                 internal override PromiseRef GetDuplicate(short promiseId, ushort depth) { throw new System.InvalidOperationException(); }
                 internal override void AddWaiter(HandleablePromiseBase waiter, ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
                 internal override void Handle(ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
-                internal override void IncrementIdAndSetFlags(short promiseId) { throw new System.InvalidOperationException(); }
 #endif
             }
 
@@ -1925,8 +1924,7 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
                     var oldFlags = _progressAndSubscribeFields._previousDepthAndFlags.InterlockedUnsetFlags(ProgressSubscribeFlags.AboutToSetPrevious);
                     var oldPrevious = _valueOrPrevious;
-                    owner.InterlockedRetainDisregardId();
-                    _valueOrPrevious = owner;
+                    _valueOrPrevious = null;
                     bool wasListeningToProgress = (oldFlags & ProgressSubscribeFlags.AboutToSetPrevious) != 0;
                     if (wasListeningToProgress)
                     {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -791,6 +791,7 @@ namespace Proto.Promises
                     if (Interlocked.CompareExchange(ref _progressListener, null, progressListener) == progressListener)
                     {
                         progress = Fixed32.FromWholePlusOne(Depth);
+                        WaitWhileProgressFlags(PromiseFlags.ReportingPriority | PromiseFlags.ReportingInitial);
                         progressListener.SetInitialProgress(this, Promise.State.Canceled, ref progress, out nextRef, ref executionScheduler);
                         return;
                     }
@@ -941,6 +942,7 @@ namespace Proto.Promises
                     if (Interlocked.CompareExchange(ref _progressListener, null, progressListener) == progressListener)
                     {
                         progress = expectedProgress;
+                        WaitWhileProgressFlags(PromiseFlags.ReportingPriority | PromiseFlags.ReportingInitial);
                         progressListener.SetInitialProgress(this, state, ref progress, out nextRef, ref executionScheduler);
                         return;
                     }
@@ -1051,6 +1053,7 @@ namespace Proto.Promises
                         if (removed)
                         {
                             progress = Fixed32.FromWholePlusOne(Depth);
+                            WaitWhileProgressFlags(PromiseFlags.ReportingPriority | PromiseFlags.ReportingInitial);
                             progressListener.SetInitialProgress(this, state, ref progress, out nextRef, ref executionScheduler);
                             return;
                         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -538,10 +538,17 @@ namespace Proto.Promises
             {
                 // Wrapping struct fields smaller than 64-bits in another struct fixes issue with extra padding
                 // (see https://stackoverflow.com/questions/67068942/c-sharp-why-do-class-fields-of-struct-types-take-up-more-space-than-the-size-of).
-                private struct SmallFields
+                [StructLayout(LayoutKind.Explicit)]
+                private partial struct SmallFields
                 {
-                    internal int _retainCounter; // int for Interlocked, even though we really only need a ushort.
+                    [FieldOffset(0)]
                     internal Fixed32 _currentProgress;
+                    [FieldOffset(4)]
+                    internal ushort _expectedProgress;
+                    [FieldOffset(6)]
+                    private ushort _retainCounter;
+                    [FieldOffset(4)]
+                    volatile private int _intValue; // int for Interlocked.
                 }
 
                 private AsyncPromiseRef _target;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -726,7 +726,7 @@ namespace Proto.Promises
                     RejectOrCancelInternal(CancelContainerVoid.GetOrCreate());
                 }
 
-                internal sealed override void Handle(ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
+                internal override void Handle(ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
             }
 
             // IDelegate to reduce the amount of classes I would have to write (Composition Over Inheritance).

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -590,6 +590,7 @@ namespace Proto.Promises
                     {
                         ThrowIfInPool(this);
                         // When this is completed, State is set then _waiter is swapped, so we must reverse that process here.
+                        Thread.MemoryBarrier();
                         _waiter = waiter;
                         ScheduleMethod previousScheduleType = (ScheduleMethod) Interlocked.Exchange(ref _mostRecentPotentialScheduleMethod, (int) ScheduleMethod.AddWaiter);
                         if (State != Promise.State.Pending)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -293,6 +293,7 @@ namespace Proto.Promises
                     lock (this)
 #endif
                     {
+                        Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
                         HandleablePromiseBase waiter = Interlocked.Exchange(ref _waiter, null);
                         if (waiter != null)
                         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -678,7 +678,7 @@ namespace Proto.Promises
                 protected void Reset()
                 {
 #if PROMISE_PROGRESS
-                    _currentProgress = default(Fixed32);
+                    _progressFields._currentProgress = default(Fixed32);
 #endif
                     _smallFields.Reset();
                     SetCreatedStacktrace(this, 3);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
@@ -114,7 +114,7 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, progress will stop being reported.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled, progress will not be reported. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+        [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
         public Promise Progress<TProgress>(TProgress progressListener, SynchronizationOption invokeOption = SynchronizationOption.Foreground, CancelationToken cancelationToken = default(CancelationToken))
@@ -134,7 +134,7 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled, onProgress will not be invoked. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+        [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
         public Promise Progress(Action<float> onProgress, SynchronizationOption invokeOption = SynchronizationOption.Foreground, CancelationToken cancelationToken = default(CancelationToken))
@@ -154,7 +154,7 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, progress will stop being reported.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled, progress will not be reported. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+        [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
         public Promise Progress<TProgress>(TProgress progressListener, SynchronizationContext invokeContext, CancelationToken cancelationToken = default(CancelationToken))
@@ -175,7 +175,7 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled, onProgress will not be invoked. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+        [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
         public Promise Progress(Action<float> onProgress, SynchronizationContext invokeContext, CancelationToken cancelationToken = default(CancelationToken))
@@ -780,7 +780,7 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled, onProgress will not be invoked. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+        [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
         public Promise Progress<TCaptureProgress>(TCaptureProgress progressCaptureValue, Action<TCaptureProgress, float> onProgress, SynchronizationOption invokeOption = SynchronizationOption.Foreground, CancelationToken cancelationToken = default(CancelationToken))
@@ -800,7 +800,7 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled, onProgress will not be invoked. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+        [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
         public Promise Progress<TCaptureProgress>(TCaptureProgress progressCaptureValue, Action<TCaptureProgress, float> onProgress, SynchronizationContext invokeContext, CancelationToken cancelationToken = default(CancelationToken))

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -139,7 +139,7 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, progress will stop being reported.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled, progress will not be reported. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+        [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         public Promise<T> Progress<TProgress>(TProgress progressListener, SynchronizationOption invokeOption = SynchronizationOption.Foreground, CancelationToken cancelationToken = default(CancelationToken))
             where TProgress : IProgress<float>
@@ -166,7 +166,7 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled, onProgress will not be invoked. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+        [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
         public Promise<T> Progress(Action<float> onProgress, SynchronizationOption invokeOption = SynchronizationOption.Foreground, CancelationToken cancelationToken = default(CancelationToken))
@@ -188,7 +188,7 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, progress will stop being reported.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled, progress will not be reported. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+        [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         public Promise<T> Progress<TProgress>(TProgress progressListener, SynchronizationContext invokeContext, CancelationToken cancelationToken = default(CancelationToken))
             where TProgress : IProgress<float>
@@ -216,7 +216,7 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled, onProgress will not be invoked. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+        [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
         public Promise<T> Progress(Action<float> onProgress, SynchronizationContext invokeContext, CancelationToken cancelationToken = default(CancelationToken))
@@ -825,7 +825,7 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled, onProgress will not be invoked. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+        [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
         public Promise<T> Progress<TCaptureProgress>(TCaptureProgress progressCaptureValue, Action<TCaptureProgress, float> onProgress, SynchronizationOption invokeOption = SynchronizationOption.Foreground, CancelationToken cancelationToken = default(CancelationToken))
@@ -847,7 +847,7 @@ namespace Proto.Promises
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
 #if !PROMISE_PROGRESS
-        [Obsolete("Progress is disabled, onProgress will not be invoked. Remove PROTO_PROMISE_PROGRESS_DISABLE from your compiler symbols to enable progress reports.", false)]
+        [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
         public Promise<T> Progress<TCaptureProgress>(TCaptureProgress progressCaptureValue, Action<TCaptureProgress, float> onProgress, SynchronizationContext invokeContext, CancelationToken cancelationToken = default(CancelationToken))
@@ -2214,7 +2214,7 @@ namespace Proto.Promises
         [Obsolete("Release is no longer valid, use Forget instead.", true)]
         public void Release()
         {
-            throw new InvalidOperationException("Release is no longer valid, use Preserve instead.", Internal.GetFormattedStacktrace(1));
+            throw new InvalidOperationException("Release is no longer valid, use Forget instead.", Internal.GetFormattedStacktrace(1));
         }
     }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ProtoPromise.asmdef
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ProtoPromise.asmdef
@@ -4,7 +4,7 @@
     "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/AsyncTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/AsyncTests.cs
@@ -1,5 +1,11 @@
 ﻿#if CSHARP_7_3_OR_NEWER
 
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
 #if !PROTO_PROMISE_PROGRESS_DISABLE
 #define PROMISE_PROGRESS
 #else
@@ -592,17 +598,624 @@ namespace ProtoPromiseTests.APIs
                 .Then(() => complete = true)
                 .Forget();
 
-            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, 0.5f * 0.3f);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0f, 0.3f, 0.5f));
             progressHelper.ResolveAndAssertResult(deferred1, 0.5f);
 
-            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 0.75f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0.5f, 1f, 0.5f));
             progressHelper.ResolveAndAssertResult(deferred2, 1f);
 
             Assert.IsTrue(complete);
         }
 
-        // TODO: more tests
+        [Test]
+        public void AsyncPromiseWillHaveProgressScaledProperly_T()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            async Promise<int> Func()
+            {
+                await deferred1.Promise.AwaitWithProgress(0f, 0.3f);
+                return await deferred2.Promise.AwaitWithProgress(0.5f, 1f);
+            }
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+            bool complete = false;
+
+            Func()
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Then(() => complete = true)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0f, 0.3f, 0.5f));
+            progressHelper.ResolveAndAssertResult(deferred1, 1, 0.5f);
+
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0.5f, 1f, 0.5f));
+            progressHelper.ResolveAndAssertResult(deferred2, 2, 1f);
+
+            Assert.IsTrue(complete);
+        }
+
+        [Test]
+        public void AsyncPromiseWontReportProgressFromCanceledPromiseChain_void0()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+            var cancelationSource1 = CancelationSource.New();
+            var cancelationSource2 = CancelationSource.New();
+
+            async Promise Func()
+            {
+                await deferred1.Promise
+                    .ThenDuplicate(cancelationSource1.Token)
+                    .CatchCancelation(() => { })
+                    .AwaitWithProgress(0f, 0.3f);
+                await deferred2.Promise
+                    .ThenDuplicate(cancelationSource2.Token)
+                    .CatchCancelation(() => { })
+                    .AwaitWithProgress(0.5f, 1f);
+            }
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+            bool complete = false;
+
+            Func()
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Then(() => complete = true)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0f, 0.3f, 0.5f));
+            progressHelper.CancelAndAssertResult(cancelationSource1, 0.5f);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.6f, 0.5f, false);
+
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0.5f, 1f, 0.5f));
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.7f, TestHelper.Lerp(0.5f, 1f, 0.5f), false);
+            progressHelper.CancelAndAssertResult(cancelationSource2, 1f);
+            Assert.IsTrue(complete);
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.8f, 1f, false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.8f, 1f, false);
+            progressHelper.ResolveAndAssertResult(deferred2, 1f, false);
+            progressHelper.ResolveAndAssertResult(deferred1, 1f, false);
+
+            cancelationSource1.Dispose();
+            cancelationSource2.Dispose();
+        }
+
+        [Test]
+        public void AsyncPromiseWontReportProgressFromCanceledPromiseChain_void1()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+            var cancelationSource1 = CancelationSource.New();
+            var cancelationSource2 = CancelationSource.New();
+            var deferred3 = Promise.NewDeferred();
+            var deferred4 = Promise.NewDeferred();
+
+            async Promise Func()
+            {
+                await deferred1.Promise
+                    .ThenDuplicate(cancelationSource1.Token)
+                    .CatchCancelation(() => deferred3.Promise)
+                    .AwaitWithProgress(0f, 0.3f);
+                await deferred2.Promise
+                    .ThenDuplicate(cancelationSource2.Token)
+                    .CatchCancelation(() => deferred4.Promise)
+                    .AwaitWithProgress(0.5f, 1f);
+            }
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+            bool complete = false;
+
+            Func()
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Then(() => complete = true)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.1f, TestHelper.Lerp(0f, 0.3f, 0.1f / 2f));
+            progressHelper.CancelAndAssertResult(cancelationSource1, TestHelper.Lerp(0f, 0.3f, 1f / 2f));
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.2f, TestHelper.Lerp(0f, 0.3f, 1f / 2f), false);
+
+            progressHelper.ReportProgressAndAssertResult(deferred3, 0.5f, TestHelper.Lerp(0f, 0.3f, 1.5f / 2f));
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.3f, TestHelper.Lerp(0f, 0.3f, 1.5f / 2f), false);
+            progressHelper.ResolveAndAssertResult(deferred3, 0.5f);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.4f, 0.5f, false);
+
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0.5f, 1f, 0.5f / 2f));
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.4f, TestHelper.Lerp(0.5f, 1f, 0.5f / 2f), false);
+            progressHelper.CancelAndAssertResult(cancelationSource2, TestHelper.Lerp(0.5f, 1f, 1f / 2f));
+
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.6f, TestHelper.Lerp(0.5f, 1f, 1f / 2f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0.5f, 1f, 1f / 2f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred4, 0.5f, TestHelper.Lerp(0.5f, 1f, 1.5f / 2f));
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.7f, TestHelper.Lerp(0.5f, 1f, 1.5f / 2f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.6f, TestHelper.Lerp(0.5f, 1f, 1.5f / 2f), false);
+
+            progressHelper.ResolveAndAssertResult(deferred4, 1f);
+            Assert.IsTrue(complete);
+
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.8f, 1f, false);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.7f, 1f, false);
+
+            progressHelper.ResolveAndAssertResult(deferred2, 1f, false);
+            progressHelper.ResolveAndAssertResult(deferred1, 1f, false);
+
+            cancelationSource1.Dispose();
+            cancelationSource2.Dispose();
+        }
+
+        [Test]
+        public void AsyncPromiseWontReportProgressFromCanceledPromiseChain_T0()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+            var cancelationSource1 = CancelationSource.New();
+            var cancelationSource2 = CancelationSource.New();
+
+            async Promise<int> Func()
+            {
+                await deferred1.Promise
+                    .ThenDuplicate(cancelationSource1.Token)
+                    .CatchCancelation(() => 2)
+                    .AwaitWithProgress(0f, 0.3f);
+                return await deferred2.Promise
+                    .ThenDuplicate(cancelationSource2.Token)
+                    .CatchCancelation(() => 2)
+                    .AwaitWithProgress(0.5f, 1f);
+            }
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+            bool complete = false;
+
+            Func()
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Then(() => complete = true)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0f, 0.3f, 0.5f));
+            progressHelper.CancelAndAssertResult(cancelationSource1, 0.5f);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.6f, 0.5f, false);
+
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0.5f, 1f, 0.5f));
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.7f, TestHelper.Lerp(0.5f, 1f, 0.5f), false);
+            progressHelper.CancelAndAssertResult(cancelationSource2, 1f);
+            Assert.IsTrue(complete);
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.8f, 1f, false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.8f, 1f, false);
+            progressHelper.ResolveAndAssertResult(deferred2, 2, 1f, false);
+            progressHelper.ResolveAndAssertResult(deferred1, 1, 1f, false);
+
+            cancelationSource1.Dispose();
+            cancelationSource2.Dispose();
+        }
+
+        [Test]
+        public void AsyncPromiseWontReportProgressFromCanceledPromiseChain_T1()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+            var cancelationSource1 = CancelationSource.New();
+            var cancelationSource2 = CancelationSource.New();
+            var deferred3 = Promise.NewDeferred<int>();
+            var deferred4 = Promise.NewDeferred<int>();
+
+            async Promise<int> Func()
+            {
+                await deferred1.Promise
+                    .ThenDuplicate(cancelationSource1.Token)
+                    .CatchCancelation(() => deferred3.Promise)
+                    .AwaitWithProgress(0f, 0.3f);
+                return await deferred2.Promise
+                    .ThenDuplicate(cancelationSource2.Token)
+                    .CatchCancelation(() => deferred4.Promise)
+                    .AwaitWithProgress(0.5f, 1f);
+            }
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+            bool complete = false;
+
+            Func()
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Then(() => complete = true)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.1f, TestHelper.Lerp(0f, 0.3f, 0.1f / 2f));
+            progressHelper.CancelAndAssertResult(cancelationSource1, TestHelper.Lerp(0f, 0.3f, 1f / 2f));
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.2f, TestHelper.Lerp(0f, 0.3f, 1f / 2f), false);
+
+            progressHelper.ReportProgressAndAssertResult(deferred3, 0.5f, TestHelper.Lerp(0f, 0.3f, 1.5f / 2f));
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.3f, TestHelper.Lerp(0f, 0.3f, 1.5f / 2f), false);
+            progressHelper.ResolveAndAssertResult(deferred3, 3, 0.5f);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.4f, 0.5f, false);
+
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0.5f, 1f, 0.5f / 2f));
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.4f, TestHelper.Lerp(0.5f, 1f, 0.5f / 2f), false);
+            progressHelper.CancelAndAssertResult(cancelationSource2, TestHelper.Lerp(0.5f, 1f, 1f / 2f));
+
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.6f, TestHelper.Lerp(0.5f, 1f, 1f / 2f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0.5f, 1f, 1f / 2f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred4, 0.5f, TestHelper.Lerp(0.5f, 1f, 1.5f / 2f));
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.7f, TestHelper.Lerp(0.5f, 1f, 1.5f / 2f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.6f, TestHelper.Lerp(0.5f, 1f, 1.5f / 2f), false);
+
+            progressHelper.ResolveAndAssertResult(deferred4, 4, 1f);
+            Assert.IsTrue(complete);
+
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.8f, 1f, false);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.7f, 1f, false);
+
+            progressHelper.ResolveAndAssertResult(deferred2, 2, 1f, false);
+            progressHelper.ResolveAndAssertResult(deferred1, 1, 1f, false);
+
+            cancelationSource1.Dispose();
+            cancelationSource2.Dispose();
+        }
 #endif // PROMISE_PROGRESS
+
+        [Test]
+        public void IfTheAwaitedPromiseResultsInACircularPromiseChain_ThrowInvalidOperationException_void0()
+        {
+            var deferred = Promise.NewDeferred();
+            var selfPromise = default(Promise);
+
+            bool thrown = false;
+
+            async Promise Func()
+            {
+                await deferred.Promise;
+                await selfPromise;
+            }
+
+            selfPromise = Func();
+            selfPromise
+                .Catch((Proto.Promises.InvalidOperationException e) => thrown = true)
+                .Forget();
+
+            deferred.Resolve();
+
+            Assert.IsTrue(thrown);
+        }
+
+        [Test]
+        public void IfTheAwaitedPromiseResultsInACircularPromiseChain_ThrowInvalidOperationException_void1()
+        {
+            var deferred = Promise.NewDeferred();
+            var selfPromise = default(Promise);
+
+            bool thrown = false;
+
+            async Promise Func()
+            {
+                await deferred.Promise;
+                try
+                {
+                    await selfPromise;
+                }
+                catch (Proto.Promises.InvalidOperationException)
+                {
+                    thrown = true;
+                }
+            }
+
+            selfPromise = Func();
+            selfPromise.Forget();
+
+            deferred.Resolve();
+
+            Assert.IsTrue(thrown);
+        }
+
+        [Test]
+        public void IfTheAwaitedPromiseResultsInACircularPromiseChain_ThrowInvalidOperationException_void2()
+        {
+            var deferred = Promise.NewDeferred();
+            var selfPromise = default(Promise);
+
+            bool thrown = false;
+
+            async Promise Func()
+            {
+                await deferred.Promise;
+                await selfPromise
+                    .ThenDuplicate()
+                    .ThenDuplicate()
+                    .Then(() => Promise.Resolved());
+            }
+
+            selfPromise = Func();
+            selfPromise
+                .Catch((Proto.Promises.InvalidOperationException e) => thrown = true)
+                .Forget();
+
+            deferred.Resolve();
+
+            Assert.IsTrue(thrown);
+        }
+
+        [Test]
+        public void IfTheAwaitedPromiseResultsInACircularPromiseChain_ThrowInvalidOperationException_void3()
+        {
+            var deferred = Promise.NewDeferred();
+            var selfPromise = default(Promise);
+
+            bool thrown = false;
+
+            async Promise Func()
+            {
+                await deferred.Promise;
+                try
+                {
+                    await selfPromise
+                        .ThenDuplicate()
+                        .ThenDuplicate()
+                        .Then(() => Promise.Resolved());
+                }
+                catch (Proto.Promises.InvalidOperationException)
+                {
+                    thrown = true;
+                }
+            }
+
+            selfPromise = Func();
+            selfPromise.Forget();
+
+            deferred.Resolve();
+
+            Assert.IsTrue(thrown);
+        }
+
+        [Test]
+        public void IfTheAwaitedPromiseResultsInACircularPromiseChain_ThrowInvalidOperationException_void4()
+        {
+            var deferred = Promise.NewDeferred();
+            var selfPromise = default(Promise);
+
+            bool thrown = false;
+
+            async Promise Func()
+            {
+                await Func2();
+            }
+
+            async Promise Func2()
+            {
+                await deferred.Promise;
+                try
+                {
+                    await selfPromise;
+                }
+                catch (Proto.Promises.InvalidOperationException)
+                {
+                    thrown = true;
+                }
+            }
+
+            selfPromise = Func();
+            selfPromise.Forget();
+
+            deferred.Resolve();
+
+            Assert.IsTrue(thrown);
+        }
+
+        [Test]
+        public void IfTheAwaitedPromiseResultsInACircularPromiseChain_ThrowInvalidOperationException_void5()
+        {
+            var deferred = Promise.NewDeferred();
+            var selfPromise = default(Promise);
+
+            bool thrown = false;
+
+            async Promise Func()
+            {
+                try
+                {
+                    await Func2();
+                }
+                catch (Proto.Promises.InvalidOperationException)
+                {
+                    thrown = true;
+                }
+            }
+
+            async Promise Func2()
+            {
+                await deferred.Promise;
+                await selfPromise;
+            }
+
+            selfPromise = Func();
+            selfPromise.Forget();
+
+            deferred.Resolve();
+
+            Assert.IsTrue(thrown);
+        }
+
+        [Test]
+        public void IfTheAwaitedPromiseResultsInACircularPromiseChain_ThrowInvalidOperationException_T0()
+        {
+            var deferred = Promise.NewDeferred<int>();
+            var selfPromise = default(Promise<int>);
+
+            bool thrown = false;
+
+            async Promise<int> Func()
+            {
+                await deferred.Promise;
+                return await selfPromise;
+            }
+
+            selfPromise = Func();
+            selfPromise
+                .Catch((Proto.Promises.InvalidOperationException e) => thrown = true)
+                .Forget();
+
+            deferred.Resolve(1);
+
+            Assert.IsTrue(thrown);
+        }
+
+        [Test]
+        public void IfTheAwaitedPromiseResultsInACircularPromiseChain_ThrowInvalidOperationException_T1()
+        {
+            var deferred = Promise.NewDeferred<int>();
+            var selfPromise = default(Promise<int>);
+
+            bool thrown = false;
+
+            async Promise<int> Func()
+            {
+                await deferred.Promise;
+                try
+                {
+                    return await selfPromise;
+                }
+                catch (Proto.Promises.InvalidOperationException)
+                {
+                    thrown = true;
+                    return 2;
+                }
+            }
+
+            selfPromise = Func();
+            selfPromise.Forget();
+
+            deferred.Resolve(1);
+
+            Assert.IsTrue(thrown);
+        }
+
+        [Test]
+        public void IfTheAwaitedPromiseResultsInACircularPromiseChain_ThrowInvalidOperationException_T2()
+        {
+            var deferred = Promise.NewDeferred<int>();
+            var selfPromise = default(Promise<int>);
+
+            bool thrown = false;
+
+            async Promise<int> Func()
+            {
+                await deferred.Promise;
+                return await selfPromise
+                    .ThenDuplicate()
+                    .ThenDuplicate()
+                    .Then(() => Promise.Resolved(2));
+            }
+
+            selfPromise = Func();
+            selfPromise
+                .Catch((Proto.Promises.InvalidOperationException e) => thrown = true)
+                .Forget();
+
+            deferred.Resolve(1);
+
+            Assert.IsTrue(thrown);
+        }
+
+        [Test]
+        public void IfTheAwaitedPromiseResultsInACircularPromiseChain_ThrowInvalidOperationException_T3()
+        {
+            var deferred = Promise.NewDeferred<int>();
+            var selfPromise = default(Promise<int>);
+
+            bool thrown = false;
+
+            async Promise<int> Func()
+            {
+                await deferred.Promise;
+                try
+                {
+                    return await selfPromise
+                        .ThenDuplicate()
+                        .ThenDuplicate()
+                        .Then(() => Promise.Resolved(2));
+                }
+                catch (Proto.Promises.InvalidOperationException)
+                {
+                    thrown = true;
+                    return 3;
+                }
+            }
+
+            selfPromise = Func();
+            selfPromise.Forget();
+
+            deferred.Resolve(1);
+
+            Assert.IsTrue(thrown);
+        }
+
+        [Test]
+        public void IfTheAwaitedPromiseResultsInACircularPromiseChain_ThrowInvalidOperationException_T4()
+        {
+            var deferred = Promise.NewDeferred<int>();
+            var selfPromise = default(Promise<int>);
+
+            bool thrown = false;
+
+            async Promise<int> Func()
+            {
+                return await Func2();
+            }
+
+            async Promise<int> Func2()
+            {
+                await deferred.Promise;
+                try
+                {
+                    return await selfPromise;
+                }
+                catch (Proto.Promises.InvalidOperationException)
+                {
+                    thrown = true;
+                    return 2;
+                }
+            }
+
+            selfPromise = Func();
+            selfPromise.Forget();
+
+            deferred.Resolve(1);
+
+            Assert.IsTrue(thrown);
+        }
+
+        [Test]
+        public void IfTheAwaitedPromiseResultsInACircularPromiseChain_ThrowInvalidOperationException_T5()
+        {
+            var deferred = Promise.NewDeferred<int>();
+            var selfPromise = default(Promise<int>);
+
+            bool thrown = false;
+
+            async Promise<int> Func()
+            {
+                try
+                {
+                    return await Func2();
+                }
+                catch (Proto.Promises.InvalidOperationException)
+                {
+                    thrown = true;
+                    return 2;
+                }
+            }
+
+            async Promise<int> Func2()
+            {
+                await deferred.Promise;
+                return await selfPromise;
+            }
+
+            selfPromise = Func();
+            selfPromise.Forget();
+
+            deferred.Resolve(1);
+
+            Assert.IsTrue(thrown);
+        }
     }
 }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/ProgressTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/ProgressTests.cs
@@ -742,6 +742,202 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
+        public void ProgressIsNotInvokedFromCanceledPromiseChain_void0()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+
+            deferred.Promise
+                .ThenDuplicate(cancelationSource.Token)
+                .ContinueWith(_ => deferred2.Promise)
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Finally(cancelationSource.Dispose)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f / 2f);
+            progressHelper.CancelAndAssertResult(cancelationSource, 1f / 2f);
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.6f, 1f / 2f, false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 1.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.7f, 1.5f / 2f, false);
+            
+            progressHelper.ResolveAndAssertResult(deferred, 1.5f / 2f, false);
+            progressHelper.ResolveAndAssertResult(deferred2, 2f / 2f);
+        }
+
+        [Test]
+        public void ProgressIsNotInvokedFromCanceledPromiseChain_void1()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+
+            deferred.Promise
+                .ThenDuplicate(cancelationSource.Token)
+                .CatchCancelation(() => deferred2.Promise)
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Finally(cancelationSource.Dispose)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f / 2f);
+            progressHelper.CancelAndAssertResult(cancelationSource, 1f / 2f);
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.6f, 1f / 2f, false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 1.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.7f, 1.5f / 2f, false);
+
+            progressHelper.ResolveAndAssertResult(deferred, 1.5f / 2f, false);
+            progressHelper.ResolveAndAssertResult(deferred2, 2f / 2f);
+        }
+
+        [Test]
+        public void ProgressIsNotInvokedFromCanceledPromiseChain_void2()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred();
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+
+            deferred.Promise
+                .ThenDuplicate(cancelationSource.Token)
+                .ContinueWith(_ => { })
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Finally(cancelationSource.Dispose)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
+            progressHelper.CancelAndAssertResult(cancelationSource, 1f);
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.75f, 1f, false);
+            progressHelper.ResolveAndAssertResult(deferred, 1f, false);
+        }
+
+        [Test]
+        public void ProgressIsNotInvokedFromCanceledPromiseChain_void3()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred();
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+
+            deferred.Promise
+                .ThenDuplicate(cancelationSource.Token)
+                .CatchCancelation(() => { })
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Finally(cancelationSource.Dispose)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
+            progressHelper.CancelAndAssertResult(cancelationSource, 1f);
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.75f, 1f, false);
+            progressHelper.ResolveAndAssertResult(deferred, 1f, false);
+        }
+
+        [Test]
+        public void ProgressIsNotInvokedFromCanceledPromiseChain_T0()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+
+            deferred.Promise
+                .ThenDuplicate(cancelationSource.Token)
+                .ContinueWith(_ => deferred2.Promise)
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Finally(cancelationSource.Dispose)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f / 2f);
+            progressHelper.CancelAndAssertResult(cancelationSource, 1f / 2f);
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.6f, 1f / 2f, false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 1.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.7f, 1.5f / 2f, false);
+
+            progressHelper.ResolveAndAssertResult(deferred, 1, 1.5f / 2f, false);
+            progressHelper.ResolveAndAssertResult(deferred2, 2, 2f / 2f);
+        }
+
+        [Test]
+        public void ProgressIsNotInvokedFromCanceledPromiseChain_T1()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+
+            deferred.Promise
+                .ThenDuplicate(cancelationSource.Token)
+                .CatchCancelation(() => deferred2.Promise)
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Finally(cancelationSource.Dispose)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f / 2f);
+            progressHelper.CancelAndAssertResult(cancelationSource, 1f / 2f);
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.6f, 1f / 2f, false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 1.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.7f, 1.5f / 2f, false);
+
+            progressHelper.ResolveAndAssertResult(deferred, 1, 1.5f / 2f, false);
+            progressHelper.ResolveAndAssertResult(deferred2, 2, 2f / 2f);
+        }
+
+        [Test]
+        public void ProgressIsNotInvokedFromCanceledPromiseChain_T2()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred<int>();
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+
+            deferred.Promise
+                .ThenDuplicate(cancelationSource.Token)
+                .ContinueWith(_ => 2)
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Finally(cancelationSource.Dispose)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
+            progressHelper.CancelAndAssertResult(cancelationSource, 1f);
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.75f, 1f, false);
+            progressHelper.ResolveAndAssertResult(deferred, 1, 1f, false);
+        }
+
+        [Test]
+        public void ProgressIsNotInvokedFromCanceledPromiseChain_T3()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred<int>();
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+
+            deferred.Promise
+                .ThenDuplicate(cancelationSource.Token)
+                .CatchCancelation(() => 2)
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Finally(cancelationSource.Dispose)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
+            progressHelper.CancelAndAssertResult(cancelationSource, 1f);
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.75f, 1f, false);
+            progressHelper.ResolveAndAssertResult(deferred, 1, 1f, false);
+        }
+
+        [Test]
         public void OnProgressWillNotBeInvokedWith1UntilPromiseIsResolved(
             [Values] ProgressType progressType,
             [Values] SynchronizationType synchronizationType)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/TestHelper.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/TestHelper.cs
@@ -131,6 +131,11 @@ namespace ProtoPromiseTests
             _foregroundContext.Execute();
         }
 
+        public static float Lerp(float a, float b, float t)
+        {
+            return a + (b - a) * t;
+        }
+
         public static Action<Promise.Deferred, CancelationSource> GetCompleterVoid(CompleteType completeType, string rejectValue)
         {
             switch (completeType)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/AwaitConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/AwaitConcurrencyTests.cs
@@ -326,6 +326,8 @@ namespace ProtoPromiseTests.Threading
                 }
             );
         }
+
+        // TODO: async Promise progress concurrency tests.
     }
 }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/AwaitConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Threading/AwaitConcurrencyTests.cs
@@ -327,7 +327,369 @@ namespace ProtoPromiseTests.Threading
             );
         }
 
-        // TODO: async Promise progress concurrency tests.
+#if PROMISE_PROGRESS
+        [Test]
+        public void PromiseMayBeCompletedAndAwaitedAndProgressReportedConcurrently_void0(
+            [Values] CompleteType completeType,
+            [Values] SynchronizationType progressSynchronizationType)
+        {
+            var deferred = default(Promise.Deferred);
+            var pendingPromise = default(Promise);
+            var cancelationSource = default(CancelationSource);
+            var tryCompleter = TestHelper.GetTryCompleterVoid(completeType, rejectValue);
+
+            Promise.State result = Promise.State.Pending;
+
+            var progressHelper = default(ProgressHelper);
+            var asyncPromise = default(Promise);
+
+            var threadHelper = new ThreadHelper();
+            threadHelper.ExecuteParallelActionsWithOffsetsAndSetup(
+                setup: () =>
+                {
+                    result = Promise.State.Pending;
+                    deferred = TestHelper.GetNewDeferredVoid(completeType, out cancelationSource);
+                    pendingPromise = deferred.Promise;
+                    progressHelper = new ProgressHelper(ProgressType.Interface, progressSynchronizationType);
+                    progressHelper.MaybeEnterLock();
+                    progressHelper.PrepareForInvoke();
+                },
+                parallelActionsSetup: new Action<Action>[]
+                {
+                    barrierAction =>
+                    {
+                        var deferredForAssign = Promise.NewDeferred();
+                        asyncPromise = Await();
+                        deferredForAssign.Resolve();
+
+                        async Promise Await()
+                        {
+                            try
+                            {
+                                await deferredForAssign.Promise; // Await this so that asyncPromise will be assigned before the thread is blocked on the barrier.
+                                barrierAction.Invoke();
+                                await pendingPromise.AwaitWithProgress(0f, 1f);
+                                result = Promise.State.Resolved;
+                            }
+                            catch (UnhandledException)
+                            {
+                                result = Promise.State.Rejected;
+                            }
+                            catch (CanceledException)
+                            {
+                                result = Promise.State.Canceled;
+                            }
+                        }
+                    }
+                },
+                parallelActions: new Action[]
+                {
+                    () => tryCompleter(deferred, cancelationSource),
+                    () => asyncPromise.SubscribeProgress(progressHelper).Forget(), // We cannot determine what the progress will be at this point due to thread races, so don't check it.
+                    () => deferred.TryReportProgress(0.5f)
+                },
+                teardown: () =>
+                {
+                    cancelationSource.TryDispose();
+
+                    // Because of thread race conditions, we cannot determine whether or not progress will be invoked if the promise is rejected or canceled.
+                    if (completeType == CompleteType.Resolve)
+                    {
+                        // We cannot determine if the progress will be 0.5 or 1 due to thread race conditions, so just wait for invoke.
+                        progressHelper.MaybeWaitForInvoke(true, true);
+                    }
+                    progressHelper.MaybeExitLock();
+
+                    Assert.AreNotEqual(Promise.State.Pending, result);
+                    switch (completeType)
+                    {
+                        case CompleteType.Resolve:
+                            Assert.AreEqual(Promise.State.Resolved, result);
+                            break;
+                        case CompleteType.Reject:
+                            Assert.AreEqual(Promise.State.Rejected, result);
+                            break;
+                        case CompleteType.Cancel:
+                        case CompleteType.CancelFromToken:
+                            Assert.AreEqual(Promise.State.Canceled, result);
+                            break;
+                    }
+                }
+            );
+        }
+
+        [Test]
+        public void PromiseMayBeCompletedAndAwaitedAndProgressReportedConcurrently_void1(
+            [Values] CompleteType completeType,
+            [Values] SynchronizationType progressSynchronizationType)
+        {
+            var deferred = default(Promise.Deferred);
+            var pendingPromise = default(Promise);
+            var cancelationSource = default(CancelationSource);
+            var tryCompleter = TestHelper.GetTryCompleterVoid(completeType, rejectValue);
+
+            Promise.State result = Promise.State.Pending;
+
+            var progressHelper = default(ProgressHelper);
+            var asyncPromise = default(Promise);
+
+            var threadHelper = new ThreadHelper();
+            threadHelper.ExecuteParallelActionsWithOffsetsAndSetup(
+                setup: () =>
+                {
+                    result = Promise.State.Pending;
+                    deferred = TestHelper.GetNewDeferredVoid(completeType, out cancelationSource);
+                    pendingPromise = deferred.Promise;
+                    progressHelper = new ProgressHelper(ProgressType.Interface, progressSynchronizationType);
+                    progressHelper.MaybeEnterLock();
+                    progressHelper.PrepareForInvoke();
+                },
+                parallelActionsSetup: new Action<Action>[]
+                {
+                    barrierAction =>
+                    {
+                        var deferredForAssign = Promise.NewDeferred();
+                        asyncPromise = Await();
+                        deferredForAssign.Resolve();
+
+                        async Promise Await()
+                        {
+                            try
+                            {
+                                await deferredForAssign.Promise.AwaitWithProgress(0f, 0.5f);
+                                barrierAction.Invoke();
+                                await pendingPromise.AwaitWithProgress(0.5f, 1f);
+                                result = Promise.State.Resolved;
+                            }
+                            catch (UnhandledException)
+                            {
+                                result = Promise.State.Rejected;
+                            }
+                            catch (CanceledException)
+                            {
+                                result = Promise.State.Canceled;
+                            }
+                        }
+                    }
+                },
+                parallelActions: new Action[]
+                {
+                    () => tryCompleter(deferred, cancelationSource),
+                    () => asyncPromise.SubscribeProgress(progressHelper).Forget(), // We cannot determine what the progress will be at this point due to thread races, so don't check it.
+                    () => deferred.TryReportProgress(0.5f)
+                },
+                teardown: () =>
+                {
+                    cancelationSource.TryDispose();
+
+                    // Because of thread race conditions, we cannot determine whether or not progress will be invoked if the promise is rejected or canceled.
+                    if (completeType == CompleteType.Resolve)
+                    {
+                        // We cannot determine if the progress will be 0.75 or 1 due to thread race conditions, so just wait for invoke.
+                        progressHelper.MaybeWaitForInvoke(true, true);
+                    }
+                    progressHelper.MaybeExitLock();
+
+                    Assert.AreNotEqual(Promise.State.Pending, result);
+                    switch (completeType)
+                    {
+                        case CompleteType.Resolve:
+                            Assert.AreEqual(Promise.State.Resolved, result);
+                            break;
+                        case CompleteType.Reject:
+                            Assert.AreEqual(Promise.State.Rejected, result);
+                            break;
+                        case CompleteType.Cancel:
+                        case CompleteType.CancelFromToken:
+                            Assert.AreEqual(Promise.State.Canceled, result);
+                            break;
+                    }
+                }
+            );
+        }
+
+        [Test]
+        public void PromiseMayBeCompletedAndAwaitedAndProgressReportedConcurrently_T0(
+            [Values] CompleteType completeType,
+            [Values] SynchronizationType progressSynchronizationType)
+        {
+            var deferred = default(Promise<int>.Deferred);
+            var pendingPromise = default(Promise<int>);
+            var cancelationSource = default(CancelationSource);
+            var tryCompleter = TestHelper.GetTryCompleterT(completeType, 1, rejectValue);
+
+            Promise.State result = Promise.State.Pending;
+
+            var progressHelper = default(ProgressHelper);
+            var asyncPromise = default(Promise<int>);
+
+            var threadHelper = new ThreadHelper();
+            threadHelper.ExecuteParallelActionsWithOffsetsAndSetup(
+                setup: () =>
+                {
+                    result = Promise.State.Pending;
+                    deferred = TestHelper.GetNewDeferredT<int>(completeType, out cancelationSource);
+                    pendingPromise = deferred.Promise;
+                    progressHelper = new ProgressHelper(ProgressType.Interface, progressSynchronizationType);
+                    progressHelper.MaybeEnterLock();
+                    progressHelper.PrepareForInvoke();
+                },
+                parallelActionsSetup: new Action<Action>[]
+                {
+                    barrierAction =>
+                    {
+                        var deferredForAssign = Promise.NewDeferred<int>();
+                        asyncPromise = Await();
+                        deferredForAssign.Resolve(1);
+
+                        async Promise<int> Await()
+                        {
+                            try
+                            {
+                                await deferredForAssign.Promise; // Await this so that asyncPromise will be assigned before the thread is blocked on the barrier.
+                                barrierAction.Invoke();
+                                await pendingPromise.AwaitWithProgress(0.5f, 1f);
+                                result = Promise.State.Resolved;
+                            }
+                            catch (UnhandledException)
+                            {
+                                result = Promise.State.Rejected;
+                            }
+                            catch (CanceledException)
+                            {
+                                result = Promise.State.Canceled;
+                            }
+                            return 2;
+                        }
+                    }
+                },
+                parallelActions: new Action[]
+                {
+                    () => tryCompleter(deferred, cancelationSource),
+                    () => asyncPromise.SubscribeProgress(progressHelper).Forget(), // We cannot determine what the progress will be at this point due to thread races, so don't check it.
+                    () => deferred.TryReportProgress(0.5f)
+                },
+                teardown: () =>
+                {
+                    cancelationSource.TryDispose();
+
+                    // Because of thread race conditions, we cannot determine whether or not progress will be invoked if the promise is rejected or canceled.
+                    if (completeType == CompleteType.Resolve)
+                    {
+                        // We cannot determine if the progress will be 0.75 or 1 due to thread race conditions, so just wait for invoke.
+                        progressHelper.MaybeWaitForInvoke(true, true);
+                    }
+                    progressHelper.MaybeExitLock();
+
+                    Assert.AreNotEqual(Promise.State.Pending, result);
+                    switch (completeType)
+                    {
+                        case CompleteType.Resolve:
+                            Assert.AreEqual(Promise.State.Resolved, result);
+                            break;
+                        case CompleteType.Reject:
+                            Assert.AreEqual(Promise.State.Rejected, result);
+                            break;
+                        case CompleteType.Cancel:
+                        case CompleteType.CancelFromToken:
+                            Assert.AreEqual(Promise.State.Canceled, result);
+                            break;
+                    }
+                }
+            );
+        }
+
+        [Test]
+        public void PromiseMayBeCompletedAndAwaitedAndProgressReportedConcurrently_T1(
+            [Values] CompleteType completeType,
+            [Values] SynchronizationType progressSynchronizationType)
+        {
+            var deferred = default(Promise<int>.Deferred);
+            var pendingPromise = default(Promise<int>);
+            var cancelationSource = default(CancelationSource);
+            var tryCompleter = TestHelper.GetTryCompleterT(completeType, 1, rejectValue);
+
+            Promise.State result = Promise.State.Pending;
+
+            var progressHelper = default(ProgressHelper);
+            var asyncPromise = default(Promise<int>);
+
+            var threadHelper = new ThreadHelper();
+            threadHelper.ExecuteParallelActionsWithOffsetsAndSetup(
+                setup: () =>
+                {
+                    result = Promise.State.Pending;
+                    deferred = TestHelper.GetNewDeferredT<int>(completeType, out cancelationSource);
+                    pendingPromise = deferred.Promise;
+                    progressHelper = new ProgressHelper(ProgressType.Interface, progressSynchronizationType);
+                    progressHelper.MaybeEnterLock();
+                    progressHelper.PrepareForInvoke();
+                },
+                parallelActionsSetup: new Action<Action>[]
+                {
+                    barrierAction =>
+                    {
+                        var deferredForAssign = Promise.NewDeferred<int>();
+                        asyncPromise = Await();
+                        deferredForAssign.Resolve(1);
+
+                        async Promise<int> Await()
+                        {
+                            try
+                            {
+                                await deferredForAssign.Promise.AwaitWithProgress(0f, 0.5f);
+                                barrierAction.Invoke();
+                                await pendingPromise.AwaitWithProgress(0.5f, 1f);
+                                result = Promise.State.Resolved;
+                            }
+                            catch (UnhandledException)
+                            {
+                                result = Promise.State.Rejected;
+                            }
+                            catch (CanceledException)
+                            {
+                                result = Promise.State.Canceled;
+                            }
+                            return 2;
+                        }
+                    }
+                },
+                parallelActions: new Action[]
+                {
+                    () => tryCompleter(deferred, cancelationSource),
+                    () => asyncPromise.SubscribeProgress(progressHelper).Forget(), // We cannot determine what the progress will be at this point due to thread races, so don't check it.
+                    () => deferred.TryReportProgress(0.5f)
+                },
+                teardown: () =>
+                {
+                    cancelationSource.TryDispose();
+
+                    // Because of thread race conditions, we cannot determine whether or not progress will be invoked if the promise is rejected or canceled.
+                    if (completeType == CompleteType.Resolve)
+                    {
+                        // We cannot determine if the progress will be 0.75 or 1 due to thread race conditions, so just wait for invoke.
+                        progressHelper.MaybeWaitForInvoke(true, true);
+                    }
+                    progressHelper.MaybeExitLock();
+
+                    Assert.AreNotEqual(Promise.State.Pending, result);
+                    switch (completeType)
+                    {
+                        case CompleteType.Resolve:
+                            Assert.AreEqual(Promise.State.Resolved, result);
+                            break;
+                        case CompleteType.Reject:
+                            Assert.AreEqual(Promise.State.Rejected, result);
+                            break;
+                        case CompleteType.Cancel:
+                        case CompleteType.CancelFromToken:
+                            Assert.AreEqual(Promise.State.Canceled, result);
+                            break;
+                    }
+                }
+            );
+        }
+#endif // PROMISE_PROGRESS
     }
 }
 


### PR DESCRIPTION
Resolves #10 

- Added `Promise.AwaitWithProgress(float minProgress, float maxProgress)` API.
- Optimized `async Promise(<T>)` awaiting another `Promise(<T>)` to hook up directly instead of creating a passthrough object.   And eliminated potential StackOverflowExceptions from continuations. #26 
- Added circular promise chain detection when awaiting a `Promise(<T>)` in an `async Promise(<T>)` function.