### PR TITLE
Refactored progress to reduce complexity.

### DIFF
--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -6,7 +6,7 @@
     <Configurations>Release;Debug;Release_NoProgress;Debug_NoProgress</Configurations>
     <Version>2.0.1</Version>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <!--Only for function pointers in await override implementation. All other async/await code should be C# 7.3 compatible, and all other code should be C# 4 compatible for old Unity versions.-->
+    <!--Only for function pointers in await override implementation. All other code should be C# 4 compatible for old Unity versions.-->
     <LangVersion>9</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!--Set true to help debug internal promise code (allows the debugger to step into the code and includes internal stacktraces).-->

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/AggregateException.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/AggregateException.cs
@@ -10,7 +10,7 @@ using System.Globalization;
 
 namespace Proto.Promises
 {
-#if !NET_LEGACY || NET40_OR_GREATER
+#if !NET_LEGACY
     /// <summary>Represents one or more errors that occur during application execution.</summary>
     /// <remarks>
     /// <see cref="AggregateException"/> is used to consolidate multiple failures into a single, throwable

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
@@ -146,7 +146,7 @@ namespace Proto.Promises
 
         internal static string FormatStackTrace(IEnumerable<StackTrace> stackTraces)
         {
-#if NET_LEGACY && !NET40_OR_GREATER
+#if NET_LEGACY
             // Format stack trace to match "throw exception" so that double-clicking log in Unity console will go to the proper line.
             List<string> _stackTraces = new List<string>();
             string[] separator = new string[1] { Environment.NewLine + " " };
@@ -181,7 +181,7 @@ namespace Proto.Promises
             }
             sb.Append(" ");
             return sb.ToString();
-#else // NET_LEGACY && !NET40_OR_GREATER
+#else // NET_LEGACY
             // StackTrace.ToString() format issue was fixed in the new runtime.
             List<StackFrame> stackFrames = new List<StackFrame>();
             foreach (StackTrace stackTrace in stackTraces)
@@ -204,7 +204,7 @@ namespace Proto.Promises
                 .ToArray();
 
             return string.Join(Environment.NewLine, trace);
-#endif // NET_LEGACY && !NET40_OR_GREATER
+#endif // NET_LEGACY
         }
 
         partial interface ITraceable
@@ -296,11 +296,11 @@ namespace Proto.Promises
                 {
                     return;
                 }
-                // This allows us to check All/Race/First Promises iteratively.
+                // This allows us to check Merge/All/Race/First Promises iteratively.
                 Stack<PromisePassThrough> passThroughs = PassthroughsForIterativeAlgorithm;
-                PromiseRef prev = other._valueOrPrevious as PromiseRef;
+                PromiseRef prev = other._previous;
             Repeat:
-                for (; prev != null; prev = prev._valueOrPrevious as PromiseRef)
+                for (; prev != null; prev = prev._previous)
                 {
                     if (prev == this)
                     {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/InterfacesInternal.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿#if UNITY_5_5 || NET_2_0 || NET_2_0_SUBSET
+#define NET_LEGACY
+#endif
+
+using System;
 
 namespace Proto.Promises
 {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -504,6 +504,8 @@ namespace Proto.Promises
                     ValidateAwait(waiter, promiseId);
                     waiter.InterlockedRetainAndSetFlagsInternal(promiseId, PromiseFlags.None);
 
+                    // TODO: detect if this is being called from another promise higher in the stack, and allow the stack to unwind instead of calling MaybeHandleNext.
+
                     var executionScheduler = new ExecutionScheduler(true);
                     SetSecondPreviousAndProgress(waiter, minProgress, maxProgress);
                     InterlockedIncrementProgressReportingCount();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -508,15 +508,11 @@ namespace Proto.Promises
 
                     var executionScheduler = new ExecutionScheduler(true);
                     SetSecondPreviousAndProgress(waiter, minProgress, maxProgress);
-                    InterlockedIncrementProgressReportingCount();
                     HandleablePromiseBase nextRef;
                     waiter.AddWaiter(this, out nextRef, ref executionScheduler);
-                    MaybeReportProgressAfterHookup(waiter, depth, ref executionScheduler);
                     waiter.MaybeHandleNext(nextRef, ref executionScheduler);
                     executionScheduler.Execute();
                 }
-
-                partial void MaybeReportProgressAfterHookup(PromiseRef waiter, ushort depth, ref ExecutionScheduler executionScheduler);
             }
 
 #if !OPTIMIZED_ASYNC_MODE

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -431,7 +431,7 @@ namespace Proto.Promises
 
 #if !PROMISE_PROGRESS
                 [MethodImpl(InlineOption)]
-                internal void SetSecondPreviousAndProgress(PromiseRef other, float minProgress, float maxProgress)
+                internal void SetPreviousAndProgress(PromiseRef other, float minProgress, float maxProgress)
                 {
 #if PROMISE_DEBUG
                     _previous = other;
@@ -504,14 +504,10 @@ namespace Proto.Promises
                     ValidateAwait(waiter, promiseId);
                     waiter.InterlockedRetainAndSetFlagsInternal(promiseId, PromiseFlags.None);
 
-                    // TODO: detect if this is being called from another promise higher in the stack, and allow the stack to unwind instead of calling MaybeHandleNext.
+                    // TODO: detect if this is being called from another promise higher in the stack, and call AddWaiter and allow the stack to unwind instead of calling HookupNewWaiter.
 
-                    var executionScheduler = new ExecutionScheduler(true);
-                    SetSecondPreviousAndProgress(waiter, minProgress, maxProgress);
-                    HandleablePromiseBase nextRef;
-                    waiter.AddWaiter(this, out nextRef, ref executionScheduler);
-                    waiter.MaybeHandleNext(nextRef, ref executionScheduler);
-                    executionScheduler.Execute();
+                    SetPreviousAndProgress(waiter, minProgress, maxProgress);
+                    waiter.HookupNewWaiter(this);
                 }
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -22,6 +22,8 @@
 #define OPTIMIZED_ASYNC_MODE
 #endif
 
+#pragma warning disable IDE0018 // Inline variable declaration
+#pragma warning disable IDE0034 // Simplify 'default' expression
 #pragma warning disable IDE0044 // Add readonly modifier
 #pragma warning disable IDE0060 // Remove unused parameter
 #pragma warning disable 0436 // Type conflicts with imported type
@@ -37,7 +39,6 @@ using Proto.Promises.Async.CompilerServices;
 
 namespace System.Runtime.CompilerServices
 {
-    // I would #ifdef this entire file, but Unity complains about namespaces changed with define symbols.
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Delegate, Inherited = false, AllowMultiple = false)]
     internal sealed class AsyncMethodBuilderAttribute : Attribute
     {
@@ -430,15 +431,19 @@ namespace Proto.Promises
 
 #if !PROMISE_PROGRESS
                 [MethodImpl(InlineOption)]
-                internal void SetPreviousAndMaybeSubscribeProgress(PromiseRef other, ushort depth, float minProgress, float maxProgress, ref ExecutionScheduler executionScheduler)
+                internal void SetSecondPreviousAndProgress(PromiseRef other, float minProgress, float maxProgress)
                 {
-                    _valueOrPrevious = other;
+#if PROMISE_DEBUG
+                    _previous = other;
+#endif
                 }
 
                 [MethodImpl(InlineOption)]
                 private void SetAwaitedComplete(PromiseRef handler, ref ExecutionScheduler executionScheduler)
                 {
-                    _valueOrPrevious = null;
+#if PROMISE_DEBUG
+                    _previous = null;
+#endif
                 }
 #endif
 
@@ -492,6 +497,24 @@ namespace Proto.Promises
                         HandleInternal(valueContainer, state);
                     }
                 }
+
+                [MethodImpl(InlineOption)]
+                internal void HookupWaiterWithProgress(PromiseRef waiter, short promiseId, ushort depth, float minProgress, float maxProgress)
+                {
+                    ValidateAwait(waiter, promiseId);
+                    waiter.InterlockedRetainAndSetFlagsInternal(promiseId, PromiseFlags.None);
+
+                    var executionScheduler = new ExecutionScheduler(true);
+                    SetSecondPreviousAndProgress(waiter, minProgress, maxProgress);
+                    InterlockedIncrementProgressReportingCount();
+                    HandleablePromiseBase nextRef;
+                    waiter.AddWaiter(this, out nextRef, ref executionScheduler);
+                    MaybeReportProgressAfterHookup(waiter, depth, ref executionScheduler);
+                    waiter.MaybeHandleNext(nextRef, ref executionScheduler);
+                    executionScheduler.Execute();
+                }
+
+                partial void MaybeReportProgressAfterHookup(PromiseRef waiter, ushort depth, ref ExecutionScheduler executionScheduler);
             }
 
 #if !OPTIMIZED_ASYNC_MODE
@@ -618,15 +641,12 @@ namespace Proto.Promises
                             Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
                             nextHandler = Interlocked.Exchange(ref _waiter, null);
                         }
-                        HandleProgressListener(handler.State, 0, ref executionScheduler);
-                        WaitWhileProgressFlags(PromiseFlags.Subscribing);
                         handler.MaybeDispose();
                         handler = this;
                     }
                     else
                     {
                         nextHandler = null;
-                        WaitWhileProgressFlags(PromiseFlags.Subscribing);
                     }
                 }
             } // class AsyncPromiseRef
@@ -687,15 +707,12 @@ namespace Proto.Promises
                                 Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
                                 nextHandler = Interlocked.Exchange(ref _waiter, null);
                             }
-                            HandleProgressListener(handler.State, 0, ref executionScheduler);
-                            WaitWhileProgressFlags(PromiseFlags.Subscribing);
                             handler.MaybeDispose();
                             handler = this;
                         }
                         else
                         {
                             nextHandler = null;
-                            WaitWhileProgressFlags(PromiseFlags.Subscribing);
                         }
                     }
                 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -139,7 +139,10 @@ namespace Proto.Promises
                 }
 
 #if PROMISE_PROGRESS
-                internal override PromiseSingleAwait SetProgress(ref Fixed32 progress, ushort depth, ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
+                internal override PromiseSingleAwait SetProgress(ref Fixed32 progress, ref ushort depth, ref ExecutionScheduler executionScheduler)
+                {
+                    return null;
+                }
 #endif
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -75,7 +75,8 @@ namespace Proto.Promises
             {
                 asyncPromiseRef.ValidateAwait(this, promiseId);
                 InterlockedRetainAndSetFlagsInternal(promiseId, PromiseFlags.None);
-                HookupNewPromise(asyncPromiseRef);
+                asyncPromiseRef.SetPreviousAndProgress(this, float.NaN, float.NaN);
+                HookupNewWaiter(asyncPromiseRef);
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -1057,16 +1057,14 @@ namespace Proto.Promises
 #if PROMISE_DEBUG
                     promise._previous = _this._ref;
 #endif
-                    promise._smallFields._currentProgress = _this._ref._smallFields._currentProgress;
                     var executionScheduler = new ExecutionScheduler(true);
-                    _this._ref.InterlockedIncrementProgressReportingCount();
                     HandleablePromiseBase nextRef;
                     _this._ref.AddWaiter(promise, out nextRef, ref executionScheduler);
-                    if (_this._ref.State == Promise.State.Pending)
+                    // If the progress is 0, progress in AddWaiter will not set, so we force the report here.
+                    if (_this._ref.State == Promise.State.Pending & (promise._smallFields._currentProgress.GetRawValue() == 0))
                     {
                         promise.MaybeReportProgress(ref executionScheduler);
                     }
-                    _this._ref.InterlockedDecrementProgressReportingCount();
                     _this._ref.MaybeHandleNext(nextRef, ref executionScheduler);
                     executionScheduler.Execute();
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
@@ -1,4 +1,8 @@
-﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+﻿#if UNITY_5_5 || NET_2_0 || NET_2_0_SUBSET
+#define NET_LEGACY
+#endif
+
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
 #define PROMISE_DEBUG
 #else
 #undef PROMISE_DEBUG
@@ -85,7 +89,6 @@ namespace Proto.Promises
             {
                 internal void HandleFromCancelation()
                 {
-                    var executionScheduler = new ExecutionScheduler(true);
                     HandleablePromiseBase nextHandler;
 #if NET_LEGACY // Interlocked.Exchange doesn't seem to work properly in Unity's old runtime. I'm not sure why, but we need a lock here to pass multi-threaded tests.
                     lock (this)
@@ -95,7 +98,7 @@ namespace Proto.Promises
                         Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
                         nextHandler = Interlocked.Exchange(ref _waiter, null);
                     }
-                    HandleProgressListener(Promise.State.Canceled, Depth, ref executionScheduler);
+                    var executionScheduler = new ExecutionScheduler(true);
                     MaybeHandleNext(nextHandler, ref executionScheduler);
                     executionScheduler.Execute();
                 }
@@ -147,7 +150,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 
@@ -212,7 +214,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 
@@ -279,7 +280,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 
@@ -355,7 +355,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 
@@ -508,7 +507,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 
@@ -573,7 +571,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
@@ -321,7 +321,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        owner.WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 
@@ -339,7 +338,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        owner.WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
             }
@@ -415,7 +413,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        owner.WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 
@@ -441,7 +438,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        owner.WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 
@@ -482,7 +478,6 @@ namespace Proto.Promises
                     }
 
                     nextHandler = null;
-                    owner.WaitForProgressSubscribeAfterCanceled(handler);
                 }
 
                 void IDelegateRejectPromise.InvokeRejecter(ref PromiseRef handler, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
@@ -520,7 +515,6 @@ namespace Proto.Promises
                     }
                     
                     nextHandler = null;
-                    owner.WaitForProgressSubscribeAfterCanceled(handler);
                 }
             }
 
@@ -591,7 +585,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        owner.WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 
@@ -630,7 +623,6 @@ namespace Proto.Promises
                     }
 
                     nextHandler = null;
-                    owner.WaitForProgressSubscribeAfterCanceled(handler);
                 }
             }
 
@@ -726,7 +718,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        owner.WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
             }
@@ -821,7 +812,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        owner.WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
             }
@@ -975,7 +965,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        owner.WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 
@@ -1001,7 +990,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        owner.WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 
@@ -1042,7 +1030,6 @@ namespace Proto.Promises
                     }
 
                     nextHandler = null;
-                    owner.WaitForProgressSubscribeAfterCanceled(handler);
                 }
 
                 void IDelegateRejectPromise.InvokeRejecter(ref PromiseRef handler, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
@@ -1080,7 +1067,6 @@ namespace Proto.Promises
                     }
 
                     nextHandler = null;
-                    owner.WaitForProgressSubscribeAfterCanceled(handler);
                 }
             }
 
@@ -1163,7 +1149,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        owner.WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
 
@@ -1202,7 +1187,6 @@ namespace Proto.Promises
                     }
 
                     nextHandler = null;
-                    owner.WaitForProgressSubscribeAfterCanceled(handler);
                 }
             }
 
@@ -1304,7 +1288,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        owner.WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
             }
@@ -1405,7 +1388,6 @@ namespace Proto.Promises
                     else
                     {
                         nextHandler = null;
-                        owner.WaitForProgressSubscribeAfterCanceled(handler);
                     }
                 }
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
@@ -134,12 +134,6 @@ namespace Proto.Promises
 #if PROMISE_PROGRESS
             partial class FirstPromise
             {
-                new private void Reset(ushort depth)
-                {
-                    _smallFields._currentProgress = default(Fixed32);
-                    base.Reset(depth);
-                }
-
                 internal override PromiseSingleAwait IncrementProgress(long amount, ref Fixed32 progress, ushort depth)
                 {
                     ThrowIfInPool(this);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
@@ -140,7 +140,7 @@ namespace Proto.Promises
                     base.Reset(depth);
                 }
 
-                internal override PromiseSingleAwait IncrementProgress(uint amount, ref Fixed32 progress, ushort depth)
+                internal override PromiseSingleAwait IncrementProgress(long amount, ref Fixed32 progress, ushort depth)
                 {
                     ThrowIfInPool(this);
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
@@ -56,7 +56,7 @@ namespace Proto.Promises
                     }
                     unchecked
                     {
-                        promise._firstSmallFields._waitCount = (int) pendingAwaits;
+                        promise._waitCount = (int) pendingAwaits;
                     }
                     promise.Reset(depth);
 
@@ -71,7 +71,7 @@ namespace Proto.Promises
                         }
 #endif
                         passThrough.SetTargetAndAddToOwner(promise);
-                        if (promise._valueOrPrevious != null)
+                        if (promise._valueContainer != null)
                         {
                             // This was completed potentially before all passthroughs were hooked up. Release all remaining passthroughs.
                             int addCount = 0;
@@ -82,7 +82,7 @@ namespace Proto.Promises
                                 p.Release();
                                 --addCount;
                             }
-                            if (addCount != 0 && InterlockedAddWithOverflowCheck(ref promise._firstSmallFields._waitCount, addCount, 0) == 0)
+                            if (addCount != 0 && InterlockedAddWithOverflowCheck(ref promise._waitCount, addCount, 0) == 0)
                             {
                                 promise.MaybeDispose();
                             }
@@ -100,13 +100,13 @@ namespace Proto.Promises
 
                     if (handler.State != Promise.State.Resolved) // Rejected/Canceled
                     {
-                        int remaining = InterlockedAddWithOverflowCheck(ref _firstSmallFields._waitCount, -1, 0);
+                        int remaining = InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
                         if (remaining == 1)
                         {
-                            if (Interlocked.CompareExchange(ref _valueOrPrevious, valueContainer, null) == null)
+                            if (Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) == null)
                             {
-                                _valueOrPrevious = valueContainer.Clone();
-                                Handle(ref _firstSmallFields._waitCount, ref handler, out nextHandler, ref executionScheduler);
+                                _valueContainer = valueContainer.Clone();
+                                Handle(ref _waitCount, ref handler, out nextHandler, ref executionScheduler);
                             }
                         }
                         else if (remaining == 0)
@@ -116,12 +116,12 @@ namespace Proto.Promises
                     }
                     else // Resolved
                     {
-                        if (Interlocked.CompareExchange(ref _valueOrPrevious, valueContainer, null) == null)
+                        if (Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) == null)
                         {
-                            _valueOrPrevious = valueContainer.Clone();
-                            Handle(ref _firstSmallFields._waitCount, ref handler, out nextHandler, ref executionScheduler);
+                            _valueContainer = valueContainer.Clone();
+                            Handle(ref _waitCount, ref handler, out nextHandler, ref executionScheduler);
                         }
-                        if (InterlockedAddWithOverflowCheck(ref _firstSmallFields._waitCount, -1, 0) == 0)
+                        if (InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0) == 0)
                         {
                             _smallFields.InterlockedTryReleaseComplete();
                         }
@@ -136,39 +136,21 @@ namespace Proto.Promises
             {
                 new private void Reset(ushort depth)
                 {
-                    _firstSmallFields._currentProgress = default(Fixed32);
+                    _smallFields._currentProgress = default(Fixed32);
                     base.Reset(depth);
                 }
 
-                protected override sealed PromiseRef MaybeAddProgressListenerAndGetPreviousRetained(ref IProgressListener progressListener, ref Fixed32 lastKnownProgress)
-                {
-                    // Unnecessary to set last known since we know SetInitialProgress will be called on this.
-                    ThrowIfInPool(this);
-                    progressListener.Retain();
-                    _progressListener = progressListener;
-                    return null;
-                }
-
-                protected override sealed void SetInitialProgress(IProgressListener progressListener, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    progress = _firstSmallFields._currentProgress;
-                    SetInitialProgress(progressListener, ref progress, Fixed32.FromWholePlusOne(Depth), out nextRef, ref executionScheduler);
-                }
-
-                internal override void IncrementProgress(uint amount, ref Fixed32 progress, ushort depth, out PromiseSingleAwaitWithProgress nextRef)
+                internal override PromiseSingleAwait IncrementProgress(uint amount, ref Fixed32 progress, ushort depth)
                 {
                     ThrowIfInPool(this);
 
                     var newAmount = progress.MultiplyAndDivide(Depth + 1, depth + 1);
-                    if (_firstSmallFields._currentProgress.InterlockedTrySetIfGreater(newAmount, progress))
+                    if (_smallFields._currentProgress.InterlockedTrySetIfGreater(newAmount))
                     {
-                        nextRef = this;
                         progress = newAmount;
+                        return this;
                     }
-                    else
-                    {
-                        nextRef = null;
-                    }
+                    return null;
                 }
             }
 #endif

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
@@ -2,6 +2,12 @@
 #define NET_LEGACY
 #endif
 
+#if !PROTO_PROMISE_PROGRESS_DISABLE
+#define PROMISE_PROGRESS
+#else
+#undef PROMISE_PROGRESS
+#endif
+
 using System.Runtime.CompilerServices;
 
 namespace Proto.Promises
