### PR TITLE
Perf refactor

### DIFF
--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -11,6 +11,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!--Set true to help debug internal promise code (allows the debugger to step into the code and includes internal stacktraces).-->
     <DeveloperMode>false</DeveloperMode>
+    <!--If true, the stack will unwind before invoking the next continuation. If false, stack traces will be longer, but it could cause a StackOverflowException if the promise chain is very long.
+        This value is ignored if DeveloperMode is false, and will default to true.-->
+    <AllowStackToUnwind>true</AllowStackToUnwind>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,6 +29,13 @@
 
   <PropertyGroup Condition="'$(DeveloperMode)'=='true'">
     <DefineConstants>$(DefineConstants);TRACE;PROTO_PROMISE_DEVELOPER_MODE</DefineConstants>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(AllowStackToUnwind)'=='false'">
+    <DefineConstants>$(DefineConstants);PROTO_PROMISE_STACK_UNWIND_DISABLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoProgress|AnyCPU'">

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -431,8 +431,7 @@ namespace Proto.Promises
 
             CancelationRef ILinked<CancelationRef>.Next { get; set; }
 
-            // TODO: replace lock(_registeredCallbacks) with Monitor.TryEnter() in abortable loop.
-            // TODO: create a custom SortedDictionary with pooled nodes instead.
+            // TODO: replace List with a double-linked list with the CancelationRegistration storing the node directly for O(1) find and removal.
             private readonly List<RegisteredDelegate> _registeredCallbacks = new List<RegisteredDelegate>();
             private ValueLinkedStackZeroGC<CancelationRegistration> _links = ValueLinkedStackZeroGC<CancelationRegistration>.Create();
             volatile private int _state; // State as int for Interlocked.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
@@ -286,8 +286,7 @@ namespace Proto.Promises
                 // A promise cannot wait on itself.
                 if (other == this)
                 {
-                    other.MarkAwaited(other.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
-                    other.MaybeDispose();
+                    other.MaybeMarkAwaitedAndDispose(other.Id);
                     if (awaited)
                         throw new InvalidOperationException("A Promise cannot wait on itself.", string.Empty);
                     throw new InvalidReturnException("A Promise cannot wait on itself.", string.Empty);
@@ -304,8 +303,7 @@ namespace Proto.Promises
                 {
                     if (prev == this)
                     {
-                        other.MarkAwaited(other.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
-                        other.MaybeDispose();
+                        other.MaybeMarkAwaitedAndDispose(other.Id);
                         while (passThroughs.Count > 0)
                         {
                             passThroughs.Pop().Release();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
@@ -296,7 +296,7 @@ namespace Proto.Promises
                     return;
                 }
                 // This allows us to check Merge/All/Race/First Promises iteratively.
-                Stack<PromisePassThrough> passThroughs = PassthroughsForIterativeAlgorithm;
+                Stack<PromiseRef> previouses = PreviousesForIterativeAlgorithm;
                 PromiseRef prev = other._previous;
             Repeat:
                 for (; prev != null; prev = prev._previous)
@@ -304,59 +304,57 @@ namespace Proto.Promises
                     if (prev == this)
                     {
                         other.MaybeMarkAwaitedAndDispose(other.Id);
-                        while (passThroughs.Count > 0)
-                        {
-                            passThroughs.Pop().Release();
-                        }
+                        previouses.Clear();
                         if (awaited)
                             throw new InvalidOperationException("Circular Promise chain detected.", GetFormattedStacktrace(other));
                         throw new InvalidReturnException("Circular Promise chain detected.", GetFormattedStacktrace(other));
                     }
-                    prev.BorrowPassthroughs(passThroughs);
+                    prev.BorrowPassthroughs(previouses);
                 }
 
-                if (passThroughs.Count > 0)
+                if (previouses.Count > 0)
                 {
-                    var passThrough = passThroughs.Pop();
-                    prev = passThrough.Owner;
-                    passThrough.Release();
+                    prev = previouses.Pop();
                     goto Repeat;
                 }
             }
 
             [ThreadStatic]
-            private static Stack<PromisePassThrough> _passthroughsForIterativeAlgorithm;
-            private static Stack<PromisePassThrough> PassthroughsForIterativeAlgorithm
+            private static Stack<PromiseRef> _previousesForIterativeAlgorithm;
+            private static Stack<PromiseRef> PreviousesForIterativeAlgorithm
             {
                 get
                 {
-                    if (_passthroughsForIterativeAlgorithm == null)
+                    if (_previousesForIterativeAlgorithm == null)
                     {
-                        _passthroughsForIterativeAlgorithm = new Stack<PromisePassThrough>();
+                        _previousesForIterativeAlgorithm = new Stack<PromiseRef>();
                     }
-                    return _passthroughsForIterativeAlgorithm;
+                    return _previousesForIterativeAlgorithm;
                 }
             }
 
-            protected virtual void BorrowPassthroughs(Stack<PromisePassThrough> borrower) { }
-
-            private static void ExchangePassthroughs(ref ValueLinkedStack<PromisePassThrough> from, Stack<PromisePassThrough> to, object locker)
-            {
-                lock (locker)
-                {
-                    foreach (var passthrough in from)
-                    {
-                        passthrough.Retain();
-                        to.Push(passthrough);
-                    }
-                }
-            }
+            protected virtual void BorrowPassthroughs(Stack<PromiseRef> borrower) { }
 
             partial class MultiHandleablePromiseBase
             {
-                protected override void BorrowPassthroughs(Stack<PromisePassThrough> borrower)
+                protected override void BorrowPassthroughs(Stack<PromiseRef> borrower)
                 {
-                    ExchangePassthroughs(ref _passThroughs, borrower, _locker);
+                    lock (_previousPromises)
+                    {
+                        foreach (var promiseRef in _previousPromises)
+                        {
+                            borrower.Push(promiseRef);
+                        }
+                    }
+                }
+                
+                new protected void Dispose()
+                {
+                    base.Dispose();
+                    lock (_previousPromises)
+                    {
+                        _previousPromises.Clear();
+                    }
                 }
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
@@ -167,7 +167,11 @@ namespace Proto.Promises
             internal void ScheduleSynchronous(HandleablePromiseBase handleable)
             {
                 AssertNotExecutingProgress();
+#if PROTO_PROMISE_STACK_UNWIND_DISABLE && PROTO_PROMISE_DEVELOPER_MODE
+                handleable.Handle(ref this);
+#else
                 _handleStack.Push(handleable);
+#endif
             }
 
             internal void ScheduleOnContext(SynchronizationContext synchronizationContext, HandleablePromiseBase handleable)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/PoolInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/PoolInternal.cs
@@ -133,6 +133,17 @@ namespace Proto.Promises
 #endif
         }
 
+        internal static void Discard(object waste)
+        {
+            GC.SuppressFinalize(waste);
+#if PROMISE_DEBUG
+            lock (_pooledObjects)
+            {
+                _inUseObjects.Remove(waste);
+            }
+#endif
+        }
+
         static partial void ThrowIfInPool(object obj);
 #if PROMISE_DEBUG
         private static bool _trackObjectsForRelease = false;
@@ -174,7 +185,7 @@ namespace Proto.Promises
                 if (_inUseObjects.Count > 0)
                 {
                     System.Text.StringBuilder sb = new System.Text.StringBuilder();
-                    sb.AppendLine("Objects not released:");
+                    sb.AppendLine(_inUseObjects.Count + " objects not released:");
                     sb.AppendLine();
                     ITraceable traceable = null;
                     foreach (var obj in _inUseObjects)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
@@ -226,34 +226,6 @@ namespace Proto.Promises
                 return temp;
             }
 
-            internal bool TryRemove(T item)
-            {
-                if (IsEmpty)
-                {
-                    return false;
-                }
-                if (item == _head)
-                {
-                    _head = _head.Next;
-                    MarkRemovedFromCollection(item);
-                    return true;
-                }
-                T node = _head;
-                T next = node.Next;
-                while (next != null)
-                {
-                    if (next == item)
-                    {
-                        node.Next = next.Next;
-                        MarkRemovedFromCollection(item);
-                        return true;
-                    }
-                    node = next;
-                    next = node.Next;
-                }
-                return false;
-            }
-
             [MethodImpl(InlineOption)]
             public Enumerator<T> GetEnumerator()
             {
@@ -388,6 +360,7 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 get { return _head == null; }
             }
+
             internal bool IsNotEmpty
             {
                 [MethodImpl(InlineOption)]
@@ -399,12 +372,6 @@ namespace Proto.Promises
             {
                 _head = head;
                 _tail = tail;
-            }
-
-            [MethodImpl(InlineOption)]
-            internal T PeekTail()
-            {
-                return _tail;
             }
 
             internal void Enqueue(T item)
@@ -459,6 +426,7 @@ namespace Proto.Promises
         internal struct ValueWriteOnlyLinkedQueue<T> where T : class, ILinked<T>
 #endif
         {
+            // TODO: sentinel can be removed as a field and passed in as an argument to save 4/8 bytes of memory.
             private readonly ILinked<T> _sentinel;
             private ILinked<T> _tail;
 
@@ -583,16 +551,11 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 get { return _stack.IsEmpty; }
             }
+
             internal bool IsNotEmpty
             {
                 [MethodImpl(InlineOption)]
                 get { return _stack.IsNotEmpty; }
-            }
-
-            [MethodImpl(InlineOption)]
-            internal void ClearWithoutRepoolUnsafe()
-            {
-                _stack = new ValueLinkedStack<Node>();
             }
 
             [MethodImpl(InlineOption)]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
@@ -393,10 +393,17 @@ namespace Proto.Promises
                 get { return _head != null; }
             }
 
+            [MethodImpl(InlineOption)]
             internal ValueLinkedQueue(T head, T tail)
             {
                 _head = head;
                 _tail = tail;
+            }
+
+            [MethodImpl(InlineOption)]
+            internal T PeekTail()
+            {
+                return _tail;
             }
 
             internal void Enqueue(T item)
@@ -412,69 +419,6 @@ namespace Proto.Promises
                     _tail.Next = item;
                     _tail = item;
                 }
-            }
-
-            internal void Push(T item)
-            {
-                AssertNotInCollection(item);
-
-                if (_head == null)
-                {
-                    _head = _tail = item;
-                }
-                else
-                {
-                    item.Next = _head;
-                    _head = item;
-                }
-            }
-
-            internal bool TryRemove(T item)
-            {
-                if (IsEmpty)
-                {
-                    return false;
-                }
-                if (item == _head)
-                {
-                    _head = _head.Next;
-                    if (item == _tail)
-                    {
-                        _tail = null;
-                    }
-                    MarkRemovedFromCollection(item);
-                    return true;
-                }
-                T node = _head;
-                T next = node.Next;
-                while (next != null)
-                {
-                    if (next == item)
-                    {
-                        node.Next = next.Next;
-                        if (item == _tail)
-                        {
-                            _tail = node;
-                        }
-                        MarkRemovedFromCollection(item);
-                        return true;
-                    }
-                    node = next;
-                    next = node.Next;
-                }
-                return false;
-            }
-
-            internal bool Contains(T item)
-            {
-                foreach (T node in this)
-                {
-                    if (item == node)
-                    {
-                        return true;
-                    }
-                }
-                return false;
             }
 
             internal ValueLinkedStack<T> MoveElementsToStack()

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
@@ -295,6 +295,7 @@ namespace Proto.Promises
                 }
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             private void EnterCore()
             {
                 // Spin until we successfully get lock.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueContainersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueContainersInternal.cs
@@ -8,14 +8,12 @@
 #undef PROMISE_DEBUG
 #endif
 
-#pragma warning disable IDE0018 // Inline variable declaration
 #pragma warning disable IDE0019 // Use pattern matching
 #pragma warning disable IDE0034 // Simplify 'default' expression
 
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace Proto.Promises
 {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Exceptions.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Exceptions.cs
@@ -5,6 +5,7 @@
 #endif
 
 #pragma warning disable IDE0034 // Simplify 'default' expression
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
 using System;
 using System.Diagnostics;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -638,7 +638,7 @@ namespace Proto.Promises
                     bool isComplete = ExchangeCurrentRunner(previousRunner) == null;
                     if (isComplete)
                     {
-                        nextHandler = CompareExchangeWaiter(PromiseCompletionSentinel._instance, null);
+                        nextHandler = TakeNextWaiter();
                         handler = this;
                     }
                     else
@@ -697,7 +697,7 @@ namespace Proto.Promises
                         bool isComplete = ExchangeCurrentRunner(previousRunner) == null;
                         if (isComplete)
                         {
-                            nextHandler = CompareExchangeWaiter(PromiseCompletionSentinel._instance, null);
+                            nextHandler = TakeNextWaiter();
                             handler = this;
                         }
                         else

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -418,6 +418,7 @@ namespace Proto.Promises
 #endif
             internal partial class AsyncPromiseRef : AsyncPromiseBase
             {
+                // TODO: change to HandleablePromiseBase and use more liberally to remove branches.
                 [ThreadStatic]
                 private static AsyncPromiseRef _currentRunner;
 
@@ -514,7 +515,7 @@ namespace Proto.Promises
                 {
                     ValidateAwait(waiter, promiseId);
 
-                    // TODO: detect if this is being called from another promise higher in the stack, allow the stack to unwind instead of calling Handle.
+                    // TODO: detect if this is being called from another promise higher in the stack, allow the stack to unwind instead of calling waiter.HandleNext.
 
                     SetPreviousAndProgress(waiter, minProgress, maxProgress);
 
@@ -533,8 +534,7 @@ namespace Proto.Promises
                         {
                             throw new InvalidOperationException("Cannot await or forget a forgotten promise or a non-preserved promise more than once.", GetFormattedStacktrace(2));
                         }
-                        HandleablePromiseBase _;
-                        Handle(ref waiter, out _, ref executionScheduler);
+                        waiter.HandleNext(this, ref executionScheduler);
                     }
                     executionScheduler.Execute();
                 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -524,7 +524,7 @@ namespace Proto.Promises
                     PromiseSingleAwait promiseSingleAwait = waiter.AddWaiter(promiseId, this, out previousWaiter, ref executionScheduler);
                     if (previousWaiter == null)
                     {
-                        waiter.ReportProgressFromAddWaiter(this, Depth, ref executionScheduler);
+                        ReportProgressFromHookupWaiterWithProgress(waiter, depth, ref executionScheduler);
                     }
                     else
                     {
@@ -538,6 +538,8 @@ namespace Proto.Promises
                     }
                     executionScheduler.Execute();
                 }
+
+                partial void ReportProgressFromHookupWaiterWithProgress(PromiseRef other, ushort depth, ref ExecutionScheduler executionScheduler);
             }
 
 #if !OPTIMIZED_ASYNC_MODE
@@ -657,7 +659,7 @@ namespace Proto.Promises
                     bool isComplete = ExchangeCurrentRunner(previousRunner) == null;
                     if (isComplete)
                     {
-                        nextHandler = TakeNextWaiter();
+                        nextHandler = TakeOrHandleNextWaiter(ref executionScheduler);
                         handler = this;
                     }
                     else
@@ -716,7 +718,7 @@ namespace Proto.Promises
                         bool isComplete = ExchangeCurrentRunner(previousRunner) == null;
                         if (isComplete)
                         {
-                            nextHandler = TakeNextWaiter();
+                            nextHandler = TakeOrHandleNextWaiter(ref executionScheduler);
                             handler = this;
                         }
                         else

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -245,6 +245,7 @@ namespace Proto.Promises
         }
 #endif // UNITY_2021_2_OR_NEWER || !UNITY_5_5_OR_NEWER
 
