### PR TITLE
ValueContainer optimization

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/InterfacesInternal.cs
@@ -4,19 +4,6 @@ namespace Proto.Promises
 {
     internal static partial class Internal
     {
-        // Abstract class is used instead of interface, because virtual calls on interfaces are twice as slow as virtual calls on classes.
-        internal abstract class ValueContainer
-        {
-            internal abstract void Retain();
-            internal abstract void Release();
-            internal abstract Promise.State GetState();
-            internal abstract Type ValueType { get; }
-            internal abstract object Value { get; }
-
-            internal abstract void ReleaseAndMaybeAddToUnhandledStack(bool shouldAdd);
-            internal abstract void AddToUnhandledStack();
-        }
-
         internal partial interface ITraceable { }
 
         internal interface ILinked<T> where T : class, ILinked<T>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
@@ -105,7 +105,7 @@ namespace Proto.Promises
                         {
                             if (Interlocked.CompareExchange(ref _valueOrPrevious, valueContainer, null) == null)
                             {
-                                valueContainer.Retain();
+                                _valueOrPrevious = valueContainer.Clone();
                                 Handle(ref _firstSmallFields._waitCount, ref handler, out nextHandler, ref executionScheduler);
                             }
                         }
@@ -118,7 +118,7 @@ namespace Proto.Promises
                     {
                         if (Interlocked.CompareExchange(ref _valueOrPrevious, valueContainer, null) == null)
                         {
-                            valueContainer.Retain();
+                            _valueOrPrevious = valueContainer.Clone();
                             Handle(ref _firstSmallFields._waitCount, ref handler, out nextHandler, ref executionScheduler);
                         }
                         if (InterlockedAddWithOverflowCheck(ref _firstSmallFields._waitCount, -1, 0) == 0)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
@@ -150,7 +150,7 @@ namespace Proto.Promises
                     {
                         if (Interlocked.CompareExchange(ref _valueOrPrevious, valueContainer, null) == null)
                         {
-                            valueContainer.Retain();
+                            _valueOrPrevious = valueContainer.Clone();
                             Handle(ref _waitCount, ref handler, out nextHandler, ref executionScheduler);
                         }
                         if (InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0) == 0)
@@ -166,7 +166,7 @@ namespace Proto.Promises
                         {
                             if (Interlocked.CompareExchange(ref _valueOrPrevious, valueContainer, null) == null)
                             {
-                                valueContainer.Retain();
+                                _valueOrPrevious = valueContainer.Clone();
                                 Handle(ref _waitCount, ref handler, out nextHandler, ref executionScheduler);
                             }
                         }
@@ -195,7 +195,7 @@ namespace Proto.Promises
                         _onPromiseResolved = null;
                         if (_valueContainer != null)
                         {
-                            _valueContainer.Release();
+                            _valueContainer.DisposeAndMaybeAddToUnhandledStack(false);
                             _valueContainer = null;
                         }
 #if PROMISE_DEBUG
@@ -233,7 +233,7 @@ namespace Proto.Promises
                         {
                             if (Interlocked.CompareExchange(ref _valueOrPrevious, valueContainer, null) == null)
                             {
-                                valueContainer.Retain();
+                                _valueOrPrevious = valueContainer.Clone();
                                 Handle(ref _waitCount, ref handler, out nextHandler, ref executionScheduler);
                             }
                             if (InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0) == 0)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -885,9 +885,7 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
                     var state = handler.State;
                     _smallProgressFields._previousState = state;
-                    var valueContainer = (ValueContainer) handler._valueOrPrevious;
-                    valueContainer.Retain();
-                    _valueOrPrevious = valueContainer;
+                    _valueOrPrevious = ((ValueContainer) handler._valueOrPrevious).Clone();
 
                     if (!_smallProgressFields._isSynchronous)
                     {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -98,7 +98,7 @@ namespace Proto.Promises
                     if (State != Promise.State.Pending & _valueOrPrevious != null)
                     {
                         // Rejection maybe wasn't caught.
-                        ((ValueContainer) _valueOrPrevious).ReleaseAndMaybeAddToUnhandledStack(!SuppressRejection);
+                        ((ValueContainer) _valueOrPrevious).DisposeAndMaybeAddToUnhandledStack(!SuppressRejection);
                     }
                 }
                 catch (Exception e)
@@ -172,7 +172,7 @@ namespace Proto.Promises
                 }
 #endif
                 // Rejection maybe wasn't caught.
-                ((ValueContainer) _valueOrPrevious).ReleaseAndMaybeAddToUnhandledStack(!SuppressRejection);
+                ((ValueContainer) _valueOrPrevious).DisposeAndMaybeAddToUnhandledStack(!SuppressRejection);
                 _valueOrPrevious = null;
             }
 
@@ -427,8 +427,7 @@ namespace Proto.Promises
                         }
                         else
                         {
-                            valueContainer = (ValueContainer) previousHandler._valueOrPrevious;
-                            valueContainer.Retain();
+                            valueContainer = ((ValueContainer) previousHandler._valueOrPrevious).Clone();
                         }
                         MaybeDisposePreviousFromCatch(previousHandler, handlerDisposedAfterCallback);
                         SetResultAndMaybeHandleFromCatch(valueContainer, previousState, out nextHandler, ref executionScheduler);