@@ -29,11 +35,14 @@ namespace Proto.Promises
             internal abstract void Handle(ref PromiseRef handler, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler);
             // This is overridden in PromiseMultiAwait and PromiseProgress and PromiseConfigured.
             internal virtual void Handle(ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
+#if PROMISE_PROGRESS
+            internal abstract PromiseRef.PromiseSingleAwait SetProgress(ref PromiseRef.Fixed32 progress, ushort depth, ref ExecutionScheduler executionScheduler);
+#endif
         }
 
         partial class PromiseRef
         {
-            internal abstract partial class MultiHandleablePromiseBase : PromiseSingleAwaitWithProgress
+            internal abstract partial class MultiHandleablePromiseBase : PromiseSingleAwait
             {
                 internal abstract void Handle(ref PromiseRef handler, ValueContainer valueContainer, PromisePassThrough passThrough, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler);
                 internal override void Handle(ref PromiseRef handler, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
@@ -36,7 +36,7 @@ namespace Proto.Promises
             // This is overridden in PromiseMultiAwait and PromiseProgress and PromiseConfigured.
             internal virtual void Handle(ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
 #if PROMISE_PROGRESS
-            internal abstract PromiseRef.PromiseSingleAwait SetProgress(ref PromiseRef.Fixed32 progress, ushort depth, ref ExecutionScheduler executionScheduler);
+            internal abstract PromiseRef.PromiseSingleAwait SetProgress(ref PromiseRef.Fixed32 progress, ref ushort depth, ref ExecutionScheduler executionScheduler);
 #endif
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
@@ -280,8 +280,9 @@ namespace Proto.Promises
 
                 partial void IncrementProgress(PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler)
                 {
-                    uint dif = passThrough.GetProgressDifferenceToCompletion();
-                    var progress = IncrementProgress(dif);
+                    Fixed32 progressFlags;
+                    uint dif = passThrough.GetProgressDifferenceToCompletion(out progressFlags);
+                    var progress = IncrementProgress(dif, progressFlags);
                     ReportProgress(progress, Depth, ref executionScheduler);
                 }
 
@@ -297,13 +298,13 @@ namespace Proto.Promises
                 {
                     ThrowIfInPool(this);
                     // This essentially acts as a pass-through to normalize the progress.
-                    progress = IncrementProgress(amount);
+                    progress = IncrementProgress(amount, progress);
                     return this;
                 }
 
-                private Fixed32 IncrementProgress(uint amount)
+                private Fixed32 IncrementProgress(uint amount, Fixed32 otherFlags)
                 {
-                    var unscaledProgress = _unscaledProgress.InterlockedIncrement(amount);
+                    var unscaledProgress = _unscaledProgress.InterlockedIncrement(amount, otherFlags);
                     return NormalizeProgress(unscaledProgress);
                 }
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
@@ -286,15 +286,15 @@ namespace Proto.Promises
                     ReportProgress(progress, Depth, ref executionScheduler);
                 }
 
-                private Fixed32 NormalizeProgress(UnsignedFixed64 unscaledProgress)
+                private Fixed32 NormalizeProgress(UnsignedFixed64 unscaledProgress, Fixed32 otherFlags)
                 {
                     ThrowIfInPool(this);
-                    var scaledProgress = Fixed32.GetScaled(unscaledProgress, _progressScaler);
+                    var scaledProgress = Fixed32.GetScaled(unscaledProgress, _progressScaler, otherFlags);
                     _smallFields._currentProgress = scaledProgress;
                     return scaledProgress;
                 }
 
-                internal override PromiseSingleAwait IncrementProgress(uint amount, ref Fixed32 progress, ushort depth)
+                internal override PromiseSingleAwait IncrementProgress(long amount, ref Fixed32 progress, ushort depth)
                 {
                     ThrowIfInPool(this);
                     // This essentially acts as a pass-through to normalize the progress.
@@ -302,10 +302,10 @@ namespace Proto.Promises
                     return this;
                 }
 
-                private Fixed32 IncrementProgress(uint amount, Fixed32 otherFlags)
+                private Fixed32 IncrementProgress(long amount, Fixed32 otherFlags)
                 {
-                    var unscaledProgress = _unscaledProgress.InterlockedIncrement(amount, otherFlags);
-                    return NormalizeProgress(unscaledProgress);
+                    var unscaledProgress = _unscaledProgress.InterlockedIncrement(amount);
+                    return NormalizeProgress(unscaledProgress, otherFlags);
                 }
             }
 #endif

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
@@ -280,10 +280,15 @@ namespace Proto.Promises
 
                 partial void IncrementProgress(PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler)
                 {
+                    var wasReportingPriority = Fixed32.ts_reportingPriority;
+                    Fixed32.ts_reportingPriority = true;
+
                     Fixed32 progressFlags;
                     uint dif = passThrough.GetProgressDifferenceToCompletion(out progressFlags);
                     var progress = IncrementProgress(dif, progressFlags);
                     ReportProgress(progress, Depth, ref executionScheduler);
+                    
+                    Fixed32.ts_reportingPriority = wasReportingPriority;
                 }
 
                 private Fixed32 NormalizeProgress(UnsignedFixed64 unscaledProgress, Fixed32 otherFlags)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
@@ -1,4 +1,8 @@
-﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+﻿#if UNITY_5_5 || NET_2_0 || NET_2_0_SUBSET
+#define NET_LEGACY
+#endif
+
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
 #define PROMISE_DEBUG
 #else
 #undef PROMISE_DEBUG
@@ -35,7 +39,6 @@ namespace Proto.Promises
                         Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
                         nextHandler = Interlocked.Exchange(ref _waiter, null);
                     }
-                    HandleProgressListener(state, Depth, ref executionScheduler);
                     // handler will be disposed higher in the call stack. We only set it if this is released completely.
                     if (InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0) == 0)
                     {
@@ -121,7 +124,7 @@ namespace Proto.Promises
                         }
 #endif
                         passThrough.SetTargetAndAddToOwner(this);
-                        if (_valueOrPrevious != null)
+                        if (_valueContainer != null)
                         {
                             // This was rejected or canceled potentially before all passthroughs were hooked up. Release all remaining passthroughs.
                             int addCount = 0;
@@ -148,9 +151,9 @@ namespace Proto.Promises
 
                     if (handler.State != Promise.State.Resolved) // Rejected/Canceled
                     {
-                        if (Interlocked.CompareExchange(ref _valueOrPrevious, valueContainer, null) == null)
+                        if (Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) == null)
                         {
-                            _valueOrPrevious = valueContainer.Clone();
+                            _valueContainer = valueContainer.Clone();
                             Handle(ref _waitCount, ref handler, out nextHandler, ref executionScheduler);
                         }
                         if (InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0) == 0)
@@ -164,9 +167,9 @@ namespace Proto.Promises
                         int remaining = InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
                         if (remaining == 1)
                         {
-                            if (Interlocked.CompareExchange(ref _valueOrPrevious, valueContainer, null) == null)
+                            if (Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) == null)
                             {
-                                _valueOrPrevious = valueContainer.Clone();
+                                _valueContainer = valueContainer.Clone();
                                 Handle(ref _waitCount, ref handler, out nextHandler, ref executionScheduler);
                             }
                         }
@@ -185,7 +188,7 @@ namespace Proto.Promises
                 private sealed class MergePromiseT<T> : MergePromise
                 {
                     private Action<ValueContainer, ResolveContainer<T>, int> _onPromiseResolved;
-                    private ResolveContainer<T> _valueContainer;
+                    private ResolveContainer<T> _resolveContainer;
 
                     private MergePromiseT() { }
 
@@ -193,10 +196,10 @@ namespace Proto.Promises
                     {
                         SuperDispose();
                         _onPromiseResolved = null;
-                        if (_valueContainer != null)
+                        if (_resolveContainer != null)
                         {
-                            _valueContainer.DisposeAndMaybeAddToUnhandledStack(false);
-                            _valueContainer = null;
+                            _resolveContainer.DisposeAndMaybeAddToUnhandledStack(false);
+                            _resolveContainer = null;
                         }
 #if PROMISE_DEBUG
                         lock (_locker)
@@ -219,7 +222,7 @@ namespace Proto.Promises
                         var promise = ObjectPool<HandleablePromiseBase>.TryTake<MergePromiseT<T>>()
                             ?? new MergePromiseT<T>();
                         promise._onPromiseResolved = onPromiseResolved;
-                        promise._valueContainer = ResolveContainer<T>.GetOrCreate(value);
+                        promise._resolveContainer = ResolveContainer<T>.GetOrCreate(value);
                         return promise;
                     }
 
@@ -231,9 +234,9 @@ namespace Proto.Promises
 
                         if (handler.State != Promise.State.Resolved) // Rejected/Canceled
                         {
-                            if (Interlocked.CompareExchange(ref _valueOrPrevious, valueContainer, null) == null)
+                            if (Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) == null)
                             {
-                                _valueOrPrevious = valueContainer.Clone();
+                                _valueContainer = valueContainer.Clone();
                                 Handle(ref _waitCount, ref handler, out nextHandler, ref executionScheduler);
                             }
                             if (InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0) == 0)