+        // TODO: only check null id in DEBUG mode. Remove duplicate id check for non-null.
         internal static void ValidateAwaiterOperation(Promise promise, int skipFrames)
         {
             bool isValid = promise._target._ref == null
@@ -367,6 +368,8 @@ namespace Proto.Promises
             [MethodImpl(Internal.InlineOption)]
             internal PromiseAwaiter(Promise<T> promise)
             {
+                // TODO: check for null and use a sentinel PromiseRef so the other calls don't need to check for null.
+                // It may be better to have the sentinel on the promise itself, rather than the awaiters, so none of the APIs need to check for null.
                 _promise = promise;
                 CreateOverride();
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -846,9 +846,7 @@ namespace Proto.Promises
                             Discard(promise);
                             throw new InvalidOperationException("Cannot await or forget a forgotten promise or a non-preserved promise more than once.", GetFormattedStacktrace(2));
                         }
-                        PromiseRef handler = _this._ref;
-                        HandleablePromiseBase _;
-                        promise.Handle(ref handler, out _, ref executionScheduler);
+                        _this._ref.HandleNext(promise, ref executionScheduler);
                     }
                     executionScheduler.Execute();
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -298,11 +298,10 @@ namespace Proto.Promises
                     // else if (_this._ref.State != Promise.State.Pending) { }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseResolve<Delegate<TArg, TResult>>.GetOrCreate(resolver, cancelationToken, _this.Depth)
                             : (PromiseRef) PromiseResolve<Delegate<TArg, TResult>>.GetOrCreate(resolver, _this.Depth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
@@ -320,11 +319,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseResolvePromise<DelegatePromise<TArg, TResult>>.GetOrCreate(resolver, cancelationToken, nextDepth)
                             : (PromiseRef) PromiseResolvePromise<DelegatePromise<TArg, TResult>>.GetOrCreate(resolver, nextDepth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
@@ -343,11 +341,10 @@ namespace Proto.Promises
                     // else if (_this._ref.State != Promise.State.Pending) { }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseResolve<DelegateCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, cancelationToken, _this.Depth)
                             : (PromiseRef) PromiseResolve<DelegateCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, _this.Depth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
@@ -365,11 +362,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseResolvePromise<DelegatePromiseCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, cancelationToken, nextDepth)
                             : (PromiseRef) PromiseResolvePromise<DelegatePromiseCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, nextDepth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
@@ -390,11 +386,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseResolveReject<Delegate<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, _this.Depth)
                             : (PromiseRef) PromiseResolveReject<Delegate<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
@@ -415,11 +410,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseResolveReject<DelegateCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, _this.Depth)
                             : (PromiseRef) PromiseResolveReject<DelegateCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
@@ -441,11 +435,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseResolveRejectPromise<Delegate<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth)
                             : (PromiseRef) PromiseResolveRejectPromise<Delegate<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
@@ -467,11 +460,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseResolveRejectPromise<DelegateCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth)
                             : (PromiseRef) PromiseResolveRejectPromise<DelegateCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
@@ -493,11 +485,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseResolveRejectPromise<DelegatePromise<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth)
                             : (PromiseRef) PromiseResolveRejectPromise<DelegatePromise<TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
@@ -519,11 +510,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseResolveRejectPromise<DelegatePromiseCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth)
                             : (PromiseRef) PromiseResolveRejectPromise<DelegatePromiseCapture<TCaptureResolve, TArgResolve, TResult>, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
@@ -544,11 +534,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseResolveReject<DelegateResolvePassthrough, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, _this.Depth)
                             : (PromiseRef) PromiseResolveReject<DelegateResolvePassthrough, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
@@ -570,11 +559,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseResolveRejectPromise<DelegateResolvePassthrough, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth)
                             : (PromiseRef) PromiseResolveRejectPromise<DelegateResolvePassthrough, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
@@ -591,11 +579,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseContinue<DelegateContinue<TArg, TResult>>.GetOrCreate(resolver, cancelationToken, _this.Depth)
                             : (PromiseRef) PromiseContinue<DelegateContinue<TArg, TResult>>.GetOrCreate(resolver, _this.Depth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
@@ -613,11 +600,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseContinuePromise<DelegateContinuePromise<TArg, TResult>>.GetOrCreate(resolver, cancelationToken, nextDepth)
                             : (PromiseRef) PromiseContinuePromise<DelegateContinuePromise<TArg, TResult>>.GetOrCreate(resolver, nextDepth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
@@ -634,11 +620,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseContinue<DelegateContinueCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, cancelationToken, _this.Depth)
                             : (PromiseRef) PromiseContinue<DelegateContinueCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, _this.Depth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
@@ -656,11 +641,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseContinuePromise<DelegateContinuePromiseCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, cancelationToken, nextDepth)
                             : (PromiseRef) PromiseContinuePromise<DelegateContinuePromiseCapture<TCapture, TArg, TResult>>.GetOrCreate(resolver, nextDepth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
@@ -673,9 +657,8 @@ namespace Proto.Promises
                         var p = Invoker<VoidResult, VoidResult>.InvokeCallbackDirect(DelegateWrapper.Create(onFinally), _this.AsPromise()._target);
                         return new Promise<TResult>(p._ref, p.Id, p.Depth, _this.Result);
                     }
-                    _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                     PromiseRef promise = PromiseFinally<DelegateFinally>.GetOrCreate(new DelegateFinally(onFinally), _this.Depth);
-                    _this._ref.HookupNewPromise(promise);
+                    _this._ref.HookupNewPromise(_this.Id, promise);
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 
@@ -691,9 +674,8 @@ namespace Proto.Promises
                         var p = Invoker<VoidResult, VoidResult>.InvokeCallbackDirect(DelegateWrapper.Create(capturedValue, onFinally), _this.AsPromise()._target);
                         return new Promise<TResult>(p._ref, p.Id, p.Depth, _this.Result);
                     }
-                    _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                     PromiseRef promise = PromiseFinally<DelegateCaptureFinally<TCapture>>.GetOrCreate(new DelegateCaptureFinally<TCapture>(capturedValue, onFinally), _this.Depth);
-                    _this._ref.HookupNewPromise(promise);
+                    _this._ref.HookupNewPromise(_this.Id, promise);
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 
@@ -710,11 +692,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseCancel<TDelegateCancel>.GetOrCreate(canceler, cancelationToken, _this.Depth)
                             : (PromiseRef) PromiseCancel<TDelegateCancel>.GetOrCreate(canceler, _this.Depth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
@@ -733,11 +714,10 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                         promise = cancelationToken.CanBeCanceled
                             ? CancelablePromiseCancelPromise<TDelegateCancel>.GetOrCreate(canceler, cancelationToken, nextDepth)
                             : (PromiseRef) PromiseCancelPromise<TDelegateCancel>.GetOrCreate(canceler, nextDepth);
-                        _this._ref.HookupNewPromise(promise);
+                        _this._ref.HookupNewPromise(_this.Id, promise);
                     }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
@@ -843,14 +823,13 @@ namespace Proto.Promises
                         }
                     }
 
-                    _this._ref.MarkAwaited(_this.Id, PromiseFlags.WasAwaitedOrForgotten | PromiseFlags.SuppressRejection);
                     promise = PromiseProgress<TProgress>.GetOrCreate(progress, cancelationToken, _this.Depth, invokeOption == SynchronizationOption.Synchronous, synchronizationContext);
 #if PROMISE_DEBUG
                     promise._previous = _this._ref;
 #endif
                     var executionScheduler = new ExecutionScheduler(true);
                     HandleablePromiseBase nextRef;
