### PR TITLE
Add `Promise(<T>)` convert to/from `ValueTask(<T>)`.

### DIFF
--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net47;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net47;netstandard2.0;netstandard2.1;netcoreapp2.1;net5.0</TargetFrameworks>
     <DefineConstants>CSHARP_7_3_OR_NEWER</DefineConstants>
     <Configurations>Release;Debug;Release_NoProgress;Debug_NoProgress</Configurations>
     <Version>2.0.2</Version>
@@ -62,6 +62,12 @@
     <Content Remove="nuget\**" />
     <EmbeddedResource Remove="nuget\**" />
     <None Remove="nuget\**" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net47' OR '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Threading.Tasks.Extensions">
+      <Version>4.5.4</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/ProtoPromise/nuget/ProtoPromise.nuspec
+++ b/ProtoPromise/nuget/ProtoPromise.nuspec
@@ -32,6 +32,9 @@
     
     <file src="..\bin\Release\netstandard2.0\**" target="lib/netstandard2.0/Release" />
     <file src="..\bin\Debug\netstandard2.0\**" target="lib/netstandard2.0/Debug" />
+
+    <file src="..\bin\Release\netstandard2.1\**" target="lib/netstandard2.1/Release" />
+    <file src="..\bin\Debug\netstandard2.1\**" target="lib/netstandard2.1/Debug" />
     
     <file src="..\bin\Release\net35\**" target="lib/net35/Release" />
     <file src="..\bin\Debug\net35\**" target="lib/net35/Debug" />
@@ -44,6 +47,9 @@
     
     <file src="..\bin\Release\net47\**" target="lib/net47/Release" />
     <file src="..\bin\Debug\net47\**" target="lib/net47/Debug" />
+
+    <file src="..\bin\Release\netcoreapp2.1\**" target="lib/netcoreapp2.1/Release" />
+    <file src="..\bin\Debug\netcoreapp2.1\**" target="lib/netcoreapp2.1/Debug" />
     
     <file src="..\bin\Release\net5.0\**" target="lib/net5.0/Release" />
     <file src="..\bin\Debug\net5.0\**" target="lib/net5.0/Debug" />

--- a/ProtoPromise/nuget/targets/netcoreapp2.1/ProtoPromise.targets
+++ b/ProtoPromise/nuget/targets/netcoreapp2.1/ProtoPromise.targets
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Choose>
+    <When Condition="$(Configuration.Contains('Release'))">
+      <ItemGroup>
+        <Reference Include="ProtoPromise">
+          <HintPath>$(MSBuildThisFileDirectory)..\..\lib\netcoreapp2.1\Release\ProtoPromise.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="ProtoPromise">
+          <HintPath>$(MSBuildThisFileDirectory)..\..\lib\netcoreapp2.1\Debug\ProtoPromise.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+</Project>