@@ -243,15 +246,15 @@ namespace Proto.Promises
                         }
                         else // Resolved
                         {
-                            _onPromiseResolved.Invoke(valueContainer, _valueContainer, passThrough.Index);
+                            _onPromiseResolved.Invoke(valueContainer, _resolveContainer, passThrough.Index);
                             IncrementProgress(passThrough, ref executionScheduler);
                             int remaining = InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
                             if (remaining == 1)
                             {
-                                if (Interlocked.CompareExchange(ref _valueOrPrevious, _valueContainer, null) == null)
+                                if (Interlocked.CompareExchange(ref _valueContainer, _resolveContainer, null) == null)
                                 {
                                     // Only nullify if all promises resolved, otherwise we let Dispose release it.
-                                    _valueContainer = null;
+                                    _resolveContainer = null;
                                     Handle(ref _waitCount, ref handler, out nextHandler, ref executionScheduler);
                                 }
                             }
@@ -269,21 +272,6 @@ namespace Proto.Promises
 #if PROMISE_PROGRESS
             partial class MergePromise
             {
-                protected override sealed PromiseRef MaybeAddProgressListenerAndGetPreviousRetained(ref IProgressListener progressListener, ref Fixed32 lastKnownProgress)
-                {
-                    // Unnecessary to set last known since we know SetInitialProgress will be called on this.
-                    ThrowIfInPool(this);
-                    progressListener.Retain();
-                    _progressListener = progressListener;
-                    return null;
-                }
-
-                protected override sealed void SetInitialProgress(IProgressListener progressListener, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    progress = NormalizeProgress(_unscaledProgress);
-                    SetInitialProgress(progressListener, ref progress, Fixed32.FromWholePlusOne(Depth), out nextRef, ref executionScheduler);
-                }
-
                 partial void SetupProgress(ValueLinkedStack<PromisePassThrough> promisePassThroughs, ulong completedProgress, ulong totalProgress)
                 {
                     _unscaledProgress = new UnsignedFixed64(completedProgress);
@@ -292,29 +280,30 @@ namespace Proto.Promises
 
                 partial void IncrementProgress(PromisePassThrough passThrough, ref ExecutionScheduler executionScheduler)
                 {
-                    Fixed32 progressFlags;
-                    uint dif = passThrough.GetProgressDifferenceToCompletion(out progressFlags);
-                    var progress = IncrementProgress(dif, progressFlags);
-                    ReportProgress(progress, ref executionScheduler);
+                    uint dif = passThrough.GetProgressDifferenceToCompletion();
+                    var progress = IncrementProgress(dif);
+                    ReportProgress(progress, Depth, ref executionScheduler);
                 }
 
                 private Fixed32 NormalizeProgress(UnsignedFixed64 unscaledProgress)
                 {
                     ThrowIfInPool(this);
-                    return Fixed32.GetScaled(unscaledProgress, _progressScaler);
+                    var scaledProgress = Fixed32.GetScaled(unscaledProgress, _progressScaler);
+                    _smallFields._currentProgress = scaledProgress;
+                    return scaledProgress;
                 }
 
-                internal override void IncrementProgress(uint amount, ref Fixed32 progress, ushort depth, out PromiseSingleAwaitWithProgress nextRef)
+                internal override PromiseSingleAwait IncrementProgress(uint amount, ref Fixed32 progress, ushort depth)
                 {
                     ThrowIfInPool(this);
                     // This essentially acts as a pass-through to normalize the progress.
-                    nextRef = this;
-                    progress = IncrementProgress(amount, progress);
+                    progress = IncrementProgress(amount);
+                    return this;
                 }
 
-                private Fixed32 IncrementProgress(uint amount, Fixed32 otherFlags)
+                private Fixed32 IncrementProgress(uint amount)
                 {
-                    var unscaledProgress = _unscaledProgress.InterlockedIncrement(amount, otherFlags);
+                    var unscaledProgress = _unscaledProgress.InterlockedIncrement(amount);
                     return NormalizeProgress(unscaledProgress);
                 }
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -925,6 +925,13 @@ namespace Proto.Promises
             partial class AsyncPromiseRef
             {
                 [MethodImpl(InlineOption)]
+                new private void Reset()
+                {
+                    _minProgress = _maxProgress = float.NaN;
+                    base.Reset();
+                }
+
+                [MethodImpl(InlineOption)]
                 private static double Lerp(double a, double b, double t)
                 {
                     return a + (b - a) * t;
@@ -978,7 +985,6 @@ namespace Proto.Promises
 #endif
                     _minProgress = minProgress;
                     _maxProgress = maxProgress;
-                    _smallFields._currentProgress = Fixed32.FromDecimal(minProgress);
                 }
 
                 [MethodImpl(InlineOption)]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -1,4 +1,8 @@
-﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+﻿#if UNITY_5_5 || NET_2_0 || NET_2_0_SUBSET
+#define NET_LEGACY
+#endif
+
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
 #define PROMISE_DEBUG
 #else
 #undef PROMISE_DEBUG
@@ -162,115 +166,48 @@ namespace Proto.Promises
 
         partial class PromiseRef
         {
-            internal partial interface IProgressListener { }
-
             // Calls to these get compiled away when PROGRESS is undefined.
-            partial void WaitWhileProgressFlags(PromiseFlags progressFlags);
-
-            partial class PromiseMultiAwait
-            {
-                partial void HandleProgressListeners(Promise.State state, ref ExecutionScheduler executionScheduler);
-            }
+            partial void WaitWhileProgressReporting();
+            partial void InterlockedIncrementProgressReportingCount();
+            partial void InterlockedDecrementProgressReportingCount();
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
             internal partial struct Fixed32
             {
-                // Since 3 bits are taken for flags, that leaves 29 bits for progress.
-                // 13 bits for decimal part gives us 1/2^13 or 0.0001220703125 step size which is nearly 4 digits of precision
+                // 16 bits for decimal part gives us 1/2^16 or 0.0000152587890625 step size which is nearly 5 digits of precision
                 // and the remaining 16 bits for whole part/depth allows up to 2^16 - 4 or 65532 promise.Then(() => otherPromise) chains, which should be plenty for typical use cases.
-                // Also, SmallFields._depth is a ushort with 16 bits, so this should not be smaller than 13 (though it can be larger, as long as it leaves some bits for the whole part).
-                internal const int DecimalBits = 13;
+                // Also, SmallFields._depth is a ushort with 16 bits, so this should not be smaller than 16 (though it can be larger, as long as it leaves some bits for the whole part).
+                internal const int DecimalBits = 16;
             }
 
-#if !PROMISE_PROGRESS
-            partial void HandleProgressListener(Promise.State state, ushort depth, ref ExecutionScheduler executionScheduler);
-#else
-
-            private void SubscribeListener(IProgressListener progressListener, Fixed32 depthAndProgress, ref ExecutionScheduler executionScheduler)
+#if PROMISE_PROGRESS
+            [MethodImpl(InlineOption)]
+            partial void WaitWhileProgressReporting()
             {
-                PromiseRef current = this;
-                current.InterlockedRetainDisregardId();
-                while (true)
+                Thread.MemoryBarrier(); // Make sure any writes happen before we read.
+                // This is used to make sure progress reports are complete before the next handler is handled.
+                if (_smallFields._reportingProgressCount != 0)
                 {
-                    IProgressListener currentListener = progressListener;
-                    PromiseRef previous = current.MaybeAddProgressListenerAndGetPreviousRetained(ref progressListener, ref depthAndProgress);
-                    if (previous == null)
-                    {
-                        PromiseSingleAwaitWithProgress nextRef;
-                        current._smallFields.InterlockedSetFlags(PromiseFlags.SettingInitial);
-                        current.SetInitialProgress(currentListener, ref depthAndProgress, out nextRef, ref executionScheduler);
-                        current._smallFields.InterlockedUnsetFlags(PromiseFlags.SettingInitial);
-                        current.MaybeDispose();
-                        if (nextRef != null)
-                        {
-                            nextRef.ReportProgress(depthAndProgress, ref executionScheduler);
-                        }
-                        return;
-                    }
-                    current.MaybeDispose();
-                    current = previous;
+                    WaitWhileProgressReportingCore();
                 }
             }
 
-            protected virtual PromiseRef MaybeAddProgressListenerAndGetPreviousRetained(ref IProgressListener progressListener, ref Fixed32 lastKnownProgress)
+            private void WaitWhileProgressReportingCore()
             {
-                ThrowIfInPool(this);
-                // Mark subscribing to prevent repooling while we get previous, then unmark after we have retained previous.
-                _smallFields.InterlockedSetFlags(PromiseFlags.Subscribing);
-                PromiseRef previous = _valueOrPrevious as PromiseRef;
-                if (previous != null)
-                {
-                    previous.InterlockedRetainDisregardId();
-                }
-                _smallFields.InterlockedUnsetFlags(PromiseFlags.Subscribing);
-                return previous;
-            }
-
-            protected virtual void SetInitialProgress(IProgressListener progressListener, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-            {
-                // Rare occurrence,
-                // this will only be called on a PromiseSingleAwait (without progress) in a race condition with another thread completing promises,
-                // or if for some reason the user subscribes progress from a .Then callback (which would be unusual, but perfectly legal).
-                // In either case, do nothing. The progress will be updated on the other thread or current thread when the promise chain completes.
-                ThrowIfInPool(this);
-                nextRef = null;
-            }
-
-            partial void WaitWhileProgressFlags(PromiseFlags progressFlags)
-            {
-                Thread.MemoryBarrier(); // Make sure any writes happen before we read progress flags.
-                // Wait until progressFlags are unset.
-                // This is used to make sure promises and progress listeners aren't disposed while still in use on another thread.
                 var spinner = new SpinWait();
-                while (_smallFields.AreFlagsSet(progressFlags))
+                do
                 {
                     spinner.SpinOnce();
-                }
-            }
-
-            protected virtual bool GetIsProgressSuspended()
-            {
-                var state = _smallFields._state;
-                return state == Promise.State.Canceled
-                    | state == Promise.State.Rejected;
+                } while (_smallFields._reportingProgressCount != 0);
             }
 
             internal partial struct Fixed32
             {
-                // Extra flags are necessary to update the value and the flags atomically without a lock.
-                // Unfortunately, this digs into how how many promises can be chained, but it should still be large enough for most use cases.
-                private const int SuspendedFlag = 1 << 31;
-                internal const int ReportedFlag = 1 << 30;
-                internal const int PriorityFlag = 1 << 29; // Priority is true when called from `Deferred.ReportProgress` or when a promise is resolved, false when called from `Promise.Progress`.
-                
-                private const int FlagsMask = SuspendedFlag | ReportedFlag | PriorityFlag;
-                private const int ValueMask = ~FlagsMask;
-
                 private const double DecimalMax = 1 << DecimalBits;
                 private const int DecimalMask = (1 << DecimalBits) - 1;
-                private const int WholeMask = ValueMask & ~DecimalMask;
+                private const int WholeMask = ~DecimalMask;
 
                 private volatile int _value; // int for Interlocked.
 
@@ -294,19 +231,12 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal static Fixed32 FromWholePlusOneForResolve(ushort wholeValue)
+                internal static Fixed32 FromDecimal(double decimalValue)
                 {
-                    // We don't need to check for overflow here.
-                    return new Fixed32(((wholeValue + 1) << DecimalBits) | PriorityFlag);
+                    return new Fixed32(ConvertToValue(decimalValue));
                 }
 
-                [MethodImpl(InlineOption)]
-                internal static Fixed32 FromDecimalForAsync(double decimalValue)
-                {
-                    // Don't bother rounding, we don't want to accidentally round to 1.0.
-                    return new Fixed32((ushort) (decimalValue * DecimalMax) | PriorityFlag);
-                }
-
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE // Useful for debugging, but not actually used.
                 internal ushort WholePart
                 {
                     [MethodImpl(InlineOption)]
@@ -318,39 +248,16 @@ namespace Proto.Promises
                     [MethodImpl(InlineOption)]
                     get { return (double) (_value & DecimalMask) / DecimalMax; }
                 }
-
-                internal bool IsSuspended
-                {
-                    [MethodImpl(InlineOption)]
-                    get { return (_value & SuspendedFlag) != 0; }
-                }
-
-                internal bool HasReported
-                {
-                    [MethodImpl(InlineOption)]
-                    get { return (_value & ReportedFlag) != 0; }
-                }
-
-                internal bool IsPriority
-                {
-                    [MethodImpl(InlineOption)]
-                    get { return GetPriorityFlag() != 0; }
-                }
-
-                [MethodImpl(InlineOption)]
-                internal int GetPriorityFlag()
-                {
-                    return _value & PriorityFlag;
-                }
+#endif
 
                 [MethodImpl(InlineOption)]
                 internal static ushort GetNextDepth(ushort depth)
                 {
-#if PROMISE_DEBUG
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
                     // We allow ushort.MaxValue to rollover for progress normalization purposes, but we don't allow overflow for regular user chains.
-                    // Subtract 4 so that promise retains will not overflow when subscribing progress (2 initial retains plus a retain in SubscribeListener plus some buffer).
-                    const int DepthBits = (32 - 3) - DecimalBits;
-                    const ushort MaxValue = ((1 << DepthBits) - 2) - (DecimalBits > 13 ? 0 : 4);
+                    // Subtract 4 so that promise retains will not overflow (2 initial retains plus some buffer).
+                    const int DepthBits = 32 - DecimalBits;
+                    const ushort MaxValue = (1 << DepthBits) - 2 - 4;
                     if (depth == MaxValue)
                     {
                         throw new OverflowException("Promise chain length exceeded maximum of " + MaxValue);
@@ -367,7 +274,7 @@ namespace Proto.Promises
                 {
                     unchecked
                     {
-                        return (uint) (_value & ValueMask);
+                        return (uint) _value;
                     }
                 }
 
@@ -387,148 +294,64 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 internal static Fixed32 GetScaled(UnsignedFixed64 value, double scaler)
                 {
-                    // Don't bother rounding, we don't want to accidentally round to 1.0.
-                    int newValue = (int) (value.ToDouble() * scaler * DecimalMax);
                     unchecked
                     {
-                        return new Fixed32(newValue | (int) (value.GetPriorityFlag() >> 32));
+                        // Don't bother rounding, we don't want to accidentally round to 1.0.
+                        int newValue = (int) (value.ToDouble() * scaler * DecimalMax);
+                        return new Fixed32(newValue);
                     }
                 }
 
-                internal bool InterlockedTrySetIfGreater(Fixed32 other, Fixed32 otherFlags)
+                internal bool InterlockedTrySetIfGreater(Fixed32 other)
                 {
                     Thread.MemoryBarrier();
                     int otherValue = other._value;
-                    int otherComparer = otherValue & ValueMask;
-                    int newValue = otherValue | ReportedFlag | (otherFlags._value & FlagsMask);
                     int current;
                     do
                     {
                         current = _value;
-                        if (otherComparer < (current & ValueMask))
+                        if (otherValue <= current)
                         {
                             return false;
                         }
-                    } while (Interlocked.CompareExchange(ref _value, newValue, current) != current);
+                    } while (Interlocked.CompareExchange(ref _value, otherValue, current) != current);
                     return true;
                 }
 
                 [MethodImpl(InlineOption)]
-                internal bool InterlockedTrySetAndGetDifference(Fixed32 other, out uint dif)
+                internal uint InterlockedSetAndGetDifference(Fixed32 other)
                 {
-                    int oldValue;
-                    bool didSet = InterlockedTrySet(other, out oldValue);
+                    Thread.MemoryBarrier();
+                    int oldValue = Exchange(other._value);
                     unchecked
                     {
-                        dif = (uint) (other._value & ValueMask) - (uint) (oldValue & ValueMask);
+                        return (uint) other._value - (uint) oldValue;
                     }
-                    return didSet;
                 }
 
                 [MethodImpl(InlineOption)]
-                internal Fixed32 SetNewDecimalPartFromDeferred(double decimalPart)
+                private int Exchange(int value)
                 {
-                    // Don't bother rounding, we don't want to accidentally round to 1.0.
-                    int newDecimalPart = (int) (decimalPart * DecimalMax);
-                    int newValue = (_value & WholeMask) | newDecimalPart | ReportedFlag | PriorityFlag;
-                    _value = newValue;
-                    return new Fixed32(newValue);
-                }
-
-                internal bool InterlockedTrySet(Fixed32 other)
-                {
-                    int _;
-                    return InterlockedTrySet(other, out _);
-                }
-
-                private bool InterlockedTrySet(Fixed32 other, out int oldValue)
-                {
-                    Thread.MemoryBarrier();
-                    int otherValue = other._value;
-                    int otherWholePart = other.WholePart;
-                    bool otherIsPriority = (other._value & PriorityFlag) != 0;
-                    int current, newValue;
-                    bool success;
+#if NET_LEGACY // Interlocked.Exchange doesn't seem to work properly in Unity's old runtime. Use CompareExchange in a loop instead.
+                    int oldValue;
                     do
                     {
-                        current = _value;
-                        int currentWholePart = (current & WholeMask) >> DecimalBits;
-                        bool currentIsSuspended = (current & SuspendedFlag) != 0;
-                        bool currentHasReported = (current & ReportedFlag) != 0;
-                        success = !(otherWholePart < currentWholePart
-                            // Same thing, but more edge-case. If this is suspended, it means this was updated from a canceled or rejected promise, so it can only be further updated by a promise with a higher depth (WholePart).
-                            | (currentIsSuspended & otherWholePart == currentWholePart)
-                            // Don't bother updating if the values are the same, unless this is the first time being set.
-                            | ((current & ValueMask) == (otherValue & ValueMask) & currentHasReported)
-                            // Only update if other is priority or this has not reported, or other whole is definitely larger.
-                            | (!otherIsPriority & currentHasReported & otherWholePart <= currentWholePart));
-                        newValue = success
-                            ? otherValue | ReportedFlag
-                            // Just update reported flag
-                            : current | ReportedFlag;
-                    } while (Interlocked.CompareExchange(ref _value, newValue, current) != current);
-                    oldValue = current;
-                    return success;
-                }
-
-                internal bool InterlockedTrySetFromResolve(Fixed32 other)
-                {
-                    Thread.MemoryBarrier();
-                    int otherValue = other._value;
-                    int otherWholePart = other.WholePart;
-                    int current, newValue;
-                    bool success;
-                    do
-                    {
-                        current = _value;
-                        int currentWholePart = (current & WholeMask) >> DecimalBits;
-                        success = otherWholePart > currentWholePart;
-                        newValue = success
-                            ? otherValue | ReportedFlag
-                            // Just update reported flag
-                            : current | ReportedFlag;
-                    } while (Interlocked.CompareExchange(ref _value, newValue, current) != current);
-                    return success;
-                }
-
-                internal void MaybeSuspend()
-                {
-                    int current = _value;
-                    Interlocked.CompareExchange(ref _value, current | SuspendedFlag, current);
-                }
-
-                internal void InterlockedSuspendIfOtherWholeIsGreater(Fixed32 other)
-                {
-                    Thread.MemoryBarrier();
-                    int otherWholePart = other.WholePart;
-                    int oldWholePart = WholePart;
-                    int current;
-                    int newValue;
-                    do
-                    {
-                        current = _value;
-                        int currentWholePart = (current & WholeMask) >> DecimalBits;
-                        // If other whole is less than or equal, or if the updated whole is greater than the old whole, do nothing.
-                        if (otherWholePart <= currentWholePart | oldWholePart < currentWholePart)
-                        {
-                            return;
-                        }
-                        newValue = current | SuspendedFlag;
-                    } while (Interlocked.CompareExchange(ref _value, newValue, current) != current);
-                }
-
-                internal Fixed32 GetIncrementedWholeTruncated()
-                {
-                    int value = _value;
-                    int newValue = (value & WholeMask) + (1 << DecimalBits);
-#if PROMISE_DEBUG
-                    if ((newValue & ValueMask) != newValue)
-                    {
-                        throw new OverflowException();
-                    }
+                        oldValue = _value;
+                    } while (Interlocked.CompareExchange(ref _value, value, oldValue) != oldValue);
+                    return oldValue;
+#else
+                    return Interlocked.Exchange(ref _value, value);
 #endif
-                    int currentReportedAndPriorityFlags = value & ReportedFlag & PriorityFlag;
-                    return new Fixed32(newValue | currentReportedAndPriorityFlags);
+                }
+
+                [MethodImpl(InlineOption)]
+                internal bool TrySetNewDecimalPartFromDeferred(double decimalPart, out Fixed32 result)
+                {
+                    int newValue = ConvertToValue(decimalPart);
+                    int oldValue = Exchange(newValue);
+                    result = new Fixed32(newValue);
+                    // If the new value is the same as the old value, we won't bother to report it.
+                    return newValue != oldValue;
                 }
 
                 [MethodImpl(InlineOption)]
@@ -542,18 +365,16 @@ namespace Proto.Promises
                 internal Fixed32 MultiplyAndDivide(double multiplier, double divisor)
                 {
                     int value = _value;
-                    int flags = value & FlagsMask;
                     double dValue = ConvertToDouble(value) * multiplier / divisor;
-                    return new Fixed32(ConvertToValue(dValue) | flags);
+                    return new Fixed32(ConvertToValue(dValue));
                 }
 
                 internal Fixed32 DivideAndAdd(double divisor, ushort addend)
                 {
                     int value = _value;
-                    int flags = value & FlagsMask;
                     double dValue = ConvertToDouble(value) / divisor;
                     value = ConvertToValue(dValue) + (addend << DecimalBits);
-                    return new Fixed32(value | flags);
+                    return new Fixed32(value);
                 }
             }
 
@@ -566,10 +387,9 @@ namespace Proto.Promises
 #endif
             internal struct UnsignedFixed64 // Simplified compared to Fixed32 to remove unused functions.
             {
-                internal const long PriorityFlag = ((long) Fixed32.PriorityFlag) << 32;
                 private const double DecimalMax = 1L << Fixed32.DecimalBits;
                 private const long DecimalMask = (1L << Fixed32.DecimalBits) - 1L;
-                private const long WholeMask = ~PriorityFlag & ~DecimalMask;
+                private const long WholeMask = ~DecimalMask;
 
                 private long _value; // long for Interlocked.
 
@@ -588,18 +408,6 @@ namespace Proto.Promises
                     _value = value;
                 }
 
-                [MethodImpl(InlineOption)]
-                internal long GetPriorityFlag()
-                {
-                    return _value | PriorityFlag;
-                }
-
-                internal bool IsPriority
-                {
-                    [MethodImpl(InlineOption)]
-                    get { return GetPriorityFlag() != 0; }
-                }
-
                 internal double ToDouble()
                 {
                     unchecked
@@ -612,50 +420,27 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal UnsignedFixed64 InterlockedIncrement(uint increment, Fixed32 otherFlags)
+                internal UnsignedFixed64 InterlockedIncrement(uint increment)
                 {
-                    Thread.MemoryBarrier();
-                    long priorityFlag = ((long) otherFlags.GetPriorityFlag()) << 32;
-                    long current;
-                    long newValue;
-                    do
-                    {
-                        current = Interlocked.Read(ref _value);
-                        newValue = (current + increment) | priorityFlag;
-                    } while (Interlocked.CompareExchange(ref _value, newValue, current) != current);
+                    long newValue = Interlocked.Add(ref _value, increment);
                     return new UnsignedFixed64(newValue);
                 }
             }
 
-            partial interface IProgressListener : ILinked<IProgressListener>
-            {
-                void SetInitialProgress(PromiseRef sender, Promise.State state, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler);
-                void SetProgress(PromiseRef sender, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler);
-                void ResolveOrSetProgress(PromiseRef sender, Fixed32 progress, ref ExecutionScheduler executionScheduler);
-                void MaybeCancelProgress(Fixed32 progress);
-                void Retain();
-            }
-
             partial class MultiHandleablePromiseBase
             {
-                internal abstract void IncrementProgress(uint increment, ref Fixed32 progress, ushort depth, out PromiseSingleAwaitWithProgress nextRef);
+                internal abstract PromiseSingleAwait IncrementProgress(uint increment, ref Fixed32 progress, ushort depth);
             }
 
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal sealed partial class PromiseProgress<TProgress> : PromiseSingleAwaitWithProgress, IProgressListener, IProgressInvokable, ICancelable
+            internal sealed partial class PromiseProgress<TProgress> : PromiseSingleAwait, IProgressInvokable, ICancelable
                 where TProgress : IProgress<float>
             {
                 private static readonly WaitCallback _threadPoolCallback = ExecuteFromContext;
                 private static readonly SendOrPostCallback _synchronizationContextCallback = ExecuteFromContext;
-
-                [MethodImpl(InlineOption)]
-                protected override bool GetIsProgressSuspended()
-                {
-                    return _smallProgressFields._currentProgress.IsSuspended;
-                }
 
                 internal bool IsInvoking1
                 {
@@ -680,7 +465,6 @@ namespace Proto.Promises
                     promise.Reset(depth);
                     promise._progress = progress;
                     promise.IsCanceled = false;
-                    promise._smallProgressFields._currentProgress = default(Fixed32);
                     promise._smallProgressFields._isSynchronous = isSynchronous;
                     promise._smallProgressFields._previousState = Promise.State.Pending;
                     promise._smallProgressFields._mostRecentPotentialScheduleMethod = (int) ScheduleMethod.None;
@@ -696,12 +480,11 @@ namespace Proto.Promises
                     promise.Reset(depth);
                     promise._progress = progress;
                     promise.IsCanceled = false;
-                    promise._smallProgressFields._currentProgress = default(Fixed32);
                     promise._smallProgressFields._isSynchronous = false;
                     promise._smallProgressFields._previousState = Promise.State.Resolved;
                     promise._smallProgressFields._mostRecentPotentialScheduleMethod = (int) ScheduleMethod.None;
                     promise._synchronizationContext = synchronizationContext;
-                    promise._valueOrPrevious = valueContainer;
+                    promise._valueContainer = valueContainer;
                     cancelationToken.TryRegister(promise, out promise._cancelationRegistration); // Very important, must register after promise is fully setup.
                     return promise;
                 }
@@ -718,157 +501,47 @@ namespace Proto.Promises
                 {
                     ThrowIfInPool(this);
                     Thread.MemoryBarrier(); // Make sure we're reading fresh progress (since the field cannot be marked volatile).
-                    var progress = _smallProgressFields._currentProgress;
+                    var progress = _smallFields._currentProgress;
                     _smallFields.InterlockedUnsetFlags(PromiseFlags.InProgressQueue);
                     // Calculate the normalized progress for the depth that the listener was added.
                     // Use double for better precision.
                     double expected = Depth + 1u;
                     float value = (float) (progress.ToDouble() / expected);
-                    if (!progress.IsSuspended & !IsInvoking1 & !IsCanceled & !_cancelationRegistration.Token.IsCancelationRequested)
+                    if (!IsInvoking1 & !IsCanceled & !_cancelationRegistration.Token.IsCancelationRequested)
                     {
                         CallbackHelper.InvokeAndCatchProgress(_progress, value, this);
                     }
                     MaybeDispose();
                 }
 
-                void IProgressListener.SetProgress(PromiseRef sender, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
+                internal void MaybeReportProgress(ref ExecutionScheduler executionScheduler)
                 {
-                    ThrowIfInPool(this);
-                    bool needsInvoke = _smallProgressFields._currentProgress.InterlockedTrySet(progress);
-                    if (needsInvoke & !IsInvoking1 & !IsCanceled)
+                    PromiseFlags oldFlags = _smallFields.InterlockedSetFlags(PromiseFlags.InProgressQueue);
+                    bool inProgressQueue = (oldFlags & PromiseFlags.InProgressQueue) != 0;
+                    if (!inProgressQueue)
                     {
-                        PromiseFlags oldFlags = _smallFields.InterlockedSetFlags(PromiseFlags.InProgressQueue);
-                        bool inProgressQueue = (oldFlags & PromiseFlags.InProgressQueue) != 0;
-                        if (!inProgressQueue)
+                        InterlockedRetainDisregardId();
+                        if (_smallProgressFields._isSynchronous)
                         {
-                            InterlockedRetainDisregardId();
-                            if (_smallProgressFields._isSynchronous)
-                            {
-                                executionScheduler.ScheduleProgressSynchronous(this);
-                            }
-                            else
-                            {
-                                executionScheduler.ScheduleProgressOnContext(_synchronizationContext, this);
-                            }
+                            executionScheduler.ScheduleProgressSynchronous(this);
                         }
-                        nextRef = this;
-                    }
-                    else
-                    {
-                        nextRef = null;
-                    }
-                }
-
-                [MethodImpl(InlineOption)]
-                private void SetProgressFromResolve(Fixed32 progress, ref ExecutionScheduler executionScheduler)
-                {
-                    bool needsInvoke = _smallProgressFields._currentProgress.InterlockedTrySetFromResolve(progress);
-                    if (needsInvoke & !IsInvoking1 & !IsCanceled)
-                    {
-                        PromiseFlags oldFlags = _smallFields.InterlockedSetFlags(PromiseFlags.InProgressQueue);
-                        bool inProgressQueue = (oldFlags & PromiseFlags.InProgressQueue) != 0;
-                        if (!inProgressQueue)
+                        else
                         {
-                            InterlockedRetainDisregardId();
-                            if (_smallProgressFields._isSynchronous)
-                            {
-                                executionScheduler.ScheduleProgressSynchronous(this);
-                            }
-                            else
-                            {
-                                executionScheduler.ScheduleProgressOnContext(_synchronizationContext, this);
-                            }
+                            executionScheduler.ScheduleProgressOnContext(_synchronizationContext, this);
                         }
                     }
                 }
 
-                void IProgressListener.ResolveOrSetProgress(PromiseRef sender, Fixed32 progress, ref ExecutionScheduler executionScheduler)
+                internal override PromiseSingleAwait SetProgress(ref Fixed32 progress, ushort depth, ref ExecutionScheduler executionScheduler)
                 {
                     ThrowIfInPool(this);
-                    if (sender != _valueOrPrevious) // If sender is previous, this is being resolved, so we don't need to set progress.
+                    _smallFields._currentProgress = progress;
+                    if (!IsCanceled)
                     {
-                        SetProgressFromResolve(progress, ref executionScheduler);
+                        MaybeReportProgress(ref executionScheduler);
+                        return this;
                     }
-                    MaybeDispose();
-                }
-
-                void IProgressListener.SetInitialProgress(PromiseRef sender, Promise.State state, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    ThrowIfInPool(this);
-                    switch (state)
-                    {
-                        case Promise.State.Pending:
-                        {
-                            if (!sender.GetIsProgressSuspended()
-                                && _smallProgressFields._currentProgress.InterlockedTrySet(progress)
-                                && (_smallFields.InterlockedSetFlags(PromiseFlags.InProgressQueue) & PromiseFlags.InProgressQueue) == 0) // Was not already in progress queue?
-                            {
-                                InterlockedRetainDisregardId();
-                                if (_smallProgressFields._isSynchronous)
-                                {
-                                    executionScheduler.ScheduleProgressSynchronous(this);
-                                }
-                                else
-                                {
-                                    executionScheduler.ScheduleProgressOnContext(_synchronizationContext, this);
-                                }
-                            }
-                            break;
-                        }
-                        case Promise.State.Resolved:
-                        {
-                            if (sender != _valueOrPrevious
-                                && _smallProgressFields._currentProgress.InterlockedTrySetFromResolve(progress)
-                                && (_smallFields.InterlockedSetFlags(PromiseFlags.InProgressQueue) & PromiseFlags.InProgressQueue) == 0) // Was not already in progress queue?
-                            {
-                                if (_smallProgressFields._isSynchronous)
-                                {
-                                    executionScheduler.ScheduleProgressSynchronous(this);
-                                }
-                                else
-                                {
-                                    executionScheduler.ScheduleProgressOnContext(_synchronizationContext, this);
-                                }
-                                break; // Break instead of InterlockedRetainDisregardId().
-                            }
-                            MaybeDispose();
-                            break;
-                        }
-                        default: // Rejected or Canceled:
-                        {
-                            _smallProgressFields._currentProgress.MaybeSuspend();
-                            MaybeDispose();
-                            break;
-                        }
-                    }
-                    nextRef = null;
-                }
-
-                void IProgressListener.MaybeCancelProgress(Fixed32 progress)
-                {
-                    ThrowIfInPool(this);
-                    _smallProgressFields._currentProgress.InterlockedSuspendIfOtherWholeIsGreater(progress);
-                    MaybeDispose();
-                }
-
-                protected override void SetInitialProgress(IProgressListener progressListener, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    ThrowIfInPool(this);
-                    Promise.State state = State;
-                    if (state == Promise.State.Pending & !IsCanceled)
-                    {
-                        progress = _smallProgressFields._currentProgress;
-                        progressListener.SetInitialProgress(this, state, ref progress, out nextRef, ref executionScheduler);
-                        return;
-                    }
-                    if (Interlocked.CompareExchange(ref _progressListener, null, progressListener) == progressListener)
-                    {
-                        progress = Fixed32.FromWholePlusOne(Depth);
-                        WaitWhileProgressFlags(PromiseFlags.ReportingPriority | PromiseFlags.ReportingInitial);
-                        progressListener.SetInitialProgress(this, state, ref progress, out nextRef, ref executionScheduler);
-                        return;
-                    }
-                    nextRef = null;
+                    return null;
                 }
 
                 internal override void Handle(ref ExecutionScheduler executionScheduler)
@@ -885,17 +558,15 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
                     var state = handler.State;
                     _smallProgressFields._previousState = state;
-                    _valueOrPrevious = ((ValueContainer) handler._valueOrPrevious).Clone();
+                    _valueContainer = handler._valueContainer.Clone();
 
                     if (!_smallProgressFields._isSynchronous)
                     {
                         nextHandler = null;
                         executionScheduler.ScheduleOnContext(_synchronizationContext, this);
-                        WaitWhileProgressFlags(PromiseFlags.Subscribing);
                         return;
                     }
 
-                    WaitWhileProgressFlags(PromiseFlags.Subscribing);
                     handler.MaybeDispose();
                     handler = this;
 
@@ -928,8 +599,6 @@ namespace Proto.Promises
                         State = state;
                         Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
                         nextHandler = Interlocked.Exchange(ref _waiter, null);
-
-                        HandleProgressListener(state, Depth, ref executionScheduler);
                     }
                 }
 
@@ -937,20 +606,6 @@ namespace Proto.Promises
                 {
                     ThrowIfInPool(this);
                     IsCanceled = true;
-                }
-
-                void IProgressListener.Retain()
-                {
-                    ThrowIfInPool(this);
-                    InterlockedRetainDisregardId();
-                }
-                protected override PromiseRef MaybeAddProgressListenerAndGetPreviousRetained(ref IProgressListener progressListener, ref Fixed32 lastKnownProgress)
-                {
-                    ThrowIfInPool(this);
-                    progressListener.Retain();
-                    SetProgressListener(progressListener);
-                    //lastKnownProgress = _smallProgressFields._depthAndProgress; // Unnecessary to set last known since we know SetInitialProgress will be called on this.
-                    return null;
                 }
 
                 protected override void OnForgetOrHookupFailed()
@@ -1028,7 +683,6 @@ namespace Proto.Promises
                         HandleablePromiseBase nextHandler = _this._waiter;
                         _this._waiter = null;
                         var executionScheduler = new ExecutionScheduler(true);
-                        _this.HandleProgressListener(_state, _this.Depth, ref executionScheduler);
                         _this.MaybeHandleNext(nextHandler, ref executionScheduler);
                         executionScheduler.Execute();
                     }
@@ -1040,328 +694,100 @@ namespace Proto.Promises
                 }
             } // PromiseProgress<TProgress>
 
-            partial class PromiseSingleAwait
+            [MethodImpl(InlineOption)]
+            partial void InterlockedIncrementProgressReportingCount()
             {
-                internal virtual void HandleProgressListener(Promise.State state, ushort depth, ref ExecutionScheduler executionScheduler) { }
+                InterlockedAddWithOverflowCheck(ref _smallFields._reportingProgressCount, 1, -1);
             }
 
-            partial class PromiseSingleAwaitWithProgress
+            [MethodImpl(InlineOption)]
+            partial void InterlockedDecrementProgressReportingCount()
             {
+                InterlockedAddWithOverflowCheck(ref _smallFields._reportingProgressCount, -1, 0);
+            }
+
+            partial class PromiseSingleAwait
+            {
+                internal override PromiseSingleAwait SetProgress(ref Fixed32 progress, ushort depth, ref ExecutionScheduler executionScheduler)
+                {
+                    _smallFields._currentProgress = progress;
+                    return this;
+                }
+
                 [MethodImpl(InlineOption)]
-                protected void SetProgressListener(IProgressListener progressListener)
+                internal void ReportProgress(Fixed32 progress, ushort depth, ref ExecutionScheduler executionScheduler)
                 {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    var oldListener = Interlocked.CompareExchange(ref _progressListener, progressListener, null);
-                    if (oldListener != null)
-                    {
-                        throw new System.InvalidOperationException("Cannot add more than 1 progress listener."
-                            + "\nAttempted to add listener: " + progressListener
-                            + "\nexisting listener: " + oldListener);
-                    }
-#else
-                    _progressListener = progressListener;
-#endif
+                    InterlockedIncrementProgressReportingCount();
+                    ReportProgressAlreadyIncremented(progress, depth, ref executionScheduler);
                 }
 
-                protected void SetInitialProgress(IProgressListener progressListener, ref Fixed32 progress, Fixed32 expectedProgress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
+                protected void ReportProgressAlreadyIncremented(Fixed32 progress, ushort depth, ref ExecutionScheduler executionScheduler)
                 {
-                    ThrowIfInPool(this);
-                    Promise.State state = State;
-                    if (state == Promise.State.Pending)
+                    PromiseSingleAwait current = this;
+                    while (true)
                     {
-                        progressListener.SetInitialProgress(this, state, ref progress, out nextRef, ref executionScheduler);
-                        return;
-                    }
-                    if (Interlocked.CompareExchange(ref _progressListener, null, progressListener) == progressListener)
-                    {
-                        progress = expectedProgress;
-                        WaitWhileProgressFlags(PromiseFlags.ReportingPriority | PromiseFlags.ReportingInitial);
-                        progressListener.SetInitialProgress(this, state, ref progress, out nextRef, ref executionScheduler);
-                        return;
-                    }
-                    nextRef = null;
-                }
-
-                internal override sealed void HandleProgressListener(Promise.State state, ushort depth, ref ExecutionScheduler executionScheduler)
-                {
-                    IProgressListener progressListener = Interlocked.Exchange(ref _progressListener, null);
-                    WaitWhileProgressFlags(PromiseFlags.ReportingPriority | PromiseFlags.ReportingInitial | PromiseFlags.SettingInitial);
-                    if (progressListener != null)
-                    {
-                        Fixed32 progress = Fixed32.FromWholePlusOneForResolve(depth);
-                        if (state == Promise.State.Resolved)
-                        {
-                            progressListener.ResolveOrSetProgress(this, progress, ref executionScheduler);
-                        }
-                        else
-                        {
-                            progressListener.MaybeCancelProgress(progress);
-                        }
-                    }
-                }
-
-                internal void ReportProgress(Fixed32 progress, ref ExecutionScheduler executionScheduler)
-                {
-                    PromiseSingleAwaitWithProgress setter = this;
-                    do
-                    {
-                        PromiseFlags setFlag = progress.IsPriority ? PromiseFlags.ReportingPriority : PromiseFlags.ReportingInitial;
-                        if ((setter._smallFields.InterlockedSetFlags(setFlag) & setFlag) != 0)
+                        var progressListener = current._waiter;
+                        if (progressListener == null)
                         {
                             break;
                         }
-                        PromiseSingleAwaitWithProgress unsetter = setter;
-
-                        IProgressListener progressListener = setter._progressListener;
-                        if (progressListener != null)
+                        var next = progressListener.SetProgress(ref progress, depth, ref executionScheduler);
+                        if (next == null)
                         {
-                            progressListener.SetProgress(this, ref progress, out setter, ref executionScheduler);
+                            break;
                         }
-                        else
-                        {
-                            setter = null;
-                        }
-                        unsetter._smallFields.InterlockedUnsetFlags(setFlag);
-                    } while (setter != null);
+                        next.InterlockedIncrementProgressReportingCount();
+                        current.InterlockedDecrementProgressReportingCount();
+                        current = next;
+                        depth = current.Depth;
+                    }
+                    current.InterlockedDecrementProgressReportingCount();
                 }
             } // PromiseSingleAwaitWithProgress
 
             partial class PromiseMultiAwait : IProgressInvokable
             {
-                [MethodImpl(InlineOption)]
-                new private void Reset(ushort depth)
-                {
-                    _progressAndLocker._currentProgress = default(Fixed32);
-                    base.Reset(depth);
-                }
-
-                protected override PromiseRef MaybeAddProgressListenerAndGetPreviousRetained(ref IProgressListener progressListener, ref Fixed32 lastKnownProgress)
+                internal override PromiseSingleAwait SetProgress(ref Fixed32 progress, ushort depth, ref ExecutionScheduler executionScheduler)
                 {
                     ThrowIfInPool(this);
-                    progressListener.Retain();
-                    lastKnownProgress = _progressAndLocker._currentProgress;
-                    bool notSubscribed = (_smallFields.InterlockedSetFlags(PromiseFlags.Subscribed) & PromiseFlags.Subscribed) == 0;
-                    _progressAndLocker._progressCollectionLocker.Enter();
-                    _progressListeners.Enqueue(progressListener);
-                    _progressAndLocker._progressCollectionLocker.Exit();
-
-                    PromiseRef previous = null;
-                    if (notSubscribed)
-                    {
-                        // Mark subscribing to prevent repooling while we get previous, then unmark after we have retained previous.
-                        _smallFields.InterlockedSetFlags(PromiseFlags.Subscribing);
-                        previous = _valueOrPrevious as PromiseRef;
-                        if (previous != null)
-                        {
-                            previous.InterlockedRetainDisregardId();
-                        }
-                        _smallFields.InterlockedUnsetFlags(PromiseFlags.Subscribing);
-                    }
-                    progressListener = this;
-                    return previous;
-                }
-
-                protected override void SetInitialProgress(IProgressListener progressListener, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    ThrowIfInPool(this);
-                    Promise.State state = State;
-                    if (state == Promise.State.Pending)
-                    {
-                        _progressAndLocker._progressCollectionLocker.Enter();
-                        bool contained = _progressListeners.Contains(progressListener);
-                        _progressAndLocker._progressCollectionLocker.Exit();
-
-                        if (contained)
-                        {
-                            progress = _progressAndLocker._currentProgress;
-                            progressListener.SetInitialProgress(this, state, ref progress, out nextRef, ref executionScheduler);
-                            return;
-                        }
-                    }
-                    else
-                    {
-                        _progressAndLocker._progressCollectionLocker.Enter();
-                        bool removed = _progressListeners.TryRemove(progressListener);
-                        _progressAndLocker._progressCollectionLocker.Exit();
-
-                        if (removed)
-                        {
-                            progress = Fixed32.FromWholePlusOne(Depth);
-                            WaitWhileProgressFlags(PromiseFlags.ReportingPriority | PromiseFlags.ReportingInitial);
-                            progressListener.SetInitialProgress(this, state, ref progress, out nextRef, ref executionScheduler);
-                            return;
-                        }
-                    }
-                    nextRef = null;
-                }
-
-                partial void HandleProgressListeners(Promise.State state, ref ExecutionScheduler executionScheduler)
-                {
-                    _progressAndLocker._progressCollectionLocker.Enter();
-                    var progressListeners = _progressListeners.MoveElementsToStack();
-                    _progressAndLocker._progressCollectionLocker.Exit();
-
-                    WaitWhileProgressFlags(PromiseFlags.ReportingPriority | PromiseFlags.ReportingInitial | PromiseFlags.SettingInitial);
-                    if (progressListeners.IsEmpty)
-                    {
-                        return;
-                    }
-
-                    Fixed32 progress = Fixed32.FromWholePlusOneForResolve(Depth);
-                    if (state == Promise.State.Resolved)
-                    {
-                        do
-                        {
-                            progressListeners.Pop().ResolveOrSetProgress(this, progress, ref executionScheduler);
-                        } while (progressListeners.IsNotEmpty);
-                        return;
-                    }
-
-                    do
-                    {
-                        progressListeners.Pop().MaybeCancelProgress(progress);
-                    } while (progressListeners.IsNotEmpty);
-                }
-
-                void IProgressListener.SetInitialProgress(PromiseRef sender, Promise.State state, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    ThrowIfInPool(this);
-                    switch (state)
-                    {
-                        case Promise.State.Pending:
-                        {
-                            if (!sender.GetIsProgressSuspended()
-                                && _progressAndLocker._currentProgress.InterlockedTrySet(progress)
-                                && (_smallFields.InterlockedSetFlags(PromiseFlags.InProgressQueue) & PromiseFlags.InProgressQueue) == 0) // Was not already in progress queue?
-                            {
-                                InterlockedRetainDisregardId();
-                                executionScheduler.ScheduleProgressSynchronous(this);
-                            }
-                            break;
-                        }
-                        case Promise.State.Resolved:
-                        {
-                            if (sender != _valueOrPrevious
-                                && _progressAndLocker._currentProgress.InterlockedTrySetFromResolve(progress)
-                                && (_smallFields.InterlockedSetFlags(PromiseFlags.InProgressQueue) & PromiseFlags.InProgressQueue) == 0) // Was not already in progress queue?
-                            {
-                                executionScheduler.ScheduleProgressSynchronous(this);
-                                break; // Break instead of InterlockedRetainDisregardId().
-                            }
-                            MaybeDispose();
-                            break;
-                        }
-                        default: // Rejected or Canceled:
-                        {
-                            _progressAndLocker._currentProgress.MaybeSuspend();
-                            MaybeDispose();
-                            break;
-                        }
-                    }
-                    nextRef = null;
-                }
-
-                private void SetProgress(Fixed32 progress, ref ExecutionScheduler executionScheduler)
-                {
-                    // If this is coming from hookup progress, we can possibly report without updating the progress.
-                    // This is to handle race condition on separate threads.
-                    if ((_progressAndLocker._currentProgress.InterlockedTrySet(progress) | !progress.IsPriority)
-                        && (_smallFields.InterlockedSetFlags(PromiseFlags.InProgressQueue) & PromiseFlags.InProgressQueue) == 0) // Was not already in progress queue?
+                    _smallFields._currentProgress = progress;
+                    if ((_smallFields.InterlockedSetFlags(PromiseFlags.InProgressQueue) & PromiseFlags.InProgressQueue) == 0) // Was not already in progress queue?
                     {
                         InterlockedRetainDisregardId();
                         executionScheduler.ScheduleProgressSynchronous(this);
                     }
-                }
-
-                void IProgressListener.SetProgress(PromiseRef sender, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    ThrowIfInPool(this);
-                    nextRef = null;
-                    SetProgress(progress, ref executionScheduler);
-                }
-
-                void IProgressListener.MaybeCancelProgress(Fixed32 progress)
-                {
-                    _progressAndLocker._currentProgress.InterlockedSuspendIfOtherWholeIsGreater(progress);
-                    MaybeDispose();
-                }
-
-                private void SetProgressFromResolve(Fixed32 progress, ref ExecutionScheduler executionScheduler)
-                {
-                    if (_progressAndLocker._currentProgress.InterlockedTrySetFromResolve(progress)
-                        && (_smallFields.InterlockedSetFlags(PromiseFlags.InProgressQueue) & PromiseFlags.InProgressQueue) == 0) // Was not already in progress queue?
-                    {
-                        InterlockedRetainDisregardId();
-                        executionScheduler.ScheduleProgressSynchronous(this);
-                    }
-                }
-
-                void IProgressListener.ResolveOrSetProgress(PromiseRef sender, Fixed32 progress, ref ExecutionScheduler executionScheduler)
-                {
-                    ThrowIfInPool(this);
-                    SetProgressFromResolve(progress, ref executionScheduler);
-                    MaybeDispose();
-                }
-
-                void IProgressListener.Retain()
-                {
-                    ThrowIfInPool(this);
-                    InterlockedRetainDisregardId();
+                    return null;
                 }
 
                 void IProgressInvokable.Invoke(ref ExecutionScheduler executionScheduler)
                 {
                     ThrowIfInPool(this);
                     Thread.MemoryBarrier(); // Make sure we're reading fresh progress (since the field cannot be marked volatile).
-                    var progress = _progressAndLocker._currentProgress;
+                    var progress = _smallFields._currentProgress;
                     _smallFields.InterlockedUnsetFlags(PromiseFlags.InProgressQueue);
-                    if (!progress.IsSuspended)
+                    // Lock is necessary for race condition with Handle.
+                    // TODO: refactor to remove the need for a lock here.
+                    lock (this)
                     {
-                        // Lock is necessary for race condition with Handle.
-                        // TODO: refactor to remove the need for a lock here.
-                        _progressAndLocker._progressCollectionLocker.Enter();
-                        foreach (var progressListener in _progressListeners)
+                        if (State == Promise.State.Pending)
                         {
-                            Fixed32 progressCopy = progress;
-                            PromiseSingleAwaitWithProgress nextRef;
-                            progressListener.SetProgress(this, ref progressCopy, out nextRef, ref executionScheduler);
-                            if (nextRef != null)
+                            foreach (var progressListener in _nextBranches)
                             {
-                                nextRef.ReportProgress(progressCopy, ref executionScheduler);
+                                Fixed32 progressCopy = progress;
+                                PromiseSingleAwait nextRef = progressListener.SetProgress(ref progressCopy, Depth, ref executionScheduler);
+                                if (nextRef != null)
+                                {
+                                    nextRef.ReportProgress(progressCopy, nextRef.Depth, ref executionScheduler);
+                                }
                             }
                         }
-                        _progressAndLocker._progressCollectionLocker.Exit();
                     }
                     MaybeDispose();
                 }
-
-                [MethodImpl(InlineOption)]
-                protected override bool GetIsProgressSuspended()
-                {
-                    return _progressAndLocker._currentProgress.IsSuspended;
-                }
             } // PromiseMultiAwait
-
-            partial class AsyncPromiseBase
-            {
-                protected override sealed void SetInitialProgress(IProgressListener progressListener, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    progress = _progressAndSubscribeFields._currentProgress;
-                    SetInitialProgress(progressListener, ref progress, _progressAndSubscribeFields._currentProgress.GetIncrementedWholeTruncated(), out nextRef, ref executionScheduler);
-                }
-            }
 
             partial class DeferredPromiseBase
             {
-                protected override sealed PromiseRef MaybeAddProgressListenerAndGetPreviousRetained(ref IProgressListener progressListener, ref Fixed32 lastKnownProgress)
-                {
-                    ThrowIfInPool(this);
-                    progressListener.Retain();
-                    lastKnownProgress = _progressAndSubscribeFields._currentProgress;
-                    SetProgressListener(progressListener);
-                    return null;
-                }
-
                 [MethodImpl(InlineOption)]
                 internal bool TryReportProgress(short deferredId, float progress)
                 {
@@ -1375,126 +801,26 @@ namespace Proto.Promises
                     // Don't report progress 1.0, that will be reported automatically when the promise is resolved.
                     if (progress >= 0 & progress < 1f)
                     {
-                        var newProgress = _progressAndSubscribeFields._currentProgress.SetNewDecimalPartFromDeferred(progress);
-                        var executionScheduler = new ExecutionScheduler(false);
-                        ReportProgress(newProgress, ref executionScheduler);
-                        executionScheduler.ExecuteProgress();
+                        Fixed32 newProgress;
+                        if (_smallFields._currentProgress.TrySetNewDecimalPartFromDeferred(progress, out newProgress))
+                        {
+                            var executionScheduler = new ExecutionScheduler(false);
+                            ReportProgress(newProgress, 0, ref executionScheduler);
+                            executionScheduler.ExecuteProgress();
+                        }
                     }
                     MaybeDispose();
                     return true;
                 }
             }
 
-            partial struct DepthAndFlags
-            {
-                internal ProgressSubscribeFlags InterlockedSetPreviousDepthAndFlags(ushort previousDepth, ProgressSubscribeFlags flags)
-                {
-                    Thread.MemoryBarrier();
-                    DepthAndFlags current = default(DepthAndFlags), newValue;
-                    do
-                    {
-                        current._intValue = _intValue;
-                        newValue = current;
-                        newValue._previousDepth = previousDepth;
-                        newValue._flags |= flags;
-                    } while (Interlocked.CompareExchange(ref _intValue, newValue._intValue, current._intValue) != current._intValue);
-                    return current._flags;
-                }
-
-                internal ProgressSubscribeFlags InterlockedSetFlags(ProgressSubscribeFlags flags)
-                {
-                    Thread.MemoryBarrier();
-                    DepthAndFlags current = default(DepthAndFlags), newValue;
-                    do
-                    {
-                        current._intValue = _intValue;
-                        newValue = current;
-                        newValue._flags |= flags;
-                    } while (Interlocked.CompareExchange(ref _intValue, newValue._intValue, current._intValue) != current._intValue);
-                    return current._flags;
-                }
-
-                internal ProgressSubscribeFlags InterlockedUnsetFlags(ProgressSubscribeFlags flags)
-                {
-                    Thread.MemoryBarrier();
-                    ProgressSubscribeFlags unsetFlags = ~flags;
-                    DepthAndFlags current = default(DepthAndFlags), newValue;
-                    do
-                    {
-                        current._intValue = _intValue;
-                        newValue = current;
-                        newValue._flags &= unsetFlags;
-                    } while (Interlocked.CompareExchange(ref _intValue, newValue._intValue, current._intValue) != current._intValue);
-                    return current._flags;
-                }
-
-                [MethodImpl(InlineOption)]
-                internal void SetPreviousDepth(ushort previousDepth)
-                {
-                    _previousDepth = previousDepth;
-                }
-
-                [MethodImpl(InlineOption)]
-                internal ProgressSubscribeFlags GetFlags()
-                {
-                    return _flags;
-                }
-
-                [MethodImpl(InlineOption)]
-                internal void SetFlags(ProgressSubscribeFlags flags)
-                {
-                    _flags |= flags;
-                }
-
-                [MethodImpl(InlineOption)]
-                internal ProgressSubscribeFlags UnsetFlags(ProgressSubscribeFlags flags)
-                {
-                    var oldFlags = _flags;
-                    _flags &= ~flags;
-                    return oldFlags;
-                }
-
-                [MethodImpl(InlineOption)]
-                internal ushort GetPreviousDepthPlusOne()
-                {
-                    unchecked
-                    {
-                        return (ushort) (GetPreviousDepth() + 1u);
-                    }
-                }
-
-                [MethodImpl(InlineOption)]
-                internal ushort GetPreviousDepth()
-                {
-                    return _previousDepth;
-                }
-            } // DepthAndFlags
-
-            protected partial struct ProgressSubscribeFields
-            {
-
-                [MethodImpl(InlineOption)]
-                internal void Reset()
-                {
-                    _previousDepthAndFlags = default(DepthAndFlags);
-                    _currentProgress = default(Fixed32);
-                }
-            }
-
             partial class PromiseWaitPromise
             {
-                [MethodImpl(InlineOption)]
-                new protected void Reset(ushort depth)
-                {
-                    _progressFields.Reset();
-                    base.Reset(depth);
-                }
-
-                [MethodImpl(InlineOption)]
-                protected override sealed bool GetIsProgressSuspended()
-                {
-                    return _progressFields._currentProgress.IsSuspended;
-                }
+                //new protected void Reset(ushort depth)
+                //{
+                //    _secondPrevious = false; // TODO
+                //    base.Reset(depth);
+                //}
 
                 internal void WaitForWithProgress<T>(Promise<T> other)
                 {
@@ -1503,452 +829,98 @@ namespace Proto.Promises
                     _ref.MarkAwaited(other.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
 
                     var executionScheduler = new ExecutionScheduler(true);
-                    SetPreviousAndSubscribeProgress(_ref, other.Depth, ref executionScheduler);
-                    _ref.HookupNewWaiter(this, ref executionScheduler);
+                    SetSecondPrevious(_ref);
+                    InterlockedIncrementProgressReportingCount();
+                    HandleablePromiseBase nextRef;
+                    _ref.AddWaiter(this, out nextRef, ref executionScheduler);
+                    MaybeReportProgressAfterSecondPreviousHookup(_ref, other.Depth, ref executionScheduler);
+                    _ref.MaybeHandleNext(nextRef, ref executionScheduler);
+                    executionScheduler.Execute();
                 }
 
                 [MethodImpl(InlineOption)]
-                private void SetPreviousAndSubscribeProgress(PromiseRef other, ushort depth, ref ExecutionScheduler executionScheduler)
+                private void SetSecondPrevious(PromiseRef other)
                 {
-                    // Write SecondPrevious flag before writing previous to fix race condition with hookup MaybeAddProgressListenerAndGetPreviousRetained.
-                    _progressFields._previousDepthAndFlags.InterlockedSetFlags(ProgressSubscribeFlags.AboutToSetPrevious);
-                    _valueOrPrevious = other;
-
-                    // Lazy subscribe: only subscribe to second previous if a progress listener is added to this (this keeps execution more efficient when progress isn't used).
-                    ProgressSubscribeFlags oldFlags = _progressFields._previousDepthAndFlags.InterlockedSetPreviousDepthAndFlags(depth, ProgressSubscribeFlags.HasPrevious);
-                    bool hasListener = (oldFlags & ProgressSubscribeFlags.HasListener) != 0;
-                    if (hasListener)
-                    {
-                        oldFlags = _progressFields._previousDepthAndFlags.InterlockedSetFlags(ProgressSubscribeFlags.SubscribedFromSetPrevious);
-                        bool notSubscribed = (oldFlags & ProgressSubscribeFlags.SubscribedFromAddListener) == 0;
-                        if (notSubscribed)
-                        {
-                            other.SubscribeListener(this, Fixed32.FromWhole(depth), ref executionScheduler);
-                        }
-                    }
-                }
-
-                protected override PromiseRef MaybeAddProgressListenerAndGetPreviousRetained(ref IProgressListener progressListener, ref Fixed32 lastKnownProgress)
-                {
-                    ThrowIfInPool(this);
-                    progressListener.Retain();
-                    SetProgressListener(progressListener);
-
-                    // Mark subscribing to prevent repooling while we get previous, then unmark after we have retained previous.
-                    _smallFields.InterlockedSetFlags(PromiseFlags.Subscribing);
-                    // Read previous before setting flag to fix race condition with SetPreviousAndSubscribeProgress.
-                    object firstRead = _valueOrPrevious;
-                    ProgressSubscribeFlags oldFlags = _progressFields._previousDepthAndFlags.InterlockedSetFlags(ProgressSubscribeFlags.HasListener);
-                    PromiseRef previous;
-                    bool hasSecondPrevious = (oldFlags & ProgressSubscribeFlags.HasPrevious) != 0;
-                    if (hasSecondPrevious)
-                    {
-                        lastKnownProgress = Fixed32.FromWhole(_progressFields._previousDepthAndFlags.GetPreviousDepth());
-                        oldFlags = _progressFields._previousDepthAndFlags.InterlockedSetFlags(ProgressSubscribeFlags.SubscribedFromAddListener);
-                        bool alreadySubscribed = (oldFlags & ProgressSubscribeFlags.SubscribedFromSetPrevious) != 0;
-                        if (alreadySubscribed)
-                        {
-                            _smallFields.InterlockedUnsetFlags(PromiseFlags.Subscribing);
-                            return null;
-                        }
-                        progressListener = this;
-                        // Read previous again to fix race condition with previous dispose.
-                        previous = _valueOrPrevious as PromiseRef;
-                    }
-                    else
-                    {
-                        lastKnownProgress = Fixed32.FromWhole(Depth);
-                        bool notAboutToSetSecondPrevious = (oldFlags & ProgressSubscribeFlags.AboutToSetPrevious) == 0;
-                        previous = notAboutToSetSecondPrevious
-                            ? firstRead as PromiseRef
-                            : null;
-                    }
-
-                    if (previous != null) // If previous is null, this is either transitioning to second previous, or has already completed.
-                    {
-                        previous.InterlockedRetainDisregardId();
-                    }
-                    _smallFields.InterlockedUnsetFlags(PromiseFlags.Subscribing);
-                    return previous;
-                }
-
-                protected override sealed void SetInitialProgress(IProgressListener progressListener, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    progress = Fixed32.FromWhole(Depth);
-                    SetInitialProgress(progressListener, ref progress, Fixed32.FromWholePlusOne(Depth), out nextRef, ref executionScheduler);
-                }
-
-                void IProgressListener.SetInitialProgress(PromiseRef sender, Promise.State state, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    // This essentially acts as a pass-through to normalize the progress.
-                    // We don't store the calculated progress here, it gets passed to the _progressListener in ReportProgress.
-                    // Progress TrySet is only used for progress suspension purposes.
-                    ThrowIfInPool(this);
-                    nextRef = null;
-                    switch (state)
-                    {
-                        case Promise.State.Pending:
-                        {
-                            if (!sender.GetIsProgressSuspended() && _progressFields._currentProgress.InterlockedTrySet(progress))
-                            {
-                                progress = NormalizeProgress(progress);
-                                nextRef = this;
-                            }
-                            return;
-                        }
-                        case Promise.State.Resolved:
-                        {
-                            if (sender != _valueOrPrevious && _progressFields._currentProgress.InterlockedTrySetFromResolve(progress))
-                            {
-                                progress = NormalizeProgress(progress);
-                                nextRef = this;
-                            }
-                            break;
-                        }
-                        default: // Rejected or Canceled:
-                        {
-                            _progressFields._currentProgress.MaybeSuspend();
-                            nextRef = null;
-                            break;
-                        }
-                    }
-                    MaybeDispose();
+#if PROMISE_DEBUG
+                    _previous = other;
+#endif
+                    //_secondPrevious = true; // TODO
+                    _smallFields.InterlockedSetFlags(PromiseFlags.SecondPrevious);
+                    _smallFields._currentProgress = Fixed32.FromWhole(Depth);
                 }
 
                 [MethodImpl(InlineOption)]
-                private Fixed32 NormalizeProgress(Fixed32 progress)
+                partial void MaybeReportProgressAfterSecondPreviousHookup(PromiseRef secondPrevious, ushort depth, ref ExecutionScheduler executionScheduler)
                 {
+                    if (secondPrevious.State != Promise.State.Pending)
+                    {
+                        InterlockedDecrementProgressReportingCount();
+                        return;
+                    }
+                    var progress = NormalizeProgress(secondPrevious._smallFields._currentProgress, depth);
+                    _smallFields._currentProgress = progress;
+                    ReportProgressAlreadyIncremented(progress, Depth, ref executionScheduler);
+                }
+
+                [MethodImpl(InlineOption)]
+                private Fixed32 NormalizeProgress(Fixed32 progress, ushort depth)
+                {
+                    // TODO: just calculate the decimal and assign it to the progress after setting the progress to Depth before the second await.
                     // Calculate the normalized progress for this and previous depth.
-                    return progress.DivideAndAdd(_progressFields._previousDepthAndFlags.GetPreviousDepthPlusOne(), Depth);
+                    return progress.DivideAndAdd(depth + 1d, Depth);
                 }
 
-                void IProgressListener.SetProgress(PromiseRef sender, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
+                internal override sealed PromiseSingleAwait SetProgress(ref Fixed32 progress, ushort depth, ref ExecutionScheduler executionScheduler)
                 {
-                    // This essentially acts as a pass-through to normalize the progress.
-                    // We don't store the calculated progress here, it gets passed to the _progressListener in ReportProgress.
-                    // TrySetProgress is only used for progress suspension purposes.
+                    // This acts as a pass-through to normalize the progress.
                     ThrowIfInPool(this);
-                    if (_progressFields._currentProgress.InterlockedTrySet(progress))
+                    //if (_secondPrevious) // TODO
+                    if (_smallFields.AreFlagsSet(PromiseFlags.SecondPrevious))
                     {
-                        nextRef = this;
-                        progress = NormalizeProgress(progress);
+                        var normalizedProgress = NormalizeProgress(progress, depth);
+                        _smallFields._currentProgress = normalizedProgress;
+                        progress = normalizedProgress;
                     }
                     else
                     {
-                        nextRef = null;
+                        _smallFields._currentProgress = progress;
                     }
-                }
-
-                void IProgressListener.ResolveOrSetProgress(PromiseRef sender, Fixed32 progress, ref ExecutionScheduler executionScheduler)
-                {
-                    ThrowIfInPool(this);
-                    // Don't set progress if this is resolved by the second wait.
-                    if (sender != _valueOrPrevious && _progressFields._currentProgress.InterlockedTrySetFromResolve(progress))
-                    {
-                        ReportProgress(NormalizeProgress(progress), ref executionScheduler);
-                    }
-                    MaybeDispose();
-                }
-
-                void IProgressListener.MaybeCancelProgress(Fixed32 progress)
-                {
-                    ThrowIfInPool(this);
-                    _progressFields._currentProgress.InterlockedSuspendIfOtherWholeIsGreater(progress);
-                    MaybeDispose();
-                }
-
-                void IProgressListener.Retain()
-                {
-                    InterlockedRetainDisregardId();
+                    return this;
                 }
             } // PromiseWaitPromise
 
             partial class PromisePassThrough
             {
-                void IProgressListener.SetInitialProgress(PromiseRef sender, Promise.State state, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
+                internal override PromiseSingleAwait SetProgress(ref Fixed32 progress, ushort depth, ref ExecutionScheduler executionScheduler)
                 {
                     ThrowIfInPool(this);
-                    nextRef = null;
-                    if (state == Promise.State.Pending)
-                    {
-                        _smallFields._settingInitialProgress = true;
-                        // InterlockedTrySet has a MemoryBarrier in it, so we know _owner is read after _settingInitialProgress is written.
-                        bool didSet = _smallFields._currentProgress.InterlockedTrySet(progress);
-                        var owner = _owner;
-                        if (didSet & owner != null)
-                        {
-                            _target.IncrementProgress(progress.GetRawValue(), ref progress, _smallFields._depth, out nextRef);
-                        }
-                        _smallFields._settingInitialProgress = false;
-                    }
-                    else
-                    {
-                        Release();
-                    }
-                }
-
-                void IProgressListener.SetProgress(PromiseRef sender, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    ThrowIfInPool(this);
-                    nextRef = null;
-                    _smallFields._reportingProgress = true;
                     // InterlockedTrySetAndGetDifference has a MemoryBarrier in it, so we know _owner is read after _reportingProgress is written.
-                    uint dif;
-                    bool didSet = _smallFields._currentProgress.InterlockedTrySetAndGetDifference(progress, out dif);
-                    var owner = _owner;
-                    if (didSet & owner != null)
-                    {
-                        _target.IncrementProgress(dif, ref progress, _smallFields._depth, out nextRef);
-                    }
-                    _smallFields._reportingProgress = false;
-                }
-
-                partial void WaitWhileProgressIsBusy()
-                {
-                    Thread.MemoryBarrier(); // Make sure any writes happen before reading the flags.
-                    var spinner = new SpinWait();
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
-#endif
-                    while (_smallFields._reportingProgress | _smallFields._settingInitialProgress)
-                    {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                        if (stopwatch.Elapsed.TotalSeconds > 1)
-                        {
-                            throw new TimeoutException();
-                        }
-#endif
-                        spinner.SpinOnce();
-                    }
-                }
-
-                void IProgressListener.ResolveOrSetProgress(PromiseRef sender, Fixed32 progress, ref ExecutionScheduler executionScheduler)
-                {
-                    Release();
-                }
-
-                void IProgressListener.MaybeCancelProgress(Fixed32 progress)
-                {
-                    _smallFields._currentProgress.InterlockedSuspendIfOtherWholeIsGreater(progress);
-                    Release();
-                }
-
-                void IProgressListener.Retain()
-                {
-                    Retain();
+                    uint dif = _smallFields._currentProgress.InterlockedSetAndGetDifference(progress);
+                    return _target.IncrementProgress(dif, ref progress, _smallFields._depth);
                 }
 
                 [MethodImpl(InlineOption)]
-                internal uint GetProgressDifferenceToCompletion(out Fixed32 progress)
+                internal uint GetProgressDifferenceToCompletion()
                 {
                     ThrowIfInPool(this);
-                    progress = _smallFields._currentProgress;
                     Fixed32 incrementedWhole = Fixed32.FromWholePlusOne(_smallFields._depth);
                     return incrementedWhole.GetRawValue() - _smallFields._currentProgress.GetRawValue();
                 }
 
                 [MethodImpl(InlineOption)]
-                partial void ResetProgress(ushort depth)
+                partial void SetDepth(ushort depth)
                 {
-                    _smallFields._currentProgress = default(Fixed32);
                     _smallFields._depth = depth;
                 }
 
-                internal ushort Depth
+                partial void SetInitialProgress()
                 {
-                    [MethodImpl(InlineOption)]
-                    get { return _smallFields._depth; }
+                    var progress = _owner._smallFields._currentProgress;
+                    _smallFields._currentProgress = progress;
+                    uint increment = progress.GetRawValue();
+                    _target.IncrementProgress(increment, ref progress, _smallFields._depth);
                 }
             } // PromisePassThrough
-
-            // We have to use a pass-through for cancelation purposes. If we used the AsyncPromiseRef directly as the listener,
-            // the promise chain could be broken and it still subscribed on another promise lower in the chain,
-            // then subscribing to the next `await`ed promise would cause problems with it being subscribed to multiple promise chains simultaneously.
-            // Using a pass-through is able to check for cancelations and not report the progress.
-#if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
-#endif
-            internal sealed partial class AsyncProgressPassThrough :
-#if PROMISE_DEBUG
-                PromiseRef, // For circular promise await detection (promise waiting on itself).
-#endif
-                IProgressListener, ILinked<AsyncProgressPassThrough>
-            {
-                partial struct ProgressSmallFields
-                {
-                    internal void InterlockedRetain()
-                    {
-                        unchecked
-                        {
-                            Thread.MemoryBarrier();
-                            ProgressSmallFields initialValue = default(ProgressSmallFields), newValue = default(ProgressSmallFields);
-                            do
-                            {
-                                initialValue._intValue = _intValue;
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                                if (initialValue._retainCounter == ushort.MaxValue)
-                                {
-                                    throw new OverflowException();
-                                }
-#endif
-                                newValue._intValue = initialValue._intValue;
-                                ++newValue._retainCounter;
-                            } while (Interlocked.CompareExchange(ref _intValue, newValue._intValue, initialValue._intValue) != initialValue._intValue);
-                        }
-                    }
-
-                    internal bool InterlockedTryReleaseComplete()
-                    {
-                        unchecked
-                        {
-                            Thread.MemoryBarrier();
-                            ProgressSmallFields initialValue = default(ProgressSmallFields), newValue = default(ProgressSmallFields);
-                            do
-                            {
-                                initialValue._intValue = _intValue;
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                                if (initialValue._retainCounter == 0)
-                                {
-                                    throw new OverflowException();
-                                }
-#endif
-                                newValue._intValue = initialValue._intValue;
-                                --newValue._retainCounter;
-                            } while (Interlocked.CompareExchange(ref _intValue, newValue._intValue, initialValue._intValue) != initialValue._intValue);
-                            return newValue._retainCounter == 0;
-                        }
-                    }
-
-                    internal ushort GetCurrentRetains()
-                    {
-                        return _retainCounter;
-                    }
-                }
-
-                internal static AsyncProgressPassThrough GetOrCreate(AsyncPromiseRef target, ushort expectedProgress, object previous)
-                {
-                    var passThrough = ObjectPool<AsyncProgressPassThrough>.TryTake<AsyncProgressPassThrough>()
-                        ?? new AsyncProgressPassThrough();
-                    passThrough._target = target;
-                    passThrough._progressSmallFields._currentProgress = default(Fixed32);
-                    passThrough._progressSmallFields._expectedProgress = expectedProgress;
-#if PROMISE_DEBUG
-                    passThrough._valueOrPrevious = previous;
-                    passThrough._smallFields.InterlockedSetFlags(PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
-#endif
-                    return passThrough;
-                }
-
-                ~AsyncProgressPassThrough()
-                {
-                    if (_progressSmallFields.GetCurrentRetains() != 0)
-                    {
-                        // For debugging. This should never happen.
-                        string message = "An AsyncProgressPassThrough was garbage collected without it being released."
-                            + " _retainCounter: " + _progressSmallFields.GetCurrentRetains() + ", _target: " + _target
-                            + ", _currentProgress: " + _progressSmallFields._currentProgress.ToDouble()
-                            + ", _expectedProgress: " + _progressSmallFields._expectedProgress;
-                        AddRejectionToUnhandledStack(new UnreleasedObjectException(message), _target);
-                    }
-                }
-
-                void IProgressListener.SetInitialProgress(PromiseRef sender, Promise.State state, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    ThrowIfInPool(this);
-                    var target = _target;
-                    if (state == Promise.State.Pending)
-                    {
-                        if (_progressSmallFields._currentProgress.InterlockedTrySet(progress))
-                        {
-                            target.SetProgress(ref progress, out nextRef);
-                            return;
-                        }
-                    }
-                    else
-                    {
-                        _progressSmallFields._currentProgress.MaybeSuspend();
-                        MaybeDispose();
-                    }
-                    nextRef = null;
-                }
-
-                void IProgressListener.SetProgress(PromiseRef sender, ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef, ref ExecutionScheduler executionScheduler)
-                {
-                    ThrowIfInPool(this);
-                    if (_progressSmallFields._currentProgress.InterlockedTrySet(progress))
-                    {
-                        _target.SetProgress(ref progress, out nextRef);
-                    }
-                    else
-                    {
-                        nextRef = null;
-                    }
-                }
-
-                void IProgressListener.ResolveOrSetProgress(PromiseRef sender, Fixed32 progress, ref ExecutionScheduler executionScheduler)
-                {
-                    ThrowIfInPool(this);
-                    bool isComplete = progress.WholePart == _progressSmallFields._expectedProgress;
-                    bool didSet = _progressSmallFields._currentProgress.InterlockedTrySetFromResolve(progress);
-                    var target = _target;
-                    MaybeDispose();
-                    // Don't set progress if this is complete.
-                    if (didSet & !isComplete)
-                    {
-                        target.SetProgress(progress, ref executionScheduler);
-                    }
-                }
-
-                void IProgressListener.MaybeCancelProgress(Fixed32 progress)
-                {
-                    ThrowIfInPool(this);
-                    _progressSmallFields._currentProgress.InterlockedSuspendIfOtherWholeIsGreater(progress);
-                    MaybeDispose();
-                }
-
-                void IProgressListener.Retain()
-                {
-                    ThrowIfInPool(this);
-                    _progressSmallFields.InterlockedRetain();
-                }
-
-                internal void MarkComplete(Fixed32 expectedProgress)
-                {
-                    // Setting the progress to the expected progress will prevent any other progress updates from promises lower in the promise chain after a cancelation has broken the chain.
-                    _progressSmallFields._currentProgress.InterlockedTrySetFromResolve(expectedProgress);
-                }
-
-#if PROMISE_DEBUG
-                new
-#endif
-                    private void MaybeDispose()
-                {
-                    if (_progressSmallFields.InterlockedTryReleaseComplete())
-                    {
-                        Dispose();
-                    }
-                }
-
-#if PROMISE_DEBUG
-                new
-#endif
-                    internal void Dispose()
-                {
-#if PROMISE_DEBUG
-                    _valueOrPrevious = null;
-#endif
-                    _target = null;
-                    ObjectPool<AsyncProgressPassThrough>.MaybeRepool(this);
-                }
-
-#if PROMISE_DEBUG
-                protected override void MarkAwaited(short promiseId, PromiseFlags flags) { throw new System.InvalidOperationException(); }
-                internal override PromiseRef GetDuplicate(short promiseId, ushort depth) { throw new System.InvalidOperationException(); }
-                internal override void AddWaiter(HandleablePromiseBase waiter, ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
-                internal override void AddWaiter(HandleablePromiseBase waiter, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
-                internal override void Handle(ref PromiseRef handler, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
-#endif
-            }
 
             partial class AsyncPromiseRef
             {
@@ -1958,126 +930,75 @@ namespace Proto.Promises
                     return a + (b - a) * t;
                 }
 
-                private Fixed32 LerpProgress(Fixed32 progress)
+                private double LerpProgress(Fixed32 progress, ushort depth)
                 {
                     ThrowIfInPool(this);
-                    double normalizedProgress = progress.ToDouble() / _progressAndSubscribeFields._previousDepthAndFlags.GetPreviousDepthPlusOne();
+                    double normalizedProgress = progress.ToDouble() / (depth + 1d);
                     double newValue = Lerp(_minProgress, _maxProgress, normalizedProgress);
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
                     if (newValue < 0 || newValue >= 1)
                     {
                         throw new ArithmeticException("Async progress calculated outside allowed bounds of [0, 1), value: " + newValue
-                            + ", progress: " + progress.ToDouble() + ", depthPlusOne: " + _progressAndSubscribeFields._previousDepthAndFlags.GetPreviousDepthPlusOne()
+                            + ", progress: " + progress.ToDouble() + ", depth: " + depth
                             + ", _minProgress: " + _minProgress + ", _maxProgress: " + _maxProgress);
                     }
 #endif
-                    return _progressAndSubscribeFields._currentProgress.SetNewDecimalPartFromDeferred(newValue);
+                    return newValue;
                 }
 
-                internal void SetProgress(ref Fixed32 progress, out PromiseSingleAwaitWithProgress nextRef)
+                internal override PromiseSingleAwait SetProgress(ref Fixed32 progress, ushort depth, ref ExecutionScheduler executionScheduler)
                 {
-                    progress = LerpProgress(progress);
-                    nextRef = this;
-                }
-
-                internal void SetProgress(Fixed32 progress, ref ExecutionScheduler executionScheduler)
-                {
-                    ReportProgress(LerpProgress(progress), ref executionScheduler);
+                    if (float.IsNaN(_minProgress))
+                    {
+                        return null;
+                    }
+                    var lerpedProgress = LerpProgress(progress, depth);
+                    return _smallFields._currentProgress.TrySetNewDecimalPartFromDeferred(lerpedProgress, out progress) ? this : null;
                 }
 
                 private void SetAwaitedComplete(PromiseRef handler, ref ExecutionScheduler executionScheduler)
                 {
                     ThrowIfInPool(this);
-                    var oldPrevious = _valueOrPrevious;
-                    _valueOrPrevious = null;
-                    _progressAndSubscribeFields._previousDepthAndFlags.InterlockedUnsetFlags(ProgressSubscribeFlags.AboutToSetPrevious);
-                    var passthrough = oldPrevious as AsyncProgressPassThrough;
-                    if (passthrough != null)
+                    // Don't report progress if it's 1. That will be reported when the async promise is resolved.
+                    // Also don't report if the awaited promise was rejected or canceled.
+                    if (handler.State == Promise.State.Resolved & _maxProgress < 1f)
                     {
-                        Fixed32 expectedProgress = Fixed32.FromWhole(_progressAndSubscribeFields._previousDepthAndFlags.GetPreviousDepthPlusOne());
-                        passthrough.MarkComplete(expectedProgress);
-                        // Don't report progress if it's 1. That will be reported when the async promise is resolved.
-                        // Also don't report if the awaited promise was rejected or canceled.
-                        if (handler.State == Promise.State.Resolved & _maxProgress < 1f)
-                        {
-                            ReportProgress(Fixed32.FromDecimalForAsync(_maxProgress), ref executionScheduler);
-                        }
+                        var progress = Fixed32.FromDecimal(_maxProgress);
+                        _smallFields._currentProgress = progress;
+                        ReportProgress(progress, 0, ref executionScheduler);
                     }
+                    _minProgress = _maxProgress = float.NaN;
                 }
 
-                // SetPreviousAndMaybeSubscribeProgress may be called multiple times, but never concurrently with itself,
-                // while MaybeAddProgressListenerAndGetPreviousRetained will only be called once, but may be called concurrently with SetPreviousAndMaybeSubscribeProgress
                 [MethodImpl(InlineOption)]
-                internal void SetPreviousAndMaybeSubscribeProgress(PromiseRef other, ushort depth, float minProgress, float maxProgress, ref ExecutionScheduler executionScheduler)
+                internal void SetSecondPreviousAndProgress(PromiseRef other, float minProgress, float maxProgress)
                 {
-                    ThrowIfInPool(this);
-                    lock (this) // Unfortunately, I couldn't figure out a lock-free solution to thread synchronization.
-                    {
-                        _progressAndSubscribeFields._previousDepthAndFlags.InterlockedSetFlags(ProgressSubscribeFlags.AboutToSetPrevious);
-                        _valueOrPrevious = other;
-                        // Lazy subscribe: only subscribe to the awaited promise if a progress listener is added to this (this keeps execution and memory more efficient when progress isn't used).
-                        if (_progressListener == null)
-                        {
-                            // These must be set inside the lock so they will be visible if/when the listener is subscribed in MaybeAddProgressListenerAndGetPreviousRetained.
-                            _progressAndSubscribeFields._previousDepthAndFlags.SetPreviousDepth(depth);
-                            _minProgress = minProgress;
-                            _maxProgress = maxProgress;
-                            return;
-                        }
-                    }
-                    // Exit the lock before subscribing the new listener.
+#if PROMISE_DEBUG
+                    _previous = other;
+#endif
                     _minProgress = minProgress;
                     _maxProgress = maxProgress;
-                    var passthrough = AsyncProgressPassThrough.GetOrCreate(this, _progressAndSubscribeFields._previousDepthAndFlags.GetPreviousDepthPlusOne(), other);
-                    // So the passthrough can be marked completed when the awaited promise completes without adding a new field.
-                    _valueOrPrevious = passthrough;
-                    other.SubscribeListener(passthrough, Fixed32.FromWhole(depth), ref executionScheduler);
+                    _smallFields._currentProgress = Fixed32.FromDecimal(minProgress);
                 }
 
-                protected override sealed PromiseRef MaybeAddProgressListenerAndGetPreviousRetained(ref IProgressListener progressListener, ref Fixed32 lastKnownProgress)
+                [MethodImpl(InlineOption)]
+                partial void MaybeReportProgressAfterHookup(PromiseRef waiter, ushort depth, ref ExecutionScheduler executionScheduler)
                 {
-                    ThrowIfInPool(this);
-                    progressListener.Retain();
-                    object previous;
-                    ProgressSubscribeFlags oldFlags;
-                    // Mark subscribing to prevent repooling while we get previous, then unmark after we have retained previous.
-                    _smallFields.InterlockedSetFlags(PromiseFlags.Subscribing);
-                    lock (this) // Unfortunately, I couldn't figure out a lock-free solution to thread synchronization.
+                    if (waiter.State != Promise.State.Pending)
                     {
-                        SetProgressListener(progressListener);
-                        // Lazy subscribe: only subscribe to the awaited promise if a progress listener is added to this (this keeps execution and memory more efficient when progress isn't used).
-                        previous = _valueOrPrevious;
-                        oldFlags = _progressAndSubscribeFields._previousDepthAndFlags.GetFlags();
+                        InterlockedDecrementProgressReportingCount();
+                        return;
                     }
-                    // Exit the lock once we have read previous before subscribing the new listener.
-                    // If previousRef is null, this is either invoking the async state machine, or has awaited a non-promise awaitable, or has already completed.
-                    PromiseRef previousRef = previous as PromiseRef;
-                    // Don't subscribe to the previous promise if it was not awaited with the AwaitWithProgress API.
-                    bool hasAwaitedPrevious = (oldFlags & ProgressSubscribeFlags.AboutToSetPrevious) != 0 & previousRef != null;
-                    if (hasAwaitedPrevious)
+                    var lerpedProgress = LerpProgress(waiter._smallFields._currentProgress, depth);
+                    Fixed32 progress;
+                    if (_smallFields._currentProgress.TrySetNewDecimalPartFromDeferred(lerpedProgress, out progress))
                     {
-                        previousRef.InterlockedRetainDisregardId();
-                    }
-                    _smallFields.InterlockedUnsetFlags(PromiseFlags.Subscribing);
-                    if (hasAwaitedPrevious)
-                    {
-                        var passthrough = AsyncProgressPassThrough.GetOrCreate(this, _progressAndSubscribeFields._previousDepthAndFlags.GetPreviousDepthPlusOne(), previous);
-                        // So the passthrough can be marked completed when the awaited promise completes without adding a new field.
-                        if (Interlocked.CompareExchange(ref _valueOrPrevious, passthrough, previous) != previous)
-                        {
-                            // previous was changed, which means the awaited promise completed on another thread.
-                            passthrough.Dispose();
-                            previousRef.MaybeDispose();
-                            return null;
-                        }
-                        progressListener = passthrough;
+                        ReportProgressAlreadyIncremented(progress, 0, ref executionScheduler);
                     }
                     else
                     {
-                        lastKnownProgress = Fixed32.FromWhole(Depth);
-                        previousRef = null;
+                        InterlockedDecrementProgressReportingCount();
                     }
-                    return previousRef;
                 }
             } // AsyncPromiseRef
 #endif // PROMISE_PROGRESS

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -425,6 +425,16 @@ namespace Proto.Promises
             #endregion
 
 #if PROMISE_PROGRESS
+            partial struct Fixed32
+            {
+                private volatile int _value; // int for Interlocked.
+            }
+
+            partial struct UnsignedFixed64
+            {
+                private long _value; // long for Interlocked.
+            }
+
             partial class PromiseProgress<TProgress> : PromiseSingleAwait
                 where TProgress : IProgress<float>
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -151,14 +151,9 @@ namespace Proto.Promises
 
             SuppressRejection = 1 << 0,
             WasAwaitedOrForgotten = 1 << 1,
-            HadCallback = 1 << 7, // Shares bit with Subscribed, since HadCallback is only used for SingleAwait and Subscribed is only used for MultiAwait.
-            // For progress below
-            InProgressQueue = 1 << 2,
-            Subscribing = 1 << 3,
-            SettingInitial = 1 << 4,
-            ReportingPriority = 1 << 5,
-            ReportingInitial = 1 << 6,
-            Subscribed = 1 << 7,
+            SecondPrevious = 1 << 2,
+            HadCallback = 1 << 3,
+            InProgressQueue = 1 << 4,
 
             All = byte.MaxValue
         }
@@ -191,6 +186,12 @@ namespace Proto.Promises
                 // _depth shares bit space with _deferredId, because it is always 0 on deferred promises, and _deferredId is not used in non-deferred promises.
                 [FieldOffset(6)]
                 volatile internal ushort _depth;
+#if PROMISE_PROGRESS
+                [FieldOffset(8)]
+                internal Fixed32 _currentProgress;
+                [FieldOffset(12)]
+                volatile internal int _reportingProgressCount;
+#endif
 
                 [MethodImpl(InlineOption)]
                 internal SmallFields(short initialId)
@@ -203,9 +204,9 @@ namespace Proto.Promises
 
 #if PROMISE_DEBUG
             CausalityTrace ITraceable.Trace { get; set; }
+            internal PromiseRef _previous; // Used to detect circular awaits.
 #endif
-
-            volatile internal object _valueOrPrevious;
+            volatile internal ValueContainer _valueContainer;
             private SmallFields _smallFields = new SmallFields(1); // Start with Id 1 instead of 0 to reduce risk of false positives.
 
             partial class PromiseSingleAwait : PromiseRef
@@ -228,81 +229,14 @@ namespace Proto.Promises
                 volatile private Promise.State _previousState;
             }
 
-            partial class PromiseSingleAwaitWithProgress : PromiseSingleAwait
-            {
-#if PROMISE_PROGRESS
-                volatile protected IProgressListener _progressListener;
-#endif
-            }
-
             partial class PromiseMultiAwait : PromiseRef
             {
-                // Wrapping struct fields smaller than 64-bits in another struct fixes issue with extra padding
-                // (see https://stackoverflow.com/questions/67068942/c-sharp-why-do-class-fields-of-struct-types-take-up-more-space-than-the-size-of).
-                private partial struct ProgressAndLocker
-                {
-                    internal SpinLocker _branchLocker;
-#if PROMISE_PROGRESS
-                    internal SpinLocker _progressCollectionLocker;
-                    internal Fixed32 _currentProgress;
-#endif
-                }
-
                 private ValueLinkedQueue<HandleablePromiseBase> _nextBranches = new ValueLinkedQueue<HandleablePromiseBase>();
-                private ProgressAndLocker _progressAndLocker;
 
 #if PROMISE_PROGRESS
-                private ValueLinkedQueue<IProgressListener> _progressListeners = new ValueLinkedQueue<IProgressListener>();
-
-                IProgressListener ILinked<IProgressListener>.Next { get; set; }
                 IProgressInvokable ILinked<IProgressInvokable>.Next { get; set; }
 #endif
             }
-
-#if PROMISE_PROGRESS
-            [Flags]
-            internal enum ProgressSubscribeFlags : ushort
-            {
-                None = 0,
-
-                AboutToSetPrevious = 1 << 0,
-                HasListener = 1 << 1,
-                HasPrevious = 1 << 2,
-                SubscribedFromSetPrevious = 1 << 3,
-                SubscribedFromAddListener = 1 << 4,
-            }
-
-            [StructLayout(LayoutKind.Explicit)]
-            protected partial struct DepthAndFlags
-            {
-                [FieldOffset(0)]
-                internal ushort _previousDepth;
-                [FieldOffset(2)]
-                internal ProgressSubscribeFlags _flags;
-                [FieldOffset(0)]
-                volatile private int _intValue; // int for Interlocked.
-            }
-
-            // Wrapping struct fields smaller than 64-bits in another struct fixes issue with extra padding
-            // (see https://stackoverflow.com/questions/67068942/c-sharp-why-do-class-fields-of-struct-types-take-up-more-space-than-the-size-of).
-            protected partial struct ProgressSubscribeFields
-            {
-                internal DepthAndFlags _previousDepthAndFlags;
-                internal Fixed32 _currentProgress; // Fixed32 is only used for progress suspension. It's simpler to just re-use the functionality there than to rewrite it for PromiseWaitPromise.
-            }
-
-            partial class AsyncPromiseBase : PromiseSingleAwaitWithProgress
-            {
-                protected ProgressSubscribeFields _progressAndSubscribeFields;
-            }
-
-            partial class PromiseWaitPromise : PromiseSingleAwaitWithProgress
-            {
-                private ProgressSubscribeFields _progressFields;
-
-                IProgressListener ILinked<IProgressListener>.Next { get; set; }
-            }
-#endif
 
             #region Non-cancelable Promises
             partial class PromiseResolve<TResolver> : PromiseSingleAwait
@@ -438,7 +372,7 @@ namespace Proto.Promises
             #endregion
 
             #region Multi Promises
-            partial class MultiHandleablePromiseBase : PromiseSingleAwaitWithProgress
+            partial class MultiHandleablePromiseBase : PromiseSingleAwait
             {
 #if PROMISE_DEBUG
                 protected readonly object _locker = new object();
@@ -460,32 +394,12 @@ namespace Proto.Promises
 
             partial class RacePromise : MultiHandleablePromiseBase
             {
-                // Wrapping struct fields smaller than 64-bits in another struct fixes issue with extra padding
-                // (see https://stackoverflow.com/questions/67068942/c-sharp-why-do-class-fields-of-struct-types-take-up-more-space-than-the-size-of).
-                private struct RaceSmallFields
-                {
-                    internal int _waitCount;
-#if PROMISE_PROGRESS
-                    internal Fixed32 _currentProgress;
-#endif
-                }
-
-                private RaceSmallFields _raceSmallFields;
+                private int _waitCount;
             }
 
             partial class FirstPromise : MultiHandleablePromiseBase
             {
-                // Wrapping struct fields smaller than 64-bits in another struct fixes issue with extra padding
-                // (see https://stackoverflow.com/questions/67068942/c-sharp-why-do-class-fields-of-struct-types-take-up-more-space-than-the-size-of).
-                private struct FirstSmallFields
-                {
-                    internal int _waitCount;
-#if PROMISE_PROGRESS
-                    internal Fixed32 _currentProgress;
-#endif
-                }
-
-                private FirstSmallFields _firstSmallFields;
+                private int _waitCount;
             }
 
             partial class PromisePassThrough : HandleablePromiseBase, ILinked<PromisePassThrough>
@@ -499,8 +413,6 @@ namespace Proto.Promises
 #if PROMISE_PROGRESS
                     internal Fixed32 _currentProgress;
                     internal ushort _depth;
-                    internal volatile bool _settingInitialProgress;
-                    internal volatile bool _reportingProgress;
 #endif
                 }
 
@@ -509,22 +421,17 @@ namespace Proto.Promises
                 private PassThroughSmallFields _smallFields;
 
                 PromisePassThrough ILinked<PromisePassThrough>.Next { get; set; }
-
-#if PROMISE_PROGRESS
-                IProgressListener ILinked<IProgressListener>.Next { get; set; }
-#endif
             }
             #endregion
 
 #if PROMISE_PROGRESS
-            partial class PromiseProgress<TProgress> : PromiseSingleAwaitWithProgress
+            partial class PromiseProgress<TProgress> : PromiseSingleAwait
                 where TProgress : IProgress<float>
             {
                 // Wrapping struct fields smaller than 64-bits in another struct fixes issue with extra padding
                 // (see https://stackoverflow.com/questions/67068942/c-sharp-why-do-class-fields-of-struct-types-take-up-more-space-than-the-size-of).
                 private struct ProgressSmallFields
                 {
-                    internal Fixed32 _currentProgress;
                     volatile internal bool _canceled;
                     internal bool _isSynchronous;
                     volatile internal Promise.State _previousState;
@@ -536,36 +443,7 @@ namespace Proto.Promises
                 private TProgress _progress;
                 private SynchronizationContext _synchronizationContext;
 
-                IProgressListener ILinked<IProgressListener>.Next { get; set; }
                 IProgressInvokable ILinked<IProgressInvokable>.Next { get; set; }
-            }
-#endif
-
-#if PROMISE_PROGRESS
-            partial class AsyncProgressPassThrough
-#if PROMISE_DEBUG
-                : PromiseRef
-#endif
-            {
-                // Wrapping struct fields smaller than 64-bits in another struct fixes issue with extra padding
-                // (see https://stackoverflow.com/questions/67068942/c-sharp-why-do-class-fields-of-struct-types-take-up-more-space-than-the-size-of).
-                [StructLayout(LayoutKind.Explicit)]
-                private partial struct ProgressSmallFields
-                {
-                    [FieldOffset(0)]
-                    internal Fixed32 _currentProgress;
-                    [FieldOffset(4)]
-                    internal ushort _expectedProgress;
-                    [FieldOffset(6)]
-                    private ushort _retainCounter;
-                    [FieldOffset(4)]
-                    volatile private int _intValue; // int for Interlocked.
-                }
-
-                private AsyncPromiseRef _target;
-                private ProgressSmallFields _progressSmallFields;
-                AsyncProgressPassThrough ILinked<AsyncProgressPassThrough>.Next { get; set; }
-                IProgressListener ILinked<IProgressListener>.Next { get; set; }
             }
 #endif
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -810,11 +810,9 @@ namespace Proto.Promises
 #endif
             internal abstract partial class AsyncPromiseBase : PromiseSingleAwait
             {
+                [MethodImpl(InlineOption)]
                 protected void Reset()
                 {
-#if PROMISE_PROGRESS
-                    _smallFields._currentProgress = default(Fixed32);
-#endif
                     _smallFields.Reset();
                     SetCreatedStacktrace(this, 3);
                 }
@@ -1532,6 +1530,9 @@ namespace Proto.Promises
                     {
                         throw new System.InvalidOperationException("Expected 0 retains, actual retains: " + _retains);
                     }
+#endif
+#if PROMISE_PROGRESS
+                    _currentProgress = default(Fixed32);
 #endif
                     _state = Promise.State.Pending;
                     _flags = PromiseFlags.None;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -1,4 +1,8 @@
-﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+﻿#if UNITY_5_5 || NET_2_0 || NET_2_0_SUBSET
+#define NET_LEGACY
+#endif
+
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
 #define PROMISE_DEBUG
 #else
 #undef PROMISE_DEBUG
@@ -95,10 +99,10 @@ namespace Proto.Promises
                         string message = "A Promise's resources were garbage collected without it being awaited. You must await, return, or forget each promise.";
                         AddRejectionToUnhandledStack(new UnobservedPromiseException(message), this);
                     }
-                    if (State != Promise.State.Pending & _valueOrPrevious != null)
+                    if (State != Promise.State.Pending & _valueContainer != null)
                     {
                         // Rejection maybe wasn't caught.
-                        ((ValueContainer) _valueOrPrevious).DisposeAndMaybeAddToUnhandledStack(!SuppressRejection);
+                        _valueContainer.DisposeAndMaybeAddToUnhandledStack(!SuppressRejection);
                     }
                 }
                 catch (Exception e)
@@ -171,15 +175,20 @@ namespace Proto.Promises
                     throw new System.InvalidOperationException("Promise disposed while pending: " + this);
                 }
 #endif
+#if PROMISE_DEBUG
+                _previous = null;
+#endif
                 // Rejection maybe wasn't caught.
-                ((ValueContainer) _valueOrPrevious).DisposeAndMaybeAddToUnhandledStack(!SuppressRejection);
-                _valueOrPrevious = null;
+                _valueContainer.DisposeAndMaybeAddToUnhandledStack(!SuppressRejection);
+                _valueContainer = null;
             }
 
             private void HookupNewCancelablePromise(PromiseRef newPromise)
             {
-                // If _valueOrPrevious is not null, it means newPromise was already canceled from the token.
-                if (Interlocked.CompareExchange(ref newPromise._valueOrPrevious, this, null) == null)
+                // TODO: just hook up normally. DelegateWrappers call TryUnregister anyway.
+                //HookupNewPromise(newPromise);
+                // If _valueContainer is not null, it means newPromise was already canceled from the token.
+                if (Interlocked.CompareExchange(ref newPromise._valueContainer, null, null) == null)
                 {
                     HookupNewWaiter(newPromise);
                 }
@@ -200,7 +209,12 @@ namespace Proto.Promises
 
             private void HookupNewPromise(PromiseRef newPromise)
             {
-                newPromise._valueOrPrevious = this;
+#if PROMISE_DEBUG
+                newPromise._previous = this;
+#endif
+#if PROMISE_PROGRESS
+                newPromise._smallFields._currentProgress = _smallFields._currentProgress;
+#endif
                 HookupNewWaiter(newPromise);
             }
 
@@ -215,21 +229,6 @@ namespace Proto.Promises
                 AddWaiter(newWaiter, ref executionScheduler);
                 executionScheduler.Execute();
             }
-
-#if PROMISE_PROGRESS
-            private void HookupNewPromiseWithProgress<TPromiseRef>(TPromiseRef newPromise, ushort depth) where TPromiseRef : PromiseRef, IProgressListener
-            {
-                newPromise._valueOrPrevious = this;
-                HookupNewWaiterWithProgress(newPromise, depth);
-            }
-
-            private void HookupNewWaiterWithProgress<TWaiter>(TWaiter newWaiter, ushort depth) where TWaiter : HandleablePromiseBase, IProgressListener
-            {
-                var executionScheduler = new ExecutionScheduler(true);
-                SubscribeListener(newWaiter, Fixed32.FromWhole(depth), ref executionScheduler);
-                HookupNewWaiter(newWaiter, ref executionScheduler);
-            }
-#endif
 
             internal PromiseRef GetPreserved(short promiseId, ushort depth)
             {
@@ -252,9 +251,10 @@ namespace Proto.Promises
             internal abstract void AddWaiter(HandleablePromiseBase waiter, ref ExecutionScheduler executionScheduler);
             internal abstract void AddWaiter(HandleablePromiseBase waiter, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler);
 
+            [MethodImpl(InlineOption)]
             private void SetResult(ValueContainer valueContainer, Promise.State state)
             {
-                _valueOrPrevious = valueContainer;
+                _valueContainer = valueContainer;
                 Thread.MemoryBarrier(); // Make sure state is written after value.
                 State = state;
             }
@@ -262,13 +262,13 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal TResult GetResult<TResult>()
             {
-                return ((ValueContainer) _valueOrPrevious).GetValue<TResult>();
+                return _valueContainer.GetValue<TResult>();
             }
 
             [MethodImpl(InlineOption)]
             private bool TryGetRejectValue<TReject>(out TReject rejectValue)
             {
-                return ((ValueContainer) _valueOrPrevious).TryGetValue(out rejectValue);
+                return _valueContainer.TryGetValue(out rejectValue);
             }
 
             internal void MaybeHandleNext(HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
@@ -276,6 +276,7 @@ namespace Proto.Promises
                 PromiseRef handler = this;
                 while (nextHandler != null)
                 {
+                    handler.WaitWhileProgressReporting();
                     nextHandler.Handle(ref handler, out nextHandler, ref executionScheduler);
                 }
                 handler.MaybeDispose();
@@ -364,10 +365,9 @@ namespace Proto.Promises
                     }
                 }
 
+                [MethodImpl(InlineOption)]
                 internal void MaybeDisposePrevious(PromiseRef previous)
                 {
-                    _valueOrPrevious = null;
-                    WaitWhileProgressFlags(PromiseFlags.Subscribing);
                     previous.MaybeDispose();
                 }
 
@@ -385,13 +385,11 @@ namespace Proto.Promises
 #endif
                 }
 
-                internal void WaitForProgressSubscribeAfterCanceled(PromiseRef previous)
+                [MethodImpl(InlineOption)]
+                internal void MaybeDisposePreviousAfterSecondWait(PromiseRef previous)
                 {
-#if PROMISE_PROGRESS
-                    // If we were unable to unregister from the cancelation token, we must try to remove the previous PromiseRef from the _valueOrPrevious field
-                    // without overwriting the new value that the token is going to set.
-                    Interlocked.CompareExchange(ref _valueOrPrevious, null, previous);
-                    WaitWhileProgressFlags(PromiseFlags.Subscribing);
+#if PROMISE_DEBUG // Dispose after the callback if we're in debug mode so that if a circular promise chain is detected, it will be disposed properly.
+                    MaybeDisposePrevious(previous);
 #endif
                 }
 
@@ -420,14 +418,14 @@ namespace Proto.Promises
                             if (handlerDisposedAfterCallback)
                             {
                                 // This is a no-op for resolve and cancel containers.
-                                ((ValueContainer) previousHandler._valueOrPrevious).AddToUnhandledStack();
+                                previousHandler._valueContainer.AddToUnhandledStack();
                             }
                             valueContainer = CreateRejectContainer(e, int.MinValue, this);
                             previousState = Promise.State.Rejected;
                         }
                         else
                         {
-                            valueContainer = ((ValueContainer) previousHandler._valueOrPrevious).Clone();
+                            valueContainer = previousHandler._valueContainer.Clone();
                         }
                         MaybeDisposePreviousFromCatch(previousHandler, handlerDisposedAfterCallback);
                         SetResultAndMaybeHandleFromCatch(valueContainer, previousState, out nextHandler, ref executionScheduler);
@@ -455,6 +453,7 @@ namespace Proto.Promises
                     throw new System.InvalidOperationException();
                 }
 