@@ -471,8 +470,7 @@ namespace Proto.Promises
                 internal void HandleSelf(ref PromiseRef handler, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
                     var state = handler.State;
-                    var valueContainer = (ValueContainer) handler._valueOrPrevious;
-                    valueContainer.Retain();
+                    var valueContainer = ((ValueContainer) handler._valueOrPrevious).Clone();
                     MaybeDisposePrevious(handler);
                     handler = this;
                     SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
@@ -517,8 +515,7 @@ namespace Proto.Promises
                 new internal void HandleSelf(ref PromiseRef handler, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
                     var state = handler.State;
-                    var valueContainer = (ValueContainer) handler._valueOrPrevious;
-                    valueContainer.Retain();
+                    var valueContainer = ((ValueContainer) handler._valueOrPrevious).Clone();
                     MaybeDisposePrevious(handler);
                     handler = this;
                     SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
@@ -633,9 +630,7 @@ namespace Proto.Promises
                 {
                     nextHandler = null;
                     ThrowIfInPool(this);
-                    var valueContainer = (ValueContainer) handler._valueOrPrevious;
-                    valueContainer.Retain();
-                    SetResult(valueContainer, handler.State);
+                    SetResult(((ValueContainer) handler._valueOrPrevious).Clone(), handler.State);
                     executionScheduler.ScheduleSynchronous(this);
                     WaitWhileProgressFlags(PromiseFlags.Subscribing);
                 }
@@ -737,9 +732,7 @@ namespace Proto.Promises
 #endif
                     {
                         ThrowIfInPool(this);
-                        var valueContainer = (ValueContainer) handler._valueOrPrevious;
-                        valueContainer.Retain();
-                        _valueOrPrevious = valueContainer;
+                        _valueOrPrevious = ((ValueContainer) handler._valueOrPrevious).Clone();
                         nextHandler = null;
                         _previousState = handler.State;
                         Thread.MemoryBarrier(); // Make sure previous writes are done before swapping schedule method.
@@ -1212,7 +1205,6 @@ namespace Proto.Promises
                 {
                     var callback = _finalizer;
                     _finalizer = default(TFinalizer);
-                    handlerDisposedAfterCallback = true;
                     try
                     {
                         callback.Invoke();
@@ -1221,6 +1213,7 @@ namespace Proto.Promises
                     {
                         // Unlike normal finally clauses, we won't swallow the previous rejection. Instead, we send it to the uncaught rejection handler.
                         ((ValueContainer) handler._valueOrPrevious).AddToUnhandledStack();
+                        MaybeDisposePrevious(handler);
                         throw;
                     }
                     HandleSelf(ref handler, out nextHandler, ref executionScheduler);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -1360,7 +1360,7 @@ namespace Proto.Promises
                 {
                     // owner._ref is checked for nullity before passing into this.
                     owner._target._ref.MarkAwaited(owner._target.Id, ownerSetFlags);
-                    var passThrough = ObjectPool<PromisePassThrough>.TryTake<PromisePassThrough>()
+                    var passThrough = ObjectPool<HandleablePromiseBase>.TryTake<PromisePassThrough>()
                         ?? new PromisePassThrough();
                     passThrough._owner = owner._target._ref;
                     passThrough._smallFields._index = index;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
@@ -100,7 +100,7 @@ namespace Proto.Promises
                     if (Interlocked.CompareExchange(ref _valueOrPrevious, valueContainer, null) == null)
                     {
                         handler.SuppressRejection = true;
-                        valueContainer.Retain();
+                        _valueOrPrevious = valueContainer.Clone();
                         Handle(ref _raceSmallFields._waitCount, ref handler, out nextHandler, ref executionScheduler);
                     }
                     else

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
@@ -640,13 +640,22 @@ namespace Proto.Promises
             {
                 return Internal.CreateResolved(value, maxDepth);
             }
-            var promise = Internal.PromiseRef.MergePromise.GetOrCreate(passThroughs, value, (feed, target, index) =>
-            {
-                if (index == 0)
+            // Check for reference type to not create new object pools for every T1 type.
+            var promise = null == default(T1)
+                ? Internal.PromiseRef.MergePromise.GetOrCreate(passThroughs, (object) value, (feed, target, index) =>
                 {
-                    target.value = feed.GetValue<T1>();
-                }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+                    if (index == 0)
+                    {
+                        target.value = feed.GetValue<object>();
+                    }
+                }, pendingCount, completedProgress, totalProgress, maxDepth)
+                : Internal.PromiseRef.MergePromise.GetOrCreate(passThroughs, value, (feed, target, index) =>
+                {
+                    if (index == 0)
+                    {
+                        target.value = feed.GetValue<T1>();
+                    }
+                }, pendingCount, completedProgress, totalProgress, maxDepth);
             return new Promise<T1>(promise, promise.Id, maxDepth);
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
@@ -435,9 +435,10 @@ namespace Proto.Promises
             {
                 return Internal.CreateResolved(valueContainer, maxDepth);
             }
-            var promise = Internal.PromiseRef.MergePromise.GetOrCreate(passThroughs, valueContainer, (feed, target, index) =>
+            // Force to object for reference type value container.
+            var promise = Internal.PromiseRef.MergePromise.GetOrCreate(passThroughs, (object) valueContainer, (feed, target, index) =>
             {
-                target.value[index] = feed.GetValue<T>();
+                ((IList<T>) target.value)[index] = feed.GetValue<T>();
             }, pendingCount, completedProgress, totalProgress, maxDepth);
             return new Promise<IList<T>>(promise, promise.Id, maxDepth);
         }
@@ -491,9 +492,10 @@ namespace Proto.Promises
             {
                 return Internal.CreateResolved(valueContainer, maxDepth);
             }
-            var promise = Internal.PromiseRef.MergePromise.GetOrCreate(passThroughs, valueContainer, (feed, target, index) =>
+            // Force to object for reference type value container.
+            var promise = Internal.PromiseRef.MergePromise.GetOrCreate(passThroughs, (object) valueContainer, (feed, target, index) =>
             {
-                target.value[index] = feed.GetValue<T>();
+                ((IList<T>) target.value)[index] = feed.GetValue<T>();
             }, pendingCount, completedProgress, totalProgress, maxDepth);
             return new Promise<IList<T>>(promise, promise.Id, maxDepth);
         }
@@ -551,9 +553,10 @@ namespace Proto.Promises
             {
                 return Internal.CreateResolved(valueContainer, maxDepth);
             }
-            var promise = Internal.PromiseRef.MergePromise.GetOrCreate(passThroughs, valueContainer, (feed, target, index) =>
+            // Force to object for reference type value container.
+            var promise = Internal.PromiseRef.MergePromise.GetOrCreate(passThroughs, (object) valueContainer, (feed, target, index) =>
             {
-                target.value[index] = feed.GetValue<T>();
+                ((IList<T>) target.value)[index] = feed.GetValue<T>();
             }, pendingCount, completedProgress, totalProgress, maxDepth);
             return new Promise<IList<T>>(promise, promise.Id, maxDepth);
         }
@@ -637,9 +640,10 @@ namespace Proto.Promises
                 return Internal.CreateResolved(valueContainer, maxDepth);
             }
 
-            var promise = Internal.PromiseRef.MergePromise.GetOrCreate(passThroughs, valueContainer, (feed, target, index) =>
+            // Force to object for reference type value container.
+            var promise = Internal.PromiseRef.MergePromise.GetOrCreate(passThroughs, (object) valueContainer, (feed, target, index) =>
             {
-                target.value[index] = feed.GetValue<T>();
+                ((IList<T>) target.value)[index] = feed.GetValue<T>();
             }, pendingCount, completedProgress, totalProgress, maxDepth);
             return new Promise<IList<T>>(promise, promise.Id, maxDepth);
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
@@ -73,7 +73,7 @@ namespace Proto.Promises
         public bool TryGetValueAs<T>(out T value)
         {
             Validate();
-            return Internal.TryGetValue(_valueContainer, out value);
+            return _valueContainer.TryGetValue(out value);
         }
 
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Unity/PromiseYieldInstruction.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Unity/PromiseYieldInstruction.cs
@@ -200,17 +200,15 @@ namespace Proto.Promises
                 yieldInstruction._retainCounter = 2; // 1 retain for complete, 1 for dispose.
                 promise.ContinueWith(yieldInstruction, (yi, resultContainer) =>
                 {
+                    yi._state = resultContainer.State;
                     if (yi._state == Promise.State.Resolved)
                     {
                         yi._result = resultContainer.Result;
                     }
                     else
                     {
-                        ValueContainer valueContainer = (ValueContainer) resultContainer._target._valueOrPrevious;
-                        valueContainer.Retain();
-                        yi._value = valueContainer;
+                        yi._value = ((ValueContainer) resultContainer._target._valueOrPrevious).Clone();
                     }
-                    yi._state = resultContainer.State;
                     
                     yi.MaybeDispose();
                 })
@@ -222,7 +220,7 @@ namespace Proto.Promises
             {
                 if (Interlocked.Exchange(ref _disposeChecker, 1) == 1)
                 {
-                    throw new InvalidOperationException("Promise yield instruction is not valid after you have disposed. You can get a valid yield instruction by calling promise.ToYieldInstruction().", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("Promise yield instruction is not valid after you have disposed. You can get a valid yield instruction by calling promise.ToYieldInstruction().", GetFormattedStacktrace(1));
                 }
                 MaybeDispose();
             }


### PR DESCRIPTION
Optimized ValueContainers when `T` is a reference type by only creating one type `ResolveContainer<object>` instead of a type for every `T`.
Optimized ValueContainers for the common case.
Fixed a memory leak with All/Merge/Race/First promises.
Fixed state check in `PromiseYieldInstruction`.

Current master:

```
|         Type |       Method | Pending | Recursion |     Mean |   Error |  StdDev | Allocated |
|------------- |------------- |-------- |---------- |---------:|--------:|--------:|----------:|
|   AsyncAwait | ProtoPromise |    True |       100 | 294.4 us | 5.85 us | 6.96 us |         - |
| ContinueWith | ProtoPromise |    True |       100 | 299.2 us | 1.60 us | 1.49 us |         - |
```

This PR:

```
|         Type |       Method | Pending | Recursion |     Mean |   Error |  StdDev | Allocated |
|------------- |------------- |-------- |---------- |---------:|--------:|--------:|----------:|
|   AsyncAwait | ProtoPromise |    True |       100 | 282.9 us | 1.37 us | 1.14 us |         - |
| ContinueWith | ProtoPromise |    True |       100 | 291.1 us | 1.90 us | 1.78 us |         - |
```