--- a/ProtoPromise/nuget/targets/netstandard2.1/ProtoPromise.targets
+++ b/ProtoPromise/nuget/targets/netstandard2.1/ProtoPromise.targets
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Choose>
+    <When Condition="$(Configuration.Contains('Release'))">
+      <ItemGroup>
+        <Reference Include="ProtoPromise">
+          <HintPath>$(MSBuildThisFileDirectory)..\..\lib\netstandard2.1\Release\ProtoPromise.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="ProtoPromise">
+          <HintPath>$(MSBuildThisFileDirectory)..\..\lib\netstandard2.1\Debug\ProtoPromise.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+</Project>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
@@ -23,6 +23,9 @@ namespace Proto.Promises
 {
     partial class Internal
     {
+        // Just a random number that's not zero.
+        internal const short ValidIdFromApi = 31265;
+
         internal static string CausalityTraceMessage
         {
             get

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Extensions.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Extensions.cs
@@ -24,7 +24,7 @@ namespace Proto.Promises
     {
 #if !NET_LEGACY
         /// <summary>
-        /// Convert the <see cref="Promise"/> to a <see cref="Task"/>.
+        /// Convert the <paramref name="promise"/> to a <see cref="Task"/>.
         /// </summary>
         public static async Task ToTask(this Promise promise)
         {
@@ -32,7 +32,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Convert the <see cref="Promise{T}"/> to a <see cref="Task{T}"/>.
+        /// Convert the <paramref name="promise"/> to a <see cref="Task{T}"/>.
         /// </summary>
         public static async Task<T> ToTask<T>(this Promise<T> promise)
         {
@@ -40,7 +40,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Convert the <see cref="Task"/> to a <see cref="Promise"/>.
+        /// Convert the <paramref name="task"/> to a <see cref="Promise"/>.
         /// </summary>
         public static async Promise ToPromise(this Task task)
         {
@@ -48,7 +48,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Convert the <see cref="Task{T}"/> to a <see cref="Promise{T}"/>.
+        /// Convert the <paramref name="task"/> to a <see cref="Promise{T}"/>.
         /// </summary>
         public static async Promise<T> ToPromise<T>(this Task<T> task)
         {
@@ -56,7 +56,7 @@ namespace Proto.Promises
         }
 #elif NET40
         /// <summary>
-        /// Convert the <see cref="Promise"/> to a <see cref="Task"/>.
+        /// Convert the <paramref name="promise"/> to a <see cref="Task"/>.
         /// </summary>
         public static Task ToTask(this Promise promise)
         {
@@ -86,7 +86,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Convert the <see cref="Promise{T}"/> to a <see cref="Task{T}"/>.
+        /// Convert the <paramref name="promise"/> to a <see cref="Task{T}"/>.
         /// </summary>
         public static Task<T> ToTask<T>(this Promise<T> promise)
         {
@@ -116,7 +116,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Convert the <see cref="Task"/> to a <see cref="Promise"/>.
+        /// Convert the <paramref name="task"/> to a <see cref="Promise"/>.
         /// </summary>
         public static Promise ToPromise(this Task task)
         {
@@ -140,7 +140,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Convert the <see cref="Task{T}"/> to a <see cref="Promise{T}"/>.
+        /// Convert the <paramref name="task"/> to a <see cref="Promise{T}"/>.
         /// </summary>
         public static Promise<T> ToPromise<T>(this Task<T> task)
         {
@@ -163,5 +163,23 @@ namespace Proto.Promises
             return deferred.Promise;
         }
 #endif // elif NET40
+
+#if UNITY_2021_2_OR_NEWER || (!NET_LEGACY && !UNITY_5_5_OR_NEWER)
+        /// <summary>
+        /// Convert the <paramref name="task"/> to a <see cref="Promise"/>.
+        /// </summary>
+        public static async Promise ToPromise(this ValueTask task)
+        {
+            await task;
+        }
+
+        /// <summary>
+        /// Convert the <paramref name="task"/> to a <see cref="Promise{T}"/>.
+        /// </summary>
+        public static async Promise<T> ToPromise<T>(this ValueTask<T> task)
+        {
+            return await task;
+        }
+#endif
     }
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -492,7 +492,7 @@ namespace Proto.Promises
                     where TStateMachine : IAsyncStateMachine
                 {
                     SetStateMachine(ref stateMachine, ref _ref);
-#if NET5_0_OR_GREATER
+#if NETCOREAPP
                     if (null != default(TAwaiter) && awaiter is IPromiseAwaiter)
                     {
                         ((IPromiseAwaiter) awaiter).AwaitOnCompletedInternal(_ref);
@@ -515,7 +515,7 @@ namespace Proto.Promises
                     where TStateMachine : IAsyncStateMachine
                 {
                     SetStateMachine(ref stateMachine, ref _ref);
-#if NET5_0_OR_GREATER
+#if NETCOREAPP
                     if (null != default(TAwaiter) && awaiter is IPromiseAwaiter)
                     {
                         ((IPromiseAwaiter) awaiter).AwaitOnCompletedInternal(_ref);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
@@ -38,6 +38,34 @@ namespace Proto.Promises
 #endif
         partial struct Promise : IEquatable<Promise>
     {
+#if UNITY_2021_2_OR_NEWER || (!NET_LEGACY && !UNITY_5_5_OR_NEWER)
+        /// <summary>
+        /// Convert this to a <see cref="System.Threading.Tasks.ValueTask"/>.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public System.Threading.Tasks.ValueTask AsValueTask()
+        {
+            ValidateOperation(1);
+            var r = _ref;
+            return r == null
+                ? new System.Threading.Tasks.ValueTask()
+                : new System.Threading.Tasks.ValueTask(_ref, _id);
+        }
+
+        /// <summary>
+        /// Cast to <see cref="System.Threading.Tasks.ValueTask"/>.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public static implicit operator System.Threading.Tasks.ValueTask(
+#if CSHARP_7_3_OR_NEWER
+            in
+#endif
+            Promise rhs)
+        {
+            return rhs.AsValueTask();
+        }
+#endif
+
         /// <summary>
         /// Gets whether this instance is valid to be awaited.
         /// </summary>
@@ -50,21 +78,6 @@ namespace Proto.Promises
                 var r = _ref;
                 return r == null || r.GetIsValid(_id);
             }
-        }
-
-        /// <summary>
-        /// Gets the string representation of this instance.
-        /// </summary>
-        /// <returns>The string representation of this instance.</returns>
-        public override string ToString()
-        {
-            var _this = this;
-            string state = _this._ref == null
-                ? State.Resolved.ToString()
-                : _this._ref.GetIsValid(_this._id)
-                ? _this._ref.State.ToString()
-                : "Invalid";
-            return string.Format("Type: Promise, State: {0}", state);
         }
 
         /// <summary>
@@ -2261,6 +2274,21 @@ namespace Proto.Promises
         public static bool operator !=(Promise lhs, Promise rhs)
         {
             return !(lhs == rhs);
+        }
+
+        /// <summary>
+        /// Gets the string representation of this instance.
+        /// </summary>
+        /// <returns>The string representation of this instance.</returns>
+        public override string ToString()
+        {
+            var _this = this;
+            string state = _this._ref == null
+                ? State.Resolved.ToString()
+                : _this._ref.GetIsValid(_this._id)
+                ? _this._ref.State.ToString()
+                : "Invalid";
+            return string.Format("Type: Promise, State: {0}", state);
         }
 
         [Obsolete("Retain is no longer valid, use Preserve instead.", true), EditorBrowsable(EditorBrowsableState.Never)]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -36,6 +36,59 @@ namespace Proto.Promises
 #endif
         partial struct Promise<T> : IEquatable<Promise<T>>
     {
+#if UNITY_2021_2_OR_NEWER || (!NET_LEGACY && !UNITY_5_5_OR_NEWER)
+        /// <summary>
+        /// Convert this to a <see cref="System.Threading.Tasks.ValueTask{T}"/>.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public System.Threading.Tasks.ValueTask<T> AsValueTask()
+        {
+            ValidateOperation(1);
+            var r = _ref;
+            return r == null
+                ? new System.Threading.Tasks.ValueTask<T>(_result)
+                : new System.Threading.Tasks.ValueTask<T>(_ref, _id);
+        }
+
+        /// <summary>
+        /// Cast to <see cref="System.Threading.Tasks.ValueTask{T}"/>.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public static implicit operator System.Threading.Tasks.ValueTask<T>(
+#if CSHARP_7_3_OR_NEWER
+            in
+#endif
+            Promise<T> rhs)
+        {
+            return rhs.AsValueTask();
+        }
+        /// <summary>
+        /// Convert this to a <see cref="System.Threading.Tasks.ValueTask"/>.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public System.Threading.Tasks.ValueTask AsValueTaskVoid()
+        {
+            ValidateOperation(1);
+            var r = _ref;
+            return r == null
+                ? new System.Threading.Tasks.ValueTask()
+                : new System.Threading.Tasks.ValueTask(_ref, _id);
+        }
+
+        /// <summary>
+        /// Cast to <see cref="System.Threading.Tasks.ValueTask"/>.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public static implicit operator System.Threading.Tasks.ValueTask(
+#if CSHARP_7_3_OR_NEWER
+            in
+#endif
+            Promise<T> rhs)
+        {
+            return rhs.AsValueTaskVoid();
+        }
+#endif
+
         /// <summary>
         /// Gets whether this instance is valid to be awaited.
         /// </summary>
@@ -69,21 +122,6 @@ namespace Proto.Promises
             Promise<T> rhs)
         {
             return rhs.AsPromise();
-        }
-
-        /// <summary>
-        /// Gets the string representation of this instance.
-        /// </summary>
-        /// <returns>The string representation of this instance.</returns>
-        public override string ToString()
-        {
-            var _this = this;
-            string state = _this._ref == null
-                ? Promise.State.Resolved.ToString()
-                : _this._ref.GetIsValid(_this._id)
-                ? _this._ref.State.ToString()
-                : "Invalid";
-            return string.Format("Type: Promise<{0}>, State: {1}", typeof(T), state);
         }
 
         /// <summary>
@@ -3666,6 +3704,21 @@ namespace Proto.Promises
         public static bool operator !=(Promise<T> lhs, Promise<T> rhs)
         {
             return !(lhs == rhs);
+        }
+
+        /// <summary>
+        /// Gets the string representation of this instance.
+        /// </summary>
+        /// <returns>The string representation of this instance.</returns>
+        public override string ToString()
+        {
+            var _this = this;
+            string state = _this._ref == null
+                ? Promise.State.Resolved.ToString()
+                : _this._ref.GetIsValid(_this._id)
+                ? _this._ref.State.ToString()
+                : "Invalid";
+            return string.Format("Type: Promise<{0}>, State: {1}", typeof(T), state);
         }
     }
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/AwaitTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/AwaitTests.cs
@@ -8,6 +8,7 @@
 
 using NUnit.Framework;
 using Proto.Promises;
+using System.Threading.Tasks;
 
 namespace ProtoPromiseTests.APIs
 {
@@ -648,6 +649,184 @@ namespace ProtoPromiseTests.APIs
 
             Assert.AreEqual(2, continuedCount);
         }
+
+        [Test]
+        public void PromiseToTaskIsResolvedProperly_void([Values] bool isPending)
+        {
+            Promise.Deferred deferred = isPending ? Promise.NewDeferred() : default(Promise.Deferred);
+            var promise = isPending ? deferred.Promise : Promise.Resolved();
+
+            bool completed = false;
+
+            Func();
+            deferred.TryResolve();
+
+            Assert.IsTrue(completed);
+
+            async void Func()
+            {
+                await promise.ToTask();
+                completed = true;
+            }
+        }
+
+        [Test]
+        public void PromiseToTaskIsResolvedProperly_T([Values] bool isPending)
+        {
+            Promise<int>.Deferred deferred = isPending ? Promise.NewDeferred<int>() : default(Promise<int>.Deferred);
+            var promise = isPending ? deferred.Promise : Promise.Resolved(1);
+
+            bool completed = false;
+
+            Func();
+            deferred.TryResolve(1);
+
+            Assert.IsTrue(completed);
+
+            async void Func()
+            {
+                int result = await promise.ToTask();
+                Assert.AreEqual(1, result);
+                completed = true;
+            }
+        }
+
+        [Test]
+        public void TaskToPromiseIsResolvedProperly_void([Values] bool isPending)
+        {
+            TaskCompletionSource<bool> taskCompletionSource = isPending ? new TaskCompletionSource<bool>() : null;
+            Task task = isPending ? taskCompletionSource.Task : Task.CompletedTask;
+
+            bool completed = false;
+
+            Func();
+            if (isPending)
+            {
+                taskCompletionSource.SetResult(true);
+            }
+
+            Assert.IsTrue(completed);
+
+            async void Func()
+            {
+                await task.ToPromise();
+                completed = true;
+            }
+        }
+
+        [Test]
+        public void TaskToPromiseIsResolvedProperly_T([Values] bool isPending)
+        {
+            TaskCompletionSource<int> taskCompletionSource = isPending ? new TaskCompletionSource<int>() : null;
+            Task<int> task = isPending ? taskCompletionSource.Task : Task.FromResult(1);
+
+            bool completed = false;
+
+            Func();
+            if (isPending)
+            {
+                taskCompletionSource.SetResult(1);
+            }
+
+            Assert.IsTrue(completed);
+
+            async void Func()
+            {
+                int result = await task.ToPromise();
+                Assert.AreEqual(1, result);
+                completed = true;
+            }
+        }
+
+#if UNITY_2021_2_OR_NEWER || (!NET_LEGACY && !UNITY_5_5_OR_NEWER)
+        [Test]
+        public void PromiseAsValueTaskIsResolvedProperly_void([Values] bool isPending)
+        {
+            Promise.Deferred deferred = isPending ? Promise.NewDeferred() : default(Promise.Deferred);
+            var promise = isPending ? deferred.Promise : Promise.Resolved();
+
+            bool completed = false;
+
+            Func();
+            deferred.TryResolve();
+
+            Assert.IsTrue(completed);
+
+            async void Func()
+            {
+                await promise.AsValueTask();
+                completed = true;
+            }
+        }
+
+        [Test]
+        public void PromiseAsValueTaskIsResolvedProperly_T([Values] bool isPending)
+        {
+            Promise<int>.Deferred deferred = isPending ? Promise.NewDeferred<int>() : default(Promise<int>.Deferred);
+            var promise = isPending ? deferred.Promise : Promise.Resolved(1);
+
+            bool completed = false;
+
+            Func();
+            deferred.TryResolve(1);
+
+            Assert.IsTrue(completed);
+
+            async void Func()
+            {
+                int result = await promise.AsValueTask();
+                Assert.AreEqual(1, result);
+                completed = true;
+            }
+        }
+
+        [Test]
+        public void ValueTaskToPromiseIsResolvedProperly_void([Values] bool isPending)
+        {
+            TaskCompletionSource<bool> taskCompletionSource = isPending ? new TaskCompletionSource<bool>() : null;
+            ValueTask task = isPending ? new ValueTask(taskCompletionSource.Task) : new ValueTask();
+
+            bool completed = false;
+
+            Func();
+            if (isPending)
+            {
+                taskCompletionSource.SetResult(true);
+            }
+
+            Assert.IsTrue(completed);
+
+            async void Func()
+            {
+                await task.ToPromise();
+                completed = true;
+            }
+        }
+
+        [Test]
+        public void ValueTaskToPromiseIsResolvedProperly_T([Values] bool isPending)
+        {
+            TaskCompletionSource<int> taskCompletionSource = isPending ? new TaskCompletionSource<int>() : null;
+            ValueTask<int> task = isPending ? new ValueTask<int>(taskCompletionSource.Task) : new ValueTask<int>(1);
+
+            bool completed = false;
+
+            Func();
+            if (isPending)
+            {
+                taskCompletionSource.SetResult(1);
+            }
+
+            Assert.IsTrue(completed);
+
+            async void Func()
+            {
+                int result = await task.ToPromise();
+                Assert.AreEqual(1, result);
+                completed = true;
+            }
+        }
+#endif
     }
 }
 


### PR DESCRIPTION
Resolves #25.

Also added `netcoreapp2.1` and `netstandard2.1` targets to help with `ValueTask` interoperability.