+                [MethodImpl(InlineOption)]
                 internal void SetResultAndMaybeHandle(ValueContainer valueContainer, Promise.State state, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
                     SetResult(valueContainer, state);
@@ -470,7 +469,7 @@ namespace Proto.Promises
                 internal void HandleSelf(ref PromiseRef handler, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
                     var state = handler.State;
-                    var valueContainer = ((ValueContainer) handler._valueOrPrevious).Clone();
+                    var valueContainer = handler._valueContainer.Clone();
                     MaybeDisposePrevious(handler);
                     handler = this;
                     SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
@@ -479,53 +478,15 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 internal void SetResultAndMaybeHandleFromCatch(ValueContainer valueContainer, Promise.State state, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
-                    SetResult(valueContainer, state);
-#if NET_LEGACY // Interlocked.Exchange doesn't seem to work properly in Unity's old runtime. I'm not sure why, but we need a lock here to pass multi-threaded tests.
-                    lock (this)
-#endif
-                    {
-                        Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
-                        nextHandler = Interlocked.Exchange(ref _waiter, null);
-                    }
-                    HandleProgressListener(state, Depth, ref executionScheduler);
-                }
-            }
-
-#if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
-#endif
-            internal abstract partial class PromiseSingleAwaitWithProgress : PromiseSingleAwait
-            {
-                // These `new` methods are used so that promises without progress can avoid a virtual call to a no-op HandleProgressListener(),
-                // and promises with progress can call it directly without virtual.
-                [MethodImpl(InlineOption)]
-                new internal void SetResultAndMaybeHandle(ValueContainer valueContainer, Promise.State state, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
-                {
-                    SetResult(valueContainer, state);
-#if NET_LEGACY // Interlocked.Exchange doesn't seem to work properly in Unity's old runtime. I'm not sure why, but we need a lock here to pass multi-threaded tests.
-                    lock (this)
-#endif
-                    {
-                        Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
-                        nextHandler = Interlocked.Exchange(ref _waiter, null);
-                    }
-                    HandleProgressListener(state, Depth, ref executionScheduler);
-                }
-
-                new internal void HandleSelf(ref PromiseRef handler, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
-                {
-                    var state = handler.State;
-                    var valueContainer = ((ValueContainer) handler._valueOrPrevious).Clone();
-                    MaybeDisposePrevious(handler);
-                    handler = this;
                     SetResultAndMaybeHandle(valueContainer, state, out nextHandler, ref executionScheduler);
+                    //HandleProgressListener(state, Depth, ref executionScheduler);
                 }
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal sealed partial class PromiseMultiAwait : PromiseRef, IProgressListener
+            internal sealed partial class PromiseMultiAwait : PromiseRef
             {
                 private PromiseMultiAwait() { }
 
@@ -533,6 +494,7 @@ namespace Proto.Promises
                 {
                     try
                     {
+                        // TODO: make sure WasAwaitedOrForgotten is only set to true when this is forgotten.
                         if (!WasAwaitedOrForgotten)
                         {
                             _smallFields.InterlockedSetFlags(PromiseFlags.WasAwaitedOrForgotten); // Stop base finalizer from adding an extra exception.
@@ -580,16 +542,15 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
                     if (State == Promise.State.Pending)
                     {
-                        _progressAndLocker._branchLocker.Enter();
-                        if (State == Promise.State.Pending)
+                        lock (this)
                         {
-                            _nextBranches.Enqueue(waiter);
-                            _progressAndLocker._branchLocker.Exit();
-
-                            MaybeDispose();
-                            return;
+                            if (State == Promise.State.Pending)
+                            {
+                                _nextBranches.Enqueue(waiter);
+                                MaybeDispose();
+                                return;
+                            }
                         }
-                        _progressAndLocker._branchLocker.Exit();
                     }
                     HandleablePromiseBase nextHandler;
                     PromiseRef handler = this;
@@ -603,15 +564,15 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
                     if (State == Promise.State.Pending)
                     {
-                        _progressAndLocker._branchLocker.Enter();
-                        if (State == Promise.State.Pending)
+                        lock (this)
                         {
-                            _nextBranches.Enqueue(waiter);
-                            _progressAndLocker._branchLocker.Exit();
-                            nextHandler = null;
-                            return;
+                            if (State == Promise.State.Pending)
+                            {
+                                _nextBranches.Enqueue(waiter);
+                                nextHandler = null;
+                                return;
+                            }
                         }
-                        _progressAndLocker._branchLocker.Exit();
                     }
                     nextHandler = waiter;
                 }
@@ -619,10 +580,7 @@ namespace Proto.Promises
                 internal override void Handle(ref ExecutionScheduler executionScheduler)
                 {
                     ThrowIfInPool(this);
-
-                    HandleProgressListeners(State, ref executionScheduler);
                     HandleBranches(ref executionScheduler);
-
                     MaybeDispose();
                 }
 
@@ -630,16 +588,17 @@ namespace Proto.Promises
                 {
                     nextHandler = null;
                     ThrowIfInPool(this);
-                    SetResult(((ValueContainer) handler._valueOrPrevious).Clone(), handler.State);
+                    SetResult(handler._valueContainer.Clone(), handler.State);
                     executionScheduler.ScheduleSynchronous(this);
-                    WaitWhileProgressFlags(PromiseFlags.Subscribing);
                 }
 
                 private void HandleBranches(ref ExecutionScheduler executionScheduler)
                 {
-                    _progressAndLocker._branchLocker.Enter();
-                    var branches = _nextBranches.MoveElementsToStack();
-                    _progressAndLocker._branchLocker.Exit();
+                    ValueLinkedStack<HandleablePromiseBase> branches;
+                    lock (this)
+                    {
+                        branches = _nextBranches.MoveElementsToStack();
+                    }
                     while (branches.IsNotEmpty)
                     {
                         var waiter = branches.Pop();
@@ -712,7 +671,7 @@ namespace Proto.Promises
                     TResult result, ushort depth)
                 {
                     var promise = GetOrCreate(synchronizationContext, depth);
-                    promise._valueOrPrevious = CreateResolveContainer(result);
+                    promise._valueContainer = CreateResolveContainer(result);
                     promise._previousState = Promise.State.Resolved;
                     promise._mostRecentPotentialScheduleMethod = (int) ScheduleMethod.Handle;
                     return promise;
@@ -732,7 +691,7 @@ namespace Proto.Promises
 #endif
                     {
                         ThrowIfInPool(this);
-                        _valueOrPrevious = ((ValueContainer) handler._valueOrPrevious).Clone();
+                        _valueContainer = handler._valueContainer.Clone();
                         nextHandler = null;
                         _previousState = handler.State;
                         Thread.MemoryBarrier(); // Make sure previous writes are done before swapping schedule method.
@@ -746,7 +705,6 @@ namespace Proto.Promises
                         {
                             executionScheduler.ScheduleSynchronous(this);
                         }
-                        WaitWhileProgressFlags(PromiseFlags.Subscribing);
                     }
                 }
 
@@ -808,16 +766,14 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal abstract partial class PromiseWaitPromise : PromiseSingleAwaitWithProgress, IProgressListener
+            internal abstract partial class PromiseWaitPromise : PromiseSingleAwait
             {
                 [MethodImpl(InlineOption)]
                 internal void WaitFor<T>(Promise<T> other, ref PromiseRef handler, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
                     ThrowIfInPool(this);
                     ValidateReturn(other);
-#if PROMISE_DEBUG
-                    MaybeDisposePrevious(handler);
-#endif
+                    MaybeDisposePreviousAfterSecondWait(handler);
                     var _ref = other._ref;
                     if (_ref == null)
                     {
@@ -829,16 +785,22 @@ namespace Proto.Promises
                     {
                         handler = _ref;
                         _ref.MarkAwaited(other.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
-                        SetPreviousAndSubscribeProgress(_ref, other.Depth, ref executionScheduler);
+                        SetSecondPrevious(_ref);
+                        InterlockedIncrementProgressReportingCount();
                         _ref.AddWaiter(this, out nextHandler, ref executionScheduler);
+                        MaybeReportProgressAfterSecondPreviousHookup(_ref, other.Depth, ref executionScheduler);
                     }
                 }
 
+                partial void MaybeReportProgressAfterSecondPreviousHookup(PromiseRef secondPrevious, ushort depth, ref ExecutionScheduler executionScheduler);
+
 #if !PROMISE_PROGRESS
                 [MethodImpl(InlineOption)]
-                private void SetPreviousAndSubscribeProgress(PromiseRef other, ushort depth, ref ExecutionScheduler executionScheduler)
+                private void SetSecondPrevious(PromiseRef other)
                 {
-                    _valueOrPrevious = other;
+#if PROMISE_DEBUG
+                    _previous = other;
+#endif
                 }
 #endif
             }
@@ -846,12 +808,12 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal abstract partial class AsyncPromiseBase : PromiseSingleAwaitWithProgress
+            internal abstract partial class AsyncPromiseBase : PromiseSingleAwait
             {
                 protected void Reset()
                 {
 #if PROMISE_PROGRESS
-                    _progressAndSubscribeFields._currentProgress = default(Fixed32);
+                    _smallFields._currentProgress = default(Fixed32);
 #endif
                     _smallFields.Reset();
                     SetCreatedStacktrace(this, 3);
@@ -869,7 +831,6 @@ namespace Proto.Promises
                         nextHandler = Interlocked.Exchange(ref _waiter, null);
                     }
                     var executionScheduler = new ExecutionScheduler(true);
-                    HandleProgressListener(state, 0, ref executionScheduler);
                     MaybeHandleNext(nextHandler, ref executionScheduler);
                     executionScheduler.Execute();
                 }
@@ -1212,7 +1173,7 @@ namespace Proto.Promises
                     catch
                     {
                         // Unlike normal finally clauses, we won't swallow the previous rejection. Instead, we send it to the uncaught rejection handler.
-                        ((ValueContainer) handler._valueOrPrevious).AddToUnhandledStack();
+                        handler._valueContainer.AddToUnhandledStack();
                         MaybeDisposePrevious(handler);
                         throw;
                     }
@@ -1309,7 +1270,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif
-            internal sealed partial class PromisePassThrough : HandleablePromiseBase, ILinked<PromisePassThrough>, IProgressListener
+            internal sealed partial class PromisePassThrough : HandleablePromiseBase, ILinked<PromisePassThrough>
             {
                 internal PromiseRef Owner
                 {
@@ -1343,7 +1304,7 @@ namespace Proto.Promises
                             string message = "A PromisePassThrough was garbage collected without it being released."
                                 + " _retainCounter: " + _smallFields._retainCounter + ", _index: " + _smallFields._index + ", _target: " + _target + ", _owner: " + _owner
 #if PROMISE_PROGRESS
-                                + ", _reportingProgress: " + _smallFields._reportingProgress + ", _settingInitialProgress: " + _smallFields._settingInitialProgress + ", _currentProgress: " + _smallFields._currentProgress.ToDouble()
+                                + ", _depth: " + _smallFields._depth + ", _currentProgress: " + _smallFields._currentProgress.ToDouble()
 #endif
                                 ;
                             AddRejectionToUnhandledStack(new UnreleasedObjectException(message), _target);
@@ -1365,32 +1326,25 @@ namespace Proto.Promises
                     passThrough._owner = owner._target._ref;
                     passThrough._smallFields._index = index;
                     passThrough._smallFields._retainCounter = 1;
-                    passThrough.ResetProgress(owner._target.Depth);
+                    passThrough.SetDepth(owner._target.Depth);
                     return passThrough;
                 }
 
-                partial void ResetProgress(ushort depth);
-                partial void WaitWhileProgressIsBusy();
+                partial void SetDepth(ushort depth);
+                partial void SetInitialProgress();
 
                 internal void SetTargetAndAddToOwner(MultiHandleablePromiseBase target)
                 {
                     ThrowIfInPool(this);
                     _target = target;
-#if PROMISE_PROGRESS
-                    // Unfortunately, we have to eagerly subscribe progress. Lazy algorithm would be much more expensive with thread safety, requiring allocations. (see ValidateReturn)
-                    // But it's not so bad, because it doesn't allocate any memory (just uses CPU cycles to set it up).
-                    _owner.HookupNewWaiterWithProgress(this, _smallFields._depth);
-#else
+                    SetInitialProgress();
                     _owner.HookupNewWaiter(this);
-#endif
                 }
 
                 internal override void Handle(ref PromiseRef handler, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
                     ThrowIfInPool(this);
-                    _owner = null;
-                    WaitWhileProgressIsBusy();
-                    _target.Handle(ref handler, (ValueContainer) handler._valueOrPrevious, this, out nextHandler, ref executionScheduler);
+                    _target.Handle(ref handler, handler._valueContainer, this, out nextHandler, ref executionScheduler);
                     Release();
                 }
 
@@ -1406,18 +1360,11 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
                     if (InterlockedAddWithOverflowCheck(ref _smallFields._retainCounter, -1, 0) == 0)
                     {
+                        _owner = null;
                         _target = null;
                         ObjectPool<HandleablePromiseBase>.MaybeRepool(this);
                     }
                 }
-
-#if !PROMISE_PROGRESS
-                internal ushort Depth
-                {
-                    [MethodImpl(InlineOption)]
-                    get { return 0; }
-                }
-#endif
             } // PromisePassThrough
 
             partial struct SmallFields

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -559,6 +559,7 @@ namespace Proto.Promises
                     {
                         branches = _nextBranches.MoveElementsToStack();
                     }
+                    WaitWhileProgressReporting();
                     while (branches.IsNotEmpty)
                     {
                         var waiter = branches.Pop();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -212,21 +212,14 @@ namespace Proto.Promises
 #if PROMISE_DEBUG
                 newPromise._previous = this;
 #endif
-#if PROMISE_PROGRESS
-                newPromise._smallFields._currentProgress = _smallFields._currentProgress;
-#endif
                 HookupNewWaiter(newPromise);
             }
 
             private void HookupNewWaiter(HandleablePromiseBase newWaiter)
             {
                 var executionScheduler = new ExecutionScheduler(true);
-                HookupNewWaiter(newWaiter, ref executionScheduler);
-            }
-
-            private void HookupNewWaiter(HandleablePromiseBase newWaiter, ref ExecutionScheduler executionScheduler)
-            {
-                AddWaiter(newWaiter, ref executionScheduler);
+                AddWaiter(newWaiter, out newWaiter, ref executionScheduler);
+                MaybeHandleNext(newWaiter, ref executionScheduler);
                 executionScheduler.Execute();
             }
 
@@ -248,7 +241,6 @@ namespace Proto.Promises
 
             internal abstract PromiseRef GetDuplicate(short promiseId, ushort depth);
 
-            internal abstract void AddWaiter(HandleablePromiseBase waiter, ref ExecutionScheduler executionScheduler);
             internal abstract void AddWaiter(HandleablePromiseBase waiter, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler);
 
             [MethodImpl(InlineOption)]
@@ -311,7 +303,7 @@ namespace Proto.Promises
 #endif
                 }
 
-                internal override void AddWaiter(HandleablePromiseBase waiter, ref ExecutionScheduler executionScheduler)
+                protected void AddWaiterImpl(HandleablePromiseBase waiter, ushort depth, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
 #if NET_LEGACY // Interlocked.Exchange doesn't seem to work properly in Unity's old runtime. I'm not sure why, but we need a lock here to pass multi-threaded tests.
                     lock (this)
@@ -320,41 +312,26 @@ namespace Proto.Promises
                         ThrowIfInPool(this);
                         // When this is completed, State is set then _waiter is swapped, so we must reverse that process here.
                         Thread.MemoryBarrier();
+                        InterlockedIncrementProgressReportingCount();
                         SetWaiter(waiter);
                         Thread.MemoryBarrier(); // Make sure State is read after _waiter is written.
-                        if (State != Promise.State.Pending)
+                        if (State == Promise.State.Pending)
                         {
-                            // Interlocked.Exchange to handle race condition with Handle on another thread.
-                            MaybeHandleNext(Interlocked.Exchange(ref _waiter, null), ref executionScheduler);
+                            nextHandler = null;
+                            ReportProgressFromAddWaiter(waiter, depth, ref executionScheduler);
                         }
                         else
                         {
-                            MaybeDispose();
+                            // Interlocked.Exchange to handle race condition with Handle on another thread.
+                            nextHandler = Interlocked.Exchange(ref _waiter, null);
+                            InterlockedDecrementProgressReportingCount();
                         }
                     }
                 }
 
                 internal override void AddWaiter(HandleablePromiseBase waiter, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
-#if NET_LEGACY // Interlocked.Exchange doesn't seem to work properly in Unity's old runtime. I'm not sure why, but we need a lock here to pass multi-threaded tests.
-                    lock (this)
-#endif
-                    {
-                        ThrowIfInPool(this);
-                        // When this is completed, State is set then _waiter is swapped, so we must reverse that process here.
-                        Thread.MemoryBarrier();
-                        SetWaiter(waiter);
-                        Thread.MemoryBarrier(); // Make sure State is read after _waiter is written.
-                        if (State != Promise.State.Pending)
-                        {
-                            // Interlocked.Exchange to handle race condition with Handle on another thread.
-                            nextHandler = Interlocked.Exchange(ref _waiter, null);
-                        }
-                        else
-                        {
-                            nextHandler = null;
-                        }
-                    }
+                    AddWaiterImpl(waiter, Depth, out nextHandler, ref executionScheduler);
                 }
 
                 internal void MaybeDisposePreviousFromCatch(PromiseRef previous, bool dispose)
@@ -537,31 +514,11 @@ namespace Proto.Promises
                     return newPromise;
                 }
 
-                internal override void AddWaiter(HandleablePromiseBase waiter, ref ExecutionScheduler executionScheduler)
-                {
-                    ThrowIfInPool(this);
-                    if (State == Promise.State.Pending)
-                    {
-                        lock (this)
-                        {
-                            if (State == Promise.State.Pending)
-                            {
-                                _nextBranches.Enqueue(waiter);
-                                MaybeDispose();
-                                return;
-                            }
-                        }
-                    }
-                    HandleablePromiseBase nextHandler;
-                    PromiseRef handler = this;
-                    // Handle or MaybeHandleNext will call MaybeDispose on this, so we don't need an extra call here.
-                    waiter.Handle(ref handler, out nextHandler, ref executionScheduler);
-                    handler.MaybeHandleNext(nextHandler, ref executionScheduler);
-                }
-
                 internal override void AddWaiter(HandleablePromiseBase waiter, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
                     ThrowIfInPool(this);
+                    nextHandler = waiter;
+                    InterlockedIncrementProgressReportingCount();
                     if (State == Promise.State.Pending)
                     {
                         lock (this)
@@ -570,11 +527,14 @@ namespace Proto.Promises
                             {
                                 _nextBranches.Enqueue(waiter);
                                 nextHandler = null;
-                                return;
+                                goto ReportProgress;
                             }
                         }
                     }
-                    nextHandler = waiter;
+                    InterlockedDecrementProgressReportingCount();
+                    return;
+                ReportProgress:
+                    ReportProgressFromAddWaiter(waiter, Depth, ref executionScheduler);
                 }
 
                 internal override void Handle(ref ExecutionScheduler executionScheduler)
@@ -734,16 +694,12 @@ namespace Proto.Promises
                     }
                 }
 
-                internal override void AddWaiter(HandleablePromiseBase waiter, ref ExecutionScheduler executionScheduler)
-                {
-                    AddWaiterImpl(waiter, ref executionScheduler);
-                    MaybeDispose();
-                }
-
                 internal override void AddWaiter(HandleablePromiseBase waiter, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
                     nextHandler = null;
+                    InterlockedIncrementProgressReportingCount();
                     AddWaiterImpl(waiter, ref executionScheduler);
+                    ReportProgressFromAddWaiter(waiter, Depth, ref executionScheduler);
                 }
 
                 protected override void OnForgetOrHookupFailed()
@@ -786,13 +742,9 @@ namespace Proto.Promises
                         handler = _ref;
                         _ref.MarkAwaited(other.Id, PromiseFlags.SuppressRejection | PromiseFlags.WasAwaitedOrForgotten);
                         SetSecondPrevious(_ref);
-                        InterlockedIncrementProgressReportingCount();
                         _ref.AddWaiter(this, out nextHandler, ref executionScheduler);
-                        MaybeReportProgressAfterSecondPreviousHookup(_ref, other.Depth, ref executionScheduler);
                     }
                 }
-
-                partial void MaybeReportProgressAfterSecondPreviousHookup(PromiseRef secondPrevious, ushort depth, ref ExecutionScheduler executionScheduler);
 
 #if !PROMISE_PROGRESS
                 [MethodImpl(InlineOption)]
@@ -815,6 +767,11 @@ namespace Proto.Promises
                 {
                     _smallFields.Reset();
                     SetCreatedStacktrace(this, 3);
+                }
+
+                internal override void AddWaiter(HandleablePromiseBase waiter, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
+                {
+                    AddWaiterImpl(waiter, 0, out nextHandler, ref executionScheduler);
                 }
 
                 protected void HandleInternal(ValueContainer valueContainer, Promise.State state)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
@@ -119,12 +119,6 @@ namespace Proto.Promises
 #if PROMISE_PROGRESS
             partial class RacePromise
             {
-                new private void Reset(ushort depth)
-                {
-                    _smallFields._currentProgress = default(Fixed32);
-                    base.Reset(depth);
-                }
-
                 internal override PromiseSingleAwait IncrementProgress(long amount, ref Fixed32 progress, ushort depth)
                 {
                     ThrowIfInPool(this);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
@@ -125,7 +125,7 @@ namespace Proto.Promises
                     base.Reset(depth);
                 }
 
-                internal override PromiseSingleAwait IncrementProgress(uint amount, ref Fixed32 progress, ushort depth)
+                internal override PromiseSingleAwait IncrementProgress(long amount, ref Fixed32 progress, ushort depth)
                 {
                     ThrowIfInPool(this);
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
@@ -307,7 +307,7 @@ namespace Proto.Promises
                 {
                     ValidateCall();
                     ValidateRejected();
-                    return new ReasonContainer((Internal.ValueContainer) _target._valueOrPrevious, Id);
+                    return new ReasonContainer(_target._valueContainer, Id);
                 }
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Unity/PromiseYieldInstruction.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Unity/PromiseYieldInstruction.cs
@@ -207,7 +207,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        yi._value = ((ValueContainer) resultContainer._target._valueOrPrevious).Clone();
+                        yi._value = resultContainer._target._valueContainer.Clone();
                     }
                     
                     yi.MaybeDispose();
@@ -233,7 +233,7 @@ namespace Proto.Promises
                     _value = null;
                     if (container != null)
                     {
-                        ((IRetainable) container).Release();
+                        ((ValueContainer) container).DisposeAndMaybeAddToUnhandledStack(false);
                     }
 #if !PROMISE_DEBUG // Don't repool in DEBUG mode.
                     ObjectPool<YieldInstruction<T>>.MaybeRepool(this);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/ProgressHelper.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/ProgressHelper.cs
@@ -14,6 +14,7 @@ namespace ProtoPromiseTests
 
     public class ProgressHelper : IProgress<float>
     {
+        private readonly float _delta;
         private readonly object _locker = new object();
         private readonly ProgressType _progressType;
         private readonly SynchronizationType _synchronizationType;
@@ -21,11 +22,12 @@ namespace ProtoPromiseTests
         volatile private bool _wasInvoked;
         volatile private float _currentProgress = float.NaN;
 
-        public ProgressHelper(ProgressType progressType, SynchronizationType synchronizationType, Action<float> onProgress = null)
+        public ProgressHelper(ProgressType progressType, SynchronizationType synchronizationType, Action<float> onProgress = null, float delta = float.NaN)
         {
             _progressType = progressType;
             _synchronizationType = synchronizationType;
             _onProgress = onProgress;
+            _delta = float.IsNaN(delta) ? TestHelper.progressEpsilon : delta;
         }
 
         public void MaybeEnterLock()
@@ -100,7 +102,7 @@ namespace ProtoPromiseTests
                 }
                 else
                 {
-                    Assert.AreEqual(expectedProgress, currentProgress, TestHelper.progressEpsilon);
+                    Assert.AreEqual(expectedProgress, currentProgress, _delta);
                 }
             }
             catch (TimeoutException e)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/ProgressHelper.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/ProgressHelper.cs
@@ -91,23 +91,56 @@ namespace ProtoPromiseTests
             }
         }
 
