### PR TITLE
Clean up warnings and hide obsolete members

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
@@ -104,11 +104,13 @@ namespace Proto.Promises
             return Internal.CancelationCallbackNode.TryUnregister(_node, _nodeId, _tokenId, out isTokenCancelationRequested);
         }
 
+        /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="CancelationRegistration"/>.</summary>
         public bool Equals(CancelationRegistration other)
         {
             return this == other;
         }
 
+        /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
         public override bool Equals(object obj)
         {
 #if CSHARP_7_3_OR_NEWER
@@ -118,16 +120,19 @@ namespace Proto.Promises
 #endif
         }
 
+        /// <summary>Returns the hash code for this instance.</summary>
         public override int GetHashCode()
         {
             return Internal.BuildHashCode(_node, _nodeId.GetHashCode(), _tokenId.GetHashCode());
         }
 
+        /// <summary>Returns a value indicating whether two <see cref="CancelationRegistration"/> values are equal.</summary>
         public static bool operator ==(CancelationRegistration lhs, CancelationRegistration rhs)
         {
             return lhs._node == rhs._node & lhs._nodeId == rhs._nodeId & lhs._tokenId == rhs._tokenId;
         }
 
+        /// <summary>Returns a value indicating whether two <see cref="CancelationRegistration"/> values are not equal.</summary>
         public static bool operator !=(CancelationRegistration lhs, CancelationRegistration rhs)
         {
             return !(lhs == rhs);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
@@ -4,7 +4,10 @@
 #undef PROMISE_DEBUG
 #endif
 
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member
+
 using System;
+using System.ComponentModel;
 
 namespace Proto.Promises
 {
@@ -97,7 +100,7 @@ namespace Proto.Promises
 
         /// <summary>
         /// Get whether or not this <see cref="CancelationSource"/> is valid.
-        /// <para/>A <see cref="CancelationSource"/> is valid if it was created from <see cref="New"/> and was not disposed.
+        /// <para/>A <see cref="CancelationSource"/> is valid if it was created from <see cref="New()"/> and was not disposed.
         /// </summary>
         public bool IsValid
         {
@@ -160,11 +163,13 @@ namespace Proto.Promises
             }
         }
 
+        /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="CancelationSource"/>.</summary>
         public bool Equals(CancelationSource other)
         {
             return this == other;
         }
 
+        /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
         public override bool Equals(object obj)
         {
 #if CSHARP_7_3_OR_NEWER
@@ -174,28 +179,31 @@ namespace Proto.Promises
 #endif
         }
 
+        /// <summary>Returns the hash code for this instance.</summary>
         public override int GetHashCode()
         {
             return Internal.BuildHashCode(_ref, _sourceId.GetHashCode(), 0);
         }
 
+        /// <summary>Returns a value indicating whether two <see cref="CancelationSource"/> values are equal.</summary>
         public static bool operator ==(CancelationSource c1, CancelationSource c2)
         {
             return c1._ref == c2._ref & c1._sourceId == c2._sourceId;
         }
 
+        /// <summary>Returns a value indicating whether two <see cref="CancelationSource"/> values are not equal.</summary>
         public static bool operator !=(CancelationSource c1, CancelationSource c2)
         {
             return !(c1 == c2);
         }
 
-        [Obsolete("Cancelation reasons are no longer supported. Use TryCancel() instead.", true)]
+        [Obsolete("Cancelation reasons are no longer supported. Use TryCancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public bool TryCancel<TCancel>(TCancel reason)
         {
             throw new InvalidOperationException("Cancelation reasons are no longer supported. Use TryCancel() instead.", Internal.GetFormattedStacktrace(1));
         }
 
-        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
+        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public void Cancel<TCancel>(TCancel reason)
         {
             throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Cancel() instead.", Internal.GetFormattedStacktrace(1));

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
@@ -52,7 +52,7 @@ namespace Proto.Promises
         public static CancelationSource New(CancelationToken token)
         {
             CancelationSource newCancelationSource = New();
-            token.MaybeLinkSourceInternal(newCancelationSource._ref);
+            newCancelationSource._ref.MaybeLinkToken(token);
             return newCancelationSource;
         }
 
@@ -66,8 +66,8 @@ namespace Proto.Promises
         public static CancelationSource New(CancelationToken token1, CancelationToken token2)
         {
             CancelationSource newCancelationSource = New();
-            token1.MaybeLinkSourceInternal(newCancelationSource._ref);
-            token2.MaybeLinkSourceInternal(newCancelationSource._ref);
+            newCancelationSource._ref.MaybeLinkToken(token1);
+            newCancelationSource._ref.MaybeLinkToken(token2);
             return newCancelationSource;
         }
 
@@ -82,7 +82,7 @@ namespace Proto.Promises
             CancelationSource newCancelationSource = New();
             for (int i = 0, max = tokens.Length; i < max; ++i)
             {
-                tokens[i].MaybeLinkSourceInternal(newCancelationSource._ref);
+                newCancelationSource._ref.MaybeLinkToken(tokens[i]);
             }
             return newCancelationSource;
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
@@ -43,14 +43,6 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// FOR INTERNAL USE ONLY!
-        /// </summary>
-        internal void MaybeLinkSourceInternal(Internal.CancelationRef cancelationRef)
-        {
-            Internal.CancelationRef.MaybeAddLinkedCancelation(cancelationRef, _ref, _id);
-        }
-
-        /// <summary>
         /// Get a token that is already in the canceled state.
         /// </summary>
         public static CancelationToken Canceled()

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
@@ -6,8 +6,10 @@
 
 #pragma warning disable IDE0018 // Inline variable declaration
 #pragma warning disable IDE0034 // Simplify 'default' expression
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
 using System;
+using System.ComponentModel;
 
 namespace Proto.Promises
 {
@@ -216,11 +218,13 @@ namespace Proto.Promises
             }
         }
 
+        /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="CancelationToken"/>.</summary>
         public bool Equals(CancelationToken other)
         {
             return this == other;
         }
 
+        /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
         public override bool Equals(object obj)
         {
 #if CSHARP_7_3_OR_NEWER
@@ -230,16 +234,19 @@ namespace Proto.Promises
 #endif
         }
 
+        /// <summary>Returns the hash code for this instance.</summary>
         public override int GetHashCode()
         {
             return Internal.BuildHashCode(_ref, _id.GetHashCode(), 0);
         }
 
+        /// <summary>Returns a value indicating whether two <see cref="CancelationToken"/> values are equal.</summary>
         public static bool operator ==(CancelationToken lhs, CancelationToken rhs)
         {
             return lhs._ref == rhs._ref & lhs._id == rhs._id;
         }
 
+        /// <summary>Returns a value indicating whether two <see cref="CancelationToken"/> values are not equal.</summary>
         public static bool operator !=(CancelationToken lhs, CancelationToken rhs)
         {
             return !(lhs == rhs);
@@ -254,7 +261,7 @@ namespace Proto.Promises
         }
 #endif
 
-        [Obsolete("Cancelation reasons are no longer supported.", true)]
+        [Obsolete("Cancelation reasons are no longer supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public Type CancelationValueType
         {
             get
@@ -263,7 +270,7 @@ namespace Proto.Promises
             }
         }
 
-        [Obsolete("Cancelation reasons are no longer supported.", true)]
+        [Obsolete("Cancelation reasons are no longer supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public object CancelationValue
         {
             get
@@ -272,7 +279,7 @@ namespace Proto.Promises
             }
         }
 
-        [Obsolete("Cancelation reasons are no longer supported.", true)]
+        [Obsolete("Cancelation reasons are no longer supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public bool TryGetCancelationValueAs<T>(out T value)
         {
             throw new InvalidOperationException("Cancelation reasons are no longer supported.", Internal.GetFormattedStacktrace(1));

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/AggregateException.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/AggregateException.cs
@@ -8,6 +8,10 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 
+#pragma warning disable IDE0019 // Use pattern matching
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0090 // Use 'new(...)'
+
 namespace Proto.Promises
 {
 #if !NET_LEGACY
@@ -120,7 +124,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Returns the <see cref="System.AggregateException"/> that is the root cause of this exception.
+        /// Returns the <see cref="AggregateException"/> that is the root cause of this exception.
         /// </summary>
         public override Exception GetBaseException()
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/ValueTuple.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/ValueTuple.cs
@@ -4,6 +4,12 @@
 
 #pragma warning disable RECS0025 // Non-readonly field referenced in 'GetHashCode()'
 #pragma warning disable RECS0017 // Possible compare of value type with 'null'
+#pragma warning disable IDE0031 // Use null propagation
+#pragma warning disable IDE0019 // Use pattern matching
+#pragma warning disable IDE0038 // Use pattern matching
+#pragma warning disable IDE0066 // Convert switch statement to expression
+#pragma warning disable 0436 // Type conflicts with imported type
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
 #if NET_LEGACY || NET45 // ValueTuples are available in .Net 4.7 and newer.
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Interfaces.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Interfaces.cs
@@ -1,5 +1,8 @@
 ﻿namespace Proto.Promises
 {
+    /// <summary>
+    /// Cancelable interface
+    /// </summary>
     public interface ICancelable
     {
         /// <summary>
@@ -8,6 +11,9 @@
         void Cancel();
     }
 
+    /// <summary>
+    /// Retainable interface
+    /// </summary>
     public interface IRetainable
     {
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
@@ -282,14 +282,14 @@ namespace Proto.Promises
         {
             private HandleablePromiseBase _head;
             // This must not be readonly.
-            private SpinLocker _spinner;
+            private SpinLocker _locker;
 
             [MethodImpl(InlineOption)]
             internal ValueLinkedStackSafe(HandleablePromiseBase tailSentinel)
             {
                 // Sentinel is PromiseRefBase.InvalidAwaitSentinel.s_instance
                 _head = tailSentinel;
-                _spinner = new SpinLocker();
+                _locker = new SpinLocker();
             }
 
             [MethodImpl(InlineOption)]
@@ -305,19 +305,19 @@ namespace Proto.Promises
             {
                 AssertNotInCollection((HandleablePromiseBase) item);
 
-                _spinner.Enter();
+                _locker.Enter();
                 item._next = _head;
                 _head = item;
-                _spinner.Exit();
+                _locker.Exit();
             }
 
             [MethodImpl(InlineOption)]
             internal T TryPop()
             {
-                _spinner.Enter();
+                _locker.Enter();
                 var head = _head;
                 _head = head._next;
-                _spinner.Exit();
+                _locker.Exit();
 
                 if (head == PromiseRefBase.InvalidAwaitSentinel.s_instance)
                 {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Config.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Config.cs
@@ -14,8 +14,10 @@
 
 #pragma warning disable IDE0034 // Simplify 'default' expression
 #pragma warning disable RECS0029 // Warns about property or indexer setters and event adders or removers that do not use the value parameter
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -23,6 +25,9 @@ namespace Proto.Promises
 {
     partial struct Promise
     {
+        /// <summary>
+        /// At what granularity should stack traces be captured when a promise is created or rejected. Higher values are more costly, but give more information for debugging purposes.
+        /// </summary>
         public enum TraceLevel : byte
         {
             /// <summary>
@@ -41,7 +46,7 @@ namespace Proto.Promises
             All
         }
 
-        [Obsolete("Promise Config now uses a simple boolean for object pooling.")]
+        [Obsolete("Promise Config now uses a simple boolean for object pooling."), EditorBrowsable(EditorBrowsableState.Never)]
         public enum PoolType : byte
         {
             None,
@@ -57,7 +62,7 @@ namespace Proto.Promises
 #endif
         public static partial class Config
         {
-            [Obsolete("Use ProgressPrecision to get the precision of progress reports.")]
+            [Obsolete("Use ProgressPrecision to get the precision of progress reports."), EditorBrowsable(EditorBrowsableState.Never)]
             public static readonly int ProgressDecimalBits = Internal.PromiseRefBase.Fixed32.DecimalBits;
 
             /// <summary>
@@ -68,13 +73,16 @@ namespace Proto.Promises
 #endif
             public static readonly float ProgressPrecision = (float) (1d / Math.Pow(2d, Internal.PromiseRefBase.Fixed32.DecimalBits));
 
-            [Obsolete("Use ObjectPoolingEnabled instead.")]
+            [Obsolete("Use ObjectPoolingEnabled instead."), EditorBrowsable(EditorBrowsableState.Never)]
             public static PoolType ObjectPooling 
             {
                 get { return ObjectPoolingEnabled ? PoolType.All : PoolType.None; }
                 set { ObjectPoolingEnabled = value != PoolType.None; }
             }
 
+            /// <summary>
+            /// Should objects be pooled or not. If this is enabled, objects can be reused to reduce GC pressure.
+            /// </summary>
 #if PROMISE_DEBUG
             // Object pooling disabled in DEBUG mode to prevent thread race conditions when validating for circular awaits.
             public static bool ObjectPoolingEnabled
@@ -156,8 +164,7 @@ namespace Proto.Promises
             }
             volatile private static SynchronizationContext s_backgroundContext;
 
-            // TODO: add EditorBrowsable(EditorBrowsableState.Never) to all obsolete APIs.
-            [Obsolete]
+            [Obsolete, EditorBrowsable(EditorBrowsableState.Never)]
             public static Action<string> WarningHandler { get; set; }
         }
     }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
@@ -12,8 +12,10 @@
 #pragma warning disable IDE0019 // Use pattern matching
 #pragma warning disable IDE0034 // Simplify 'default' expression
 #pragma warning disable 0618 // Type or member is obsolete
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace Proto.Promises
@@ -54,7 +56,7 @@ namespace Proto.Promises
                 }
             }
 
-            [Obsolete("Use IsValidAndPending.", false)]
+            [Obsolete("Use IsValidAndPending.", false), EditorBrowsable(EditorBrowsableState.Never)]
             public bool IsValid
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -237,12 +239,14 @@ namespace Proto.Promises
                 return Internal.DeferredPromiseHelper.TryReportProgress(_ref, _deferredId, progress);
             }
 
+            /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="DeferredBase"/>.</summary>
             [MethodImpl(Internal.InlineOption)]
             public bool Equals(DeferredBase other)
             {
                 return this == other;
             }
 
+            /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
             public override bool Equals(object obj)
             {
 #if CSHARP_7_3_OR_NEWER
@@ -252,12 +256,14 @@ namespace Proto.Promises
 #endif
             }
 
+            /// <summary>Returns the hash code for this instance.</summary>
             [MethodImpl(Internal.InlineOption)]
             public override int GetHashCode()
             {
                 return Internal.BuildHashCode(_ref, _deferredId.GetHashCode(), _promiseId.GetHashCode());
             }
 
+            /// <summary>Returns a value indicating whether two <see cref="DeferredBase"/> values are equal.</summary>
             [MethodImpl(Internal.InlineOption)]
             public static bool operator ==(DeferredBase lhs, DeferredBase rhs)
             {
@@ -266,25 +272,26 @@ namespace Proto.Promises
                     & lhs._promiseId == rhs._promiseId;
             }
 
+            /// <summary>Returns a value indicating whether two <see cref="DeferredBase"/> values are not equal.</summary>
             [MethodImpl(Internal.InlineOption)]
             public static bool operator !=(DeferredBase lhs, DeferredBase rhs)
             {
                 return !(lhs == rhs);
             }
 
-            [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
+            [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public void Cancel<TCancel>(TCancel reason)
             {
                 throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Cancel() instead.", Internal.GetFormattedStacktrace(1));
             }
 
-            [Obsolete("Cancelation reasons are no longer supported. Use TryCancel() instead.", true)]
+            [Obsolete("Cancelation reasons are no longer supported. Use TryCancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public bool TryCancel<TCancel>(TCancel reason)
             {
                 throw new InvalidOperationException("Cancelation reasons are no longer supported. Use TryCancel() instead.", Internal.GetFormattedStacktrace(1));
             }
 
-            [Obsolete("DeferredBase.State is no longer valid. Use IsValidAndPending.", true)]
+            [Obsolete("DeferredBase.State is no longer valid. Use IsValidAndPending.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public State State
             {
                 get
@@ -293,13 +300,13 @@ namespace Proto.Promises
                 }
             }
 
-            [Obsolete("DeferredBase.Retain is no longer valid.", true)]
+            [Obsolete("DeferredBase.Retain is no longer valid.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public void Retain()
             {
                 throw new InvalidOperationException("DeferredBase.Retain is no longer valid.", Internal.GetFormattedStacktrace(1));
             }
 
-            [Obsolete("DeferredBase.Release is no longer valid.", true)]
+            [Obsolete("DeferredBase.Release is no longer valid.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public void Release()
             {
                 throw new InvalidOperationException("DeferredBase.Release is no longer valid.", Internal.GetFormattedStacktrace(1));
@@ -340,7 +347,7 @@ namespace Proto.Promises
                 }
             }
 
-            [Obsolete("Use IsValidAndPending.", false)]
+            [Obsolete("Use IsValidAndPending.", false), EditorBrowsable(EditorBrowsableState.Never)]
             public bool IsValid
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -531,12 +538,14 @@ namespace Proto.Promises
                 return rhs.ToDeferred();
             }
 
+            /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="Deferred"/>.</summary>
             [MethodImpl(Internal.InlineOption)]
             public bool Equals(Deferred other)
             {
                 return this == other;
             }
 
+            /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
             public override bool Equals(object obj)
             {
 #if CSHARP_7_3_OR_NEWER
@@ -546,12 +555,14 @@ namespace Proto.Promises
 #endif
             }
 
+            /// <summary>Returns the hash code for this instance.</summary>
             [MethodImpl(Internal.InlineOption)]
             public override int GetHashCode()
             {
                 return Internal.BuildHashCode(_ref, _deferredId.GetHashCode(), _promiseId.GetHashCode());
             }
 
+            /// <summary>Returns a value indicating whether two <see cref="Deferred"/> values are equal.</summary>
             [MethodImpl(Internal.InlineOption)]
             public static bool operator ==(Deferred lhs, Deferred rhs)
             {
@@ -560,25 +571,26 @@ namespace Proto.Promises
                     & lhs._promiseId == rhs._promiseId;
             }
 
+            /// <summary>Returns a value indicating whether two <see cref="Deferred"/> values are not equal.</summary>
             [MethodImpl(Internal.InlineOption)]
             public static bool operator !=(Deferred lhs, Deferred rhs)
             {
                 return !(lhs == rhs);
             }
 
-            [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
+            [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public void Cancel<TCancel>(TCancel reason)
             {
                 throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Cancel() instead.", Internal.GetFormattedStacktrace(1));
             }
 
-            [Obsolete("Cancelation reasons are no longer supported. Use TryCancel() instead.", true)]
+            [Obsolete("Cancelation reasons are no longer supported. Use TryCancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public bool TryCancel<TCancel>(TCancel reason)
             {
                 throw new InvalidOperationException("Cancelation reasons are no longer supported. Use TryCancel() instead.", Internal.GetFormattedStacktrace(1));
             }
 
-            [Obsolete("Deferred.State is no longer valid. Use IsValidAndPending.", true)]
+            [Obsolete("Deferred.State is no longer valid. Use IsValidAndPending.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public State State
             {
                 get
@@ -587,13 +599,13 @@ namespace Proto.Promises
                 }
             }
 
-            [Obsolete("Deferred.Retain is no longer valid.", true)]
+            [Obsolete("Deferred.Retain is no longer valid.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public void Retain()
             {
                 throw new InvalidOperationException("Deferred.Retain is no longer valid.", Internal.GetFormattedStacktrace(1));
             }
 
-            [Obsolete("Deferred.Release is no longer valid.", true)]
+            [Obsolete("Deferred.Release is no longer valid.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public void Release()
             {
                 throw new InvalidOperationException("Deferred.Release is no longer valid.", Internal.GetFormattedStacktrace(1));
@@ -636,7 +648,7 @@ namespace Proto.Promises
                 }
             }
 
-            [Obsolete("Use IsValidAndPending.", false)]
+            [Obsolete("Use IsValidAndPending.", false), EditorBrowsable(EditorBrowsableState.Never)]
             public bool IsValid
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -826,12 +838,14 @@ namespace Proto.Promises
                 return rhs.ToDeferred<T>();
             }
 
+            /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="Deferred"/>.</summary>
             [MethodImpl(Internal.InlineOption)]
             public bool Equals(Deferred other)
             {
                 return this == other;
             }
 
+            /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
             public override bool Equals(object obj)
             {
 #if CSHARP_7_3_OR_NEWER
@@ -841,12 +855,14 @@ namespace Proto.Promises
 #endif
             }
 
+            /// <summary>Returns the hash code for this instance.</summary>
             [MethodImpl(Internal.InlineOption)]
             public override int GetHashCode()
             {
                 return Internal.BuildHashCode(_ref, _deferredId.GetHashCode(), _promiseId.GetHashCode());
             }
 
+            /// <summary>Returns a value indicating whether two <see cref="Deferred"/> values are equal.</summary>
             [MethodImpl(Internal.InlineOption)]
             public static bool operator ==(Deferred lhs, Deferred rhs)
             {
@@ -855,25 +871,26 @@ namespace Proto.Promises
                     & lhs._promiseId == rhs._promiseId;
             }
 
+            /// <summary>Returns a value indicating whether two <see cref="Deferred"/> values are not equal.</summary>
             [MethodImpl(Internal.InlineOption)]
             public static bool operator !=(Deferred lhs, Deferred rhs)
             {
                 return !(lhs == rhs);
             }
 
-            [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
+            [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public void Cancel<TCancel>(TCancel reason)
             {
                 throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Cancel() instead.", Internal.GetFormattedStacktrace(1));
             }
 
-            [Obsolete("Cancelation reasons are no longer supported. Use TryCancel() instead.", true)]
+            [Obsolete("Cancelation reasons are no longer supported. Use TryCancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public bool TryCancel<TCancel>(TCancel reason)
             {
                 throw new InvalidOperationException("Cancelation reasons are no longer supported. Use TryCancel() instead.", Internal.GetFormattedStacktrace(1));
             }
 
-            [Obsolete("Deferred.State is no longer valid. Use IsValidAndPending.", true)]
+            [Obsolete("Deferred.State is no longer valid. Use IsValidAndPending.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public Promise.State State
             {
                 get
@@ -882,13 +899,13 @@ namespace Proto.Promises
                 }
             }
 
-            [Obsolete("Deferred.Retain is no longer valid.", true)]
+            [Obsolete("Deferred.Retain is no longer valid.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public void Retain()
             {
                 throw new InvalidOperationException("Deferred.Retain is no longer valid.", Internal.GetFormattedStacktrace(1));
             }
 
-            [Obsolete("Deferred.Release is no longer valid.", true)]
+            [Obsolete("Deferred.Release is no longer valid.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public void Release()
             {
                 throw new InvalidOperationException("Deferred.Release is no longer valid.", Internal.GetFormattedStacktrace(1));

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/EnumsAndDelegates.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/EnumsAndDelegates.cs
@@ -1,34 +1,98 @@
 ﻿namespace Proto.Promises
 {
+    /// <summary>
+    /// How the next continuation should be scheduled.
+    /// </summary>
     public enum SynchronizationOption : byte
     {
+        /// <summary>
+        /// Schedule the next continuation to execute synchronously.
+        /// </summary>
         Synchronous,
+        /// <summary>
+        /// Schedule the next continuation to execute on the <see cref="Promise.Config.ForegroundContext"/>.
+        /// </summary>
         Foreground,
+        /// <summary>
+        /// Schedule the next continuation to execute on the <see cref="Promise.Config.BackgroundContext"/>.
+        /// </summary>
         Background
     }
 
     partial struct Promise
     {
+        /// <summary>
+        /// The state of the promise.
+        /// </summary>
         public enum State : byte
         {
+            /// <summary>
+            /// The promise has not yet completed. (The operation is in progress.)
+            /// </summary>
             Pending,
+            /// <summary>
+            /// The promise completed successfully. (The operation ran to completion with no errors.)
+            /// </summary>
             Resolved,
+            /// <summary>
+            /// The promise failed to complete due to a reason.
+            /// </summary>
             Rejected,
+            /// <summary>
+            /// The promise was canceled before the operation was able to complete.
+            /// </summary>
             Canceled
         }
 
         // These are necesary to pass ResultContainer to ContinueWith callbacks (because it is a ref struct, it cannot be used as a generic argument in System.Action<> and System.Func<>).
+
+        /// <summary>
+        /// The delegate type used for <see cref="ContinueWith(ContinueAction, CancelationToken)"/>.
+        /// </summary>
+        /// <param name="resultContainer">The container from which the promise's state and result or reason can be extracted.</param>
         public delegate void ContinueAction(ResultContainer resultContainer);
+        /// <summary>
+        /// The delegate type used for <see cref="ContinueWith{TCapture}(TCapture, ContinueAction{TCapture}, CancelationToken)"/>.
+        /// </summary>
+        /// <param name="capturedValue">The value that was passed to <see cref="ContinueWith{TCapture}(TCapture, ContinueAction{TCapture}, CancelationToken)"/>.</param>
+        /// <param name="resultContainer">The container from which the promise's state and result or reason can be extracted.</param>
         public delegate void ContinueAction<TCapture>(TCapture capturedValue, ResultContainer resultContainer);
+        /// <summary>
+        /// The delegate type used for <see cref="ContinueWith{TResult}(ContinueFunc{TResult}, CancelationToken)"/>.
+        /// </summary>
+        /// <param name="resultContainer">The container from which the promise's state and result or reason can be extracted.</param>
         public delegate TResult ContinueFunc<TResult>(ResultContainer resultContainer);
+        /// <summary>
+        /// The delegate type used for <see cref="ContinueWith{TCapture, TResult}(TCapture, ContinueFunc{TCapture, TResult}, CancelationToken)"/>.
+        /// </summary>
+        /// <param name="capturedValue">The value that was passed to <see cref="ContinueWith{TCapture, TResult}(TCapture, ContinueFunc{TCapture, TResult}, CancelationToken)"/>.</param>
+        /// <param name="resultContainer">The container from which the promise's state and result or reason can be extracted.</param>
         public delegate TResult ContinueFunc<TCapture, TResult>(TCapture capturedValue, ResultContainer resultContainer);
     }
 
     partial struct Promise<T>
     {
+        /// <summary>
+        /// The delegate type used for <see cref="ContinueWith(ContinueAction, CancelationToken)"/>.
+        /// </summary>
+        /// <param name="resultContainer">The container from which the promise's state and result or reason can be extracted.</param>
         public delegate void ContinueAction(ResultContainer resultContainer);
+        /// <summary>
+        /// The delegate type used for <see cref="ContinueWith{TCapture}(TCapture, ContinueAction{TCapture}, CancelationToken)"/>.
+        /// </summary>
+        /// <param name="capturedValue">The value that was passed to <see cref="ContinueWith{TCapture}(TCapture, ContinueAction{TCapture}, CancelationToken)"/>.</param>
+        /// <param name="resultContainer">The container from which the promise's state and result or reason can be extracted.</param>
         public delegate void ContinueAction<TCapture>(TCapture capturedValue, ResultContainer resultContainer);
+        /// <summary>
+        /// The delegate type used for <see cref="ContinueWith{TResult}(ContinueFunc{TResult}, CancelationToken)"/>.
+        /// </summary>
+        /// <param name="resultContainer">The container from which the promise's state and result or reason can be extracted.</param>
         public delegate TResult ContinueFunc<TResult>(ResultContainer resultContainer);
+        /// <summary>
+        /// The delegate type used for <see cref="ContinueWith{TCapture, TResult}(TCapture, ContinueFunc{TCapture, TResult}, CancelationToken)"/>.
+        /// </summary>
+        /// <param name="capturedValue">The value that was passed to <see cref="ContinueWith{TCapture, TResult}(TCapture, ContinueFunc{TCapture, TResult}, CancelationToken)"/>.</param>
+        /// <param name="resultContainer">The container from which the promise's state and result or reason can be extracted.</param>
         public delegate TResult ContinueFunc<TCapture, TResult>(TCapture capturedValue, ResultContainer resultContainer);
     }
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Exceptions.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Exceptions.cs
@@ -8,6 +8,7 @@
 #pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 
 namespace Proto.Promises
@@ -189,7 +190,7 @@ namespace Proto.Promises
         internal CanceledException(string message) : base(message) { }
 
 
-        [Obsolete("Cancelation reasons are no longer supported.", true)]
+        [Obsolete("Cancelation reasons are no longer supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public Type ValueType
         {
             get
@@ -198,7 +199,7 @@ namespace Proto.Promises
             }
         }
 
-        [Obsolete("Cancelation reasons are no longer supported.", true)]
+        [Obsolete("Cancelation reasons are no longer supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public object Value
         {
             get
@@ -207,7 +208,7 @@ namespace Proto.Promises
             }
         }
 
-        [Obsolete("Cancelation reasons are no longer supported.", true)]
+        [Obsolete("Cancelation reasons are no longer supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public bool TryGetValueAs<T>(out T value)
         {
             throw new InvalidOperationException("Cancelation reasons are no longer supported.", Internal.GetFormattedStacktrace(1));

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Extensions.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Extensions.cs
@@ -14,6 +14,9 @@ using System.Threading.Tasks;
 
 namespace Proto.Promises
 {
+    /// <summary>
+    /// Helpful extensions to convert promises to and from other asynchronous types.
+    /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [System.Diagnostics.DebuggerNonUserCode]
 #endif

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -51,6 +51,7 @@ namespace System.Runtime.CompilerServices
     }
 
 #if NET_LEGACY
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public interface INotifyCompletion
     {
         void OnCompleted(Action continuation);
@@ -66,6 +67,7 @@ namespace System.Runtime.CompilerServices
         void MoveNext();
         void SetStateMachine(IAsyncStateMachine stateMachine);
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 #endif // NET_LEGACY
 }
 
@@ -80,13 +82,21 @@ namespace Proto.Promises
     namespace Async.CompilerServices
     {
         /// <summary>
-        /// This type and its members are intended for use by the compiler.
+        /// Provides a builder for asynchronous methods that return <see cref="Promise"/>.
+        /// This type is intended for compiler use only.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
 #endif
         public partial struct PromiseMethodBuilder
         {
+            /// <summary>
+            /// Schedules the specified state machine to be pushed forward when the specified awaiter completes.
+            /// </summary>
+            /// <typeparam name="TAwaiter">Specifies the type of the awaiter.</typeparam>
+            /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
+            /// <param name="awaiter">The awaiter.</param>
+            /// <param name="stateMachine">The state machine.</param>
             [MethodImpl(Internal.InlineOption)]
             public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
                 where TAwaiter : INotifyCompletion
@@ -95,6 +105,13 @@ namespace Proto.Promises
                 Internal.PromiseRefBase.AsyncPromiseRef<Internal.VoidResult>.AwaitOnCompleted(ref awaiter, ref stateMachine, ref _ref);
             }
 
+            /// <summary>
+            /// Schedules the specified state machine to be pushed forward when the specified awaiter completes.
+            /// </summary>
+            /// <typeparam name="TAwaiter">Specifies the type of the awaiter.</typeparam>
+            /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
+            /// <param name="awaiter">The awaiter.</param>
+            /// <param name="stateMachine">The state machine.</param>
             [SecuritySafeCritical]
             [MethodImpl(Internal.InlineOption)]
             public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
@@ -104,6 +121,9 @@ namespace Proto.Promises
                 Internal.PromiseRefBase.AsyncPromiseRef<Internal.VoidResult>.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref _ref);
             }
 
+            /// <summary>Initiates the builder's execution with the associated state machine.</summary>
+            /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
+            /// <param name="stateMachine">The state machine instance, passed by reference.</param>
             [MethodImpl(Internal.InlineOption)]
             public void Start<TStateMachine>(ref TStateMachine stateMachine)
                 where TStateMachine : IAsyncStateMachine
@@ -113,18 +133,28 @@ namespace Proto.Promises
                 stateMachine.MoveNext();
             }
 
+            /// <summary>Does nothing.</summary>
+            /// <param name="stateMachine">The heap-allocated state machine object.</param>
             [MethodImpl(Internal.InlineOption)]
             public void SetStateMachine(IAsyncStateMachine stateMachine) { }
         }
 
         /// <summary>
-        /// This type and its members are intended for use by the compiler.
+        /// Provides a builder for asynchronous methods that return <see cref="Promise{T}"/>.
+        /// This type is intended for compiler use only.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
 #endif
         public partial struct PromiseMethodBuilder<T>
         {
+            /// <summary>
+            /// Schedules the specified state machine to be pushed forward when the specified awaiter completes.
+            /// </summary>
+            /// <typeparam name="TAwaiter">Specifies the type of the awaiter.</typeparam>
+            /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
+            /// <param name="awaiter">The awaiter.</param>
+            /// <param name="stateMachine">The state machine.</param>
             [MethodImpl(Internal.InlineOption)]
             public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
                 where TAwaiter : INotifyCompletion
@@ -133,6 +163,13 @@ namespace Proto.Promises
                 Internal.PromiseRefBase.AsyncPromiseRef<T>.AwaitOnCompleted(ref awaiter, ref stateMachine, ref _ref);
             }
 
+            /// <summary>
+            /// Schedules the specified state machine to be pushed forward when the specified awaiter completes.
+            /// </summary>
+            /// <typeparam name="TAwaiter">Specifies the type of the awaiter.</typeparam>
+            /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
+            /// <param name="awaiter">The awaiter.</param>
+            /// <param name="stateMachine">The state machine.</param>
             [SecuritySafeCritical]
             [MethodImpl(Internal.InlineOption)]
             public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
@@ -142,6 +179,9 @@ namespace Proto.Promises
                 Internal.PromiseRefBase.AsyncPromiseRef<T>.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref _ref);
             }
 
+            /// <summary>Initiates the builder's execution with the associated state machine.</summary>
+            /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
+            /// <param name="stateMachine">The state machine instance, passed by reference.</param>
             [MethodImpl(Internal.InlineOption)]
             public void Start<TStateMachine>(ref TStateMachine stateMachine)
                 where TStateMachine : IAsyncStateMachine
@@ -151,6 +191,8 @@ namespace Proto.Promises
                 stateMachine.MoveNext();
             }
 
+            /// <summary>Does nothing.</summary>
+            /// <param name="stateMachine">The heap-allocated state machine object.</param>
             [MethodImpl(Internal.InlineOption)]
             public void SetStateMachine(IAsyncStateMachine stateMachine) { }
         }
@@ -165,23 +207,34 @@ namespace Proto.Promises
                 _ref = promise;
             }
 
+            /// <summary>Gets the <see cref="Promise"/> for this builder.</summary>
+            /// <returns>The <see cref="Promise"/> representing the builder's asynchronous operation.</returns>
             public Promise Task
             {
                 [MethodImpl(Internal.InlineOption)]
                 get { return new Promise(_ref, _ref.Id, 0); }
             }
 
+            /// <summary>Initializes a new <see cref="PromiseMethodBuilder"/>.</summary>
+            /// <returns>The initialized <see cref="PromiseMethodBuilder"/>.</returns>
             [MethodImpl(Internal.InlineOption)]
             public static PromiseMethodBuilder Create()
             {
                 return new PromiseMethodBuilder(Internal.PromiseRefBase.AsyncPromiseRef<Internal.VoidResult>.GetOrCreate());
             }
 
+            /// <summary>
+            /// Completes the <see cref="Promise"/> in the <see cref="Promise.State">Rejected</see> state with the specified exception.
+            /// </summary>
+            /// <param name="exception">The <see cref="Exception"/> to use to reject the promise.</param>
             public void SetException(Exception exception)
             {
                 _ref.SetException(exception);
             }
 
+            /// <summary>
+            /// Completes the <see cref="Promise{T}"/> in the <see cref="Promise.State">Resolved</see> state.
+            /// </summary>
             [MethodImpl(Internal.InlineOption)]
             public void SetResult()
             {
@@ -197,23 +250,35 @@ namespace Proto.Promises
                 _ref = promise;
             }
 
+            /// <summary>Gets the <see cref="Promise{T}"/> for this builder.</summary>
+            /// <returns>The <see cref="Promise{T}"/> representing the builder's asynchronous operation.</returns>
             public Promise<T> Task
             {
                 [MethodImpl(Internal.InlineOption)]
                 get { return new Promise<T>(_ref, _ref.Id, 0); }
             }
 
+            /// <summary>Initializes a new <see cref="PromiseMethodBuilder{T}"/>.</summary>
+            /// <returns>The initialized <see cref="PromiseMethodBuilder{T}"/>.</returns>
             [MethodImpl(Internal.InlineOption)]
             public static PromiseMethodBuilder<T> Create()
             {
                 return new PromiseMethodBuilder<T>(Internal.PromiseRefBase.AsyncPromiseRef<T>.GetOrCreate());
             }
 
+            /// <summary>
+            /// Completes the <see cref="Promise{T}"/> in the <see cref="Promise.State">Rejected</see> state with the specified exception.
+            /// </summary>
+            /// <param name="exception">The <see cref="Exception"/> to use to reject the promise.</param>
             public void SetException(Exception exception)
             {
                 _ref.SetException(exception);
             }
 
+            /// <summary>
+            /// Completes the <see cref="Promise{T}"/> in the <see cref="Promise.State">Resolved</see> state with the specified result.
+            /// </summary>
+            /// <param name="result">The result to use to complete the task.</param>
             [MethodImpl(Internal.InlineOption)]
             public void SetResult(T result)
             {
@@ -226,6 +291,8 @@ namespace Proto.Promises
         // This code could be used for DEBUG mode, but IL2CPP requires the non-optimized code even in RELEASE mode, and I don't want to add extra unnecessary null checks there.
         partial struct PromiseMethodBuilder
         {
+            /// <summary>Gets the <see cref="Promise"/> for this builder.</summary>
+            /// <returns>The <see cref="Promise"/> representing the builder's asynchronous operation.</returns>
             public Promise Task
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -234,13 +301,19 @@ namespace Proto.Promises
                     return _ref == null ? Promise.Resolved() : new Promise(_ref, _ref.Id, 0);
                 }
             }
-
+            
+            /// <summary>Initializes a new <see cref="PromiseMethodBuilder"/>.</summary>
+            /// <returns>The initialized <see cref="PromiseMethodBuilder"/>.</returns>
             [MethodImpl(Internal.InlineOption)]
             public static PromiseMethodBuilder Create()
             {
                 return default(PromiseMethodBuilder);
             }
 
+            /// <summary>
+            /// Completes the <see cref="Promise"/> in the <see cref="Promise.State">Rejected</see> state with the specified exception.
+            /// </summary>
+            /// <param name="exception">The <see cref="Exception"/> to use to reject the promise.</param>
             public void SetException(Exception exception)
             {
                 if (_ref == null)
@@ -250,6 +323,9 @@ namespace Proto.Promises
                 _ref.SetException(exception);
             }
 
+            /// <summary>
+            /// Completes the <see cref="Promise{T}"/> in the <see cref="Promise.State">Resolved</see> state.
+            /// </summary>
             [MethodImpl(Internal.InlineOption)]
             public void SetResult()
             {
@@ -262,6 +338,8 @@ namespace Proto.Promises
 
         partial struct PromiseMethodBuilder<T>
         {
+            /// <summary>Gets the <see cref="Promise{T}"/> for this builder.</summary>
+            /// <returns>The <see cref="Promise{T}"/> representing the builder's asynchronous operation.</returns>
             public Promise<T> Task
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -271,12 +349,18 @@ namespace Proto.Promises
                 }
             }
 
+            /// <summary>Initializes a new <see cref="PromiseMethodBuilder{T}"/>.</summary>
+            /// <returns>The initialized <see cref="PromiseMethodBuilder{T}"/>.</returns>
             [MethodImpl(Internal.InlineOption)]
             public static PromiseMethodBuilder<T> Create()
             {
                 return default(PromiseMethodBuilder<T>);
             }
 
+            /// <summary>
+            /// Completes the <see cref="Promise{T}"/> in the <see cref="Promise.State">Rejected</see> state with the specified exception.
+            /// </summary>
+            /// <param name="exception">The <see cref="Exception"/> to use to reject the promise.</param>
             public void SetException(Exception exception)
             {
                 if (_ref == null)
@@ -286,6 +370,10 @@ namespace Proto.Promises
                 _ref.SetException(exception);
             }
 
+            /// <summary>
+            /// Completes the <see cref="Promise{T}"/> in the <see cref="Promise.State">Resolved</see> state with the specified result.
+            /// </summary>
+            /// <param name="result">The result to use to complete the task.</param>
             [MethodImpl(Internal.InlineOption)]
             public void SetResult(T result)
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -344,8 +344,9 @@ namespace Proto.Promises
 #endif // !NET5_0_OR_GREATER
 
         /// <summary>
-        /// Used to support the await keyword.
+        /// Provides an awaiter for awaiting a <see cref="Promise"/>.
         /// </summary>
+        /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
 #endif
@@ -373,6 +374,9 @@ namespace Proto.Promises
 
             static partial void CreateOverride();
 
+            /// <summary>Gets whether the <see cref="Promise"/> being awaited is completed.</summary>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             public bool IsCompleted
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -383,6 +387,9 @@ namespace Proto.Promises
                 }
             }
 
+            /// <summary>Ends the await on the completed <see cref="Promise"/>.</summary>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten, or it has not yet completed.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void GetResult()
             {
@@ -404,6 +411,10 @@ namespace Proto.Promises
 #endif
             }
 
+            /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseAwaiterVoid"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void OnCompleted(Action continuation)
             {
@@ -417,6 +428,10 @@ namespace Proto.Promises
                 _ref.OnCompleted(continuation, _promise._id);
             }
 
+            /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseAwaiterVoid"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void UnsafeOnCompleted(Action continuation)
             {
@@ -439,8 +454,9 @@ namespace Proto.Promises
         } // struct PromiseAwaiterVoid
 
         /// <summary>
-        /// Used to support the await keyword.
+        /// Provides an awaiter for awaiting a <see cref="Promise{T}"/>.
         /// </summary>
+        /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
 #endif
@@ -468,6 +484,9 @@ namespace Proto.Promises
 
             static partial void CreateOverride();
 
+            /// <summary>Gets whether the <see cref="Promise{T}"/> being awaited is completed.</summary>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             public bool IsCompleted
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -478,6 +497,10 @@ namespace Proto.Promises
                 }
             }
 
+            /// <summary>Ends the await on the completed <see cref="Promise{T}"/>.</summary>
+            /// <returns>The result of the completed <see cref="Promise{T}"/></returns>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten, or it has not yet completed.</exception>
             [MethodImpl(Internal.InlineOption)]
             public T GetResult()
             {
@@ -499,6 +522,10 @@ namespace Proto.Promises
                 throw null; // This will never be reached, but the compiler needs help understanding that.
             }
 
+            /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseAwaiter{T}"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void OnCompleted(Action continuation)
             {
@@ -512,6 +539,10 @@ namespace Proto.Promises
                 _ref.OnCompleted(continuation, _promise._id);
             }
 
+            /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseAwaiter{T}"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void UnsafeOnCompleted(Action continuation)
             {
@@ -534,8 +565,9 @@ namespace Proto.Promises
         } // struct PromiseAwaiter<T>
 
         /// <summary>
-        /// Used to support the await keyword.
+        /// Provides an awaiter for awaiting a <see cref="Promise"/> and reporting its progress to the associated async <see cref="Promise"/> or <see cref="Promise{T}"/>.
         /// </summary>
+        /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
 #endif
@@ -567,12 +599,18 @@ namespace Proto.Promises
 
             static partial void CreateOverride();
 
+            /// <summary>Gets the awaiter for this.</summary>
+            /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
+            /// <returns>this</returns>
             [MethodImpl(Internal.InlineOption)]
             public PromiseProgressAwaiterVoid GetAwaiter()
             {
                 return this;
             }
 
+            /// <summary>Gets whether the <see cref="Promise"/> being awaited is completed.</summary>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             public bool IsCompleted
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -583,6 +621,9 @@ namespace Proto.Promises
                 }
             }
 
+            /// <summary>Ends the await on the completed <see cref="Promise"/>.</summary>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten, or it has not yet completed.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void GetResult()
             {
@@ -604,6 +645,10 @@ namespace Proto.Promises
 #endif
             }
 
+            /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseProgressAwaiterVoid"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void OnCompleted(Action continuation)
             {
@@ -617,6 +662,10 @@ namespace Proto.Promises
                 _promise._ref.OnCompleted(continuation, _promise._id);
             }
 
+            /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseProgressAwaiterVoid"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void UnsafeOnCompleted(Action continuation)
             {
@@ -639,8 +688,9 @@ namespace Proto.Promises
         } // struct PromiseAwaiterVoid
 
         /// <summary>
-        /// Used to support the await keyword.
+        /// Provides an awaiter for awaiting a <see cref="Promise{T}"/> and reporting its progress to the associated async <see cref="Promise"/> or <see cref="Promise{T}"/>.
         /// </summary>
+        /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
 #endif
@@ -672,12 +722,18 @@ namespace Proto.Promises
 
             static partial void CreateOverride();
 
+            /// <summary>Gets the awaiter for this.</summary>
+            /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
+            /// <returns>this</returns>
             [MethodImpl(Internal.InlineOption)]
             public PromiseProgressAwaiter<T> GetAwaiter()
             {
                 return this;
             }
 
+            /// <summary>Gets whether the <see cref="Promise{T}"/> being awaited is completed.</summary>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             public bool IsCompleted
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -688,6 +744,10 @@ namespace Proto.Promises
                 }
             }
 
+            /// <summary>Ends the await on the completed <see cref="Promise{T}"/>.</summary>
+            /// <returns>The result of the completed <see cref="Promise{T}"/></returns>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten, or it has not yet completed.</exception>
             [MethodImpl(Internal.InlineOption)]
             public T GetResult()
             {
@@ -709,6 +769,10 @@ namespace Proto.Promises
                 throw null; // This will never be reached, but the compiler needs help understanding that.
             }
 
+            /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseProgressAwaiter{T}"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void OnCompleted(Action continuation)
             {
@@ -722,6 +786,10 @@ namespace Proto.Promises
                 _promise._ref.OnCompleted(continuation, _promise._id);
             }
 
+            /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseProgressAwaiter{T}"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void UnsafeOnCompleted(Action continuation)
             {
@@ -746,9 +814,9 @@ namespace Proto.Promises
 
     partial struct Promise
     {
-        /// <summary>
-        /// Used to support the await keyword.
-        /// </summary>
+        /// <summary>Gets an awaiter for this <see cref="Promise"/>.</summary>
+        /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
+        /// <returns>The awaiter.</returns>
         [MethodImpl(Internal.InlineOption)]
         public PromiseAwaiterVoid GetAwaiter()
         {
@@ -757,9 +825,11 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Used to support reporting progress to the async Promise function. The progress reported will be lerped from <paramref name="minProgress"/> to <paramref name="maxProgress"/>. Both values must be between 0 and 1 inclusive.
-        /// <para/> Use as `await promise.AwaitWithprogress(minProgress, maxProgress);`
+        /// Gets an awaiter for this <see cref="Promise"/> that supports reporting progress to the async <see cref="Promise"/> or <see cref="Promise{T}"/> function.
+        /// The progress reported will be lerped from <paramref name="minProgress"/> to <paramref name="maxProgress"/>. Both values must be between 0 and 1 inclusive.
         /// </summary>
+        /// <remarks> Use as `await promise.AwaitWithProgress(minProgress, maxProgress);`</remarks>
+        /// <returns>The awaiter.</returns>
         public PromiseProgressAwaiterVoid AwaitWithProgress(float minProgress, float maxProgress)
         {
             ValidateOperation(1);
@@ -771,9 +841,9 @@ namespace Proto.Promises
 
     partial struct Promise<T>
     {
-        /// <summary>
-        /// Used to support the await keyword.
-        /// </summary>
+        /// <summary>Gets an awaiter for this <see cref="Promise{T}"/>.</summary>
+        /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
+        /// <returns>The awaiter.</returns>
         [MethodImpl(Internal.InlineOption)]
         public PromiseAwaiter<T> GetAwaiter()
         {
@@ -782,9 +852,11 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Used to support reporting progress to the async Promise function. The progress reported will be lerped from <paramref name="minProgress"/> to <paramref name="maxProgress"/>. Both values must be between 0 and 1 inclusive.
-        /// <para/> Use as `await promise.AwaitWithProgress(minProgress, maxProgress);`
+        /// Gets an awaiter for this <see cref="Promise{T}"/> that supports reporting progress to the async <see cref="Promise"/> or <see cref="Promise{T}"/> function.
+        /// The progress reported will be lerped from <paramref name="minProgress"/> to <paramref name="maxProgress"/>. Both values must be between 0 and 1 inclusive.
         /// </summary>
+        /// <remarks> Use as `await promise.AwaitWithProgress(minProgress, maxProgress);`</remarks>
+        /// <returns>The awaiter.</returns>
         public PromiseProgressAwaiter<T> AwaitWithProgress(float minProgress, float maxProgress)
         {
             ValidateOperation(1);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Manager.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Manager.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#pragma warning disable 1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.ComponentModel;
 
 namespace Proto.Promises
 {
@@ -12,19 +15,19 @@ namespace Proto.Promises
 #endif
         public static class Manager
         {
-            [Obsolete("Promise.Manager.HandleCompletes is no longer valid. Set Promise.Config.ForegroundContext instead.", true)]
+            [Obsolete("Promise.Manager.HandleCompletes is no longer valid. Set Promise.Config.ForegroundContext instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public static void HandleCompletes()
             {
                 throw new System.InvalidOperationException("Promise.Manager.HandleCompletes is no longer valid. Set Promise.Config.ForegroundContext instead.");
             }
 
-            [Obsolete("Promise.Manager.HandleCompletesAndProgress is no longer valid. Set Promise.Config.ForegroundContext instead.", true)]
+            [Obsolete("Promise.Manager.HandleCompletesAndProgress is no longer valid. Set Promise.Config.ForegroundContext instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public static void HandleCompletesAndProgress()
             {
                 throw new System.InvalidOperationException("Promise.Manager.HandleCompletesAndProgress is no longer valid. Set Promise.Config.ForegroundContext instead.");
             }
 
-            [Obsolete("Promise.Manager.HandleProgress is no longer valid. Set Promise.Config.ForegroundContext instead.", true)]
+            [Obsolete("Promise.Manager.HandleProgress is no longer valid. Set Promise.Config.ForegroundContext instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public static void HandleProgress()
             {
                 throw new System.InvalidOperationException("Promise.Manager.HandleProgress is no longer valid. Set Promise.Config.ForegroundContext instead.");
@@ -38,7 +41,7 @@ namespace Proto.Promises
                 Internal.ClearPool();
             }
 
-            [Obsolete]
+            [Obsolete, EditorBrowsable(EditorBrowsableState.Never)]
             public static void LogWarning(string message)
             {
                 var temp = Config.WarningHandler;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
@@ -17,8 +17,10 @@
 #endif
 
 #pragma warning disable IDE0034 // Simplify 'default' expression
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -36,6 +38,9 @@ namespace Proto.Promises
 #endif
         partial struct Promise : IEquatable<Promise>
     {
+        /// <summary>
+        /// Gets whether this instance is valid to be awaited.
+        /// </summary>
         public bool IsValid
         {
             [MethodImpl(Internal.InlineOption)]
@@ -47,6 +52,10 @@ namespace Proto.Promises
             }
         }
 
+        /// <summary>
+        /// Gets the string representation of this instance.
+        /// </summary>
+        /// <returns>The string representation of this instance.</returns>
         public override string ToString()
         {
             var _this = this;
@@ -2214,12 +2223,14 @@ namespace Proto.Promises
         }
         #endregion
 
+        /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="Promise"/>.</summary>
         [MethodImpl(Internal.InlineOption)]
         public bool Equals(Promise other)
         {
             return this == other;
         }
 
+        /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
         public override bool Equals(object obj)
         {
 #if CSHARP_7_3_OR_NEWER
@@ -2230,12 +2241,14 @@ namespace Proto.Promises
         }
 
         // Promises really shouldn't be used for lookups, but GetHashCode is overridden to complement ==.
+        /// <summary>Returns the hash code for this instance.</summary>
         [MethodImpl(Internal.InlineOption)]
         public override int GetHashCode()
         {
             return Internal.BuildHashCode(_ref, _id.GetHashCode(), 0);
         }
 
+        /// <summary>Returns a value indicating whether two <see cref="Promise"/> values are equal.</summary>
         [MethodImpl(Internal.InlineOption)]
         public static bool operator ==(Promise lhs, Promise rhs)
         {
@@ -2243,19 +2256,20 @@ namespace Proto.Promises
                 & lhs._id == rhs._id;
         }
 
+        /// <summary>Returns a value indicating whether two <see cref="Promise"/> values are not equal.</summary>
         [MethodImpl(Internal.InlineOption)]
         public static bool operator !=(Promise lhs, Promise rhs)
         {
             return !(lhs == rhs);
         }
 
-        [Obsolete("Retain is no longer valid, use Preserve instead.", true)]
+        [Obsolete("Retain is no longer valid, use Preserve instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public void Retain()
         {
             throw new InvalidOperationException("Retain is no longer valid, use Preserve instead.", Internal.GetFormattedStacktrace(1));
         }
 
-        [Obsolete("Release is no longer valid, use Forget instead.", true)]
+        [Obsolete("Release is no longer valid, use Forget instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public void Release()
         {
             throw new InvalidOperationException("Release is no longer valid, use Forget instead.", Internal.GetFormattedStacktrace(1));

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
@@ -1,7 +1,9 @@
 ﻿#pragma warning disable IDE0034 // Simplify 'default' expression
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -155,37 +157,37 @@ namespace Proto.Promises
             return new Promise(promise, promise.Id, minDepth);
         }
 
-        [Obsolete("Prefer Promise<T>.Race()")]
+        [Obsolete("Prefer Promise<T>.Race()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> Race<T>(Promise<T> promise1, Promise<T> promise2)
         {
             return Promise<T>.Race(promise1, promise2);
         }
 
-        [Obsolete("Prefer Promise<T>.Race()")]
+        [Obsolete("Prefer Promise<T>.Race()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> Race<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
             return Promise<T>.Race(promise1, promise2, promise3);
         }
 
-        [Obsolete("Prefer Promise<T>.Race()")]
+        [Obsolete("Prefer Promise<T>.Race()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> Race<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
             return Promise<T>.Race(promise1, promise2, promise3, promise4);
         }
 
-        [Obsolete("Prefer Promise<T>.Race()")]
+        [Obsolete("Prefer Promise<T>.Race()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> Race<T>(params Promise<T>[] promises)
         {
             return Promise<T>.Race(promises);
         }
 
-        [Obsolete("Prefer Promise<T>.Race()")]
+        [Obsolete("Prefer Promise<T>.Race()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> Race<T>(IEnumerable<Promise<T>> promises)
         {
             return Promise<T>.Race(promises);
         }
 
-        [Obsolete("Prefer Promise<T>.Race()")]
+        [Obsolete("Prefer Promise<T>.Race()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> Race<T, TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
         {
             return Promise<T>.Race(promises);
@@ -337,37 +339,37 @@ namespace Proto.Promises
             return new Promise(promise, promise.Id, minDepth);
         }
 
-        [Obsolete("Prefer Promise<T>.First()")]
+        [Obsolete("Prefer Promise<T>.First()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> First<T>(Promise<T> promise1, Promise<T> promise2)
         {
             return Promise<T>.First(promise1, promise2);
         }
 
-        [Obsolete("Prefer Promise<T>.First()")]
+        [Obsolete("Prefer Promise<T>.First()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> First<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
             return Promise<T>.First(promise1, promise2, promise3);
         }
 
-        [Obsolete("Prefer Promise<T>.First()")]
+        [Obsolete("Prefer Promise<T>.First()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> First<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
             return Promise<T>.First(promise1, promise2, promise3, promise4);
         }
 
-        [Obsolete("Prefer Promise<T>.First()")]
+        [Obsolete("Prefer Promise<T>.First()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> First<T>(params Promise<T>[] promises)
         {
             return Promise<T>.First(promises);
         }
 
-        [Obsolete("Prefer Promise<T>.First()")]
+        [Obsolete("Prefer Promise<T>.First()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> First<T>(IEnumerable<Promise<T>> promises)
         {
             return Promise<T>.First(promises);
         }
 
-        [Obsolete("Prefer Promise<T>.First()")]
+        [Obsolete("Prefer Promise<T>.First()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> First<T, TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
         {
             return Promise<T>.First(promises);
@@ -577,43 +579,43 @@ namespace Proto.Promises
             return new Promise(promise, promise.Id, maxDepth);
         }
 
-        [Obsolete("Prefer Promise<T>.All()")]
+        [Obsolete("Prefer Promise<T>.All()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<IList<T>> All<T>(Promise<T> promise1, Promise<T> promise2, IList<T> valueContainer = null)
         {
             return Promise<T>.All(promise1, promise2, valueContainer);
         }
 
-        [Obsolete("Prefer Promise<T>.All()")]
+        [Obsolete("Prefer Promise<T>.All()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<IList<T>> All<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, IList<T> valueContainer = null)
         {
             return Promise<T>.All(promise1, promise2, promise3, valueContainer);
         }
 
-        [Obsolete("Prefer Promise<T>.All()")]
+        [Obsolete("Prefer Promise<T>.All()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<IList<T>> All<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4, IList<T> valueContainer = null)
         {
             return Promise<T>.All(promise1, promise2, promise3, promise4, valueContainer);
         }
 
-        [Obsolete("Prefer Promise<T>.All()")]
+        [Obsolete("Prefer Promise<T>.All()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<IList<T>> All<T>(params Promise<T>[] promises)
         {
             return Promise<T>.All(promises);
         }
 
-        [Obsolete("Prefer Promise<T>.All()")]
+        [Obsolete("Prefer Promise<T>.All()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<IList<T>> All<T>(IEnumerable<Promise<T>> promises)
         {
             return Promise<T>.All(promises);
         }
 
-        [Obsolete("Prefer Promise<T>.All()")]
+        [Obsolete("Prefer Promise<T>.All()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<IList<T>> All<T, TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
         {
             return Promise<T>.All(promises);
         }
 
-        [Obsolete("Prefer Promise<T>.All()")]
+        [Obsolete("Prefer Promise<T>.All()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<IList<T>> AllNonAlloc<T, TEnumerator>(TEnumerator promises, IList<T> valueContainer) where TEnumerator : IEnumerator<Promise<T>>
         {
             return Promise<T>.AllNonAlloc(promises, valueContainer);
@@ -1348,13 +1350,13 @@ namespace Proto.Promises
             return deferred.Promise;
         }
 
-        [Obsolete("Prefer Promise<T>.New()")]
+        [Obsolete("Prefer Promise<T>.New()"), EditorBrowsable(EditorBrowsableState.Never)]
 		public static Promise<T> New<T>(Action<Promise<T>.Deferred> resolver, SynchronizationOption synchronizationOption = SynchronizationOption.Synchronous)
         {
             return Promise<T>.New(resolver, synchronizationOption);
         }
 
-        [Obsolete("Prefer Promise<T>.New()")]
+        [Obsolete("Prefer Promise<T>.New()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> New<T>(Action<Promise<T>.Deferred> resolver, SynchronizationContext synchronizationContext)
         {
             return Promise<T>.New(resolver, synchronizationContext);
@@ -1421,13 +1423,13 @@ namespace Proto.Promises
             return deferred.Promise;
         }
 
-        [Obsolete("Prefer Promise<T>.New()")]
+        [Obsolete("Prefer Promise<T>.New()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> New<TCapture, T>(TCapture captureValue, Action<TCapture, Promise<T>.Deferred> resolver, SynchronizationOption synchronizationOption = SynchronizationOption.Synchronous)
         {
             return Promise<T>.New(captureValue, resolver, synchronizationOption);
         }
 
-        [Obsolete("Prefer Promise<T>.New()")]
+        [Obsolete("Prefer Promise<T>.New()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> New<TCapture, T>(TCapture captureValue, Action<TCapture, Promise<T>.Deferred> resolver, SynchronizationContext synchronizationContext)
         {
             return Promise<T>.New(captureValue, resolver, synchronizationContext);
@@ -1677,7 +1679,7 @@ namespace Proto.Promises
             return deferred.Promise;
         }
 
-        [Obsolete("Prefer Promise<T>.Rejected<TReject>(TReject reason)")]
+        [Obsolete("Prefer Promise<T>.Rejected<TReject>(TReject reason)"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> Rejected<T, TReject>(TReject reason)
         {
             return Promise<T>.Rejected(reason);
@@ -1693,7 +1695,7 @@ namespace Proto.Promises
             return deferred.Promise;
         }
 
-        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
+        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise Canceled<TCancel>(TCancel reason)
         {
             throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Canceled() instead.", Internal.GetFormattedStacktrace(1));
@@ -1707,7 +1709,7 @@ namespace Proto.Promises
             return Promise<T>.Canceled();
         }
 
-        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
+        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> Canceled<T, TCancel>(TCancel reason)
         {
             return Promise<T>.Canceled(reason);
@@ -1753,7 +1755,7 @@ namespace Proto.Promises
             return Internal.CanceledExceptionInternal.GetOrCreate();
         }
 
-        [Obsolete("Cancelation reasons are no longer supported. Use CancelException() instead.", true)]
+        [Obsolete("Cancelation reasons are no longer supported. Use CancelException() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public static CanceledException CancelException<T>(T value)
         {
             throw new InvalidOperationException("Cancelation reasons are no longer supported. Use CancelException() instead.", Internal.GetFormattedStacktrace(1));

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -14,9 +14,11 @@
 #endif
 
 #pragma warning disable IDE0034 // Simplify 'default' expression
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -34,6 +36,9 @@ namespace Proto.Promises
 #endif
         partial struct Promise<T> : IEquatable<Promise<T>>
     {
+        /// <summary>
+        /// Gets whether this instance is valid to be awaited.
+        /// </summary>
         public bool IsValid
         {
             get
@@ -66,6 +71,10 @@ namespace Proto.Promises
             return rhs.AsPromise();
         }
 
+        /// <summary>
+        /// Gets the string representation of this instance.
+        /// </summary>
+        /// <returns>The string representation of this instance.</returns>
         public override string ToString()
         {
             var _this = this;
@@ -2227,13 +2236,13 @@ namespace Proto.Promises
         }
 #endregion
 
-        [Obsolete("Retain is no longer valid, use Preserve instead.", true)]
+        [Obsolete("Retain is no longer valid, use Preserve instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public void Retain()
         {
             throw new InvalidOperationException("Retain is no longer valid, use Preserve instead.", Internal.GetFormattedStacktrace(1));
         }
 
-        [Obsolete("Release is no longer valid, use Forget instead.", true)]
+        [Obsolete("Release is no longer valid, use Forget instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public void Release()
         {
             throw new InvalidOperationException("Release is no longer valid, use Forget instead.", Internal.GetFormattedStacktrace(1));
@@ -3616,14 +3625,16 @@ namespace Proto.Promises
         {
             return AsPromise().Then(resolveCaptureValue, onResolved, rejectCaptureValue, onRejected, cancelationToken);
         }
-#endregion
+        #endregion
 
+        /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="Promise{T}"/>.</summary>
         [MethodImpl(Internal.InlineOption)]
         public bool Equals(Promise<T> other)
         {
             return this == other;
         }
 
+        /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
         public override bool Equals(object obj)
         {
 #if CSHARP_7_3_OR_NEWER
@@ -3634,6 +3645,7 @@ namespace Proto.Promises
         }
 
         // Promises really shouldn't be used for lookups, but GetHashCode is overridden to complement ==.
+        /// <summary>Returns the hash code for this instance.</summary>
         public override int GetHashCode()
         {
             T result = _result;
@@ -3641,6 +3653,7 @@ namespace Proto.Promises
             return Internal.BuildHashCode(_ref, _id.GetHashCode(), resultHashCode, typeof(T).TypeHandle.GetHashCode()); // Hashcode variance for different T types.
         }
 
+        /// <summary>Returns a value indicating whether two <see cref="Promise{T}"/> values are equal.</summary>
         public static bool operator ==(Promise<T> lhs, Promise<T> rhs)
         {
             return lhs._ref == rhs._ref
@@ -3648,6 +3661,7 @@ namespace Proto.Promises
                 & EqualityComparer<T>.Default.Equals(lhs._result, rhs._result);
         }
 
+        /// <summary>Returns a value indicating whether two <see cref="Promise{T}"/> values are not equal.</summary>
         [MethodImpl(Internal.InlineOption)]
         public static bool operator !=(Promise<T> lhs, Promise<T> rhs)
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
@@ -1,7 +1,9 @@
 ﻿#pragma warning disable IDE0034 // Simplify 'default' expression
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading;
 
 namespace Proto.Promises
@@ -394,6 +396,8 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve with a list of the promises' values in the same order when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be rejected or canceled with the same reason.
         /// </summary>
+        /// <param name="promise1">The first promise to combine.</param>
+        /// <param name="promise2">The second promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
         public static Promise<IList<T>> All(Promise<T> promise1, Promise<T> promise2, IList<T> valueContainer = null)
         {
@@ -446,6 +450,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve with a list of the promises' values in the same order when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be rejected or canceled with the same reason.
         /// </summary>
+        /// <param name="promise1">The first promise to combine.</param>
+        /// <param name="promise2">The second promise to combine.</param>
+        /// <param name="promise3">The third promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
         public static Promise<IList<T>> All(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, IList<T> valueContainer = null)
         {
@@ -502,6 +509,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve with a list of the promises' values in the same order when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be rejected or canceled with the same reason.
         /// </summary>
+        /// <param name="promise1">The first promise to combine.</param>
+        /// <param name="promise2">The second promise to combine.</param>
+        /// <param name="promise3">The third promise to combine.</param>
+        /// <param name="promise4">The fourth promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
         public static Promise<IList<T>> All(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4, IList<T> valueContainer = null)
         {
@@ -571,6 +582,7 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve with a list of values in the same order as <paramref name="promises"/> when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be rejected or canceled with the same reason.
         /// </summary>
+        /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
         public static Promise<IList<T>> All(Promise<T>[] promises, IList<T> valueContainer = null)
         {
@@ -581,6 +593,7 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve with a list of values in the same order as <paramref name="promises"/>s when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be rejected or canceled with the same reason.
         /// </summary>
+        /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
         public static Promise<IList<T>> All(IEnumerable<Promise<T>> promises, IList<T> valueContainer = null)
         {
@@ -591,6 +604,7 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve a list of values in the same order as <paramref name="promises"/> when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be rejected or canceled with the same reason.
         /// </summary>
+        /// <param name="promises">The enumerator of promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
         public static Promise<IList<T>> All<TEnumerator>(TEnumerator promises, IList<T> valueContainer = null) where TEnumerator : IEnumerator<Promise<T>>
         {
@@ -644,7 +658,7 @@ namespace Proto.Promises
             return new Promise<IList<T>>(promise, promise.Id, maxDepth);
         }
 
-        [Obsolete("Prefer Promise<T>.All()")]
+        [Obsolete("Prefer Promise<T>.All()"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<IList<T>> AllNonAlloc<TEnumerator>(TEnumerator promises, IList<T> valueContainer) where TEnumerator : IEnumerator<Promise<T>>
         {
             ValidateArgument(valueContainer, "valueContainer", 1);
@@ -805,7 +819,7 @@ namespace Proto.Promises
             return deferred.Promise;
         }
 
-        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true)]
+        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> Canceled<TCancel>(TCancel reason)
         {
             throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Canceled() instead.", Internal.GetFormattedStacktrace(1));

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
@@ -5,8 +5,10 @@
 # endif
 
 #pragma warning disable IDE0034 // Simplify 'default' expression
+#pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace Proto.Promises
@@ -166,7 +168,7 @@ namespace Proto.Promises
                 get { return _target.RejectContainer; }
             }
 
-            [Obsolete("Cancelation reasons are no longer supported.", true)]
+            [Obsolete("Cancelation reasons are no longer supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public ReasonContainer CancelContainer
             {
                 get { return _target.CancelContainer; }
@@ -312,6 +314,9 @@ namespace Proto.Promises
                 }
             }
 
+            /// <summary>
+            /// Cast to <see cref="Promise.ResultContainer"/>.
+            /// </summary>
             [MethodImpl(Internal.InlineOption)]
             public static implicit operator Promise.ResultContainer(ResultContainer rhs)
             {
@@ -348,7 +353,7 @@ namespace Proto.Promises
             }
 #endif
 
-            [Obsolete("Cancelation reasons are no longer supported.", true)]
+            [Obsolete("Cancelation reasons are no longer supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
             public ReasonContainer CancelContainer
             {
                 [MethodImpl(Internal.InlineOption)]


### PR DESCRIPTION
Added missing XML comments for valid members, suppressed warning for obsolete members.

Hide obsolete members in the IDE.

Fixed a race condition with cancelations introduced in #75.