-                    _this._ref.AddWaiter(promise, out nextRef, ref executionScheduler);
+                    _this._ref.AddWaiter(_this.Id, promise, out nextRef, ref executionScheduler);
                     // If the progress is 0, progress in AddWaiter will not set, so we force the report here.
                     if (_this._ref.State == Promise.State.Pending & (promise._smallFields._currentProgress.GetRawValue() == 0))
                     {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -827,10 +827,10 @@ namespace Proto.Promises
 #if PROMISE_DEBUG
                     promise._previous = _this._ref;
 #endif
+                    promise._smallFields._currentProgress = _this._ref._smallFields._currentProgress;
                     var executionScheduler = new ExecutionScheduler(true);
                     _this._ref.InterlockedIncrementProgressReportingCount();
                     HandleablePromiseBase previousWaiter;
-                    promise._smallFields._currentProgress = _this._ref._smallFields._currentProgress;
                     PromiseSingleAwait promiseSingleAwait = _this._ref.AddWaiter(_this.Id, promise, out previousWaiter, ref executionScheduler);
                     if (previousWaiter == null)
                     {
@@ -843,7 +843,7 @@ namespace Proto.Promises
                         if (!PromiseSingleAwait.VerifyWaiter(promiseSingleAwait))
                         {
                             // We're throwing InvalidOperationException here, so we don't want the new object to also add exceptions from its finalizer.
-                            GC.SuppressFinalize(promise);
+                            Discard(promise);
                             throw new InvalidOperationException("Cannot await or forget a forgotten promise or a non-preserved promise more than once.", GetFormattedStacktrace(2));
                         }
                         PromiseRef handler = _this._ref;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
@@ -17,9 +17,7 @@
 #pragma warning disable IDE0034 // Simplify 'default' expression
 #pragma warning disable 0420 // A reference to a volatile field will not be treated as volatile
 
-using System;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace Proto.Promises
 {
@@ -63,8 +61,8 @@ namespace Proto.Promises
                 {
                     ThrowIfInPool(this);
                     SetResult(CancelContainerVoid.GetOrCreate(), Promise.State.Canceled);
-                    HandleablePromiseBase nextHandler = TakeNextWaiter();
                     var executionScheduler = new ExecutionScheduler(true);
+                    HandleablePromiseBase nextHandler = TakeOrHandleNextWaiter(ref executionScheduler);
                     MaybeHandleNext(nextHandler, ref executionScheduler);
                     executionScheduler.Execute();
                 }
@@ -117,7 +115,7 @@ namespace Proto.Promises
                     else if (unregistered)
                     {
                         _cancelationHelper.TryRelease();
-                        HandleSelf(ref handler, out nextHandler);
+                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
@@ -172,7 +170,7 @@ namespace Proto.Promises
                     if (_resolver.IsNull)
                     {
                         // The returned promise is handling this.
-                        HandleSelf(ref handler, out nextHandler);
+                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                         return;
                     }
 
@@ -188,7 +186,7 @@ namespace Proto.Promises
                     else if (unregistered)
                     {
                         _cancelationHelper.TryRelease();
-                        HandleSelf(ref handler, out nextHandler);
+                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
@@ -268,7 +266,7 @@ namespace Proto.Promises
                     else
                     {
                         _cancelationHelper.TryRelease();
-                        HandleSelf(ref handler, out nextHandler);
+                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                     }
                 }
 
@@ -321,7 +319,7 @@ namespace Proto.Promises
                     if (_resolver.IsNull)
                     {
                         // The returned promise is handling this.
-                        HandleSelf(ref handler, out nextHandler);
+                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                         return;
                     }
 
@@ -352,7 +350,7 @@ namespace Proto.Promises
                     else
                     {
                         _cancelationHelper.TryRelease();
-                        HandleSelf(ref handler, out nextHandler);
+                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                     }
                 }
 
@@ -459,7 +457,7 @@ namespace Proto.Promises
                     if (_continuer.IsNull)
                     {
                         // The returned promise is handling this.
-                        HandleSelf(ref handler, out nextHandler);
+                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                         return;
                     }
 
@@ -532,7 +530,7 @@ namespace Proto.Promises
                     else if (unregistered)
                     {
                         _cancelationHelper.TryRelease();
-                        HandleSelf(ref handler, out nextHandler);
+                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
@@ -587,7 +585,7 @@ namespace Proto.Promises
                     if (_canceler.IsNull)
                     {
                         // The returned promise is handling this.
-                        HandleSelf(ref handler, out nextHandler);
+                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                         return;
                     }
 
@@ -603,7 +601,7 @@ namespace Proto.Promises
                     else if (unregistered)
                     {
                         _cancelationHelper.TryRelease();
-                        HandleSelf(ref handler, out nextHandler);
+                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                     }
                     else
                     {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
@@ -32,27 +32,28 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 internal void Register(CancelationToken cancelationToken, ICancelable owner)
                 {
+                    // _retainCounter is necessary to make sure the promise is disposed after the cancelation has invoked or unregistered,
+                    // and the previous promise has handled this.
+                    _retainCounter = 2;
                     cancelationToken.TryRegister(owner, out _cancelationRegistration);
                 }
 
                 internal bool TryUnregister(PromiseSingleAwait owner)
                 {
                     ThrowIfInPool(owner);
-                    bool isCanceling;
-                    bool unregistered = _cancelationRegistration.TryUnregister(out isCanceling);
-                    if (unregistered | (!isCanceling & owner.State == Promise.State.Pending))
-                    {
-                        owner._smallFields.InterlockedTryReleaseComplete();
-                        return true;
-                    }
-                    return false;
+                    return TryUnregisterAndIsNotCanceling(ref _cancelationRegistration) & owner.State == Promise.State.Pending;
                 }
 
-                internal static void SetNextAfterCanceled(PromiseSingleAwait owner, ref PromiseRef handler, out HandleablePromiseBase nextHandler)
+                internal static void SetNextAfterCanceled(ref PromiseRef handler, out HandleablePromiseBase nextHandler)
                 {
                     nextHandler = null;
                     handler.MaybeDispose();
-                    handler = owner;
+                }
+
+                [MethodImpl(InlineOption)]
+                internal bool TryRelease()
+                {
+                    return InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0;
                 }
             }
 
@@ -61,17 +62,23 @@ namespace Proto.Promises
                 protected void HandleFromCancelation()
                 {
                     ThrowIfInPool(this);
-                    HandleablePromiseBase nextHandler;
-#if NET_LEGACY // Interlocked.Exchange doesn't seem to work properly in Unity's old runtime. I'm not sure why, but we need a lock here to pass multi-threaded tests.
-                    lock (this)
-#endif
+                    SetResult(CancelContainerVoid.GetOrCreate(), Promise.State.Canceled);
+                    HandleablePromiseBase nextHandler = CompareExchangeWaiter(PromiseCompletionSentinel._instance, null);
+                    if (nextHandler == null)
                     {
-                        SetResult(CancelContainerVoid.GetOrCreate(), Promise.State.Canceled);
-                        Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
-                        nextHandler = Interlocked.Exchange(ref _waiter, null);
+                        return;
                     }
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    if (nextHandler == PromiseCompletionSentinel._instance)
+                    {
+                        throw new System.InvalidOperationException("waiter was PromiseCompletionSentinel");
+                    }
+#endif
+                    // Set the waiter to InvalidAwaitSentinel to break the chain.
+                    _waiter = InvalidAwaitSentinel._instance;
                     var executionScheduler = new ExecutionScheduler(true);
-                    MaybeHandleNext(nextHandler, ref executionScheduler);
+                    // We already checked nextHandler for null, so we can call HandleNext instead of MaybeHandleNext.
+                    HandleNext(nextHandler, ref executionScheduler);
                     executionScheduler.Execute();
                 }
             }
@@ -89,13 +96,21 @@ namespace Proto.Promises
                 {
                     var promise = ObjectPool<HandleablePromiseBase>.TryTake<CancelablePromiseResolve<TResolver>>()
                         ?? new CancelablePromiseResolve<TResolver>();
-                    promise.Reset(depth, 3);
+                    promise.Reset(depth);
                     promise._resolver = resolver;
                     promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
                     return promise;
                 }
 
-                protected override void Dispose()
+                protected override void MaybeDispose()
+                {
+                    if (_cancelationHelper.TryRelease())
+                    {
+                        Dispose();
+                    }
+                }
+
+                new private void Dispose()
                 {
                     base.Dispose();
                     _cancelationHelper = default(CancelationHelper);
@@ -109,15 +124,19 @@ namespace Proto.Promises
                     bool unregistered = _cancelationHelper.TryUnregister(this);
                     if (unregistered & handler.State == Promise.State.Resolved)
                     {
+                        _cancelationHelper.TryRelease();
                         resolveCallback.InvokeResolver(ref handler, out nextHandler, this, ref executionScheduler);
                     }
                     else if (unregistered)
                     {
-                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        handler.SuppressRejection = true;
+                        _cancelationHelper.TryRelease();
+                        HandleSelf(ref handler, out nextHandler);
                     }
                     else
                     {
-                        CancelationHelper.SetNextAfterCanceled(this, ref handler, out nextHandler);
+                        MaybeDispose();
+                        CancelationHelper.SetNextAfterCanceled(ref handler, out nextHandler);
                     }
                 }
 
@@ -140,13 +159,21 @@ namespace Proto.Promises
                 {
                     var promise = ObjectPool<HandleablePromiseBase>.TryTake<CancelablePromiseResolvePromise<TResolver>>()
                         ?? new CancelablePromiseResolvePromise<TResolver>();
-                    promise.Reset(depth, 3);
+                    promise.Reset(depth);
                     promise._resolver = resolver;
                     promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
                     return promise;
                 }
 
-                protected override void Dispose()
+                protected override void MaybeDispose()
+                {
+                    if (_cancelationHelper.TryRelease())
+                    {
+                        Dispose();
+                    }
+                }
+
+                new private void Dispose()
                 {
                     base.Dispose();
                     _cancelationHelper = default(CancelationHelper);
@@ -159,7 +186,8 @@ namespace Proto.Promises
                     if (_resolver.IsNull)
                     {
                         // The returned promise is handling this.
-                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        handler.SuppressRejection = true;
+                        HandleSelf(ref handler, out nextHandler);
                         return;
                     }
 
@@ -168,16 +196,20 @@ namespace Proto.Promises
                     bool unregistered = _cancelationHelper.TryUnregister(this);
                     if (unregistered & handler.State == Promise.State.Resolved)
                     {
+                        _cancelationHelper.TryRelease();
                         handlerDisposedAfterCallback = _resolveWillDisposeAfterSecondAwait;
                         resolveCallback.InvokeResolver(ref handler, out nextHandler, this, ref executionScheduler);
                     }
                     else if (unregistered)
                     {
-                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        handler.SuppressRejection = true;
+                        _cancelationHelper.TryRelease();
+                        HandleSelf(ref handler, out nextHandler);
                     }
                     else
                     {
-                        CancelationHelper.SetNextAfterCanceled(this, ref handler, out nextHandler);
+                        MaybeDispose();
+                        CancelationHelper.SetNextAfterCanceled(ref handler, out nextHandler);
                     }
                 }
 
@@ -201,14 +233,22 @@ namespace Proto.Promises
                 {
                     var promise = ObjectPool<HandleablePromiseBase>.TryTake<CancelablePromiseResolveReject<TResolver, TRejecter>>()
                         ?? new CancelablePromiseResolveReject<TResolver, TRejecter>();
-                    promise.Reset(depth, 3);
+                    promise.Reset(depth);
                     promise._resolver = resolver;
                     promise._rejecter = rejecter;
                     promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
                     return promise;
                 }
 
-                protected override void Dispose()
+                protected override void MaybeDispose()
+                {
+                    if (_cancelationHelper.TryRelease())
+                    {
+                        Dispose();
+                    }
+                }
+
+                new private void Dispose()
                 {
                     base.Dispose();
                     _cancelationHelper = default(CancelationHelper);
@@ -225,21 +265,26 @@ namespace Proto.Promises
                     bool unregistered = _cancelationHelper.TryUnregister(this);
                     if (unregistered & state == Promise.State.Resolved)
                     {
+                        _cancelationHelper.TryRelease();
                         resolveCallback.InvokeResolver(ref handler, out nextHandler, this, ref executionScheduler);
                     }
                     else if (!unregistered)
                     {
-                        CancelationHelper.SetNextAfterCanceled(this, ref handler, out nextHandler);
+                        MaybeDispose();
+                        CancelationHelper.SetNextAfterCanceled(ref handler, out nextHandler);
                     }
                     else if (state == Promise.State.Rejected)
                     {
+                        handler.SuppressRejection = true;
+                        _cancelationHelper.TryRelease();
                         invokingRejected = true;
                         handlerDisposedAfterCallback = true;
                         rejectCallback.InvokeRejecter(ref handler, out nextHandler, this, ref executionScheduler);
                     }
                     else
                     {
-                        HandleSelf(ref handler , out nextHandler, ref executionScheduler);
+                        _cancelationHelper.TryRelease();
+                        HandleSelf(ref handler, out nextHandler);
                     }
                 }
 
@@ -263,14 +308,22 @@ namespace Proto.Promises
                 {
                     var promise = ObjectPool<HandleablePromiseBase>.TryTake<CancelablePromiseResolveRejectPromise<TResolver, TRejecter>>()
                         ?? new CancelablePromiseResolveRejectPromise<TResolver, TRejecter>();
-                    promise.Reset(depth, 3);
+                    promise.Reset(depth);
                     promise._resolver = resolver;
                     promise._rejecter = rejecter;
                     promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
                     return promise;
                 }
 
-                protected override void Dispose()
+                protected override void MaybeDispose()
+                {
+                    if (_cancelationHelper.TryRelease())
+                    {
+                        Dispose();
+                    }
+                }
+
+                new private void Dispose()
                 {
                     base.Dispose();
                     _cancelationHelper = default(CancelationHelper);
@@ -284,7 +337,8 @@ namespace Proto.Promises
                     if (_resolver.IsNull)
                     {
                         // The returned promise is handling this.
-                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        handler.SuppressRejection = true;
+                        HandleSelf(ref handler, out nextHandler);
                         return;
                     }
 
@@ -295,22 +349,27 @@ namespace Proto.Promises
                     bool unregistered = _cancelationHelper.TryUnregister(this);
                     if (unregistered & state == Promise.State.Resolved)
                     {
+                        _cancelationHelper.TryRelease();
                         handlerDisposedAfterCallback = _resolveWillDisposeAfterSecondAwait;
                         resolveCallback.InvokeResolver(ref handler, out nextHandler, this, ref executionScheduler);
                     }
                     else if (!unregistered)
                     {
-                        CancelationHelper.SetNextAfterCanceled(this, ref handler, out nextHandler);
+                        MaybeDispose();
+                        CancelationHelper.SetNextAfterCanceled(ref handler, out nextHandler);
                     }
                     else if (state == Promise.State.Rejected)
                     {
+                        handler.SuppressRejection = true;
+                        _cancelationHelper.TryRelease();
                         invokingRejected = true;
                         handlerDisposedAfterCallback = true;
                         rejectCallback.InvokeRejecter(ref handler, out nextHandler, this, ref executionScheduler);
                     }
                     else
                     {
-                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        _cancelationHelper.TryRelease();
+                        HandleSelf(ref handler, out nextHandler);
                     }
                 }
 
@@ -333,13 +392,21 @@ namespace Proto.Promises
                 {
                     var promise = ObjectPool<HandleablePromiseBase>.TryTake<CancelablePromiseContinue<TContinuer>>()
                         ?? new CancelablePromiseContinue<TContinuer>();
-                    promise.Reset(depth, 3);
+                    promise.Reset(depth);
                     promise._continuer = continuer;
                     promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
                     return promise;
                 }
 
-                protected override void Dispose()
+                protected override void MaybeDispose()
+                {
+                    if (_cancelationHelper.TryRelease())
+                    {
+                        Dispose();
+                    }
+                }
+
+                new private void Dispose()
                 {
                     base.Dispose();
                     _cancelationHelper = default(CancelationHelper);
@@ -352,11 +419,14 @@ namespace Proto.Promises
                     handlerDisposedAfterCallback = true;
                     if (_cancelationHelper.TryUnregister(this))
                     {
+                        handler.SuppressRejection = true;
+                        _cancelationHelper.TryRelease();
                         _continuer.Invoke(ref handler, out nextHandler, this, ref executionScheduler);
                     }
                     else
                     {
-                        CancelationHelper.SetNextAfterCanceled(this, ref handler, out nextHandler);
+                        MaybeDispose();
+                        CancelationHelper.SetNextAfterCanceled(ref handler, out nextHandler);
                     }
                 }
 
@@ -379,13 +449,21 @@ namespace Proto.Promises
                 {
                     var promise = ObjectPool<HandleablePromiseBase>.TryTake<CancelablePromiseContinuePromise<TContinuer>>()
                         ?? new CancelablePromiseContinuePromise<TContinuer>();
-                    promise.Reset(depth, 3);
+                    promise.Reset(depth);
                     promise._continuer = continuer;
                     promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
                     return promise;
                 }
 
-                protected override void Dispose()
+                protected override void MaybeDispose()
+                {
+                    if (_cancelationHelper.TryRelease())
+                    {
+                        Dispose();
+                    }
+                }
+
+                new private void Dispose()
                 {
                     base.Dispose();
                     _cancelationHelper = default(CancelationHelper);
@@ -398,7 +476,8 @@ namespace Proto.Promises
                     if (_continuer.IsNull)
                     {
                         // The returned promise is handling this.
-                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        handler.SuppressRejection = true;
+                        HandleSelf(ref handler, out nextHandler);
                         return;
                     }
 
@@ -407,11 +486,14 @@ namespace Proto.Promises
                     handlerDisposedAfterCallback = true;
                     if (_cancelationHelper.TryUnregister(this))
                     {
+                        handler.SuppressRejection = true;
+                        _cancelationHelper.TryRelease();
                         callback.Invoke(ref handler, out nextHandler, this, ref executionScheduler);
                     }
                     else
                     {
-                        CancelationHelper.SetNextAfterCanceled(this, ref handler, out nextHandler);
+                        MaybeDispose();
+                        CancelationHelper.SetNextAfterCanceled(ref handler, out nextHandler);
                     }
                 }
 
@@ -434,13 +516,21 @@ namespace Proto.Promises
                 {
                     var promise = ObjectPool<HandleablePromiseBase>.TryTake<CancelablePromiseCancel<TCanceler>>()
                         ?? new CancelablePromiseCancel<TCanceler>();
-                    promise.Reset(depth, 3);
+                    promise.Reset(depth);
                     promise._canceler = canceler;
                     promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
                     return promise;
                 }
 
-                protected override void Dispose()
+                protected override void MaybeDispose()
+                {
+                    if (_cancelationHelper.TryRelease())
+                    {
+                        Dispose();
+                    }
+                }
+
+                new private void Dispose()
                 {
                     base.Dispose();
                     _cancelationHelper = default(CancelationHelper);
@@ -454,15 +544,19 @@ namespace Proto.Promises
                     bool unregistered = _cancelationHelper.TryUnregister(this);
                     if (unregistered & handler.State == Promise.State.Canceled)
                     {
+                        _cancelationHelper.TryRelease();
                         callback.InvokeResolver(ref handler, out nextHandler, this, ref executionScheduler);
                     }
                     else if (unregistered)
                     {
-                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        handler.SuppressRejection = true;
+                        _cancelationHelper.TryRelease();
+                        HandleSelf(ref handler, out nextHandler);
                     }
                     else
                     {
-                        CancelationHelper.SetNextAfterCanceled(this, ref handler, out nextHandler);
+                        MaybeDispose();
+                        CancelationHelper.SetNextAfterCanceled(ref handler, out nextHandler);
                     }
                 }
 
@@ -485,13 +579,21 @@ namespace Proto.Promises
                 {
                     var promise = ObjectPool<HandleablePromiseBase>.TryTake<CancelablePromiseCancelPromise<TCanceler>>()
                         ?? new CancelablePromiseCancelPromise<TCanceler>();
-                    promise.Reset(depth, 3);
+                    promise.Reset(depth);
                     promise._canceler = canceler;
                     promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
                     return promise;
                 }
 
-                protected override void Dispose()
+                protected override void MaybeDispose()
+                {
+                    if (_cancelationHelper.TryRelease())
+                    {
+                        Dispose();
+                    }
+                }
+
+                new private void Dispose()
                 {
                     base.Dispose();
                     _cancelationHelper = default(CancelationHelper);
@@ -504,7 +606,8 @@ namespace Proto.Promises
                     if (_canceler.IsNull)
                     {
                         // The returned promise is handling this.
-                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        handler.SuppressRejection = true;
+                        HandleSelf(ref handler, out nextHandler);
                         return;
                     }
 
@@ -513,16 +616,20 @@ namespace Proto.Promises
                     bool unregistered = _cancelationHelper.TryUnregister(this);
                     if (unregistered & handler.State == Promise.State.Canceled)
                     {
+                        _cancelationHelper.TryRelease();
                         handlerDisposedAfterCallback = _resolveWillDisposeAfterSecondAwait;
                         callback.InvokeResolver(ref handler, out nextHandler, this, ref executionScheduler);
                     }
                     else if (unregistered)
                     {
-                        HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        handler.SuppressRejection = true;
+                        _cancelationHelper.TryRelease();
+                        HandleSelf(ref handler, out nextHandler);
                     }
                     else
                     {
-                        CancelationHelper.SetNextAfterCanceled(this, ref handler, out nextHandler);
+                        MaybeDispose();
+                        CancelationHelper.SetNextAfterCanceled(ref handler, out nextHandler);
                     }
                 }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
@@ -101,6 +101,34 @@ namespace Proto.Promises
                     return _this != null && _this.TryReportProgress(deferredId, progress);
 #endif
                 }
+
+                [MethodImpl(InlineOption)]
+                internal void ResolveDirect<T>(
+#if CSHARP_7_3_OR_NEWER
+                    in
+#endif
+                    T value)
+                {
+                    ThrowIfInPool(this);
+                    HandleInternal(CreateResolveContainer(value), Promise.State.Resolved);
+                }
+
+                protected void RejectDirect<TReject>(
+#if CSHARP_7_3_OR_NEWER
+                    in
+#endif
+                    TReject reason, int rejectSkipFrames)
+                {
+                    ThrowIfInPool(this);
+                    HandleInternal(CreateRejectContainer(reason, rejectSkipFrames + 1, this), Promise.State.Rejected);
+                }
+
+                [MethodImpl(InlineOption)]
+                internal void CancelDirect()
+                {
+                    ThrowIfInPool(this);
+                    HandleInternal(CancelContainerVoid.GetOrCreate(), Promise.State.Canceled);
+                }
             }
 
             // The only purpose of this is to cast the ref when converting a DeferredBase to a Deferred(<T>) to avoid extra checks.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
@@ -112,18 +112,10 @@ namespace Proto.Promises
             {
                 protected DeferredPromise() { }
 
-                protected override void Dispose()
+                protected override void MaybeDispose()
                 {
-                    base.Dispose();
+                    Dispose();
                     ObjectPool<HandleablePromiseBase>.MaybeRepool(this);
-                }
-
-                // Used for child to call base dispose without repooling for both types.
-                // This is necessary because C# doesn't allow `base.base.Dispose()`.
-                [MethodImpl(InlineOption)]
-                protected void SuperDispose()
-                {
-                    base.Dispose();
                 }
 
                 internal static DeferredPromise<T> GetOrCreate()
@@ -157,9 +149,9 @@ namespace Proto.Promises
             {
                 private DeferredPromiseCancel() { }
 
-                protected override void Dispose()
+                protected override void MaybeDispose()
                 {
-                    SuperDispose();
+                    Dispose();
                     _cancelationRegistration = default(CancelationRegistration);
                     ObjectPool<HandleablePromiseBase>.MaybeRepool(this);
                 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
@@ -308,12 +308,12 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 void IDelegateResolveOrCancel.InvokeResolver(ref PromiseRef handler, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
-                    owner.HandleSelf(ref handler, out nextHandler);
+                    owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                 }
 
                 void IDelegateResolveOrCancelPromise.InvokeResolver(ref PromiseRef handler, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
-                    owner.HandleSelf(ref handler, out nextHandler);
+                    owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                 }
             }
 
@@ -368,10 +368,10 @@ namespace Proto.Promises
                 void IDelegateResolveOrCancel.InvokeResolver(ref PromiseRef handler, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = handler.GetResult<TArg>();
-                    owner.MaybeDisposePrevious(handler);
+                    handler.MaybeDispose();
                     TResult result = Invoke(arg);
                     handler = owner;
-                    owner.SetResultAndTakeNextWaiter(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
+                    owner.SetResultAndTakeNextWaiter(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler, ref executionScheduler);
                 }
 
                 [MethodImpl(InlineOption)]
@@ -389,13 +389,13 @@ namespace Proto.Promises
                     if (handler.TryGetRejectValue(out arg))
                     {
                         TResult result = Invoke(arg);
-                        owner.MaybeDisposePrevious(handler);
+                        handler.MaybeDispose();
                         handler = owner;
-                        owner.SetResultAndTakeNextWaiter(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
+                        owner.SetResultAndTakeNextWaiter(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
-                        owner.HandleSelf(ref handler, out nextHandler);
+                        owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                     }
                 }
 
@@ -410,7 +410,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner.HandleSelf(ref handler, out nextHandler);
+                        owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                     }
                 }
             }
@@ -480,7 +480,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner.HandleSelf(ref handler, out nextHandler);
+                        owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                     }
                 }
             }