+        private bool AreEqual(float expected, float actual)
+        {
+            if (float.IsNaN(expected))
+            {
+                return float.IsNaN(actual);
+            }
+            float dif = Math.Abs(expected - actual);
+            return dif <= _delta;
+        }
+
         public void AssertCurrentProgress(float expectedProgress, bool waitForInvoke = true, bool executeForeground = true, TimeSpan timeout = default(TimeSpan))
+        {
+            if (!GetCurrentProgressEqualsExpected(expectedProgress, waitForInvoke, executeForeground, timeout))
+            {
+                WaitForExpectedProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
+            }
+        }
+
+        private bool GetCurrentProgressEqualsExpected(float expectedProgress, bool waitForInvoke = true, bool executeForeground = true, TimeSpan timeout = default(TimeSpan))
         {
             try
             {
                 float currentProgress = GetCurrentProgress(waitForInvoke, executeForeground, timeout);
-                if (float.IsNaN(expectedProgress))
-                {
-                    Assert.IsNaN(currentProgress);
-                }
-                else
-                {
-                    Assert.AreEqual(expectedProgress, currentProgress, _delta);
-                }
+                return AreEqual(expectedProgress, currentProgress);
             }
             catch (TimeoutException e)
             {
                 throw new TimeoutException("expectedProgress: " + expectedProgress + ", executeForeground: " + executeForeground, e);
+            }
+        }
+
+        private void WaitForExpectedProgress(float expectedProgress, bool waitForInvoke, bool executeForeground, TimeSpan timeout = default(TimeSpan))
+        {
+            if (executeForeground)
+            {
+                TestHelper.ExecuteForegroundCallbacks();
+            }
+            if (!waitForInvoke)
+            {
+                return;
+            }
+
+            if (timeout <= TimeSpan.Zero)
+            {
+                timeout = TimeSpan.FromSeconds(1);
+            }
+            float current = float.NaN;
+            if (!SpinWait.SpinUntil(() => { current = _currentProgress; return current == expectedProgress; }, timeout))
+            {
+                throw new TimeoutException("Progress was not invoked with expected progress " + expectedProgress + " after " + timeout + ", _currentProgress: " + _currentProgress + ", current thread is background: " + Thread.CurrentThread.IsBackground);
             }
         }
 
