### PR TITLE
Optimize Cancelations

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
@@ -9,7 +9,7 @@ using System;
 namespace Proto.Promises
 {
     /// <summary>
-    /// Cancelation source used to cancel promises.
+    /// Cancelation source used to cancel operations.
     /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
@@ -21,8 +21,8 @@ namespace Proto.Promises
         struct CancelationSource : ICancelable, IDisposable, IEquatable<CancelationSource>
     {
         private readonly Internal.CancelationRef _ref;
-        private readonly short _sourceId;
-        private readonly short _tokenId;
+        private readonly int _sourceId;
+        private readonly int _tokenId;
 
         /// <summary>
         /// Create a new <see cref="CancelationSource"/>.
@@ -91,7 +91,7 @@ namespace Proto.Promises
         {
             get
             {
-                return new CancelationToken(_ref, _tokenId, false);
+                return new CancelationToken(_ref, _tokenId);
             }
         }
 
@@ -176,7 +176,7 @@ namespace Proto.Promises
 
         public override int GetHashCode()
         {
-            return Internal.BuildHashCode(_ref, _sourceId.GetHashCode(), _tokenId.GetHashCode());
+            return Internal.BuildHashCode(_ref, _sourceId.GetHashCode(), 0);
         }
 
         public static bool operator ==(CancelationSource c1, CancelationSource c2)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
@@ -24,8 +24,7 @@ namespace Proto.Promises
         partial struct CancelationToken : IRetainable, IEquatable<CancelationToken>
     {
         private readonly Internal.CancelationRef _ref;
-        private readonly short _id;
-        private readonly bool _isCanceled;
+        private readonly int _id;
 
         /// <summary>
         /// Returns an empty <see cref="CancelationToken"/>.
@@ -35,11 +34,10 @@ namespace Proto.Promises
         /// <summary>
         /// FOR INTERNAL USE ONLY!
         /// </summary>
-        internal CancelationToken(Internal.CancelationRef cancelationRef, short tokenId, bool isCanceled)
+        internal CancelationToken(Internal.CancelationRef cancelationRef, int tokenId)
         {
             _ref = cancelationRef;
             _id = tokenId;
-            _isCanceled = isCanceled;
         }
 
         /// <summary>
@@ -47,7 +45,7 @@ namespace Proto.Promises
         /// </summary>
         internal void MaybeLinkSourceInternal(Internal.CancelationRef cancelationRef)
         {
-            Internal.CancelationRef.MaybeAddLinkedCancelation(cancelationRef, _ref, _id, _isCanceled);
+            Internal.CancelationRef.MaybeAddLinkedCancelation(cancelationRef, _ref, _id);
         }
 
         /// <summary>
@@ -55,7 +53,7 @@ namespace Proto.Promises
         /// </summary>
         public static CancelationToken Canceled()
         {
-            return new CancelationToken(null, Internal.ValidIdFromApi, true);
+            return new CancelationToken(Internal.CancelationRef.s_canceledSentinel, Internal.CancelationRef.s_canceledSentinel.TokenId);
         }
 
         /// <summary>
@@ -66,7 +64,7 @@ namespace Proto.Promises
         {
             get
             {
-                return _isCanceled | Internal.CancelationRef.CanTokenBeCanceled(_ref, _id);
+                return Internal.CancelationRef.CanTokenBeCanceled(_ref, _id);
             }
         }
 
@@ -77,7 +75,7 @@ namespace Proto.Promises
         {
             get
             {
-                return _isCanceled | Internal.CancelationRef.IsTokenCanceled(_ref, _id);
+                return Internal.CancelationRef.IsTokenCanceled(_ref, _id);
             }
         }
 
@@ -87,7 +85,7 @@ namespace Proto.Promises
         /// <exception cref="CanceledException"/>
         public void ThrowIfCancelationRequested()
         {
-            Internal.CancelationRef.ThrowIfCanceled(_ref, _id, _isCanceled);
+            Internal.CancelationRef.ThrowIfCanceled(_ref, _id);
         }
 
         /// <summary>
@@ -100,7 +98,7 @@ namespace Proto.Promises
         public bool TryRegister(Action callback, out CancelationRegistration cancelationRegistration)
         {
             ValidateArgument(callback, "callback", 1);
-            return Internal.CancelationRef.TryRegister(_ref, _id, _isCanceled, new Internal.CancelDelegateTokenVoid(callback), out cancelationRegistration);
+            return Internal.CancelationRef.TryRegister(_ref, _id, new Internal.CancelDelegateTokenVoid(callback), out cancelationRegistration);
         }
 
         /// <summary>
@@ -114,21 +112,20 @@ namespace Proto.Promises
         public bool TryRegister<TCapture>(TCapture captureValue, Action<TCapture> callback, out CancelationRegistration cancelationRegistration)
         {
             ValidateArgument(callback, "callback", 1);
-            return Internal.CancelationRef.TryRegister(_ref, _id, _isCanceled, new Internal.CancelDelegateToken<TCapture>(captureValue, callback), out cancelationRegistration);
+            return Internal.CancelationRef.TryRegister(_ref, _id, new Internal.CancelDelegateToken<TCapture>(captureValue, callback), out cancelationRegistration);
         }
 
         /// <summary>
         /// Try to register a cancelable that will be canceled when this <see cref="CancelationToken"/> is canceled.
         /// If this is already canceled, it will be canceled immediately. If the associated <see cref="CancelationSource"/> was disposed (and this was not retained and canceled), it will not be registered.
         /// </summary>
-        /// <param name="captureValue">The value to pass into <paramref name="callback"/>.</param>
         /// <param name="cancelable">The cancelable to be canceled when the <see cref="CancelationToken"/> is canceled.</param>
         /// <param name="cancelationRegistration">The <see cref="CancelationRegistration"/> instance that can be used to unregister the callback.</param>
         /// <returns>true if <paramref name="cancelable"/> was registered successfully, false otherwise.</returns>
         public bool TryRegister<TCancelable>(TCancelable cancelable, out CancelationRegistration cancelationRegistration) where TCancelable : ICancelable
         {
             ValidateArgument(cancelable, "cancelable", 1);
-            return Internal.CancelationRef.TryRegister(_ref, _id, _isCanceled, cancelable, out cancelationRegistration);
+            return Internal.CancelationRef.TryRegister(_ref, _id, cancelable, out cancelationRegistration);
         }
 
         /// <summary>
@@ -152,6 +149,7 @@ namespace Proto.Promises
         /// Capture a value and register a delegate that will be invoked with the captured value when this <see cref="CancelationToken"/> is canceled.
         /// If this is already canceled, the callback will be invoked immediately.
         /// </summary>
+        /// <param name="captureValue">The value to pass into <paramref name="callback"/>.</param>
         /// <param name="callback">The delegate to be executed when the <see cref="CancelationToken"/> is canceled.</param>
         /// <returns>The <see cref="CancelationRegistration"/> instance that can be used to unregister the callback.</returns>
         /// <exception cref="InvalidOperationException"/>
@@ -189,7 +187,7 @@ namespace Proto.Promises
         /// </summary>
         public bool TryRetain()
         {
-            return Internal.CancelationRef.TryRetainUser(_ref, _id, _isCanceled);
+            return Internal.CancelationRef.TryRetainUser(_ref, _id);
         }
 
         /// <summary>
@@ -212,7 +210,7 @@ namespace Proto.Promises
         /// <exception cref="InvalidOperationException"/>
         public void Release()
         {
-            if (!Internal.CancelationRef.TryReleaseUser(_ref, _id, _isCanceled))
+            if (!Internal.CancelationRef.TryReleaseUser(_ref, _id))
             {
                 throw new InvalidOperationException("CancelationToken.Release: you must call Retain before you call Release.", Internal.GetFormattedStacktrace(1));
             }
@@ -234,17 +232,17 @@ namespace Proto.Promises
 
         public override int GetHashCode()
         {
-            return Internal.BuildHashCode(_ref, _id.GetHashCode(), 0, _isCanceled.GetHashCode());
+            return Internal.BuildHashCode(_ref, _id.GetHashCode(), 0);
         }
 
-        public static bool operator ==(CancelationToken c1, CancelationToken c2)
+        public static bool operator ==(CancelationToken lhs, CancelationToken rhs)
         {
-            return c1._ref == c2._ref & c1._id == c2._id;
+            return lhs._ref == rhs._ref & lhs._id == rhs._id;
         }
 
-        public static bool operator !=(CancelationToken c1, CancelationToken c2)
+        public static bool operator !=(CancelationToken lhs, CancelationToken rhs)
         {
-            return !(c1 == c2);
+            return !(lhs == rhs);
         }
 
         // Calls to this get compiled away in RELEASE mode


### PR DESCRIPTION
Optimized Cancelations to register and unregister in O(1) time instead of O(n).

Master:

|                Method | Registrations |        Mean |     Error |    StdDev | Allocated | Survived |
|---------------------- |-------------- |------------:|----------:|----------:|----------:|---------:|
| RegisterAndUnregister |             1 |    281.0 ns |   1.38 ns |   1.29 ns |         - |     72 B |
| RegisterAndUnregister |            10 |  3,019.9 ns |   8.10 ns |   6.76 ns |         - |    320 B |
| RegisterAndUnregister |           100 | 35,129.4 ns | 144.63 ns | 128.21 ns |         - |  3,200 B |

This PR:

|                Method | Registrations |       Mean |    Error |   StdDev | Allocated | Survived |
|---------------------- |-------------- |-----------:|---------:|---------:|----------:|---------:|
| RegisterAndUnregister |             1 |   109.9 ns |  2.20 ns |  2.62 ns |         - |     56 B |
| RegisterAndUnregister |            10 |   995.9 ns |  6.82 ns |  6.38 ns |         - |    560 B |
| RegisterAndUnregister |           100 | 9,866.8 ns | 49.43 ns | 75.49 ns |         - |  5,600 B |