@@ -562,9 +562,9 @@ namespace Proto.Promises
                         }
                         valueContainer = CreateResolveContainer(result);
                     }
-                    owner.MaybeDisposePrevious(handler);
+                    handler.MaybeDispose();
                     handler = owner;
-                    owner.SetResultAndTakeNextWaiter(valueContainer, Promise.State.Resolved, out nextHandler);
+                    owner.SetResultAndTakeNextWaiter(valueContainer, Promise.State.Resolved, out nextHandler, ref executionScheduler);
                 }
             }
 
@@ -778,10 +778,10 @@ namespace Proto.Promises
                 void IDelegateResolveOrCancel.InvokeResolver(ref PromiseRef handler, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
                     TArg arg = handler.GetResult<TArg>();
-                    owner.MaybeDisposePrevious(handler);
+                    handler.MaybeDispose();
                     handler = owner;
                     TResult result = Invoke(arg);
-                    owner.SetResultAndTakeNextWaiter(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
+                    owner.SetResultAndTakeNextWaiter(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler, ref executionScheduler);
                 }
 
                 [MethodImpl(InlineOption)]
@@ -799,13 +799,13 @@ namespace Proto.Promises
                     if (handler.TryGetRejectValue(out arg))
                     {
                         TResult result = Invoke(arg);
-                        owner.MaybeDisposePrevious(handler);
+                        handler.MaybeDispose();
                         handler = owner;
-                        owner.SetResultAndTakeNextWaiter(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
+                        owner.SetResultAndTakeNextWaiter(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler, ref executionScheduler);
                     }
                     else
                     {
-                        owner.HandleSelf(ref handler, out nextHandler);
+                        owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                     }
                 }
 
@@ -820,7 +820,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner.HandleSelf(ref handler, out nextHandler);
+                        owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                     }
                 }
             }