@@ -122,84 +155,124 @@ namespace ProtoPromiseTests
 
         public void ReportProgressAndAssertResult(Promise.DeferredBase deferred, float reportValue, float expectedProgress, bool waitForInvoke = true, bool executeForeground = true, TimeSpan timeout = default(TimeSpan))
         {
+            bool areEqual;
             lock (_locker)
             {
                 PrepareForInvoke();
                 deferred.ReportProgress(reportValue);
-                AssertCurrentProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
+                areEqual = GetCurrentProgressEqualsExpected(expectedProgress, waitForInvoke, executeForeground, timeout);
+            }
+            if (!areEqual)
+            {
+                WaitForExpectedProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
             }
         }
 
         public void RejectAndAssertResult<TReject>(Promise.DeferredBase deferred, TReject reason, float expectedProgress, bool waitForInvoke = true, bool executeForeground = true, TimeSpan timeout = default(TimeSpan))
         {
+            bool areEqual;
             lock (_locker)
             {
                 PrepareForInvoke();
                 deferred.Reject(reason);
-                AssertCurrentProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
+                areEqual = GetCurrentProgressEqualsExpected(expectedProgress, waitForInvoke, executeForeground, timeout);
+            }
+            if (!areEqual)
+            {
+                WaitForExpectedProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
             }
         }
 
         public void CancelAndAssertResult(Promise.DeferredBase deferred, float expectedProgress, bool waitForInvoke = true, bool executeForeground = true, TimeSpan timeout = default(TimeSpan))
         {
+            bool areEqual;
             lock (_locker)
             {
                 PrepareForInvoke();
                 deferred.Cancel();
-                AssertCurrentProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
+                areEqual = GetCurrentProgressEqualsExpected(expectedProgress, waitForInvoke, executeForeground, timeout);
+            }
+            if (!areEqual)
+            {
+                WaitForExpectedProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
             }
         }
 
         public void CancelAndAssertResult(CancelationSource cancelationSource, float expectedProgress, bool waitForInvoke = true, bool executeForeground = true, TimeSpan timeout = default(TimeSpan))
         {
+            bool areEqual;
             lock (_locker)
             {
                 PrepareForInvoke();
                 cancelationSource.Cancel();
-                AssertCurrentProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
+                areEqual = GetCurrentProgressEqualsExpected(expectedProgress, waitForInvoke, executeForeground, timeout);
+            }
+            if (!areEqual)
+            {
+                WaitForExpectedProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
             }
         }
 
         public void ResolveAndAssertResult(Promise.Deferred deferred, float expectedProgress, bool waitForInvoke = true, bool executeForeground = true, TimeSpan timeout = default(TimeSpan))
         {
+            bool areEqual;
             lock (_locker)
             {
                 PrepareForInvoke();
                 deferred.Resolve();
-                AssertCurrentProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
+                areEqual = GetCurrentProgressEqualsExpected(expectedProgress, waitForInvoke, executeForeground, timeout);
+            }
+            if (!areEqual)
+            {
+                WaitForExpectedProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
             }
         }
 
         public void ResolveAndAssertResult<T>(Promise<T>.Deferred deferred, T result, float expectedProgress, bool waitForInvoke = true, bool executeForeground = true, TimeSpan timeout = default(TimeSpan))
         {
+            bool areEqual;
             lock (_locker)
             {
                 PrepareForInvoke();
                 deferred.Resolve(result);
-                AssertCurrentProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
+                areEqual = GetCurrentProgressEqualsExpected(expectedProgress, waitForInvoke, executeForeground, timeout);
+            }
+            if (!areEqual)
+            {
+                WaitForExpectedProgress(expectedProgress, waitForInvoke, executeForeground, timeout);
             }
         }
 
         public Promise SubscribeAndAssertCurrentProgress(Promise promise, float expectedProgress, CancelationToken cancelationToken = default(CancelationToken), TimeSpan timeout = default(TimeSpan))
         {
+            bool areEqual;
             lock (_locker)
             {
                 PrepareForInvoke();
                 promise = Subscribe(promise, cancelationToken);
-                AssertCurrentProgress(expectedProgress, timeout: timeout);
-                return promise;
+                areEqual = GetCurrentProgressEqualsExpected(expectedProgress, timeout: timeout);
             }
+            if (!areEqual)
+            {
+                WaitForExpectedProgress(expectedProgress, true, true, timeout);
+            }
+            return promise;
         }
 
         public Promise<T> SubscribeAndAssertCurrentProgress<T>(Promise<T> promise, float expectedProgress, CancelationToken cancelationToken = default(CancelationToken), TimeSpan timeout = default(TimeSpan))
         {
+            bool areEqual;
             lock (_locker)
             {
                 PrepareForInvoke();
                 promise = Subscribe(promise, cancelationToken);
-                AssertCurrentProgress(expectedProgress, timeout: timeout);
-                return promise;
+                areEqual = GetCurrentProgressEqualsExpected(expectedProgress, timeout: timeout);
             }
+            if (!areEqual)
+            {
+                WaitForExpectedProgress(expectedProgress, true, true, timeout);
+            }
+            return promise;
         }
 
         public Promise Subscribe(Promise promise, CancelationToken cancelationToken = default(CancelationToken))

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/TestHelper.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/TestHelper.cs
@@ -380,7 +380,7 @@ namespace ProtoPromiseTests
             throw new Exception("Unexpected callback contexts, expectedContext: " + expectedContext + ", invokeContext: " + invokeContext);
         }
 
