### PR TITLE
Handle combine

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
@@ -221,7 +221,7 @@ namespace Proto.Promises
                 // In case this is executed from a background thread, catch the exception and report it instead of crashing the app.
                 try
                 {
-                    ExecutionScheduler executionScheduler = new ExecutionScheduler(true);
+                    var executionScheduler = new ExecutionScheduler(true);
                     ((HandleablePromiseBase) state).Handle(ref executionScheduler);
                     executionScheduler.Execute();
                 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
@@ -139,18 +139,6 @@ namespace Proto.Promises
 #endif
             }
 
-            [MethodImpl(InlineOption)]
-            internal ExecutionScheduler GetEmptyCopy()
-            {
-                bool isExecutingProgress =
-#if PROMISE_PROGRESS && (PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE)
-                    _isExecutingProgress;
-#else
-                    false;
-#endif
-                return new ExecutionScheduler(_synchronizationHandler, isExecutingProgress);
-            }
-
             internal void Execute()
             {
                 // In case this is executed from a background thread, catch the exception and report it instead of crashing the app.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/InterfacesInternal.cs
@@ -1,26 +1,10 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 
 namespace Proto.Promises
 {
     internal static partial class Internal
     {
-        // Abstract classes are used instead of interfaces, because virtual calls on interfaces are twice as slow as virtual calls on classes.
-        internal abstract partial class HandleablePromiseBase : ILinked<HandleablePromiseBase>
-        {
-            HandleablePromiseBase ILinked<HandleablePromiseBase>.Next
-            {
-                [MethodImpl(InlineOption)]
-                get { return _next; }
-                [MethodImpl(InlineOption)]
-                set { _next = value; }
-            }
-
-            internal abstract void Handle(ref ExecutionScheduler executionScheduler);
-            internal abstract void MakeReady(PromiseRef owner, ValueContainer valueContainer, ref ExecutionScheduler executionScheduler);
-            internal abstract void Handle(ref ValueContainer valueContainer, ref Promise.State state, ref PromiseRef.PromiseSingleAwait handler, ref ExecutionScheduler executionScheduler);
-        }
-
+        // Abstract class is used instead of interface, because virtual calls on interfaces are twice as slow as virtual calls on classes.
         internal abstract class ValueContainer
         {
             internal abstract void Retain();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/InterfacesInternal.cs
@@ -18,6 +18,7 @@ namespace Proto.Promises
 
             internal abstract void Handle(ref ExecutionScheduler executionScheduler);
             internal abstract void MakeReady(PromiseRef owner, ValueContainer valueContainer, ref ExecutionScheduler executionScheduler);
+            internal abstract void Handle(ref ValueContainer valueContainer, ref Promise.State state, ref PromiseRef.PromiseSingleAwait handler, ref ExecutionScheduler executionScheduler);
         }
 
         internal abstract class ValueContainer

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueContainersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueContainersInternal.cs
@@ -238,7 +238,7 @@ namespace Proto.Promises
             }
 #endif
 
-                    private RejectionContainerException() { }
+            private RejectionContainerException() { }
 
             internal static RejectionContainerException GetOrCreate(Exception value)
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Config.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Config.cs
@@ -106,21 +106,6 @@ namespace Proto.Promises
             }
 #endif
 
-            // Used so that libraries can have a ProtoPromise dependency without forcing progress enabled/disabled on those libraries' users.
-            // e.g. a library depends on ProtoPromise v2.0.0 or higher, a user of that library could opt to use ProtoPromise v2.0.0.0 (no progress) or v2.0.0.1 (with progress)
-            public static bool IsProgressEnabled
-            {
-                [MethodImpl(MethodImplOptions.NoInlining)] // Don't allow inlining, otherwise it could break library code that functions depending on if progress is enabled or not.
-                get
-                {
-#if PROMISE_PROGRESS
-                    return true;
-#else
-                    return false;
-#endif
-                }
-            }
-
             /// <summary>
             /// Uncaught rejections get routed through this delegate.
             /// This must be set to a non-null delegate, otherwise uncaught rejections will continue to pile up without being reported.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -214,10 +214,8 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
 #endif
-        internal struct PromiseMethodBuilderInternal<T>
+        internal partial struct PromiseMethodBuilderInternal<T>
         {
-            private readonly PromiseRef.AsyncPromiseRef _ref;
-
             [MethodImpl(InlineOption)]
             private PromiseMethodBuilderInternal(PromiseRef.AsyncPromiseRef promise)
             {
@@ -298,17 +296,12 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
 #endif
-        [StructLayout(LayoutKind.Auto)]
-        internal struct PromiseMethodBuilderInternal<T>
+        internal partial struct PromiseMethodBuilderInternal<T>
         {
-            private PromiseRef.AsyncPromiseRef _ref;
-            private short _id;
-            private T _result;
-
             public Promise<T> Task
             {
                 [MethodImpl(InlineOption)]
-                get { return new Promise<T>(_ref, _id, 0, _result); }
+                get { return new Promise<T>(_ref, _smallFields._id, 0, _smallFields._result); }
             }
 
             [MethodImpl(InlineOption)]
@@ -322,7 +315,7 @@ namespace Proto.Promises
                 if (_ref is null)
                 {
                     _ref = PromiseRef.AsyncPromiseRef.GetOrCreate();
-                    _id = _ref.Id;
+                    _smallFields._id = _ref.Id;
                 }
                 _ref.SetException(exception);
             }
@@ -331,8 +324,8 @@ namespace Proto.Promises
             {
                 if (_ref is null)
                 {
-                    _result = result;
-                    _id = ValidIdFromApi;
+                    _smallFields._result = result;
+                    _smallFields._id = ValidIdFromApi;
                 }
                 else
                 {
@@ -391,7 +384,7 @@ namespace Proto.Promises
                 if (_ref is null)
                 {
                     PromiseRef.AsyncPromiseRef.SetStateMachine(ref stateMachine, ref _ref);
-                    _id = _ref.Id;
+                    _smallFields._id = _ref.Id;
                 }
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -609,7 +609,7 @@ namespace Proto.Promises
                             Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
                             nextHandler = Interlocked.Exchange(ref _waiter, null);
                         }
-                        HandleProgressListener(state, ref executionScheduler);
+                        HandleProgressListener(state, 0, ref executionScheduler);
                         WaitWhileProgressFlags(PromiseFlags.Subscribing);
                         handler.MaybeDispose();
                         handler = this;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -680,7 +680,7 @@ namespace Proto.Promises
                                 Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
                                 nextHandler = Interlocked.Exchange(ref _waiter, null);
                             }
-                            HandleProgressListener(state, ref executionScheduler);
+                            HandleProgressListener(state, 0, ref executionScheduler);
                             WaitWhileProgressFlags(PromiseFlags.Subscribing);
                             handler.MaybeDispose();
                             handler = this;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -117,17 +117,11 @@ namespace Proto.Promises
 #endif
                 }
 
-                internal override void MakeReady(PromiseRef owner, ValueContainer valueContainer, ref ExecutionScheduler executionScheduler)
+                internal override void Handle(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
+                    nextHandler = null;
                     Invoke();
                 }
-
-                internal override void Handle(ref ValueContainer valueContainer, ref Promise.State state, ref PromiseSingleAwait handler, ref ExecutionScheduler executionScheduler)
-                {
-                    Invoke();
-                }
-
-                internal override void Handle(ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
             }
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
@@ -80,6 +80,8 @@ namespace Proto.Promises
                     owner.WaitWhileProgressFlags(PromiseFlags.Subscribing);
                     if (madeReady)
                     {
+                        handler.MaybeDispose();
+                        handler = owner;
                         owner.HandleWithCatch(ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                     }
                     else
@@ -163,7 +165,7 @@ namespace Proto.Promises
                         Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
                         nextHandler = Interlocked.Exchange(ref _waiter, null);
                     }
-                    HandleProgressListener(Promise.State.Canceled, ref executionScheduler);
+                    HandleProgressListener(Promise.State.Canceled, Depth, ref executionScheduler);
                     MaybeHandleNext(nextHandler, valueContainer, Promise.State.Canceled, ref executionScheduler);
                     executionScheduler.Execute();
                 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
@@ -306,38 +306,38 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancel.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
-                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancel.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
 
-                void IDelegateResolveOrCancelPromise.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
-                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                 }
 
-                void IDelegateResolveOrCancelPromise.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
             }