@@ -902,7 +902,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner.HandleSelf(ref handler, out nextHandler);
+                        owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
                     }
                 }
             }
@@ -990,9 +990,9 @@ namespace Proto.Promises
                         }
                         valueContainer = CreateResolveContainer(result);
                     }
-                    owner.MaybeDisposePrevious(handler);
+                    handler.MaybeDispose();
                     handler = owner;
-                    owner.SetResultAndTakeNextWaiter(valueContainer, Promise.State.Resolved, out nextHandler);
+                    owner.SetResultAndTakeNextWaiter(valueContainer, Promise.State.Resolved, out nextHandler, ref executionScheduler);
                 }
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
@@ -308,12 +308,12 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 void IDelegateResolveOrCancel.InvokeResolver(ref PromiseRef handler, out HandleablePromiseBase nextHandler, PromiseSingleAwait owner, ref ExecutionScheduler executionScheduler)
                 {
-                    owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                    owner.HandleSelf(ref handler, out nextHandler);
                 }
 
                 void IDelegateResolveOrCancelPromise.InvokeResolver(ref PromiseRef handler, out HandleablePromiseBase nextHandler, PromiseWaitPromise owner, ref ExecutionScheduler executionScheduler)
                 {
-                    owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                    owner.HandleSelf(ref handler, out nextHandler);
                 }
             }
 
@@ -371,7 +371,7 @@ namespace Proto.Promises
                     owner.MaybeDisposePrevious(handler);
                     TResult result = Invoke(arg);
                     handler = owner;
-                    owner.SetResultAndMaybeHandle(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler, ref executionScheduler);
+                    owner.SetResultAndMaybeHandle(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
                 }
 
                 [MethodImpl(InlineOption)]
@@ -391,11 +391,11 @@ namespace Proto.Promises
                         TResult result = Invoke(arg);
                         owner.MaybeDisposePrevious(handler);
                         handler = owner;
-                        owner.SetResultAndMaybeHandle(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
                     }
                     else
                     {
-                        owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        owner.HandleSelf(ref handler, out nextHandler);
                     }
                 }
 
@@ -410,7 +410,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        owner.HandleSelf(ref handler, out nextHandler);
                     }
                 }
             }
@@ -480,7 +480,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        owner.HandleSelf(ref handler, out nextHandler);
                     }
                 }
             }
@@ -564,7 +564,7 @@ namespace Proto.Promises
                     }
                     owner.MaybeDisposePrevious(handler);
                     handler = owner;
-                    owner.SetResultAndMaybeHandle(valueContainer, Promise.State.Resolved, out nextHandler, ref executionScheduler);
+                    owner.SetResultAndMaybeHandle(valueContainer, Promise.State.Resolved, out nextHandler);
                 }
             }
 
@@ -781,7 +781,7 @@ namespace Proto.Promises
                     owner.MaybeDisposePrevious(handler);
                     handler = owner;
                     TResult result = Invoke(arg);
-                    owner.SetResultAndMaybeHandle(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler, ref executionScheduler);
+                    owner.SetResultAndMaybeHandle(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
                 }
 
                 [MethodImpl(InlineOption)]
@@ -801,11 +801,11 @@ namespace Proto.Promises
                         TResult result = Invoke(arg);
                         owner.MaybeDisposePrevious(handler);
                         handler = owner;
-                        owner.SetResultAndMaybeHandle(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler, ref executionScheduler);
+                        owner.SetResultAndMaybeHandle(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
                     }
                     else
                     {
-                        owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        owner.HandleSelf(ref handler, out nextHandler);
                     }
                 }
 
@@ -820,7 +820,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        owner.HandleSelf(ref handler, out nextHandler);
                     }
                 }
             }
@@ -902,7 +902,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner.HandleSelf(ref handler, out nextHandler, ref executionScheduler);
+                        owner.HandleSelf(ref handler, out nextHandler);
                     }
                 }
             }
@@ -992,7 +992,7 @@ namespace Proto.Promises
                     }
                     owner.MaybeDisposePrevious(handler);
                     handler = owner;
-                    owner.SetResultAndMaybeHandle(valueContainer, Promise.State.Resolved, out nextHandler, ref executionScheduler);
+                    owner.SetResultAndMaybeHandle(valueContainer, Promise.State.Resolved, out nextHandler);
                 }
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
@@ -371,7 +371,7 @@ namespace Proto.Promises
                     owner.MaybeDisposePrevious(handler);
                     TResult result = Invoke(arg);
                     handler = owner;
-                    owner.SetResultAndMaybeHandle(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
+                    owner.SetResultAndTakeNextWaiter(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
                 }
 
                 [MethodImpl(InlineOption)]
@@ -391,7 +391,7 @@ namespace Proto.Promises
                         TResult result = Invoke(arg);
                         owner.MaybeDisposePrevious(handler);
                         handler = owner;
-                        owner.SetResultAndMaybeHandle(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
+                        owner.SetResultAndTakeNextWaiter(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
                     }
                     else
                     {
@@ -564,7 +564,7 @@ namespace Proto.Promises
                     }
                     owner.MaybeDisposePrevious(handler);
                     handler = owner;
-                    owner.SetResultAndMaybeHandle(valueContainer, Promise.State.Resolved, out nextHandler);
+                    owner.SetResultAndTakeNextWaiter(valueContainer, Promise.State.Resolved, out nextHandler);
                 }
             }
 
@@ -781,7 +781,7 @@ namespace Proto.Promises
                     owner.MaybeDisposePrevious(handler);
                     handler = owner;
                     TResult result = Invoke(arg);
-                    owner.SetResultAndMaybeHandle(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
+                    owner.SetResultAndTakeNextWaiter(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
                 }
 
                 [MethodImpl(InlineOption)]
@@ -801,7 +801,7 @@ namespace Proto.Promises
                         TResult result = Invoke(arg);
                         owner.MaybeDisposePrevious(handler);
                         handler = owner;
-                        owner.SetResultAndMaybeHandle(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
+                        owner.SetResultAndTakeNextWaiter(CreateResolveContainer(result), Promise.State.Resolved, out nextHandler);
                     }
                     else
                     {
@@ -992,7 +992,7 @@ namespace Proto.Promises
                     }
                     owner.MaybeDisposePrevious(handler);
                     handler = owner;
-                    owner.SetResultAndMaybeHandle(valueContainer, Promise.State.Resolved, out nextHandler);
+                    owner.SetResultAndTakeNextWaiter(valueContainer, Promise.State.Resolved, out nextHandler);
                 }
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
@@ -99,14 +99,14 @@ namespace Proto.Promises
                         if (InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0) == 0
                             && Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) == null)
                         {
-                            SetResultAndTakeNextWaiter(valueContainer.Clone(), state, out nextHandler);
+                            SetResultAndTakeNextWaiter(valueContainer.Clone(), state, out nextHandler, ref executionScheduler);
                         }
                     }
                     else // Resolved
                     {
                         if (Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) == null)
                         {
-                            SetResultAndTakeNextWaiter(valueContainer.Clone(), state, out nextHandler);
+                            SetResultAndTakeNextWaiter(valueContainer.Clone(), state, out nextHandler, ref executionScheduler);
                         }
                         InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
                     }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
@@ -44,7 +44,7 @@ namespace Proto.Promises
         {
             internal abstract partial class MultiHandleablePromiseBase : PromiseSingleAwait
             {
-                internal abstract void Handle(ref PromiseRef handler, ValueContainer valueContainer, PromisePassThrough passThrough, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler);
+                internal abstract void Handle(PromisePassThrough passThrough, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler);
                 internal override void Handle(ref PromiseRef handler, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler) { throw new System.InvalidOperationException(); }
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
@@ -22,6 +22,9 @@ namespace Proto.Promises
     partial class Internal
     {
         // Abstract classes are used instead of interfaces, because virtual calls on interfaces are twice as slow as virtual calls on classes.
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [System.Diagnostics.DebuggerNonUserCode]
+#endif
         internal abstract partial class HandleablePromiseBase : ILinked<HandleablePromiseBase>
         {
             HandleablePromiseBase ILinked<HandleablePromiseBase>.Next
@@ -42,6 +45,9 @@ namespace Proto.Promises
 
         partial class PromiseRef
         {
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [System.Diagnostics.DebuggerNonUserCode]
+#endif
             internal abstract partial class MultiHandleablePromiseBase : PromiseSingleAwait
             {
                 internal abstract void Handle(PromisePassThrough passThrough, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
@@ -125,7 +125,7 @@ namespace Proto.Promises
                         if (Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) == null)
                         {
                             handler.SuppressRejection = true;
-                            SetResultAndTakeNextWaiter(valueContainer.Clone(), state, out nextHandler);
+                            SetResultAndTakeNextWaiter(valueContainer.Clone(), state, out nextHandler, ref executionScheduler);
                         }
                         InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
                     }
@@ -135,7 +135,7 @@ namespace Proto.Promises
                         if (InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0) == 0
                             && Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) == null)
                         {
-                            SetResultAndTakeNextWaiter(valueContainer.Clone(), state, out nextHandler);
+                            SetResultAndTakeNextWaiter(valueContainer.Clone(), state, out nextHandler, ref executionScheduler);
                         }
                     }
                     MaybeDisposeNonVirt();
@@ -190,7 +190,7 @@ namespace Proto.Promises
                             if (Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) == null)
                             {
                                 handler.SuppressRejection = true;
-                                SetResultAndTakeNextWaiter(valueContainer.Clone(), state, out nextHandler);
+                                SetResultAndTakeNextWaiter(valueContainer.Clone(), state, out nextHandler, ref executionScheduler);
                             }
                             InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
                         }
@@ -204,7 +204,7 @@ namespace Proto.Promises
                                 // Only nullify if all promises resolved, otherwise we let MaybeDispose dispose it.
                                 _resolveContainer = null;
                                 State = state;
-                                nextHandler = TakeNextWaiter();
+                                nextHandler = TakeOrHandleNextWaiter(ref executionScheduler);
                             }
                         }
                         MaybeDispose();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -195,6 +195,7 @@ namespace Proto.Promises
                 }
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             private void WaitWhileProgressReportingCore()
             {
                 var spinner = new SpinWait();
@@ -223,6 +224,30 @@ namespace Proto.Promises
                 }
 
                 Fixed32.ts_reportingPriority = wasReportingPriority;
+            }
+
+            partial class PromiseCompletionSentinel : HandleablePromiseBase
+            {
+                internal override PromiseSingleAwait SetProgress(ref Fixed32 progress, ref ushort depth, ref ExecutionScheduler executionScheduler)
+                {
+                    return null;
+                }
+            }
+
+            internal sealed partial class PromiseForgetSentinel : HandleablePromiseBase
+            {
+                internal override PromiseSingleAwait SetProgress(ref Fixed32 progress, ref ushort depth, ref ExecutionScheduler executionScheduler)
+                {
+                    return null;
+                }
+            }
+
+            internal sealed partial class InvalidAwaitSentinel : PromiseSingleAwait
+            {
+                internal override PromiseSingleAwait SetProgress(ref Fixed32 progress, ref ushort depth, ref ExecutionScheduler executionScheduler)
+                {
+                    return null;
+                }
             }
 
             internal partial struct Fixed32
@@ -671,7 +696,7 @@ namespace Proto.Promises
                     }
 
                     State = state;
-                    nextHandler = CompareExchangeWaiter(PromiseCompletionSentinel._instance, null);
+                    nextHandler = TakeNextWaiter();
                 }
 
                 void ICancelable.Cancel()

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -502,7 +502,6 @@ namespace Proto.Promises
                 internal abstract PromiseSingleAwait IncrementProgress(long increment, ref Fixed32 progress, ushort depth);
             }
 