-        public static readonly double progressEpsilon = 1d / Math.Pow(2d, Promise.Config.ProgressDecimalBits);
+        public static readonly float progressEpsilon = Promise.Config.ProgressPrecision;
 
         public const int callbacksMultiplier = 3
 #if CSHARP_7_3_OR_NEWER

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/AsyncFunctionTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/AsyncFunctionTests.cs
@@ -704,7 +704,7 @@ namespace ProtoPromiseTests.APIs
                     .AwaitWithProgress(0.5f, 1f);
             }
 
-            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous, delta: TestHelper.progressEpsilon * 2); // Increase delta to accommodate for internal scaling operations with loss of precision.
             bool complete = false;
 
             Func()
@@ -812,7 +812,7 @@ namespace ProtoPromiseTests.APIs
                     .AwaitWithProgress(0.5f, 1f);
             }
 
-            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous, delta: TestHelper.progressEpsilon * 2); // Increase delta to accommodate for internal scaling operations with loss of precision.
             bool complete = false;
 
             Func()

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/ProgressTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/ProgressTests.cs
@@ -1687,6 +1687,78 @@ namespace ProtoPromiseTests.APIs
             CollectionAssert.AreEqual(System.Linq.Enumerable.Range(0, results.Length), results);
         }
 
+        [Test]
+        public void AllProgressMayIncrementOrDecrement_void(
+            [Values] SynchronizationType synchronizationType)
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, synchronizationType);
+
+            Promise.All(deferred1.Promise, deferred2.Promise)
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, 0.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 1f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0f, 0.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.75f, 0.75f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0f, 0f / 2f);
+            progressHelper.ResolveAndAssertResult(deferred1, 1f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 1.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0f, 1f / 2f);
+            progressHelper.ResolveAndAssertResult(deferred2, 2f / 2f);
+        }
+
+        [Test]
+        public void AllProgressMayIncrementOrDecrement_T(
+            [Values] SynchronizationType synchronizationType)
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, synchronizationType);
+
+            Promise<int>.All(deferred1.Promise, deferred2.Promise)
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, 0.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 1f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0f, 0.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.75f, 0.75f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0f, 0f / 2f);
+            progressHelper.ResolveAndAssertResult(deferred1, 1, 1f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 1.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0f, 1f / 2f);
+            progressHelper.ResolveAndAssertResult(deferred2, 2, 2f / 2f);
+        }
+
+        [Test]
+        public void MergeProgressMayIncrementOrDecrement(
+            [Values] SynchronizationType synchronizationType)
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<string>();
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, synchronizationType);
+
+            Promise.Merge(deferred1.Promise, deferred2.Promise)
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, 0.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 1f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0f, 0.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.75f, 0.75f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0f, 0f / 2f);
+            progressHelper.ResolveAndAssertResult(deferred1, 1, 1f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 1.5f / 2f);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0f, 1f / 2f);
+            progressHelper.ResolveAndAssertResult(deferred2, "success", 2f / 2f);
+        }
+
 #else // PROMISE_PROGRESS
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/ProtoPromise_Unity/ProjectSettings/ProjectSettings.asset
+++ b/ProtoPromise_Unity/ProjectSettings/ProjectSettings.asset
@@ -514,7 +514,8 @@ PlayerSettings:
   webGLCompressionFormat: 2
   webGLLinkerTarget: 2
   webGLThreadsSupport: 0