@@ -390,17 +390,17 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancel.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     TResult result = Invoke(valueContainer.GetValue<TArg>());
                     valueContainer.Release();
                     valueContainer = CreateResolveContainer(result);
                     state = Promise.State.Resolved;
-                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancel.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -409,41 +409,41 @@ namespace Proto.Promises
                         valueContainer.Release();
                         valueContainer = CreateResolveContainer(result);
                         state = Promise.State.Resolved;
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TResult result = Invoke(valueContainer.GetValue<TArg>());
                     ValueContainer oldContainer = valueContainer;
-                    owner.WaitFor(CreateResolved(result, 0), ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                    owner.WaitFor(CreateResolved(result, 0), ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                     oldContainer.Release();
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
                     {
                         TResult result = Invoke(arg);
                         ValueContainer oldContainer = valueContainer;
-                        owner.WaitFor(CreateResolved(result, 0), ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                        owner.WaitFor(CreateResolved(result, 0), ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                         oldContainer.Release();
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
 
-                void IDelegateReject.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateReject.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -453,10 +453,10 @@ namespace Proto.Promises
                         valueContainer = CreateResolveContainer(result);
                         state = Promise.State.Resolved;
                     }
-                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                 }
 
-                void IDelegateReject.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateReject.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -467,40 +467,40 @@ namespace Proto.Promises
                             valueContainer.Release();
                             valueContainer = CreateResolveContainer(result);
                             state = Promise.State.Resolved;
-                            owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                            owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                         }
                         else
                         {
-                            nextRef = null;
+                            nextHandler = null;
                         }
                     }
                     else if (cancelationHelper.TryUnregister(owner))
                     {
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
                     {
                         TResult result = Invoke(arg);
                         ValueContainer oldContainer = valueContainer;
-                        owner.WaitFor(CreateResolved(result, 0), ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                        owner.WaitFor(CreateResolved(result, 0), ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                         oldContainer.Release();
                     }
                     else
                     {
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -509,21 +509,21 @@ namespace Proto.Promises
                         {
                             TResult result = Invoke(arg);
                             ValueContainer oldContainer = valueContainer;
-                            owner.WaitFor(CreateResolved(result, 0), ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                            owner.WaitFor(CreateResolved(result, 0), ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                             oldContainer.Release();
                         }
                         else
                         {
-                            nextRef = null;
+                            nextHandler = null;
                         }
                     }
                     else if (cancelationHelper.TryUnregister(owner))
                     {
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
             }
@@ -574,48 +574,48 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     Promise<TResult> result = Invoke(valueContainer.GetValue<TArg>());
                     ValueContainer oldContainer = valueContainer;
-                    owner.WaitFor(result, ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                    owner.WaitFor(result, ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                     oldContainer.Release();
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
                     {
                         Promise<TResult> result = Invoke(arg);
                         ValueContainer oldContainer = valueContainer;
-                        owner.WaitFor(result, ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                        owner.WaitFor(result, ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                         oldContainer.Release();
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
                     {
                         Promise<TResult> result = Invoke(arg);
                         ValueContainer oldContainer = valueContainer;
-                        owner.WaitFor(result, ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                        owner.WaitFor(result, ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                         oldContainer.Release();
                     }
                     else
                     {
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -624,21 +624,21 @@ namespace Proto.Promises
                         {
                             Promise<TResult> result = Invoke(arg);
                             ValueContainer oldContainer = valueContainer;
-                            owner.WaitFor(result, ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                            owner.WaitFor(result, ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                             oldContainer.Release();
                         }
                         else
                         {
-                            nextRef = null;
+                            nextHandler = null;
                         }
                     }
                     else if (cancelationHelper.TryUnregister(owner))
                     {
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
             }
@@ -689,7 +689,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     // JIT constant-optimizes these checks away.
                     bool isVoidArg = null != default(TArg) && typeof(TArg) == typeof(VoidResult);
@@ -722,19 +722,19 @@ namespace Proto.Promises
                         valueContainer = CreateResolveContainer(result);
                     }
                     state = Promise.State.Resolved;
-                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
-                        Invoke(ref valueContainer, ref state, out nextRef, owner, ref executionScheduler);
+                        Invoke(ref valueContainer, ref state, out nextHandler, owner, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
             }
@@ -785,7 +785,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     // JIT constant-optimizes these checks away.
                     bool isVoidArg = null != default(TArg) && typeof(TArg) == typeof(VoidResult);
@@ -816,20 +816,20 @@ namespace Proto.Promises
                         }
                     }
                     ValueContainer oldContainer = valueContainer;
-                    owner.WaitFor(result, ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                    owner.WaitFor(result, ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                     oldContainer.Release();
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
-                        Invoke(ref valueContainer, ref state, out nextRef, owner, ref executionScheduler);
+                        Invoke(ref handler, ref valueContainer, ref state, out nextHandler, owner, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
             }
@@ -960,17 +960,17 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancel.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     TResult result = Invoke(valueContainer.GetValue<TArg>());
                     valueContainer.Release();
                     valueContainer = CreateResolveContainer(result);
                     state = Promise.State.Resolved;
-                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancel.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancel.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
@@ -979,41 +979,41 @@ namespace Proto.Promises
                         valueContainer.Release();
                         valueContainer = CreateResolveContainer(result);
                         state = Promise.State.Resolved;
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TResult result = Invoke(valueContainer.GetValue<TArg>());
                     ValueContainer oldContainer = valueContainer;
-                    owner.WaitFor(CreateResolved(result, 0), ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                    owner.WaitFor(CreateResolved(result, 0), ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                     oldContainer.Release();
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
                     {
                         TResult result = Invoke(arg);
                         ValueContainer oldContainer = valueContainer;
-                        owner.WaitFor(CreateResolved(result, 0), ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                        owner.WaitFor(CreateResolved(result, 0), ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                         oldContainer.Release();
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
 
-                void IDelegateReject.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateReject.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -1023,10 +1023,10 @@ namespace Proto.Promises
                         valueContainer = CreateResolveContainer(result);
                         state = Promise.State.Resolved;
                     }
-                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                 }
 
-                void IDelegateReject.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateReject.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -1037,40 +1037,40 @@ namespace Proto.Promises
                             valueContainer.Release();
                             valueContainer = CreateResolveContainer(result);
                             state = Promise.State.Resolved;
-                            owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                            owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                         }
                         else
                         {
-                            nextRef = null;
+                            nextHandler = null;
                         }
                     }
                     else if (cancelationHelper.TryUnregister(owner))
                     {
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
                     {
                         TResult result = Invoke(arg);
                         ValueContainer oldContainer = valueContainer;
-                        owner.WaitFor(CreateResolved(result, 0), ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                        owner.WaitFor(CreateResolved(result, 0), ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                         oldContainer.Release();
                     }
                     else
                     {
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -1079,21 +1079,21 @@ namespace Proto.Promises
                         {
                             TResult result = Invoke(arg);
                             ValueContainer oldContainer = valueContainer;
-                            owner.WaitFor(CreateResolved(result, 0), ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                            owner.WaitFor(CreateResolved(result, 0), ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                             oldContainer.Release();
                         }
                         else
                         {
-                            nextRef = null;
+                            nextHandler = null;
                         }
                     }
                     else if (cancelationHelper.TryUnregister(owner))
                     {
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
             }
@@ -1156,48 +1156,48 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     Promise<TResult> result = Invoke(valueContainer.GetValue<TArg>());
                     ValueContainer oldContainer = valueContainer;
-                    owner.WaitFor(result, ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                    owner.WaitFor(result, ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                     oldContainer.Release();
                 }
 
                 [MethodImpl(InlineOption)]
-                void IDelegateResolveOrCancelPromise.InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateResolveOrCancelPromise.InvokeResolver(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = valueContainer.GetValue<TArg>();
                     if (cancelationHelper.TryUnregister(owner))
                     {
                         Promise<TResult> result = Invoke(arg);
                         ValueContainer oldContainer = valueContainer;
-                        owner.WaitFor(result, ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                        owner.WaitFor(result, ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                         oldContainer.Release();
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
                     {
                         Promise<TResult> result = Invoke(arg);
                         ValueContainer oldContainer = valueContainer;
-                        owner.WaitFor(result, ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                        owner.WaitFor(result, ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                         oldContainer.Release();
                     }
                     else
                     {
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                 }
 
-                void IDelegateRejectPromise.InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                void IDelegateRejectPromise.InvokeRejecter(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg;
                     if (valueContainer.TryGetValue(out arg))
@@ -1206,21 +1206,21 @@ namespace Proto.Promises
                         {
                             Promise<TResult> result = Invoke(arg);
                             ValueContainer oldContainer = valueContainer;
-                            owner.WaitFor(result, ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                            owner.WaitFor(result, ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                             oldContainer.Release();
                         }
                         else
                         {
-                            nextRef = null;
+                            nextHandler = null;
                         }
                     }
                     else if (cancelationHelper.TryUnregister(owner))
                     {
-                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
             }
@@ -1277,7 +1277,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     // JIT constant-optimizes these checks away.
                     bool isVoidArg = null != default(TArg) && typeof(TArg) == typeof(VoidResult);
@@ -1310,19 +1310,19 @@ namespace Proto.Promises
                         valueContainer = CreateResolveContainer(result);
                     }
                     state = Promise.State.Resolved;
-                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextRef, ref executionScheduler);
+                    owner.SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
-                        Invoke(ref valueContainer, ref state, out nextRef, owner, ref executionScheduler);
+                        Invoke(ref valueContainer, ref state, out nextHandler, owner, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
             }
@@ -1379,7 +1379,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
                     // JIT constant-optimizes these checks away.
                     bool isVoidArg = null != default(TArg) && typeof(TArg) == typeof(VoidResult);
@@ -1410,20 +1410,20 @@ namespace Proto.Promises
                         }
                     }
                     ValueContainer oldContainer = valueContainer;
-                    owner.WaitFor(result, ref valueContainer, ref state, out nextRef, ref executionScheduler);
+                    owner.WaitFor(result, ref handler, ref valueContainer, ref state, out nextHandler, ref executionScheduler);
                     oldContainer.Release();
                 }
 
                 [MethodImpl(InlineOption)]
-                public void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
+                public void Invoke(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler)
                 {
                     if (cancelationHelper.TryUnregister(owner))
                     {
-                        Invoke(ref valueContainer, ref state, out nextRef, owner, ref executionScheduler);
+                        Invoke(ref handler, ref valueContainer, ref state, out nextHandler, owner, ref executionScheduler);
                     }
                     else
                     {
-                        nextRef = null;
+                        nextHandler = null;
                     }
                 }
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
@@ -94,16 +94,7 @@ namespace Proto.Promises
 
                 internal override void Handle(ref ExecutionScheduler executionScheduler)
                 {
-                    ValueContainer valueContainer = (ValueContainer) _valueOrPrevious;
-                    Promise.State state = valueContainer.GetState();
-                    State = state;
-                    HandleWaiter(valueContainer, ref executionScheduler);
-                    HandleProgressListener(state, ref executionScheduler);
-
-                    if (InterlockedAddWithOverflowCheck(ref _firstSmallFields._waitCount, -1, 0) == 0)
-                    {
-                        MaybeDispose();
-                    }
+                    Handle(ref _firstSmallFields._waitCount, ref executionScheduler);
                 }
 
                 internal override void Handle(PromiseRef owner, ValueContainer valueContainer, PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
@@ -144,11 +144,6 @@ namespace Proto.Promises
                     base.Reset(depth);
                 }
 
-                internal override void HandleProgressListener(Promise.State state, ref ExecutionScheduler executionScheduler)
-                {
-                    HandleProgressListener(state, Fixed32.FromWholePlusOne(Depth), ref executionScheduler);
-                }
-
                 protected override sealed PromiseRef MaybeAddProgressListenerAndGetPreviousRetained(ref IProgressListener progressListener, ref Fixed32 lastKnownProgress)
                 {
                     // Unnecessary to set last known since we know SetInitialProgress will be called on this.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
@@ -1,14 +1,31 @@
-﻿namespace Proto.Promises
+﻿using System.Runtime.CompilerServices;
+
+namespace Proto.Promises
 {
     partial class Internal
     {
+        // Abstract classes are used instead of interfaces, because virtual calls on interfaces are twice as slow as virtual calls on classes.
+        internal abstract partial class HandleablePromiseBase : ILinked<HandleablePromiseBase>
+        {
+            HandleablePromiseBase ILinked<HandleablePromiseBase>.Next
+            {
+                [MethodImpl(InlineOption)]
+                get { return _next; }
+                [MethodImpl(InlineOption)]
+                set { _next = value; }
+            }
+
+            internal abstract void Handle(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler);
+            // This is overridden in PromiseMultiAwait and PromiseProgress and PromiseConfigured.
+            internal virtual void Handle(ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
+        }
+
         partial class PromiseRef
         {
-            // Abstract class is used instead of interface, because virtual calls on interfaces are twice as slow as virtual calls on classes.
             internal abstract partial class MultiHandleablePromiseBase : PromiseSingleAwaitWithProgress
             {
                 internal abstract void Handle(PromiseRef owner, ValueContainer valueContainer, PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler);
-                internal override sealed void Handle(ref ValueContainer valueContainer, ref Promise.State state, ref PromiseSingleAwait handler, ref ExecutionScheduler executionScheduler)
+                internal override void Handle(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
                     throw new System.InvalidOperationException();
                 }
@@ -16,39 +33,39 @@
 
             internal interface IDelegateResolveOrCancel
             {
-                void InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
-                void InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
+                void InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateResolveOrCancelPromise
             {
-                void InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
-                void InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void InvokeResolver(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
+                void InvokeResolver(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
                 bool IsNull { get; }
             }
 
             internal interface IDelegateReject
             {
-                void InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
-                void InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
+                void InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateRejectPromise
             {
-                void InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
-                void InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void InvokeRejecter(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
+                void InvokeRejecter(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateContinue
             {
-                void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
-                void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
+                void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateContinuePromise
             {
-                void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
-                void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void Invoke(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
+                void Invoke(ref PromiseRef handler, ref ValueContainer valueContainer, ref Promise.State state, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
                 bool IsNull { get; }
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
@@ -8,43 +8,47 @@
             internal abstract partial class MultiHandleablePromiseBase : PromiseSingleAwaitWithProgress
             {
                 internal abstract void Handle(PromiseRef owner, ValueContainer valueContainer, PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler);
+                internal override sealed void Handle(ref ValueContainer valueContainer, ref Promise.State state, ref PromiseSingleAwait handler, ref ExecutionScheduler executionScheduler)
+                {
+                    throw new System.InvalidOperationException();
+                }
             }
 
             internal interface IDelegateResolveOrCancel
             {
-                void InvokeResolver(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
-                void InvokeResolver(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
+                void InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateResolveOrCancelPromise
             {
-                void InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
-                void InvokeResolver(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
+                void InvokeResolver(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
                 bool IsNull { get; }
             }
 
             internal interface IDelegateReject
             {
-                void InvokeRejecter(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
-                void InvokeRejecter(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
+                void InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateRejectPromise
             {
-                void InvokeRejecter(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
-                void InvokeRejecter(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
+                void InvokeRejecter(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateContinue
             {
-                void Invoke(ValueContainer valueContainer, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
-                void Invoke(ValueContainer valueContainer, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler);
+                void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseSingleAwait owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
             }
 
             internal interface IDelegateContinuePromise
             {
-                void Invoke(ValueContainer valueContainer, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
-                void Invoke(ValueContainer valueContainer, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
+                void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler);
+                void Invoke(ref ValueContainer valueContainer, ref Promise.State state, out PromiseSingleAwait nextRef, PromiseWaitPromise owner, ref CancelationHelper cancelationHelper, ref ExecutionScheduler executionScheduler);
                 bool IsNull { get; }
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
@@ -36,7 +36,7 @@ namespace Proto.Promises
                         Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
                         nextHandler = Interlocked.Exchange(ref _waiter, null);
                     }
-                    HandleProgressListener(state, ref executionScheduler);
+                    HandleProgressListener(state, Depth, ref executionScheduler);
                     InterlockedRetainDisregardId(); // Retain since Handle will release indiscriminately.
                     if (InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0) == 0)
                     {
@@ -273,11 +273,6 @@ namespace Proto.Promises
 #if PROMISE_PROGRESS
             partial class MergePromise : IProgressInvokable
             {
-                internal override void HandleProgressListener(Promise.State state, ref ExecutionScheduler executionScheduler)
-                {
-                    HandleProgressListener(state, Fixed32.FromWholePlusOne(Depth), ref executionScheduler);
-                }
-
                 protected override sealed PromiseRef MaybeAddProgressListenerAndGetPreviousRetained(ref IProgressListener progressListener, ref Fixed32 lastKnownProgress)
                 {
                     // Unnecessary to set last known since we know SetInitialProgress will be called on this.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
@@ -25,6 +25,7 @@ namespace Proto.Promises
             {
                 protected void Handle(ref int _waitCount, ref ExecutionScheduler executionScheduler)
                 {
+                    ThrowIfInPool(this);
                     var valueContainer = (ValueContainer) _valueOrPrevious;
                     var state = valueContainer.GetState();
                     State = state;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -846,7 +846,7 @@ namespace Proto.Promises
                     {
                         progress = Fixed32.FromWholePlusOne(Depth);
                         WaitWhileProgressFlags(PromiseFlags.ReportingPriority | PromiseFlags.ReportingInitial);
-                        progressListener.SetInitialProgress(this, Promise.State.Canceled, ref progress, out nextRef, ref executionScheduler);
+                        progressListener.SetInitialProgress(this, state, ref progress, out nextRef, ref executionScheduler);
                         return;
                     }
                     nextRef = null;
@@ -962,6 +962,8 @@ namespace Proto.Promises
                             }
 
                             // If this was configured to execute progress on a SynchronizationContext or the ThreadPool, force the waiter to execute on the same context for consistency.
+                            // Retain since this will be released higher in the call stack.
+                            InterlockedRetainDisregardId();
                             if (_synchronizationContext == null)
                             {
                                 // If there is no context, send it to the ThreadPool.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -60,9 +60,8 @@ namespace Proto.Promises
     {
         // This is used so that _result will be packed efficiently and not padded with extra bytes (only relevant for small, non-primitive struct T types).
         // Otherwise, if all fields are on the same level as _ref, because it is a class type, it will pad T up to IntPtr.Size if T is not primitive, causing the Promise<T> struct to be larger than necessary.
-        // This is especially needed for Promise, which has an internal Promise<Internal.VoidResult> field (and sadly, the runtime does not allow 0-sized structs, minimum size is 1 byte).
+        // This is especially needed for `Promise`, which has an internal `Promise<Internal.VoidResult>` field (and sadly, the runtime does not allow 0-sized structs, minimum size is 1 byte).
         // See https://stackoverflow.com/questions/24742325/why-does-struct-alignment-depend-on-whether-a-field-type-is-primitive-or-user-de
-        [StructLayout(LayoutKind.Auto)]
         private
 #if CSHARP_7_3_OR_NEWER
             readonly
@@ -616,5 +615,27 @@ namespace Proto.Promises
             } // AsyncPromiseRef
 #endif // CSHARP_7_3_OR_NEWER
         } // PromiseRef
+
+#if CSHARP_7_3_OR_NEWER
+        partial struct PromiseMethodBuilderInternal<T>
+        {
+#if PROMISE_DEBUG
+            private readonly PromiseRef.AsyncPromiseRef _ref;
+#else
+            // This is used so that _result will be packed efficiently and not padded with extra bytes (only relevant for small, non-primitive struct T types).
+            // Otherwise, if all fields are on the same level as _ref, because it is a class type, it will pad T up to IntPtr.Size if T is not primitive, causing the Promise<T> struct to be larger than necessary.
+            // This is especially needed for `Promise`, which uses `Internal.VoidResult` as T (and sadly, the runtime does not allow 0-sized structs, minimum size is 1 byte).
+            // See https://stackoverflow.com/questions/24742325/why-does-struct-alignment-depend-on-whether-a-field-type-is-primitive-or-user-de
+            private struct SmallFields
+            {
+                internal short _id;
+                internal T _result;
+            }
+
+            private PromiseRef.AsyncPromiseRef _ref;
+            private SmallFields _smallFields;
+#endif // PROMISE_DEBUG
+#endif // CSHARP_7_3_OR_NEWER
+        }
     } // Internal
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -21,6 +21,7 @@
 #endif
 
 #pragma warning disable IDE0034 // Simplify 'default' expression
+#pragma warning disable IDE0090 // Use 'new(...)'
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
 using System;
@@ -246,11 +247,7 @@ namespace Proto.Promises
 #endif
                 }
 
-#if PROTO_PROMISE_NO_STACK_UNWIND // Must use a queue instead of a stack so that the ExecutionScheduler.ScheduleSynchronous can invoke immediately and still be in proper order.
                 private ValueLinkedQueue<HandleablePromiseBase> _nextBranches = new ValueLinkedQueue<HandleablePromiseBase>();
-#else
-                private ValueLinkedStack<HandleablePromiseBase> _nextBranches = new ValueLinkedStack<HandleablePromiseBase>();
-#endif
                 private ProgressAndLocker _progressAndLocker;
 
 #if PROMISE_PROGRESS
@@ -538,6 +535,7 @@ namespace Proto.Promises
                     volatile internal bool _complete;
                     volatile internal bool _canceled;
                     internal bool _isSynchronous;
+                    internal Promise.State _previousState;
                 }
 
                 private ProgressSmallFields _smallProgressFields;
@@ -635,7 +633,7 @@ namespace Proto.Promises
             private PromiseRef.AsyncPromiseRef _ref;
             private SmallFields _smallFields;
 #endif // PROMISE_DEBUG
-#endif // CSHARP_7_3_OR_NEWER
         }
+#endif // CSHARP_7_3_OR_NEWER
     } // Internal
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -218,7 +218,7 @@ namespace Proto.Promises
                 private enum ScheduleMethod : int
                 {
                     None,
-                    MakeReady,
+                    Handle,
                     AddWaiter,
                     OnForgetOrHookupFailed
                 }
@@ -582,7 +582,6 @@ namespace Proto.Promises
 
             partial class AsyncPromiseRef : AsyncPromiseBase
             {
-                private long _completionState;
 #if PROMISE_PROGRESS
                 private float _minProgress;
                 private float _maxProgress;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
@@ -126,11 +126,6 @@ namespace Proto.Promises
                     base.Reset(depth);
                 }
 
-                internal override void HandleProgressListener(Promise.State state, ref ExecutionScheduler executionScheduler)
-                {
-                    HandleProgressListener(state, Fixed32.FromWholePlusOne(Depth), ref executionScheduler);
-                }
-
                 protected override sealed PromiseRef MaybeAddProgressListenerAndGetPreviousRetained(ref IProgressListener progressListener, ref Fixed32 lastKnownProgress)
                 {
                     // Unnecessary to set last known since we know SetInitialProgress will be called on this.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
@@ -94,16 +94,7 @@ namespace Proto.Promises
 
                 internal override void Handle(ref ExecutionScheduler executionScheduler)
                 {
-                    ValueContainer valueContainer = (ValueContainer) _valueOrPrevious;
-                    Promise.State state = valueContainer.GetState();
-                    State = state;
-                    HandleWaiter(valueContainer, ref executionScheduler);
-                    HandleProgressListener(state, ref executionScheduler);
-
-                    if (InterlockedAddWithOverflowCheck(ref _raceSmallFields._waitCount, -1, 0) == 0)
-                    {
-                        MaybeDispose();
-                    }
+                    Handle(ref _raceSmallFields._waitCount, ref executionScheduler);
                 }
 
                 internal override void Handle(PromiseRef owner, ValueContainer valueContainer, PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/APlus_2_2_TheThenMethod.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/APlus_2_2_TheThenMethod.cs
@@ -855,33 +855,19 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred();
                 var promise = deferred.Promise.Preserve();
 
-                int order = 0;
                 int counter = 0;
-
-                Action<int> callback = expected =>
+                for (int i = 0; i < 10; ++i)
                 {
-                    Assert.AreEqual(expected, order);
-                    if (++counter == TestHelper.resolveVoidCallbacks * 2)
-                    {
-                        counter = 0;
-                        ++order;
-                    }
-                };
-
-                TestHelper.AddResolveCallbacks<bool, string>(promise, () => callback(0));
-                TestHelper.AddCallbacks<bool, object, string>(promise, () => callback(0), s => Assert.Fail("Promise was rejected when it should have been resolved."));
-
-                TestHelper.AddResolveCallbacks<bool, string>(promise, () => callback(1));
-                TestHelper.AddCallbacks<bool, object, string>(promise, () => callback(1), s => Assert.Fail("Promise was rejected when it should have been resolved."));
-
-                TestHelper.AddResolveCallbacks<bool, string>(promise, () => callback(2));
-                TestHelper.AddCallbacks<bool, object, string>(promise, () => callback(2), s => Assert.Fail("Promise was rejected when it should have been resolved."));
+                    int expected = i;
+                    promise
+                        .Then(() => Assert.AreEqual(expected, counter++))
+                        .Forget();
+                }
 
                 deferred.Resolve();
-
-                Assert.AreEqual(3, order);
-
                 promise.Forget();
+
+                Assert.AreEqual(10, counter);
             }
 
             [Test]
@@ -890,33 +876,19 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred<int>();
                 var promise = deferred.Promise.Preserve();
 
-                int orderT = 0;
-                int counterT = 0;
-
-                Action<int> callbackT = expected =>
+                int counter = 0;
+                for (int i = 0; i < 10; ++i)
                 {
-                    Assert.AreEqual(expected, orderT);
-                    if (++counterT == TestHelper.resolveTCallbacks * 2)
-                    {
-                        counterT = 0;
-                        ++orderT;
-                    }
-                };
-
-                TestHelper.AddResolveCallbacks<int, bool, string>(promise, v => callbackT(0));
-                TestHelper.AddCallbacks<int, bool, object, string>(promise, v => callbackT(0), s => Assert.Fail("Promise was rejected when it should have been resolved."));
-
-                TestHelper.AddResolveCallbacks<int, bool, string>(promise, v => callbackT(1));
-                TestHelper.AddCallbacks<int, bool, object, string>(promise, v => callbackT(1), s => Assert.Fail("Promise was rejected when it should have been resolved."));
-
-                TestHelper.AddResolveCallbacks<int, bool, string>(promise, v => callbackT(2));
-                TestHelper.AddCallbacks<int, bool, object, string>(promise, v => callbackT(2), s => Assert.Fail("Promise was rejected when it should have been resolved."));
+                    int expected = i;
+                    promise
+                        .Then(v => Assert.AreEqual(expected, counter++))
+                        .Forget();
+                }
 
                 deferred.Resolve(100);
-
-                Assert.AreEqual(3, orderT);
-
                 promise.Forget();
+
+                Assert.AreEqual(10, counter);
             }
 
             [Test]
@@ -925,42 +897,19 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred();
                 var promise = deferred.Promise.Preserve();
 
-                int order = 0;
                 int counter = 0;
-
-                Action<int> callback = expected =>
+                for (int i = 0; i < 10; ++i)
                 {
-                    Assert.AreEqual(expected, order);
-                    if (++counter == TestHelper.rejectVoidCallbacks * 2)
-                    {
-                        counter = 0;
-                        ++order;
-                    }
-                };
-
-                TestHelper.AddCallbacks<bool, object, string>(promise,
-                    () => Assert.Fail("Promise was resolved when it should have been rejected."),
-                    _ => callback(0),
-                    () => callback(0)
-                );
-
-                TestHelper.AddCallbacks<bool, object, string>(promise,
-                    () => Assert.Fail("Promise was resolved when it should have been rejected."),
-                    _ => callback(1),
-                    () => callback(1)
-                );
-
-                TestHelper.AddCallbacks<bool, object, string>(promise,
-                    () => Assert.Fail("Promise was resolved when it should have been rejected."),
-                    _ => callback(2),
-                    () => callback(2)
-                );
+                    int expected = i;
+                    promise
+                        .Catch(() => Assert.AreEqual(expected, counter++))
+                        .Forget();
+                }
 
                 deferred.Reject("Fail value");
-
-                Assert.AreEqual(3, order);
-
                 promise.Forget();
+
+                Assert.AreEqual(10, counter);
             }
 
             [Test]
@@ -969,42 +918,19 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred<int>();
                 var promise = deferred.Promise.Preserve();
 
-                int orderT = 0;
-                int counterT = 0;
-
-                Action<int> callbackT = expected =>
+                int counter = 0;
+                for (int i = 0; i < 10; ++i)
                 {
-                    Assert.AreEqual(expected, orderT);
-                    if (++counterT == TestHelper.rejectTCallbacks * 2)
-                    {
-                        counterT = 0;
-                        ++orderT;
-                    }
-                };
-
-                TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                    v => Assert.Fail("Promise was resolved when it should have been rejected."),
-                    _ => callbackT(0),
-                    () => callbackT(0)
-                );
-
-                TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                    v => Assert.Fail("Promise was resolved when it should have been rejected."),
-                    _ => callbackT(1),
-                    () => callbackT(1)
-                );
-
-                TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                    v => Assert.Fail("Promise was resolved when it should have been rejected."),
-                    _ => callbackT(2),
-                    () => callbackT(2)
-                );
+                    int expected = i;
+                    promise
+                        .Catch(() => Assert.AreEqual(expected, counter++))
+                        .Forget();
+                }
 
                 deferred.Reject("Fail value");
-
-                Assert.AreEqual(3, orderT);
-
                 promise.Forget();
+
+                Assert.AreEqual(10, counter);
             }
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/ProgressTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/ProgressTests.cs
@@ -1005,7 +1005,7 @@ namespace ProtoPromiseTests.APIs
                 {
                     Assert.GreaterOrEqual(p, 0f);
                     Assert.LessOrEqual(p, 1f);
-                })
+                }, SynchronizationOption.Synchronous)
                 .Forget();
 
             Assert.Throws<Proto.Promises.ArgumentOutOfRangeException>(() => deferred.ReportProgress(float.NaN));

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/PromiseCancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/PromiseCancelationTests.cs
@@ -608,35 +608,19 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred(cancelationSource.Token);
                 var promise = deferred.Promise.Preserve();
 
-                int order = 0;
                 int counter = 0;
 
-                Action<int> callback = expected =>
+                for (int i = 0; i < 10; ++i)
                 {
-                    Assert.AreEqual(expected, order);
-                    if (++counter == TestHelper.onCancelCallbacks * 2)
-                    {
-                        counter = 0;
-                        ++order;
-                    }
-                };
-
-                TestHelper.AddCancelCallbacks<float>(promise,
-                    onCancel: () => callback(0),
-                    onCancelCapture: cv => callback(0)
-                );
-                TestHelper.AddCancelCallbacks<float>(promise,
-                    onCancel: () => callback(1),
-                    onCancelCapture: cv => callback(1)
-                );
-                TestHelper.AddCancelCallbacks<float>(promise,
-                    onCancel: () => callback(2),
-                    onCancelCapture: cv => callback(2)
-                );
+                    int index = i;
+                    promise
+                        .CatchCancelation(() => Assert.AreEqual(index, counter++))
+                        .Forget();
+                }
 
                 cancelationSource.Cancel();
 
-                Assert.AreEqual(3, order);
+                Assert.AreEqual(10, counter);
 
                 cancelationSource.Dispose();
                 promise.Forget();
@@ -649,35 +633,19 @@ namespace ProtoPromiseTests.APIs
                 var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
                 var promise = deferred.Promise.Preserve();
 
-                int order = 0;
                 int counter = 0;
 
-                Action<int> callback = expected =>
+                for (int i = 0; i < 10; ++i)
                 {
-                    Assert.AreEqual(expected, order);
-                    if (++counter == TestHelper.onCancelCallbacks * 2)
-                    {
-                        counter = 0;
-                        ++order;
-                    }
-                };
-
-                TestHelper.AddCancelCallbacks<int, float>(promise,
-                    onCancel: () => callback(0),
-                    onCancelCapture: cv => callback(0)
-                );
-                TestHelper.AddCancelCallbacks<int, float>(promise,
-                    onCancel: () => callback(1),
-                    onCancelCapture: cv => callback(1)
-                );
-                TestHelper.AddCancelCallbacks<int, float>(promise,
-                    onCancel: () => callback(2),
-                    onCancelCapture: cv => callback(2)
-                );
+                    int index = i;
+                    promise
+                        .CatchCancelation(() => Assert.AreEqual(index, counter++))
+                        .Forget();
+                }
 
                 cancelationSource.Cancel();
 
-                Assert.AreEqual(3, order);
+                Assert.AreEqual(10, counter);
 
                 cancelationSource.Dispose();
                 promise.Forget();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/WaitAsyncTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/APIs/WaitAsyncTests.cs
@@ -105,13 +105,8 @@ namespace ProtoPromiseTests.APIs
             });
         }
 
-        private static IEnumerable<TestCaseData> GetArgs_CancelFinally()
+        private static IEnumerable<TestCaseData> GetArgs_CancelFinally(CompleteType[] completeTypes)
         {
-            CompleteType[] completeTypes = new CompleteType[]
-            {
-                CompleteType.Cancel,
-                CompleteType.CancelFromToken
-            };
             SynchronizationType[] synchronizationTypes = new SynchronizationType[]
             {
                 SynchronizationType.Synchronous,
@@ -140,6 +135,26 @@ namespace ProtoPromiseTests.APIs
             }
         }
 
+        private static IEnumerable<TestCaseData> GetArgs_Cancel()
+        {
+            return GetArgs_CancelFinally(new CompleteType[]
+            {
+                CompleteType.Cancel,
+                CompleteType.CancelFromToken
+            });
+        }
+
+
+        private static IEnumerable<TestCaseData> GetArgs_Finally()
+        {
+            return GetArgs_CancelFinally(new CompleteType[]
+            {
+                CompleteType.Resolve,
+                CompleteType.Reject,
+                CompleteType.Cancel,
+                CompleteType.CancelFromToken
+            });
+        }
         private readonly TimeSpan timeout = TimeSpan.FromSeconds(20);
 
         // promise
@@ -188,8 +203,8 @@ namespace ProtoPromiseTests.APIs
 
             Action onFirstCallback = () =>
             {
-                Interlocked.Increment(ref firstInvokeCounter);
                 TestHelper.AssertCallbackContext(firstWaitType, firstReportType, foregroundThread);
+                Interlocked.Increment(ref firstInvokeCounter);
             };
             Action onSecondCallback = () =>
             {
@@ -361,8 +376,8 @@ namespace ProtoPromiseTests.APIs
 
             Action onFirstCallback = () =>
             {
-                Interlocked.Increment(ref firstInvokeCounter);
                 TestHelper.AssertCallbackContext(firstWaitType, firstReportType, foregroundThread);
+                Interlocked.Increment(ref firstInvokeCounter);
             };
             Action onSecondCallback = () =>
             {
@@ -534,8 +549,8 @@ namespace ProtoPromiseTests.APIs
 
             Action onFirstCallback = () =>
             {
-                Interlocked.Increment(ref firstInvokeCounter);
                 TestHelper.AssertCallbackContext(firstWaitType, firstReportType, foregroundThread);
+                Interlocked.Increment(ref firstInvokeCounter);
             };
             Action onSecondCallback = () =>
             {
@@ -642,8 +657,8 @@ namespace ProtoPromiseTests.APIs
 
             Action onFirstCallback = () =>
             {
-                Interlocked.Increment(ref firstInvokeCounter);
                 TestHelper.AssertCallbackContext(firstWaitType, firstReportType, foregroundThread);
+                Interlocked.Increment(ref firstInvokeCounter);
             };
             Action onSecondCallback = () =>
             {
@@ -716,7 +731,7 @@ namespace ProtoPromiseTests.APIs
             secondCancelationSource.TryDispose();
         }
 
-        [Test, TestCaseSource("GetArgs_CancelFinally")]
+        [Test, TestCaseSource("GetArgs_Cancel")]
         public void CallbacksWillBeInvokedOnTheCorrectSynchronizationContext_Cancel_void(
             CompleteType completeType,
             SynchronizationType waitType,
@@ -743,8 +758,8 @@ namespace ProtoPromiseTests.APIs
                 p.ConfigureAwait((ConfigureAwaitType) waitType)
                     .CatchCancelation(() =>
                     {
-                        Interlocked.Increment(ref invokeCounter);
                         TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                        Interlocked.Increment(ref invokeCounter);
                     })
                     .Forget();
             }
@@ -754,8 +769,8 @@ namespace ProtoPromiseTests.APIs
                 p.ConfigureAwait((ConfigureAwaitType) waitType)
                     .CatchCancelation(1, cv =>
                     {
-                        Interlocked.Increment(ref invokeCounter);
                         TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                        Interlocked.Increment(ref invokeCounter);
                     })
                     .Forget();
             }
@@ -781,7 +796,7 @@ namespace ProtoPromiseTests.APIs
             cancelationSource.TryDispose();
         }
 
-        [Test, TestCaseSource("GetArgs_CancelFinally")]
+        [Test, TestCaseSource("GetArgs_Cancel")]
         public void CallbacksWillBeInvokedOnTheCorrectSynchronizationContext_Cancel_T(
             CompleteType completeType,
             SynchronizationType waitType,
@@ -808,8 +823,8 @@ namespace ProtoPromiseTests.APIs
                 p.ConfigureAwait((ConfigureAwaitType) waitType)
                     .CatchCancelation(() =>
                     {
-                        Interlocked.Increment(ref invokeCounter);
                         TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                        Interlocked.Increment(ref invokeCounter);
                     })
                     .Forget();
             }
@@ -819,8 +834,8 @@ namespace ProtoPromiseTests.APIs
                 p.ConfigureAwait((ConfigureAwaitType) waitType)
                     .CatchCancelation(1, cv =>
                     {
-                        Interlocked.Increment(ref invokeCounter);
                         TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                        Interlocked.Increment(ref invokeCounter);
                     })
                     .Forget();
             }
@@ -846,7 +861,7 @@ namespace ProtoPromiseTests.APIs
             cancelationSource.TryDispose();
         }
 
-        [Test, TestCaseSource("GetArgs_CancelFinally")]
+        [Test, TestCaseSource("GetArgs_Finally")]
         public void CallbacksWillBeInvokedOnTheCorrectSynchronizationContext_Finally_void(
             CompleteType completeType,
             SynchronizationType waitType,
@@ -873,9 +888,10 @@ namespace ProtoPromiseTests.APIs
                 p.ConfigureAwait((ConfigureAwaitType) waitType)
                     .Finally(() =>
                     {
-                        Interlocked.Increment(ref invokeCounter);
                         TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                        Interlocked.Increment(ref invokeCounter);
                     })
+                    .Catch(() => { })
                     .Forget();
             }
             foreach (var p in TestHelper.GetTestablePromises(promise))
@@ -884,9 +900,10 @@ namespace ProtoPromiseTests.APIs
                 p.ConfigureAwait((ConfigureAwaitType) waitType)
                     .Finally(1, cv =>
                     {
-                        Interlocked.Increment(ref invokeCounter);
                         TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                        Interlocked.Increment(ref invokeCounter);
                     })
+                    .Catch(() => { })
                     .Forget();
             }
 
@@ -911,7 +928,7 @@ namespace ProtoPromiseTests.APIs
             cancelationSource.TryDispose();
         }
 
-        [Test, TestCaseSource("GetArgs_CancelFinally")]
+        [Test, TestCaseSource("GetArgs_Finally")]
         public void CallbacksWillBeInvokedOnTheCorrectSynchronizationContext_Finally_T(
             CompleteType completeType,
             SynchronizationType waitType,
@@ -938,9 +955,10 @@ namespace ProtoPromiseTests.APIs
                 p.ConfigureAwait((ConfigureAwaitType) waitType)
                     .Finally(() =>
                     {
-                        Interlocked.Increment(ref invokeCounter);
                         TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                        Interlocked.Increment(ref invokeCounter);
                     })
+                    .Catch(() => { })
                     .Forget();
             }
             foreach (var p in TestHelper.GetTestablePromises(promise))
@@ -949,9 +967,10 @@ namespace ProtoPromiseTests.APIs
                 p.ConfigureAwait((ConfigureAwaitType) waitType)
                     .Finally(1, cv =>
                     {
-                        Interlocked.Increment(ref invokeCounter);
                         TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                        Interlocked.Increment(ref invokeCounter);
                     })
+                    .Catch(() => { })
                     .Forget();
             }
 
@@ -1029,8 +1048,8 @@ namespace ProtoPromiseTests.APIs
                 catch { }
                 finally
                 {
-                    Interlocked.Increment(ref firstInvokeCounter);
                     TestHelper.AssertCallbackContext(firstWaitType, firstReportType, foregroundThread);
+                    Interlocked.Increment(ref firstInvokeCounter);
                 }
 
                 try
@@ -1040,13 +1059,13 @@ namespace ProtoPromiseTests.APIs
                 catch { }
                 finally
                 {
-                    Interlocked.Increment(ref secondInvokeCounter);
                     // If there's a race condition, p2 could be completed on a separate thread before it's awaited, causing the assert to fail.
                     // This only matters for SynchronizationOption.Synchronous, for which the caller does not care on what context it executes.
                     if (!hasRaceCondition)
                     {
                         TestHelper.AssertCallbackContext(secondWaitType, secondReportType, foregroundThread);
                     }
+                    Interlocked.Increment(ref secondInvokeCounter);
                 }
             }
 
@@ -1140,8 +1159,8 @@ namespace ProtoPromiseTests.APIs
                 catch { }
                 finally
                 {
-                    Interlocked.Increment(ref firstInvokeCounter);
                     TestHelper.AssertCallbackContext(firstWaitType, firstReportType, foregroundThread);
+                    Interlocked.Increment(ref firstInvokeCounter);
                 }
 
                 try
@@ -1151,13 +1170,13 @@ namespace ProtoPromiseTests.APIs
                 catch { }
                 finally
                 {
-                    Interlocked.Increment(ref secondInvokeCounter);
                     // If there's a race condition, p2 could be completed on a separate thread before it's awaited, causing the assert to fail.
                     // This only matters for SynchronizationOption.Synchronous, for which the caller does not care on what context it executes.
                     if (!hasRaceCondition)
                     {
                         TestHelper.AssertCallbackContext(secondWaitType, secondReportType, foregroundThread);
                     }
+                    Interlocked.Increment(ref secondInvokeCounter);
                 }
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/BackgroundSynchronizationContext.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/BackgroundSynchronizationContext.cs
@@ -5,18 +5,24 @@ using System.Threading;
 namespace ProtoPromiseTests
 {
     // Used instead of ThreadPool, because ThreadPool has issues in old runtime, causing tests to fail.
+    // This also allows the test runner to wait for all background actions to complete.
     public sealed class BackgroundSynchronizationContext : SynchronizationContext
     {
+        volatile private int _runningActionCount;
+
         private sealed class ThreadRunner
         {
+            // Pool threads globally because creating new threads is expensive.
             private static readonly Stack<ThreadRunner> _pool = new Stack<ThreadRunner>();
 
+            private BackgroundSynchronizationContext _owner;
             private readonly object _locker = new object();
             private SendOrPostCallback _callback;
             private object _state;
 
-            public static void Run(SendOrPostCallback callback, object state)
+            public static void Run(BackgroundSynchronizationContext owner, SendOrPostCallback callback, object state)
             {
+                Interlocked.Increment(ref owner._runningActionCount);
                 bool reused = false;
                 ThreadRunner threadRunner = null;
                 lock (_pool)
@@ -33,6 +39,7 @@ namespace ProtoPromiseTests
                 }
                 lock (threadRunner._locker)
                 {
+                    threadRunner._owner = owner;
                     threadRunner._callback = callback;
                     threadRunner._state = state;
                     if (reused)
@@ -51,12 +58,15 @@ namespace ProtoPromiseTests
             {
                 while (true)
                 {
+                    BackgroundSynchronizationContext owner = _owner;
                     SendOrPostCallback callback = _callback;
                     object state = _state;
                     // Allow GC to reclaim memory.
+                    _owner = null;
                     _callback = null;
                     _state = null;
                     callback.Invoke(state);
+                    Interlocked.Decrement(ref owner._runningActionCount);
                     lock (_locker)
                     {
                         lock (_pool)
@@ -66,6 +76,21 @@ namespace ProtoPromiseTests
                         Monitor.Wait(_locker);
                     }
                 }
+            }
+        }
+
+        public void WaitForAllThreadsToComplete()
+        {
+            int runningActions = _runningActionCount;
+            if (runningActions == 0)
+            {
+                return;
+            }
+
+            TimeSpan timeout = TimeSpan.FromSeconds(runningActions);
+            if (!SpinWait.SpinUntil(() => _runningActionCount == 0, timeout))
+            {
+                throw new TimeoutException("WaitForAllThreadsToComplete timed out after " + timeout + ", _runningActionCount: " + _runningActionCount);
             }
         }
 
@@ -81,7 +106,7 @@ namespace ProtoPromiseTests
                 throw new ArgumentNullException("d", "SendOrPostCallback may not be null.");
             }
 
-            ThreadRunner.Run(d, state);
+            ThreadRunner.Run(this, d, state);
         }
 
         public override void Send(SendOrPostCallback d, object state)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/TestHelper.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/TestHelper.cs
@@ -1,4 +1,9 @@
-﻿#if !PROTO_PROMISE_PROGRESS_DISABLE
+﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+#if !PROTO_PROMISE_PROGRESS_DISABLE
 #define PROMISE_PROGRESS
 #else
 #undef PROMISE_PROGRESS
@@ -107,6 +112,10 @@ namespace ProtoPromiseTests
             GC.WaitForPendingFinalizers();
             GC.Collect();
             ExecuteForegroundCallbacks();
+
+#if PROMISE_DEBUG
+            Internal.AssertAllObjectsReleased();
+#endif
 
             Exception[] exceptions;
             lock (_uncaughtExceptions)


### PR DESCRIPTION
- Combined `MakeReady` and `Handle` for single await promises while still allowing the stack to unwind. #26 
- Reduced size of `Promise(<T>)`s when T is a small struct.
- Corrected `async Promise` continuation to execute on the same thread as the last awaited object.
- Refactored unit tests to be more reliable with improperly used objects.

Current master:

```
|         Type |       Method | Pending | Recursion |       Mean | Allocated | Survived |
|------------- |------------- |-------- |---------- |-----------:|----------:|---------:|
|   AsyncAwait | ProtoPromise |    True |         1 |   2.546 us |         - |    248 B |
|   AsyncAwait | ProtoPromise |    True |        10 |  26.244 us |         - |  2,480 B |
|   AsyncAwait | ProtoPromise |    True |       100 | 263.094 us |         - | 24,800 B |
| ContinueWith | ProtoPromise |    True |         1 |   2.774 us |         - |     80 B |
| ContinueWith | ProtoPromise |    True |        10 |  27.859 us |         - |    800 B |
| ContinueWith | ProtoPromise |    True |       100 | 276.091 us |         - |  8,000 B |
```

This PR:

```
|         Type |       Method | Pending | Recursion |       Mean | Allocated | Survived |
|------------- |------------- |-------- |---------- |-----------:|----------:|---------:|
|   AsyncAwait | ProtoPromise |    True |         1 |   2.495 us |         - |    224 B |
|   AsyncAwait | ProtoPromise |    True |        10 |  26.766 us |         - |  2,240 B |
|   AsyncAwait | ProtoPromise |    True |       100 | 255.388 us |         - | 22,400 B |
| ContinueWith | ProtoPromise |    True |         1 |   2.600 us |         - |     80 B |
| ContinueWith | ProtoPromise |    True |        10 |  26.030 us |         - |    800 B |
| ContinueWith | ProtoPromise |    True |       100 | 259.979 us |         - |  8,000 B |
```