-
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [System.Diagnostics.DebuggerNonUserCode]
 #endif

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -158,7 +158,7 @@ namespace Proto.Promises
             private partial struct SmallFields
             {
                 [FieldOffset(0)]
-                internal Promise.State _state;
+                volatile internal Promise.State _state;
                 [FieldOffset(1)]
                 internal bool _suppressRejection;
                 [FieldOffset(2)]
@@ -217,7 +217,7 @@ namespace Proto.Promises
 
 #if PROMISE_PROGRESS
                 IProgressInvokable ILinked<IProgressInvokable>.Next { get; set; }
-                volatile private int _isProgressScheduled; // int for Interlocked. 1 if scheduled, 0 if not.
+                private bool _isProgressScheduled;
 #endif
 
                 private int _retainCounter;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -207,7 +207,6 @@ namespace Proto.Promises
             partial class PromiseConfigured : PromiseSingleAwait
             {
                 private SynchronizationContext _synchronizationContext;
-                private int _mostRecentPotentialScheduleMethod; // ScheduleMethod for Interlocked. This is to make sure this is only scheduled once, even if multiple threads are racing.
                 volatile private Promise.State _previousState;
             }
 
@@ -429,7 +428,6 @@ namespace Proto.Promises
                 private SynchronizationContext _synchronizationContext;
                 private CancelationRegistration _cancelationRegistration;
 
-                private int _mostRecentPotentialScheduleMethod; // ScheduleMethod for Interlocked. This is to make sure the waiter is only scheduled once, even if multiple threads are racing.
                 volatile private int _isProgressScheduled; // int for Interlocked. 1 if scheduled, 0 if not.
                 private int _retainCounter;
                 volatile private bool _canceled;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -188,9 +188,7 @@ namespace Proto.Promises
                     {
                         throw new InvalidOperationException("Cannot await or forget a forgotten promise or a non-preserved promise more than once.", GetFormattedStacktrace(2));
                     }
-                    PromiseRef handler = this;
-                    HandleablePromiseBase _;
-                    newWaiter.Handle(ref handler, out _, ref executionScheduler);
+                    HandleNext(newWaiter, ref executionScheduler);
                 }
                 executionScheduler.Execute();
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
@@ -29,36 +29,33 @@ namespace Proto.Promises
             {
                 private RacePromise() { }
 
-                protected override void Dispose()
+                protected override void MaybeDispose()
+                {
+                    if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
+                    {
+                        Dispose();
+                    }
+                }
+
+                new private void Dispose()
                 {
                     base.Dispose();
-#if PROMISE_DEBUG
-                    lock (_locker)
-                    {
-                        while (_passThroughs.IsNotEmpty)
-                        {
-                            _passThroughs.Pop().Release();
-                        }
-                    }
-#endif
                     ObjectPool<HandleablePromiseBase>.MaybeRepool(this);
                 }
 
-                internal static RacePromise GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, uint pendingAwaits, ushort depth)
+                internal static RacePromise GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits, ushort depth)
                 {
                     var promise = ObjectPool<HandleablePromiseBase>.TryTake<RacePromise>()
                         ?? new RacePromise();
 
-                    checked
-                    {
-                        // Extra retain for handle.
-                        ++pendingAwaits;
-                    }
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE // _waitCount isn't actually used in Race, but can be useful for debugging.
+                    promise._waitCount = pendingAwaits;
+#endif
                     unchecked
                     {
-                        promise._waitCount = (int) pendingAwaits;
+                        promise._retainCounter = pendingAwaits + 1;
                     }
-                    promise.Reset(depth, 2);
+                    promise.Reset(depth);
 
                     while (promisePassThroughs.IsNotEmpty)
                     {
@@ -74,17 +71,17 @@ namespace Proto.Promises
                         if (promise._valueContainer != null)
                         {
                             // This was completed potentially before all passthroughs were hooked up. Release all remaining passthroughs.
-                            int addCount = 0;
+                            int releaseCount = 0;
                             while (promisePassThroughs.IsNotEmpty)
                             {
                                 var p = promisePassThroughs.Pop();
                                 p.Owner.MaybeDispose();
                                 p.Release();
-                                --addCount;
+                                ++releaseCount;
                             }
-                            if (addCount != 0 && InterlockedAddWithOverflowCheck(ref promise._waitCount, addCount, 0) == 0)
+                            if (releaseCount != 0 && InterlockedAddWithOverflowCheck(ref promise._retainCounter, -releaseCount, releaseCount - 1) == 0)
                             {
-                                promise.MaybeDispose();
+                                promise.Dispose();
                             }
                         }
                     }
@@ -92,26 +89,22 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                internal override void Handle(ref PromiseRef handler, ValueContainer valueContainer, PromisePassThrough passThrough, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
+                internal override void Handle(PromisePassThrough passThrough, out HandleablePromiseBase nextHandler, ref ExecutionScheduler executionScheduler)
                 {
-                    // Retain while handling, then release when complete for thread safety.
-                    InterlockedRetainDisregardId();
-
+                    var handler = passThrough.Owner;
+                    var valueContainer = handler._valueContainer;
                     if (Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) == null)
                     {
                         handler.SuppressRejection = true;
-                        _valueContainer = valueContainer.Clone();
-                        Handle(ref _waitCount, ref handler, out nextHandler, ref executionScheduler);
+                        SetResultAndMaybeHandle(valueContainer.Clone(), handler.State, out nextHandler);
                     }
                     else
                     {
                         nextHandler = null;
                     }
-                    if (InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0) == 0)
-                    {
-                        _smallFields.InterlockedTryReleaseComplete();
-                    }
-
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE // _waitCount isn't actually used in Race, but can be useful for debugging.
+                    InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
+#endif
                     MaybeDispose();
                 }
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
@@ -95,7 +95,7 @@ namespace Proto.Promises
                     if (Interlocked.CompareExchange(ref _valueContainer, valueContainer, null) == null)
                     {
                         handler.SuppressRejection = true;
-                        SetResultAndTakeNextWaiter(valueContainer.Clone(), handler.State, out nextHandler);
+                        SetResultAndTakeNextWaiter(valueContainer.Clone(), handler.State, out nextHandler, ref executionScheduler);
                     }
                     else
                     {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
@@ -22,12 +22,12 @@ namespace Proto.Promises
             ValidateArgument(promise2, "promise2", 1);
             if (promise1._target._ref == null | promise2._target._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._target._ref, promise1._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._target._ref, promise2._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._target._ref, promise1._target.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._target._ref, promise2._target.Id, false);
                 return Internal.CreateResolved(depth);
             }
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0, Internal.PromiseFlags.WasAwaitedOrForgotten));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1, Internal.PromiseFlags.WasAwaitedOrForgotten));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1));
 
             var promise = Internal.PromiseRef.RacePromise.GetOrCreate(passThroughs, 2, depth);
             return new Promise(promise, promise.Id, depth);
@@ -48,14 +48,14 @@ namespace Proto.Promises
             ValidateArgument(promise3, "promise3", 1);
             if (promise1._target._ref == null | promise2._target._ref == null | promise3._target._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._target._ref, promise1._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._target._ref, promise2._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._target._ref, promise3._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._target._ref, promise1._target.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._target._ref, promise2._target.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._target._ref, promise3._target.Id, false);
                 return Internal.CreateResolved(depth);
             }
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0, Internal.PromiseFlags.WasAwaitedOrForgotten));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1, Internal.PromiseFlags.WasAwaitedOrForgotten));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2, Internal.PromiseFlags.WasAwaitedOrForgotten));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2));
 
             var promise = Internal.PromiseRef.RacePromise.GetOrCreate(passThroughs, 3, depth);
             return new Promise(promise, promise.Id, depth);
@@ -77,16 +77,16 @@ namespace Proto.Promises
             ValidateArgument(promise4, "promise4", 1);
             if (promise1._target._ref == null | promise2._target._ref == null | promise3._target._ref == null | promise4._target._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._target._ref, promise1._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._target._ref, promise2._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._target._ref, promise3._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._target._ref, promise4._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._target._ref, promise1._target.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._target._ref, promise2._target.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._target._ref, promise3._target.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise4._target._ref, promise4._target.Id, false);
                 return Internal.CreateResolved(depth);
             }
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0, Internal.PromiseFlags.WasAwaitedOrForgotten));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1, Internal.PromiseFlags.WasAwaitedOrForgotten));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2, Internal.PromiseFlags.WasAwaitedOrForgotten));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise4, 3, Internal.PromiseFlags.WasAwaitedOrForgotten));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise4, 3));
 
             var promise = Internal.PromiseRef.RacePromise.GetOrCreate(passThroughs, 4, depth);
             return new Promise(promise, promise.Id, depth);
@@ -122,7 +122,7 @@ namespace Proto.Promises
                 throw new EmptyArgumentException("promises", "You must provide at least one element to Race.", Internal.GetFormattedStacktrace(1));
             }
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ushort minDepth = ushort.MaxValue;
 
             int index = -1; // Index isn't necessary for Race, but might help with debugging.
@@ -130,14 +130,14 @@ namespace Proto.Promises
             {
                 var p = promises.Current;
                 ValidateElement(p, "promises", 1);
-                if (!Internal.TryPrepareForRace(p, ref passThroughs, ++index, ref minDepth, Internal.PromiseFlags.WasAwaitedOrForgotten))
+                if (!Internal.TryPrepareForRace(p, ref passThroughs, ++index, ref minDepth))
                 {
                     // Validate and release remaining elements.
                     while (promises.MoveNext())
                     {
                         p = promises.Current;
                         ValidateElement(p, "promises", 1);
-                        Internal.MaybeMarkAwaitedAndDispose(p._target._ref, p._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                        Internal.MaybeMarkAwaitedAndDispose(p._target._ref, p._target.Id, false);
                         minDepth = Math.Min(minDepth, p._target.Depth);
                     }
                     // Repool any created passthroughs.
@@ -204,12 +204,12 @@ namespace Proto.Promises
             ValidateArgument(promise2, "promise2", 1);
             if (promise1._target._ref == null | promise2._target._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._target._ref, promise1._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._target._ref, promise2._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._target._ref, promise1._target.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._target._ref, promise2._target.Id, true);
                 return Internal.CreateResolved(depth);
             }
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1));
 
             var promise = Internal.PromiseRef.FirstPromise.GetOrCreate(passThroughs, 2, depth);
             return new Promise(promise, promise.Id, depth);
@@ -230,14 +230,14 @@ namespace Proto.Promises
             ValidateArgument(promise3, "promise3", 1);
             if (promise1._target._ref == null | promise2._target._ref == null | promise3._target._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._target._ref, promise1._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._target._ref, promise2._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._target._ref, promise3._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._target._ref, promise1._target.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._target._ref, promise2._target.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._target._ref, promise3._target.Id, true);
                 return Internal.CreateResolved(depth);
             }
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2));
 
             var promise = Internal.PromiseRef.FirstPromise.GetOrCreate(passThroughs, 3, depth);
             return new Promise(promise, promise.Id, depth);
@@ -259,16 +259,16 @@ namespace Proto.Promises
             ValidateArgument(promise4, "promise4", 1);
             if (promise1._target._ref == null | promise2._target._ref == null | promise3._target._ref == null | promise4._target._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._target._ref, promise1._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._target._ref, promise2._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._target._ref, promise3._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._target._ref, promise4._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._target._ref, promise1._target.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._target._ref, promise2._target.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._target._ref, promise3._target.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise4._target._ref, promise4._target.Id, true);
                 return Internal.CreateResolved(depth);
             }
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise4, 3, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise4, 3));
 
             var promise = Internal.PromiseRef.FirstPromise.GetOrCreate(passThroughs, 4, depth);
             return new Promise(promise, promise.Id, depth);
@@ -304,7 +304,7 @@ namespace Proto.Promises
                 throw new EmptyArgumentException("promises", "You must provide at least one element to First.", Internal.GetFormattedStacktrace(1));
             }
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ushort minDepth = ushort.MaxValue;
 
             int index = -1; // Index isn't necessary for First, but might help with debugging.