-  scriptingDefineSymbols: {}
+  scriptingDefineSymbols:
+    1: PROTO_PROMISE_DEBUG_DISABLE
   platformArchitecture: {}
   scriptingBackend: {}
   il2cppCompilerConfiguration: {}
@@ -522,7 +523,7 @@ PlayerSettings:
   incrementalIl2cppBuild: {}
   allowUnsafeCode: 0
   additionalIl2CppArgs: 
-  scriptingRuntimeVersion: 0
+  scriptingRuntimeVersion: 1
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
@@ -603,7 +604,7 @@ PlayerSettings:
   facebookStatus: 1
   facebookXfbml: 0
   facebookFrictionlessRequests: 1
-  apiCompatibilityLevel: 2
+  apiCompatibilityLevel: 6
   cloudProjectId: 
   framebufferDepthMemorylessMode: 0
   projectName: 


### PR DESCRIPTION
Simplified progress so that each PromiseRef is also a progress listener. Subscribing progress no longer needs to walk the promise chain. The downside to this is reporting progress will walk the entire promise chain, which will be a little more expensive for `.Then` chains, but it doesn't affect async/await because it had to do that already anyway. Actually, async/await progress is even cheaper now, as a passthrough object is no longer required. Subscribing to progress is now O(1) for both cpu and memory.

Also increased progress precision by 3 bits (from 13 to 16), so progress step size went from 0.0001220703125 to 0.0000152587890625.

Measurements with normal awaits, no progress reports:

Master:

```
|         Type |          Method | Pending | Recursion |     Mean |   Error | Allocated | Survived |
|------------- |---------------- |-------- |---------- |---------:|--------:|----------:|---------:|
|   AsyncAwait | ProtoPromise_V2 |    True |       100 | 261.2 μs | 1.21 μs |         - | 23,552 B |
| ContinueWith | ProtoPromise_V2 |    True |       100 | 261.4 μs | 0.95 μs |         - | 11,504 B |
```

This PR:

```
|         Type |          Method | Pending | Recursion |     Mean |   Error | Allocated | Survived |
|------------- |---------------- |-------- |---------- |---------:|--------:|----------:|---------:|
|   AsyncAwait | ProtoPromise_V2 |    True |       100 | 260.0 μs | 1.67 μs |         - | 23,552 B |
| ContinueWith | ProtoPromise_V2 |    True |       100 | 254.9 μs | 1.48 μs |         - | 11,504 B |
```