### PR TITLE
Async perf

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -430,22 +430,11 @@ namespace Proto.Promises
             protected virtual void HookupAwaiterWithProgressVirt(PromiseRefBase awaiter, short promiseId, ushort depth, float minProgress, float maxProgress) { throw new System.InvalidOperationException(); }
 #endif
 
-            [ThreadStatic]
-            private static HandleablePromiseBase ts_next;
-
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode]
 #endif
             internal partial class AsyncPromiseRef<TResult> : AsyncPromiseBase<TResult>
             {
-                [MethodImpl(InlineOption)]
-                private static HandleablePromiseBase ExchangeNext(HandleablePromiseBase currentRunner)
-                {
-                    var previous = ts_next;
-                    ts_next = currentRunner;
-                    return previous;
-                }
-
                 [MethodImpl(InlineOption)]
                 internal static AsyncPromiseRef<TResult> GetOrCreate()
                 {
@@ -461,7 +450,7 @@ namespace Proto.Promises
                     // We let the stack unwind here instead of immediately handling next.
                     // If this is completed from another promise, the other promise will schedule the continuation.
                     // If this is completed from a different type of awaiter, next will be handled from the move next higher in the stack.
-                    ts_next = TakeOrHandleNextWaiter();
+                    _nextForComplete = TakeOrHandleNextWaiter();
                 }
 
                 internal void SetException(Exception exception)
@@ -636,16 +625,13 @@ namespace Proto.Promises
 
                         public override void Dispose()
                         {
-#if PROMISE_DEBUG
                             _owner = null;
-#endif
                             _stateMachine = default(TStateMachine);
                             ObjectPool.MaybeRepool(this);
                         }
 
                         private void MoveNextMethod()
                         {
-#if PROMISE_DEBUG
                             SetCurrentInvoker(_owner);
                             try
                             {
@@ -655,16 +641,12 @@ namespace Proto.Promises
                             {
                                 ClearCurrentInvoker();
                             }
-#else
-                            _stateMachine.MoveNext();
-#endif
                         }
 
                         private void ContinueMethod()
                         {
-                            var previousNext = ts_next;
                             MoveNextMethod();
-                            _owner.MaybeHandleNext(ExchangeNext(previousNext));
+                            _owner.MaybeHandleNext(_owner._nextForComplete);
                         }
 
                         internal override void MoveNextWithoutHandle()
@@ -688,6 +670,7 @@ namespace Proto.Promises
                 protected override void MaybeDispose()
                 {
                     Dispose();
+                    _nextForComplete = null;
                     if (_continuer != null)
                     {
                         _continuer.Dispose();
@@ -701,12 +684,10 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
                     SetAwaitedComplete(handler);
 
-                    var previousNext = ts_next;
-
                     _continuer.MoveNextWithoutHandle();
 
                     handler = this;
-                    nextHandler = ExchangeNext(previousNext);
+                    nextHandler = _nextForComplete;
                 }
             } // class AsyncPromiseRef
 
@@ -737,6 +718,7 @@ namespace Proto.Promises
                     protected override void MaybeDispose()
                     {
                         Dispose();
+                        _nextForComplete = null;
                         _stateMachine = default(TStateMachine);
                         ObjectPool.MaybeRepool(this);
                     }
@@ -744,9 +726,8 @@ namespace Proto.Promises
                     [MethodImpl(InlineOption)]
                     private void ContinueMethod()
                     {
-                        var previousNext = ts_next;
                         _stateMachine.MoveNext();
-                        MaybeHandleNext(ExchangeNext(previousNext));
+                        MaybeHandleNext(_nextForComplete);
                     }
 
                     internal override void Handle(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler)
@@ -754,12 +735,10 @@ namespace Proto.Promises
                         ThrowIfInPool(this);
                         SetAwaitedComplete(handler);
 
-                        var previousNext = ts_next;
-
                         _stateMachine.MoveNext();
 
                         handler = this;
-                        nextHandler = ExchangeNext(previousNext);
+                        nextHandler = _nextForComplete;
                     }
                 }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -461,6 +461,7 @@ namespace Proto.Promises
 
             partial class AsyncPromiseRef<TResult> : AsyncPromiseBase<TResult>
             {
+                private HandleablePromiseBase _nextForComplete;
 #if PROMISE_PROGRESS
                 private float _minProgress;
                 private float _maxProgress;


### PR DESCRIPTION
Changed async thread static field to instance field. This decreases execution time at the cost of increased memory.

Master:

|         Type | Pending |       Mean |    Error |   StdDev | Allocated | Survived |
|------------- |-------- |-----------:|---------:|---------:|----------:|---------:|
|   AsyncAwait |    True | 2,367.0 ns | 12.25 ns | 10.86 ns |         - |    688 B |

This PR:

|         Type | Pending |       Mean |    Error |   StdDev | Allocated | Survived |
|------------- |-------- |-----------:|---------:|---------:|----------:|---------:|
|   AsyncAwait |    True | 2,241.8 ns |  9.61 ns |  8.99 ns |         - |    712 B |