@@ -312,14 +312,14 @@ namespace Proto.Promises
             {
                 var p = promises.Current;
                 ValidateElement(p, "promises", 1);
-                if (!Internal.TryPrepareForRace(p, ref passThroughs, ++index, ref minDepth, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection))
+                if (!Internal.TryPrepareForRace(p, ref passThroughs, ++index, ref minDepth))
                 {
                     // Validate and release remaining elements.
                     while (promises.MoveNext())
                     {
                         p = promises.Current;
                         ValidateElement(p, "promises", 1);
-                        Internal.MaybeMarkAwaitedAndDispose(p._target._ref, p._target.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                        Internal.MaybeMarkAwaitedAndDispose(p._target._ref, p._target.Id, true);
                         minDepth = Math.Min(minDepth, p._target.Depth);
                     }
                     // Repool any created passthroughs.
@@ -455,7 +455,7 @@ namespace Proto.Promises
         public static Promise All(Promise promise1, Promise promise2)
         {
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -480,7 +480,7 @@ namespace Proto.Promises
         public static Promise All(Promise promise1, Promise promise2, Promise promise3)
         {
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -507,7 +507,7 @@ namespace Proto.Promises
         public static Promise All(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -555,7 +555,7 @@ namespace Proto.Promises
         {
             ValidateArgument(promises, "promises", 1);
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -626,7 +626,7 @@ namespace Proto.Promises
         {
             T1 value = default(T1);
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -667,7 +667,7 @@ namespace Proto.Promises
         {
             var value = new ValueTuple<T1, T2>();
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -703,7 +703,7 @@ namespace Proto.Promises
         {
             var value = new ValueTuple<T1, T2>();
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -742,7 +742,7 @@ namespace Proto.Promises
         {
             var value = new ValueTuple<T1, T2, T3>();
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -784,7 +784,7 @@ namespace Proto.Promises
         {
             var value = new ValueTuple<T1, T2, T3>();
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -828,7 +828,7 @@ namespace Proto.Promises
         {
             var value = new ValueTuple<T1, T2, T3, T4>();
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -875,7 +875,7 @@ namespace Proto.Promises
         {
             var value = new ValueTuple<T1, T2, T3, T4>();
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -924,7 +924,7 @@ namespace Proto.Promises
         {
             var value = new ValueTuple<T1, T2, T3, T4, T5>();
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -976,7 +976,7 @@ namespace Proto.Promises
         {
             var value = new ValueTuple<T1, T2, T3, T4, T5>();
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -1030,7 +1030,7 @@ namespace Proto.Promises
         {
             var value = new ValueTuple<T1, T2, T3, T4, T5, T6>();
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -1087,7 +1087,7 @@ namespace Proto.Promises
         {
             var value = new ValueTuple<T1, T2, T3, T4, T5, T6>();
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -1146,7 +1146,7 @@ namespace Proto.Promises
         {
             var value = new ValueTuple<T1, T2, T3, T4, T5, T6, T7>();
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -1208,7 +1208,7 @@ namespace Proto.Promises
         {
             var value = new ValueTuple<T1, T2, T3, T4, T5, T6, T7>();
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
@@ -143,7 +143,7 @@ namespace Proto.Promises
                     // Repool any created passthroughs.
                     foreach (var passthrough in passThroughs)
                     {
-                        passthrough.Release();
+                        passthrough.Dispose();
                     }
                     return Internal.CreateResolved(minDepth);
                 }
@@ -325,7 +325,7 @@ namespace Proto.Promises
                     // Repool any created passthroughs.
                     foreach (var passthrough in passThroughs)
                     {
-                        passthrough.Release();
+                        passthrough.Dispose();
                     }
                     return Internal.CreateResolved(minDepth);
                 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -39,7 +39,9 @@ namespace Proto.Promises
             get
             {
                 var _this = GetVoidCopy();
-                return _this.Id == (_this._ref == null ? Internal.ValidIdFromApi : _this._ref.Id);
+                return _this._ref == null
+                    ? _this.Id == Internal.ValidIdFromApi
+                    : _this._ref.GetIsValid(_this.Id);
             }
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
@@ -188,7 +188,7 @@ namespace Proto.Promises
                     // Repool any created passthroughs.
                     foreach (var passthrough in passThroughs)
                     {
-                        passthrough.Release();
+                        passthrough.Dispose();
                     }
                     return Internal.CreateResolved(value, minDepth);
                 }
@@ -379,7 +379,7 @@ namespace Proto.Promises
                     // Repool any created passthroughs.
                     foreach (var passthrough in passThroughs)
                     {
-                        passthrough.Release();
+                        passthrough.Dispose();
                     }
                     return Internal.CreateResolved(value, minDepth);
                 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
@@ -22,18 +22,18 @@ namespace Proto.Promises
             ValidateArgument(promise2, "promise2", 1);
             if (promise1._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, false);
                 T value = promise1.Result;
                 return Internal.CreateResolved(value, depth);
             }
             if (promise2._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, false);
                 T value = promise2.Result;
                 return Internal.CreateResolved(value, depth);
             }
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0, Internal.PromiseFlags.WasAwaitedOrForgotten));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1, Internal.PromiseFlags.WasAwaitedOrForgotten));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1));
 
             var promise = Internal.PromiseRef.RacePromise.GetOrCreate(passThroughs, 2, depth);
             return new Promise<T>(promise, promise.Id, depth);
@@ -54,28 +54,28 @@ namespace Proto.Promises
             ValidateArgument(promise3, "promise3", 1);
             if (promise1._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, false);
                 T value = promise1.Result;
                 return Internal.CreateResolved(value, depth);
             }
             if (promise2._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, false);
                 T value = promise2.Result;
                 return Internal.CreateResolved(value, depth);
             }
             if (promise3._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, false);
                 T value = promise3.Result;
                 return Internal.CreateResolved(value, depth);
             }
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0, Internal.PromiseFlags.WasAwaitedOrForgotten));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1, Internal.PromiseFlags.WasAwaitedOrForgotten));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2, Internal.PromiseFlags.WasAwaitedOrForgotten));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2));
 
             var promise = Internal.PromiseRef.RacePromise.GetOrCreate(passThroughs, 3, depth);
             return new Promise<T>(promise, promise.Id, depth);
@@ -97,40 +97,40 @@ namespace Proto.Promises
             ValidateArgument(promise4, "promise4", 1);
             if (promise1._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4.Id, false);
                 T value = promise1.Result;
                 return Internal.CreateResolved(value, depth);
             }
             if (promise2._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4.Id, false);
                 T value = promise2.Result;
                 return Internal.CreateResolved(value, depth);
             }
             if (promise3._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4.Id, false);
                 T value = promise3.Result;
                 return Internal.CreateResolved(value, depth);
             }
             if (promise4._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, false);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, false);
                 T value = promise4.Result;
                 return Internal.CreateResolved(value, depth);
             }
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0, Internal.PromiseFlags.WasAwaitedOrForgotten));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1, Internal.PromiseFlags.WasAwaitedOrForgotten));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2, Internal.PromiseFlags.WasAwaitedOrForgotten));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise4, 3, Internal.PromiseFlags.WasAwaitedOrForgotten));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise4, 3));
 
             var promise = Internal.PromiseRef.RacePromise.GetOrCreate(passThroughs, 4, depth);
             return new Promise<T>(promise, promise.Id, depth);
@@ -167,7 +167,7 @@ namespace Proto.Promises
             }
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
             T value = default(T);
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ushort minDepth = ushort.MaxValue;
 
             int index = -1; // Index isn't necessary for Race, but might help with debugging.
@@ -175,14 +175,14 @@ namespace Proto.Promises
             {
                 var p = promises.Current;
                 ValidateElement(p, "promises", 1);
-                if (!Internal.TryPrepareForRace(p, ref value, ref passThroughs, ++index, ref minDepth, Internal.PromiseFlags.WasAwaitedOrForgotten))
+                if (!Internal.TryPrepareForRace(p, ref value, ref passThroughs, ++index, ref minDepth))
                 {
                     // Validate and release remaining elements.
                     while (promises.MoveNext())
                     {
                         p = promises.Current;
                         ValidateElement(p, "promises", 1);
-                        Internal.MaybeMarkAwaitedAndDispose(p._ref, p.Id, Internal.PromiseFlags.WasAwaitedOrForgotten);
+                        Internal.MaybeMarkAwaitedAndDispose(p._ref, p.Id, false);
                         minDepth = Math.Min(minDepth, p.Depth);
                     }
                     // Repool any created passthroughs.
@@ -213,18 +213,18 @@ namespace Proto.Promises
             ValidateArgument(promise2, "promise2", 1);
             if (promise1._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, true);
                 T value = promise1.Result;
                 return Internal.CreateResolved(value, depth);
             }
             if (promise2._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, true);
                 T value = promise2.Result;
                 return Internal.CreateResolved(value, depth);
             }
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1));
 
             var promise = Internal.PromiseRef.FirstPromise.GetOrCreate(passThroughs, 2, depth);
             return new Promise<T>(promise, promise.Id, depth);
@@ -245,28 +245,28 @@ namespace Proto.Promises
             ValidateArgument(promise3, "promise3", 1);
             if (promise1._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, true);
                 T value = promise1.Result;
                 return Internal.CreateResolved(value, depth);
             }
             if (promise2._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, true);
                 T value = promise2.Result;
                 return Internal.CreateResolved(value, depth);
             }
             if (promise3._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, true);
                 T value = promise3.Result;
                 return Internal.CreateResolved(value, depth);
             }
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2));
 
             var promise = Internal.PromiseRef.FirstPromise.GetOrCreate(passThroughs, 3, depth);
             return new Promise<T>(promise, promise.Id, depth);
@@ -288,40 +288,40 @@ namespace Proto.Promises
             ValidateArgument(promise4, "promise4", 1);
             if (promise1._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4.Id, true);
                 T value = promise1.Result;
                 return Internal.CreateResolved(value, depth);
             }
             if (promise2._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4.Id, true);
                 T value = promise2.Result;
                 return Internal.CreateResolved(value, depth);
             }
             if (promise3._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4.Id, true);
                 T value = promise3.Result;
                 return Internal.CreateResolved(value, depth);
             }
             if (promise4._ref == null)
             {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2.Id, true);
+                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3.Id, true);
                 T value = promise4.Result;
                 return Internal.CreateResolved(value, depth);
             }
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
-            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise4, 3, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise1, 0));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise2, 1));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise3, 2));
+            passThroughs.Push(Internal.PromiseRef.PromisePassThrough.GetOrCreate(promise4, 3));
 
             var promise = Internal.PromiseRef.FirstPromise.GetOrCreate(passThroughs, 4, depth);
             return new Promise<T>(promise, promise.Id, depth);
@@ -358,7 +358,7 @@ namespace Proto.Promises
             }
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
             T value = default(T);
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ushort minDepth = ushort.MaxValue;
 
             int index = -1; // Index isn't necessary for First, but might help with debugging.
@@ -366,14 +366,14 @@ namespace Proto.Promises
             {
                 var p = promises.Current;
                 ValidateElement(p, "promises", 1);
-                if (!Internal.TryPrepareForRace(p, ref value, ref passThroughs, ++index, ref minDepth, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection))
+                if (!Internal.TryPrepareForRace(p, ref value, ref passThroughs, ++index, ref minDepth))
                 {
                     // Validate and release remaining elements.
                     while (promises.MoveNext())
                     {
                         p = promises.Current;
                         ValidateElement(p, "promises", 1);
-                        Internal.MaybeMarkAwaitedAndDispose(p._ref, p.Id, Internal.PromiseFlags.WasAwaitedOrForgotten | Internal.PromiseFlags.SuppressRejection);
+                        Internal.MaybeMarkAwaitedAndDispose(p._ref, p.Id, true);
                         minDepth = Math.Min(minDepth, p.Depth);
                     }
                     // Repool any created passthroughs.
@@ -398,7 +398,7 @@ namespace Proto.Promises
         public static Promise<IList<T>> All(Promise<T> promise1, Promise<T> promise2, IList<T> valueContainer = null)
         {
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -451,7 +451,7 @@ namespace Proto.Promises
         public static Promise<IList<T>> All(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, IList<T> valueContainer = null)
         {
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -508,7 +508,7 @@ namespace Proto.Promises
         public static Promise<IList<T>> All(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4, IList<T> valueContainer = null)
         {
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;
@@ -599,7 +599,7 @@ namespace Proto.Promises
         {
             ValidateArgument(promises, "promises", 1);
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRef.PromisePassThrough>();
-            uint pendingCount = 0;
+            int pendingCount = 0;
             ulong completedProgress = 0;
             ulong totalProgress = 0;
             ushort maxDepth = 0;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/TestHelper.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/TestHelper.cs
@@ -2515,8 +2515,8 @@ namespace ProtoPromiseTests
                     .CatchCancelation(() => { onCancel(); return convertValue; });
                 onAdoptCallbackAddedConvert(ref p4);
                 onCallbackAddedConvert(ref p4);
-
             }
+
             foreach (var p in GetTestablePromises(promise))
             {
                 Promise p5 = default(Promise);
@@ -2671,8 +2671,8 @@ namespace ProtoPromiseTests
                     .CatchCancelation(() => { onCancel(); return convertValue; });
                 onAdoptCallbackAddedConvert(ref p4);
                 onCallbackAddedConvert(ref p4);
-
             }
+
             foreach (var p in GetTestablePromises(promise))
             {
                 Promise p5 = default(Promise);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/PromiseCancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/PromiseCancelationTests.cs
@@ -1970,9 +1970,29 @@ namespace ProtoPromiseTests.APIs
                 promise.Forget();
             }
 
+            // When a callback is canceled and the previous promise is rejected, the rejection is unhandled.
+            private const string expectedRejection = "Reject";
+            private Action<UnhandledException> previousRejectionHandler;
+
+            private void SetupExpectedUncaughtRejections()
+            {
+                previousRejectionHandler = Promise.Config.UncaughtRejectionHandler;
+                Promise.Config.UncaughtRejectionHandler = e =>
+                {
+                    Assert.AreEqual(expectedRejection, e.Value);
+                };
+            }
+
+            private void CleanupExpectedUncaughtRejections()
+            {
+                Promise.Config.UncaughtRejectionHandler = previousRejectionHandler;
+            }
+
             [Test]
             public void OnRejectedIsNotInvokedIfTokenIsCanceled_void()
             {
+                SetupExpectedUncaughtRejections();
+
                 CancelationSource cancelationSource = CancelationSource.New();
 
                 var deferred = Promise.NewDeferred();
@@ -1987,14 +2007,18 @@ namespace ProtoPromiseTests.APIs
                 );
 
                 cancelationSource.Cancel();
-                deferred.Reject("Reject");
+                deferred.Reject(expectedRejection);
 
                 cancelationSource.Dispose();
+
+                CleanupExpectedUncaughtRejections();
             }
 
             [Test]
             public void OnRejectedIsNotInvokedIfTokenIsCanceled_T()
             {
+                SetupExpectedUncaughtRejections();
+
                 CancelationSource cancelationSource = CancelationSource.New();
 
                 var deferred = Promise.NewDeferred<int>();
@@ -2009,14 +2033,18 @@ namespace ProtoPromiseTests.APIs
                 );
 
                 cancelationSource.Cancel();
-                deferred.Reject("Reject");
+                deferred.Reject(expectedRejection);
 
                 cancelationSource.Dispose();
+
+                CleanupExpectedUncaughtRejections();
             }
 
             [Test]
             public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_void0()
             {
+                SetupExpectedUncaughtRejections();
+
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
 
@@ -2031,14 +2059,18 @@ namespace ProtoPromiseTests.APIs
                     cancelationToken: cancelationSource.Token
                 );
 
-                deferred.Reject("Reject");
+                deferred.Reject(expectedRejection);
 
                 cancelationSource.Dispose();
+
+                CleanupExpectedUncaughtRejections();
             }
 
             [Test]
             public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_void1()
             {
+                SetupExpectedUncaughtRejections();
+
                 var deferred = Promise.NewDeferred();
 
                 TestHelper.AddCallbacksWithCancelation<float, object, string>(
@@ -2050,12 +2082,16 @@ namespace ProtoPromiseTests.APIs
                     cancelationToken: Proto.Promises.CancelationToken.Canceled()
                 );
 
-                deferred.Reject("Reject");
+                deferred.Reject(expectedRejection);
+
+                CleanupExpectedUncaughtRejections();
             }
 
             [Test]
             public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_T0()
             {
+                SetupExpectedUncaughtRejections();
+
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
 
@@ -2070,14 +2106,18 @@ namespace ProtoPromiseTests.APIs
                     cancelationToken: cancelationSource.Token
                 );
 
-                deferred.Reject("Reject");
+                deferred.Reject(expectedRejection);
 
                 cancelationSource.Dispose();
+
+                CleanupExpectedUncaughtRejections();
             }
 
             [Test]
             public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_T1()
             {
+                SetupExpectedUncaughtRejections();
+
                 var deferred = Promise.NewDeferred<int>();
 
                 TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
@@ -2089,7 +2129,9 @@ namespace ProtoPromiseTests.APIs
                     cancelationToken: Proto.Promises.CancelationToken.Canceled()
                 );
 
-                deferred.Reject("Reject");
+                deferred.Reject(expectedRejection);
+
+                CleanupExpectedUncaughtRejections();
             }
 
             [Test]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/PromiseCancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/PromiseCancelationTests.cs
@@ -1970,17 +1970,15 @@ namespace ProtoPromiseTests.APIs
                 promise.Forget();
             }
 
-            // When a callback is canceled and the previous promise is rejected, the rejection is unhandled.
             private const string expectedRejection = "Reject";
             private Action<UnhandledException> previousRejectionHandler;
 
             private void SetupExpectedUncaughtRejections()
             {
+                // When a callback is canceled and the previous promise is rejected, the rejection is unhandled.
+                // So we need to suppress that here and make sure it's correct.
                 previousRejectionHandler = Promise.Config.UncaughtRejectionHandler;
-                Promise.Config.UncaughtRejectionHandler = e =>
-                {
-                    Assert.AreEqual(expectedRejection, e.Value);
-                };
+                Promise.Config.UncaughtRejectionHandler = e => Assert.AreEqual(expectedRejection, e.Value);
             }
 
             private void CleanupExpectedUncaughtRejections()

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/PromiseConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/PromiseConcurrencyTests.cs
@@ -266,6 +266,7 @@ namespace ProtoPromiseTests.Threading
         }
 
         private static readonly TimeSpan progressConcurrencyTimeout = TimeSpan.FromSeconds(ThreadHelper.multiExecutionCount);
+        private const int numProgressReports = 10;
 
         [Test]
         public void PromiseProgressMayBeSubscribedWhilePromiseIsCompletedAndProgressIsReportedConcurrently_Pending_void(
@@ -277,14 +278,14 @@ namespace ProtoPromiseTests.Threading
             [Values(ProgressType.Interface)] ProgressType progressType,
             [Values(SynchronizationType.Synchronous, SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType synchronizationType)
         {
-            int expectedInvokes = completeType == CompleteType.Resolve ? 10 : 0;
+            int expectedInvokes = completeType == CompleteType.Resolve ? numProgressReports : 0;
             if (subscribePlace == ActionPlace.InSetup)
             {
-                expectedInvokes += 10;
+                expectedInvokes += numProgressReports;
                 if (reportPlace == ActionPlace.InSetup)
                 {
                     // Implementation detail: when progress is reported with the same value, the callback will not be invoked. This behavior is not guaranteed by the API.
-                    expectedInvokes += 10;
+                    expectedInvokes += numProgressReports;
                 }
             }
             else // parallel or teardown
@@ -293,7 +294,7 @@ namespace ProtoPromiseTests.Threading
                 // We only know there are extra invokes if complete (and report) come after subscribe.
                 if (completeType == CompleteType.Resolve && completePlace == ActionPlace.InTeardown)
                 {
-                    expectedInvokes += 10;
+                    expectedInvokes += numProgressReports;
                 }
             }
 
@@ -302,7 +303,7 @@ namespace ProtoPromiseTests.Threading
             var cancelationSource = default(CancelationSource);
             int invokedCount = 0;
 
-            ProgressHelper[] progressHelpers = new ProgressHelper[10];
+            ProgressHelper[] progressHelpers = new ProgressHelper[numProgressReports];
 
             Action AssertInvokes = completeType != CompleteType.Resolve && completePlace == ActionPlace.InSetup
                 // If the promise is rejected or canceled in the setup, we know that it should not be invoked more times than expected.
@@ -317,7 +318,7 @@ namespace ProtoPromiseTests.Threading
             int index = -1;
             var progressSubscriber = ParallelActionTestHelper.Create(
                 subscribePlace,
-                10,
+                numProgressReports,
                 () => promise
                     .SubscribeProgress(progressHelpers[Interlocked.Increment(ref index)])
                     .Catch((string error) => { Assert.AreEqual(rejectValue, error); })
@@ -327,7 +328,7 @@ namespace ProtoPromiseTests.Threading
 
             var progressReporter = ParallelActionTestHelper.Create(
                 reportPlace,
-                10,
+                numProgressReports,
                 () => deferred.TryReportProgress(0.5f)
             );
             progressReporter.MaybeAddParallelAction(parallelActions);
@@ -335,7 +336,7 @@ namespace ProtoPromiseTests.Threading
             var tryCompleter = TestHelper.GetTryCompleterVoid(completeType, rejectValue);
             var promiseCompleter = ParallelActionTestHelper.Create(
                 completePlace,
-                10,
+                numProgressReports,
                 () => tryCompleter(deferred, cancelationSource)
             );
             promiseCompleter.MaybeAddParallelAction(parallelActions);
@@ -430,14 +431,14 @@ namespace ProtoPromiseTests.Threading
             [Values(ProgressType.Interface)] ProgressType progressType,
             [Values(SynchronizationType.Synchronous, SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType synchronizationType)
         {
-            int expectedInvokes = completeType == CompleteType.Resolve ? 10 : 0;
+            int expectedInvokes = completeType == CompleteType.Resolve ? numProgressReports : 0;
             if (subscribePlace == ActionPlace.InSetup)
             {
-                expectedInvokes += 10;
+                expectedInvokes += numProgressReports;
                 if (reportPlace == ActionPlace.InSetup)
                 {
                     // Implementation detail: when progress is reported with the same value, the callback will not be invoked. This behavior is not guaranteed by the API.
-                    expectedInvokes += 10;
+                    expectedInvokes += numProgressReports;
                 }
             }
             else // parallel or teardown
@@ -446,7 +447,7 @@ namespace ProtoPromiseTests.Threading
                 // We only know there are extra invokes if complete (and report) come after subscribe.
                 if (completeType == CompleteType.Resolve && completePlace == ActionPlace.InTeardown)
                 {
-                    expectedInvokes += 10;
+                    expectedInvokes += numProgressReports;
                 }
             }
 
@@ -455,7 +456,7 @@ namespace ProtoPromiseTests.Threading
             var cancelationSource = default(CancelationSource);
             int invokedCount = 0;
 
-            ProgressHelper[] progressHelpers = new ProgressHelper[10];
+            ProgressHelper[] progressHelpers = new ProgressHelper[numProgressReports];
 
             Action AssertInvokes = completeType != CompleteType.Resolve && completePlace == ActionPlace.InSetup
                 // If the promise is rejected or canceled in the setup, we know that it should not be invoked more times than expected.
@@ -470,7 +471,7 @@ namespace ProtoPromiseTests.Threading
             int index = -1;
             var progressSubscriber = ParallelActionTestHelper.Create(
                 subscribePlace,
-                10,
+                numProgressReports,
                 () => promise
                     .SubscribeProgress(progressHelpers[Interlocked.Increment(ref index)])
                     .Catch((string error) => { Assert.AreEqual(rejectValue, error); })
@@ -480,7 +481,7 @@ namespace ProtoPromiseTests.Threading
 
             var progressReporter = ParallelActionTestHelper.Create(
                 reportPlace,
-                10,
+                numProgressReports,
                 () => deferred.TryReportProgress(0.5f)
             );
             progressReporter.MaybeAddParallelAction(parallelActions);
@@ -488,7 +489,7 @@ namespace ProtoPromiseTests.Threading
             var tryCompleter = TestHelper.GetTryCompleterT(completeType, 1, rejectValue);
             var promiseCompleter = ParallelActionTestHelper.Create(
                 completePlace,
-                10,
+                numProgressReports,
                 () => tryCompleter(deferred, cancelationSource)
             );
             promiseCompleter.MaybeAddParallelAction(parallelActions);

--- a/ProtoPromise_Unity/ProjectSettings/ProjectSettings.asset
+++ b/ProtoPromise_Unity/ProjectSettings/ProjectSettings.asset
@@ -514,8 +514,7 @@ PlayerSettings:
   webGLCompressionFormat: 2
   webGLLinkerTarget: 2
   webGLThreadsSupport: 0
-  scriptingDefineSymbols:
-    1: PROTO_PROMISE_DEBUG_DISABLE
+  scriptingDefineSymbols: {}
   platformArchitecture: {}
   scriptingBackend: {}
   il2cppCompilerConfiguration: {}
@@ -523,7 +522,7 @@ PlayerSettings:
   incrementalIl2cppBuild: {}
   allowUnsafeCode: 0
   additionalIl2CppArgs: 
-  scriptingRuntimeVersion: 1
+  scriptingRuntimeVersion: 0
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
@@ -604,7 +603,7 @@ PlayerSettings:
   facebookStatus: 1
   facebookXfbml: 0
   facebookFrictionlessRequests: 1
-  apiCompatibilityLevel: 6
+  apiCompatibilityLevel: 2
   cloudProjectId: 
   framebufferDepthMemorylessMode: 0
   projectName: 


### PR DESCRIPTION
Refactored to improve performance.
Changed cancelations back to not suppress rejections.
Fixed a race condition with progress with a cancelation token.
Added `AllowStackToUnwind` property in the csproj for better stacktraces for debugging.

Master:

```
|         Type | Pending | Recursion |     Mean |   Error | Allocated | Survived |
|------------- |-------- |---------- |---------:|--------:|----------:|---------:|
|   AsyncAwait |    True |       100 | 278.4 μs | 4.70 μs |         - | 25,152 B |
| ContinueWith |    True |       100 | 464.1 μs | 4.32 μs |         - | 13,104 B |
```

This PR:

```
|         Type | Pending | Recursion |     Mean |   Error | Allocated | Survived |
|------------- |-------- |---------- |---------:|--------:|----------:|---------:|
|   AsyncAwait |    True |       100 | 191.9 μs | 3.24 μs |         - | 25,152 B |
| ContinueWith |    True |       100 | 403.5 μs | 3.92 μs |         - | 13,104 B |
```