### PR TITLE
Fix for `CancellationTokenSource.TryReset()`

### DIFF
--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net47;netstandard2.0;netstandard2.1;netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net47;netstandard2.0;netstandard2.1;netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
     <DefineConstants>CSHARP_7_3_OR_NEWER</DefineConstants>
     <Configurations>Release;Debug;Release_NoProgress;Debug_NoProgress</Configurations>
     <Version>2.1.0</Version>

--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -27,13 +27,6 @@
     <DefineConstants>$(DefineConstants);NET_LEGACY</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DeveloperMode)'=='true'">
-    <DefineConstants>$(DefineConstants);TRACE;PROTO_PROMISE_DEVELOPER_MODE</DefineConstants>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>portable</DebugType>
-    <Optimize>false</Optimize>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(AllowStackToUnwind)'=='false'">
     <DefineConstants>$(DefineConstants);PROTO_PROMISE_STACK_UNWIND_DISABLE</DefineConstants>
   </PropertyGroup>
@@ -43,6 +36,13 @@
     <DebugSymbols>false</DebugSymbols>
     <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DeveloperMode)'=='true'">
+    <DefineConstants>$(DefineConstants);TRACE;PROTO_PROMISE_DEVELOPER_MODE</DefineConstants>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_NoProgress|AnyCPU'">

--- a/ProtoPromise/nuget/ProtoPromise.nuspec
+++ b/ProtoPromise/nuget/ProtoPromise.nuspec
@@ -18,12 +18,18 @@
     <tags>promise promises task tasks csharp unity dotnet mono coroutine coroutines concurrency concurrent parallel asynchronous async await thread threads threading then thenable callback callbacks</tags>
 
     <dependencies>
-      <group targetFramework="netstandard2.0" />
       <group targetFramework="net35" />
       <group targetFramework="net40" />
       <group targetFramework="net45" />
       <group targetFramework="net47" />
+      
+      <group targetFramework="netstandard2.0" />
+      <group targetFramework="netstandard2.1" />
+      
+      <group targetFramework="netcoreapp2.1" />
+      
       <group targetFramework="net5.0" />
+      <group targetFramework="net6.0" />
     </dependencies>
 
     <readme>readme.md</readme>
@@ -31,12 +37,6 @@
 
   <files>
     <file src="targets\**" target="build" />
-    
-    <file src="..\bin\Release\netstandard2.0\**" target="lib/netstandard2.0/Release" />
-    <file src="..\bin\Debug\netstandard2.0\**" target="lib/netstandard2.0/Debug" />
-
-    <file src="..\bin\Release\netstandard2.1\**" target="lib/netstandard2.1/Release" />
-    <file src="..\bin\Debug\netstandard2.1\**" target="lib/netstandard2.1/Debug" />
     
     <file src="..\bin\Release\net35\**" target="lib/net35/Release" />
     <file src="..\bin\Debug\net35\**" target="lib/net35/Debug" />
@@ -49,12 +49,21 @@
     
     <file src="..\bin\Release\net47\**" target="lib/net47/Release" />
     <file src="..\bin\Debug\net47\**" target="lib/net47/Debug" />
+    
+    <file src="..\bin\Release\netstandard2.0\**" target="lib/netstandard2.0/Release" />
+    <file src="..\bin\Debug\netstandard2.0\**" target="lib/netstandard2.0/Debug" />
 
+    <file src="..\bin\Release\netstandard2.1\**" target="lib/netstandard2.1/Release" />
+    <file src="..\bin\Debug\netstandard2.1\**" target="lib/netstandard2.1/Debug" />
+    
     <file src="..\bin\Release\netcoreapp2.1\**" target="lib/netcoreapp2.1/Release" />
     <file src="..\bin\Debug\netcoreapp2.1\**" target="lib/netcoreapp2.1/Debug" />
     
     <file src="..\bin\Release\net5.0\**" target="lib/net5.0/Release" />
     <file src="..\bin\Debug\net5.0\**" target="lib/net5.0/Debug" />
+
+    <file src="..\bin\Release\net6.0\**" target="lib/net6.0/Release" />
+    <file src="..\bin\Debug\net6.0\**" target="lib/net6.0/Debug" />
     
     <file src="readme.md" target="" />
   </files>

--- a/ProtoPromise/nuget/targets/net6.0/ProtoPromise.targets
+++ b/ProtoPromise/nuget/targets/net6.0/ProtoPromise.targets
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Choose>
+    <When Condition="$(Configuration.Contains('Release'))">
+      <ItemGroup>
+        <Reference Include="ProtoPromise">
+          <HintPath>$(MSBuildThisFileDirectory)..\..\lib\net6.0\Release\ProtoPromise.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="ProtoPromise">
+          <HintPath>$(MSBuildThisFileDirectory)..\..\lib\net6.0\Debug\ProtoPromise.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+</Project>

--- a/ProtoPromiseTests/ProtoPromiseTests.csproj
+++ b/ProtoPromiseTests/ProtoPromiseTests.csproj
@@ -10,13 +10,6 @@
     <DeveloperMode>false</DeveloperMode>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DeveloperMode)'=='true'">
-    <DefineConstants>$(DefineConstants);TRACE;PROTO_PROMISE_DEVELOPER_MODE</DefineConstants>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>portable</DebugType>
-    <Optimize>false</Optimize>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoProgress|AnyCPU'">
     <DefineConstants>$(DefineConstants);RELEASE;PROTO_PROMISE_PROGRESS_DISABLE</DefineConstants>
     <DebugSymbols>false</DebugSymbols>
@@ -26,6 +19,13 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_NoProgress|AnyCPU'">
     <DefineConstants>$(DefineConstants);DEBUG;PROTO_PROMISE_PROGRESS_DISABLE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DeveloperMode)'=='true'">
+    <DefineConstants>$(DefineConstants);TRACE;PROTO_PROMISE_DEVELOPER_MODE</DefineConstants>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <!-- For command-line testing -->

--- a/ProtoPromiseTests/ProtoPromiseTests.csproj
+++ b/ProtoPromiseTests/ProtoPromiseTests.csproj
@@ -5,11 +5,23 @@
     <IsPackable>false</IsPackable>
     <DefineConstants>TRACE;CSHARP_7_3_OR_NEWER</DefineConstants>
     <Configurations>Release;Debug;Release_NoProgress;Debug_NoProgress</Configurations>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>9</LangVersion>
+    <!-- Set from command line -->
+    <DeveloperMode>false</DeveloperMode>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DeveloperMode)'=='true'">
+    <DefineConstants>$(DefineConstants);TRACE;PROTO_PROMISE_DEVELOPER_MODE</DefineConstants>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoProgress|AnyCPU'">
     <DefineConstants>$(DefineConstants);RELEASE;PROTO_PROMISE_PROGRESS_DISABLE</DefineConstants>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>true</Optimize>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_NoProgress|AnyCPU'">

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
@@ -20,6 +20,7 @@ namespace Proto.Promises
 #endif
         struct CancelationRegistration : IEquatable<CancelationRegistration>
     {
+        private readonly Internal.CancelationRef _ref;
         private readonly Internal.CancelationCallbackNode _node;
         private readonly int _nodeId;
         private readonly int _tokenId;
@@ -27,15 +28,16 @@ namespace Proto.Promises
         /// <summary>
         /// FOR INTERNAL USE ONLY!
         /// </summary>
-        internal CancelationRegistration(Internal.CancelationCallbackNode node, int nodeId, int tokenId)
+        internal CancelationRegistration(Internal.CancelationRef cancelationRef, Internal.CancelationCallbackNode node, int nodeId, int tokenId)
         {
+            _ref = cancelationRef;
             _node = node;
             _nodeId = nodeId;
             _tokenId = tokenId;
         }
 
         /// <summary>
-        /// Get the <see cref="CancelationToken"/> associated with this <see cref="CancelationRegistration"/> if this is still registered, or a non-cancelable token if it's not registered.
+        /// Get the <see cref="CancelationToken"/> associated with this <see cref="CancelationRegistration"/>.
         /// </summary>
         public CancelationToken Token
         {
@@ -44,7 +46,7 @@ namespace Proto.Promises
                 var node = _node;
                 return node == null
                     ? new CancelationToken()
-                    : new CancelationToken(_node.Parent, _tokenId);
+                    : new CancelationToken(_ref, _tokenId);
             }
         }
 
@@ -68,7 +70,7 @@ namespace Proto.Promises
         /// <param name="isTokenCancelationRequested">true if the associated <see cref="CancelationToken"/> is requesting cancelation, false otherwise</param>
         public void GetIsRegisteredAndIsCancelationRequested(out bool isRegistered, out bool isTokenCancelationRequested)
         {
-            isRegistered = Internal.CancelationCallbackNode.GetIsRegisteredAndIsCanceled(_node, _nodeId, _tokenId, out isTokenCancelationRequested);
+            isRegistered = Internal.CancelationCallbackNode.GetIsRegisteredAndIsCanceled(_ref, _node, _nodeId, _tokenId, out isTokenCancelationRequested);
         }
 
         /// <summary>
@@ -101,7 +103,7 @@ namespace Proto.Promises
         /// <returns>true if the callback was previously registered and the associated <see cref="CancelationSource"/> not yet canceled or disposed, false otherwise</returns>
         public bool TryUnregister(out bool isTokenCancelationRequested)
         {
-            return Internal.CancelationCallbackNode.TryUnregister(_node, _nodeId, _tokenId, out isTokenCancelationRequested);
+            return Internal.CancelationCallbackNode.TryUnregister(_ref, _node, _nodeId, _tokenId, out isTokenCancelationRequested);
         }
 
         /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="CancelationRegistration"/>.</summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
@@ -35,7 +35,7 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Get the <see cref="CancelationToken"/> associated with this <see cref="CancelationRegistration"/>.
+        /// Get the <see cref="CancelationToken"/> associated with this <see cref="CancelationRegistration"/> if this is still registered, or a non-cancelable token if it's not registered.
         /// </summary>
         public CancelationToken Token
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
@@ -9,17 +9,11 @@
 #endif
 
 #pragma warning disable IDE0018 // Inline variable declaration
-#pragma warning disable IDE0031 // Use null propagation
 #pragma warning disable IDE0034 // Simplify 'default' expression
-#pragma warning disable IDE0090 // Use 'new(...)'
 #pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
 using System;
 using System.ComponentModel;
-
-#if !NET_LEGACY || NET40
-using System.Linq;
-#endif
 
 namespace Proto.Promises
 {
@@ -302,22 +296,6 @@ namespace Proto.Promises
     partial class Extensions
     {
 #if !NET_LEGACY || NET40
-        // ConditionalWeakTable is necessary to return a cached value in case `ToCancelationToken` is called on the same token more than once,
-        // and it allows the sources to be garbage collected when the original source was never canceled.
-        private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<System.Threading.CancellationTokenSource, Internal.CancelationRef> s_cancelationSourceMap = new System.Runtime.CompilerServices.ConditionalWeakTable<System.Threading.CancellationTokenSource, Internal.CancelationRef>();
-
-        // Implementation detail, the token wraps the source, so we can retrieve it by placing it in this explicit layout struct and reading the source.
-        // This is equivalent to `Unsafe.As`, but also works in older runtimes that don't support Unsafe.
-        // I think it is very unlikely, but the internal implementation of CancellationToken could change in the future to break this code. Hopefully fast reflection APIs will become available before that happens. https://github.com/dotnet/runtime/issues/23716
-        [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit)]
-        private struct TokenSourceExtractor
-        {
-            [System.Runtime.InteropServices.FieldOffset(0)]
-            internal System.Threading.CancellationToken _token;
-            [System.Runtime.InteropServices.FieldOffset(0)]
-            internal System.Threading.CancellationTokenSource _source;
-        }
-
         /// <summary>
         /// Convert <paramref name="token"/> to a <see cref="CancelationToken"/>.
         /// </summary>
@@ -325,56 +303,8 @@ namespace Proto.Promises
         /// <returns>A <see cref="CancelationToken"/> that will be canceled when <paramref name="token"/> is canceled.</returns>
         public static CancelationToken ToCancelationToken(this System.Threading.CancellationToken token)
         {
-            if (!token.CanBeCanceled)
-            {
-                return default(CancelationToken);
-            }
-            if (token.IsCancellationRequested)
-            {
-                return CancelationToken.Canceled();
-            }
-
-            // Warning: this relies on internal implementation details. Should update to a stable API as soon as one becomes available.
-            var source = new TokenSourceExtractor() { _token = token }._source;
-
-            Internal.CancelationRef _ref;
-            if (source == null)
-            {
-                _ref = Internal.CancelationRef.GetOrCreateWithoutDisposedCheck();
-                token.Register(state => state.UnsafeAs<Internal.CancelationRef>().Cancel(), _ref, false);
-                return new CancelationToken(_ref, _ref.TokenId);
-            }
-            if (!s_cancelationSourceMap.TryGetValue(source, out _ref))
-            {
-#if NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-                // It is possible for multiple cancelation refs to be created on separate threads. That is fine.
-                _ref = Internal.CancelationRef.GetOrCreateWithoutDisposedCheck();
-                s_cancelationSourceMap.AddOrUpdate(source, _ref);
-#else
-                lock (s_cancelationSourceMap)
-                {
-                    if (!s_cancelationSourceMap.TryGetValue(source, out _ref))
-                    {
-                        _ref = Internal.CancelationRef.GetOrCreateWithoutDisposedCheck();
-                        s_cancelationSourceMap.Add(source, _ref);
-                    }
-                }
-#endif
-                _ref._cancellationTokenSource = source;
-                token.Register(state => state.UnsafeAs<Internal.CancelationRef>().Cancel(), _ref, false);
-                return new CancelationToken(_ref, _ref.TokenId);
-            }
-            var tokenId = _ref.TokenId;
-            System.Threading.Thread.MemoryBarrier();
-            return _ref._cancellationTokenSource != source // In case of race condition on another thread.
-                ? default(CancelationToken)
-                : new CancelationToken(_ref, tokenId);
+            return Internal.CancelationRef.CancelationConverter.Convert(token);
         }
-
-        internal static void AttachCancelationRef(this System.Threading.CancellationTokenSource source, Internal.CancelationRef _ref)
-        {
-            s_cancelationSourceMap.Add(source, _ref);
-        }
-#endif
+#endif // !NET_LEGACY || NET40
     }
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -69,9 +69,10 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode]
 #endif
-        internal sealed class CancelationRef : HandleablePromiseBase, ICancelable, ITraceable
+        internal sealed partial class CancelationRef : HandleablePromiseBase, ICancelable, ITraceable
         {
-            internal static readonly CancelationRef s_canceledSentinel = new CancelationRef() { _state = State.Canceled, _internalRetainCounter = 1 };
+            internal static readonly CancelationRef s_canceledSentinel = new CancelationRef() { _state = State.Canceled, _internalRetainCounter = 1, _tokenId = -1 };
+            internal static readonly CancelationRef s_disposedSentinel = new CancelationRef() { _state = State.Disposed, _internalRetainCounter = 1, _tokenId = -1 };
 
 #if PROMISE_DEBUG
             CausalityTrace ITraceable.Trace { get; set; }
@@ -87,7 +88,8 @@ namespace Proto.Promises
                         string message = "A CancelationToken's resources were garbage collected without being released. You must release all IRetainable objects that you have retained.";
                         ReportRejection(new UnreleasedObjectException(message), this);
                     }
-                    if (_checkForDisposed & _state != State.Disposed)
+                    // We don't check the disposed state if this was linked to a System.Threading.CancellationToken.
+                    if (!_linkedToBclToken & _state != State.Disposed)
                     {
                         // CancelationSource wasn't disposed.
                         ReportRejection(new UnreleasedObjectException("CancelationSource's resources were garbage collected without being disposed."), this);
@@ -107,9 +109,12 @@ namespace Proto.Promises
                 Disposed
             }
 
-#if !NET_LEGACY || NET40
-            internal CancellationTokenSource _cancellationTokenSource;
+#if NET6_0_OR_GREATER
+            // Used to prevent a deadlock from synchronous invoke.
+            [ThreadStatic]
+            private static bool ts_isLinkingToBclToken;
 #endif
+
             private ValueLinkedStackZeroGC<CancelationRegistration> _links = ValueLinkedStackZeroGC<CancelationRegistration>.Create();
             // Use a sentinel for the linked list so we don't need to null check.
             private readonly CancelationCallbackNode _registeredCallbacksHead = CancelationCallbackNode.CreateLinkedListSentinel();
@@ -119,7 +124,7 @@ namespace Proto.Promises
             private int _tokenId = 1;
             private uint _userRetainCounter;
             private byte _internalRetainCounter;
-            private bool _checkForDisposed;
+            private bool _linkedToBclToken;
             internal State _state;
 
             internal int SourceId
@@ -134,20 +139,12 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            private void Initialize(bool checkForDisposed)
+            private void Initialize(bool linkedToBclToken)
             {
                 _internalRetainCounter = 1; // 1 for Dispose.
-                _checkForDisposed = checkForDisposed;
+                _linkedToBclToken = linkedToBclToken;
                 _state = State.Pending;
                 SetCreatedStacktrace(this, 2);
-            }
-
-            internal static CancelationRef GetOrCreateWithoutDisposedCheck()
-            {
-                // Don't take from the object pool, just create new.
-                var cancelRef = new CancelationRef();
-                cancelRef.Initialize(false);
-                return cancelRef;
             }
 
             [MethodImpl(InlineOption)]
@@ -155,46 +152,9 @@ namespace Proto.Promises
             {
                 var cancelRef = ObjectPool.TryTake<CancelationRef>()
                     ?? new CancelationRef();
-                cancelRef.Initialize(true);
+                cancelRef.Initialize(false);
                 return cancelRef;
             }
-
-#if !NET_LEGACY || NET40
-            internal static CancellationToken GetCancellationToken(CancelationRef _this, int _tokenId)
-            {
-                return _this == null ? default(CancellationToken) : _this.GetCancellationToken(_tokenId);
-            }
-
-            private CancellationToken GetCancellationToken(int _tokenId)
-            {
-                _locker.Enter();
-                try
-                {
-                    var state = _state;
-                    if (_tokenId != TokenId | state == State.Disposed)
-                    {
-                        return default(CancellationToken);
-                    }
-                    if (state == State.Canceled)
-                    {
-                        return new CancellationToken(true);
-                    }
-                    if (_cancellationTokenSource == null)
-                    {
-                        _cancellationTokenSource = new CancellationTokenSource();
-                        _cancellationTokenSource.AttachCancelationRef(this);
-                        var del = new CancelDelegateToken<CancellationTokenSource>(_cancellationTokenSource, source => source.Cancel(false));
-                        var node = CallbackNodeImpl<CancelDelegateToken<CancellationTokenSource>>.GetOrCreate(del, this);
-                        _registeredCallbacksHead.InsertPrevious(node);
-                    }
-                    return _cancellationTokenSource.Token;
-                }
-                finally
-                {
-                    _locker.Exit();
-                }
-            }
-#endif
 
             [MethodImpl(InlineOption)]
             internal static bool IsValidSource(CancelationRef _this, int sourceId)
@@ -290,11 +250,87 @@ namespace Proto.Promises
                 State state = _state;
                 if (state == State.Pending)
                 {
-                    var node = CallbackNodeImpl<TCancelable>.GetOrCreate(cancelable, this);
-                    _registeredCallbacksHead.InsertPrevious(node);
-                    _locker.Exit();
-                    registration = new CancelationRegistration(node, node.NodeId, oldTokenId);
-                    return true;
+                    // TODO: Unity hasn't adopted .Net 6+ yet, and they usually use different compilation symbols than .Net SDK, so we'll have to update the compilation symbols here once Unity finally does adopt it.
+#if NET6_0_OR_GREATER
+                    // This is only necessary in .Net 6 or later, since `CancellationTokenSource.TryReset()` was added.
+                    if (_linkedToBclToken)
+                    {
+                        System.Threading.CancellationToken token;
+                        // If the source was disposed, the Token property will throw ObjectDisposedException. Unfortunately, this is the only way to check if it's disposed.
+                        try
+                        {
+                            token = _bclSource.Token;
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            int sourceId = SourceId;
+                            _locker.Exit();
+                            bool isCanceled = _bclSource.IsCancellationRequested;
+                            if (isCanceled)
+                            {
+                                cancelable.Cancel();
+                            }
+                            // Dispose to forcibly wait for the callback to complete, or unregister the callback if it wasn't canceled.
+                            _bclRegistration.Dispose();
+                            TryDispose(sourceId);
+                            registration = default(CancelationRegistration);
+                            return isCanceled;
+                        }
+
+                        // If we are unable to unregister, it means the source had TryReset() called on it, or the token was canceled on another thread (and the other thread may be waiting on the lock).
+                        if (!_bclRegistration.Unregister())
+                        {
+                            if (token.IsCancellationRequested)
+                            {
+                                _locker.Exit();
+                                cancelable.Cancel();
+                                registration = default(CancelationRegistration);
+                                return true;
+                            }
+                            UnregisterAll();
+                        }
+                        // Callback could be invoked synchronously if the token is canceled on another thread,
+                        // so we set a flag to prevent a deadlock, then check the flag again after the hookup to see if it was invoked.
+                        ts_isLinkingToBclToken = true;
+                        _bclRegistration = token.Register(state =>
+                        {
+                            // This could be invoked synchronously if the token is canceled, so we check the flag to prevent a deadlock.
+                            if (ts_isLinkingToBclToken)
+                            {
+                                // Reset the flag so that we can tell that this was invoked synchronously.
+                                ts_isLinkingToBclToken = false;
+                                return;
+                            }
+                            state.UnsafeAs<CancelationRef>().Cancel();
+                        }, this, false);
+
+                        if (!ts_isLinkingToBclToken)
+                        {
+                            // Hook up the node instead of invoking since it might throw, and we need all registered callbacks to be invoked.
+                            var node = CallbackNodeImpl<TCancelable>.GetOrCreate(cancelable, this);
+                            int oldNodeId = node.NodeId;
+                            _registeredCallbacksHead.InsertPrevious(node);
+
+                            _state = State.Canceled;
+                            ++_internalRetainCounter;
+                            _locker.Exit();
+
+                            InvokeCallbacks();
+                            registration = new CancelationRegistration(node, oldNodeId, oldTokenId);
+                            return true;
+                        }
+                        ts_isLinkingToBclToken = false;
+                    }
+#endif
+
+                    {
+                        var node = CallbackNodeImpl<TCancelable>.GetOrCreate(cancelable, this);
+                        int oldNodeId = node.NodeId;
+                        _registeredCallbacksHead.InsertPrevious(node);
+                        _locker.Exit();
+                        registration = new CancelationRegistration(node, oldNodeId, oldTokenId);
+                        return true;
+                    }
                 }
 
                 _locker.Exit();
@@ -390,6 +426,14 @@ namespace Proto.Promises
                 ThrowIfInPool(this);
                 _state = State.Disposed;
                 Unlink();
+                UnregisterAll();
+
+                MaybeResetAndRepoolAlreadyLocked();
+                return true;
+            }
+
+            private void UnregisterAll()
+            {
                 var next = _registeredCallbacksHead._next;
                 _registeredCallbacksHead._next = _registeredCallbacksHead;
                 _registeredCallbacksHead._previous = _registeredCallbacksHead;
@@ -399,9 +443,6 @@ namespace Proto.Promises
                     next = current._next;
                     current.Dispose();
                 }
-
-                MaybeResetAndRepoolAlreadyLocked();
-                return true;
             }
 
             private void Unlink()
@@ -477,12 +518,17 @@ namespace Proto.Promises
                 if (--_internalRetainCounter == 0 & _userRetainCounter == 0)
                 {
 #if !NET_LEGACY || NET40
-                    if (_cancellationTokenSource != null)
+                    if (_bclSource != null)
                     {
-                        // TODO: We can call _cancellationTokenSource.TryReset() in .Net 6+ instead of always creating a new one.
-                        // But this should only be done if we add a TryReset() API to our own CancelationSource, because if a user still holds an old token after this is reused, it could have cancelations triggered unexpectedly.
-                        _cancellationTokenSource.Dispose();
-                        _cancellationTokenSource = null;
+                        CancelationConverter.DetachCancelationRef(_bclSource);
+                        // We should only dispose the source if we were the one that created it.
+                        if (!_linkedToBclToken)
+                        {
+                            // TODO: We can call _cancellationTokenSource.TryReset() in .Net 6+ instead of always creating a new one.
+                            // But this should only be done if we add a TryReset() API to our own CancelationSource, because if a user still holds an old token after this is reused, it could have cancelations triggered unexpectedly.
+                            _bclSource.Dispose();
+                        }
+                        _bclSource = null;
                         Thread.MemoryBarrier();
                     }
 #endif
@@ -572,7 +618,6 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
                     var parent = _parent;
                     var canceler = _cancelable;
-#if PROMISE_DEBUG
                     SetCurrentInvoker(this);
                     try
                     {
@@ -584,11 +629,6 @@ namespace Proto.Promises
                         parent._locker.Enter();
                         DisposeAlreadyLocked(parent);
                     }
-#else
-                    parent._locker.Enter();
-                    DisposeAlreadyLocked(parent);
-                    canceler.Cancel();
-#endif
                 }
 
                 [MethodImpl(InlineOption)]
@@ -603,6 +643,9 @@ namespace Proto.Promises
                 {
                     ThrowIfInPool(this);
                     ++_nodeId;
+                    // We set the parent to the disposed sentinel so the previous parent can be garbage collected and so the cancel state check will still keep this as marked unregistered.
+                    // We don't set null so we can avoid null checks.
+                    _parent = s_disposedSentinel;
                     _previous = null;
                     _cancelable = default(TCancelable);
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
@@ -679,9 +722,9 @@ namespace Proto.Promises
             private bool GetIsRegistered(CancelationRef parent, int nodeId, int tokenId, out bool isCanceled)
             {
                 bool canceled = parent._state == CancelationRef.State.Canceled;
-                bool tokenIdMatches = parent.TokenId == tokenId;
+                bool tokenIdMatches = parent.TokenId == tokenId & parent != CancelationRef.s_disposedSentinel;
                 isCanceled = canceled & tokenIdMatches;
-                return !canceled & tokenIdMatches && _nodeId == nodeId;
+                return !canceled & tokenIdMatches & _nodeId == nodeId;
             }
 
             [MethodImpl(InlineOption)]
@@ -718,6 +761,167 @@ namespace Proto.Promises
             }
 
             protected virtual void DisposeAlreadyLocked(CancelationRef parent) { throw new System.InvalidOperationException(); }
-        }
+        } // class CancelationCallbackNode
+
+        partial class CancelationRef
+        {
+#if !NET_LEGACY || NET40
+            // A separate class so that static data won't need to be created if it is never used.
+            internal static class CancelationConverter
+            {
+                private static readonly bool s_canExtractSource = GetCanExtractSource();
+                // Cache so if ToCancelationToken() is called multiple times on the same token, we don't need to allocate for every call.
+                // ConditionalWeakTable so we aren't extending the lifetime of any sources beyond what the user is using them for.
+                private static readonly ConditionalWeakTable<CancellationTokenSource, CancelationRef> s_tokenCache = new ConditionalWeakTable<CancellationTokenSource, CancelationRef>();
+
+                private static bool GetCanExtractSource()
+                {
+                    // This assumes the CancellationToken is implemented like this, and will return false if it's different.
+                    // public struct CancellationToken
+                    // {
+                    //     private CancellationTokenSource m_source;
+                    //     ...
+                    // }
+                    var fields = typeof(System.Threading.CancellationToken).GetFields(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+                    return fields.Length == 1 && typeof(CancellationTokenSource).IsAssignableFrom(fields[0].FieldType);
+                }
+
+                // Implementation detail, the token wraps the source, so we can retrieve it by placing it in this explicit layout struct and reading the source.
+                // This is equivalent to `Unsafe.As`, but also works in older runtimes that don't support Unsafe. It's also more efficient than using reflection (and some runtimes don't support TypedReference).
+                // I think it is very unlikely, but the internal implementation of CancellationToken could change in the future (or different runtime) to break this code, which is why we have the s_canExtractSource check.
+                [StructLayout(LayoutKind.Explicit)]
+                private struct TokenSourceExtractor
+                {
+                    [FieldOffset(0)]
+                    internal System.Threading.CancellationToken _token;
+                    [FieldOffset(0)]
+                    internal CancellationTokenSource _source;
+                }
+
+                internal static void AttachCancelationRef(CancellationTokenSource source, CancelationRef _ref)
+                {
+                    s_tokenCache.Add(source, _ref);
+                }
+
+                internal static void DetachCancelationRef(CancellationTokenSource source)
+                {
+                    s_tokenCache.Remove(source);
+                }
+
+                internal static CancelationToken Convert(System.Threading.CancellationToken token)
+                {
+                    if (!s_canExtractSource)
+                    {
+                        throw new System.Reflection.TargetException("Cannot convert System.Threading.CancellationToken to Proto.Promises.CancelationToken due to an implementation change. Please notify the developer.");
+                    }
+
+                    if (!token.CanBeCanceled)
+                    {
+                        return default(CancelationToken);
+                    }
+                    if (token.IsCancellationRequested)
+                    {
+                        return CancelationToken.Canceled();
+                    }
+
+                    // This relies on internal implementation details. If the implementation changes, the s_canExtractSource check should catch it.
+                    var source = new TokenSourceExtractor() { _token = token }._source;
+
+                    if (source == null)
+                    {
+                        // Source should never be null if token.CanBeCanceled returned true.
+                        throw new System.Reflection.TargetException("The token's internal source was null.");
+                    }
+
+                    if (s_tokenCache.TryGetValue(source, out var cancelationRef))
+                    {
+                        var tokenId = cancelationRef.TokenId;
+                        Thread.MemoryBarrier();
+                        return cancelationRef._bclSource != source // In case of race condition on another thread.
+                            ? default(CancelationToken)
+                            : new CancelationToken(cancelationRef, tokenId);
+                    }
+
+                    // Lock instead of AddOrUpdate so multiple refs won't be created on separate threads.
+                    lock (s_tokenCache)
+                    {
+                        if (!s_tokenCache.TryGetValue(source, out cancelationRef))
+                        {
+                            cancelationRef = GetOrCreateForBclTokenConvert(source);
+                            s_tokenCache.Add(source, cancelationRef);
+                        }
+                    }
+                    {
+                        var tokenId = cancelationRef.TokenId;
+                        cancelationRef.HookupBclCancelation(token);
+                        return new CancelationToken(cancelationRef, tokenId);
+                    }
+                }
+            } // class CancelationConverter
+
+            private CancellationTokenSource _bclSource;
+            private CancellationTokenRegistration _bclRegistration;
+
+            internal static CancelationRef GetOrCreateForBclTokenConvert(CancellationTokenSource source)
+            {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                // Don't take from the object pool, just create new (this is so the object pool's tracker won't report this since Dispose is never called on it).
+                var cancelRef = new CancelationRef();
+#else
+                var cancelRef = ObjectPool.TryTake<CancelationRef>()
+                    ?? new CancelationRef();
+#endif
+                cancelRef.Initialize(true);
+                cancelRef._bclSource = source;
+                return cancelRef;
+            }
+
+            private void HookupBclCancelation(System.Threading.CancellationToken token)
+            {
+                // We don't need the synchronous invoke check when this is created.
+                _bclRegistration = token.Register(state => state.UnsafeAs<CancelationRef>().Cancel(), this, false);
+            }
+
+            internal static CancellationToken GetCancellationToken(CancelationRef _this, int _tokenId)
+            {
+                return _this == null ? default(CancellationToken) : _this.GetCancellationToken(_tokenId);
+            }
+
+            private CancellationToken GetCancellationToken(int _tokenId)
+            {
+                _locker.Enter();
+                try
+                {
+                    var state = _state;
+                    if (_tokenId != TokenId | state == State.Disposed)
+                    {
+                        return default(CancellationToken);
+                    }
+                    if (state == State.Canceled)
+                    {
+                        return new CancellationToken(true);
+                    }
+                    if (_bclSource == null)
+                    {
+                        _bclSource = new CancellationTokenSource();
+                        CancelationConverter.AttachCancelationRef(_bclSource, this);
+                        var del = new CancelDelegateToken<CancellationTokenSource>(_bclSource, source => source.Cancel(false));
+                        var node = CallbackNodeImpl<CancelDelegateToken<CancellationTokenSource>>.GetOrCreate(del, this);
+                        _registeredCallbacksHead.InsertPrevious(node);
+                    }
+                    return _bclSource.Token;
+                }
+                // The original source may be disposed, in which case the Token property will throw ObjectDisposedException.
+                catch (ObjectDisposedException)
+                {
+                    return _bclSource.IsCancellationRequested ? new CancellationToken(true) : default(CancellationToken);
+                }
+                finally
+                {
+                    _locker.Exit();
+                }
+            }
+#endif // !NET_LEGACY || NET40
+        } // class CancelationRef
     } // class Internal
 } // namespace Proto.Promises

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -1039,13 +1039,13 @@ namespace Proto.Promises
             }
 
             partial void ReportProgressFromWaitFor(PromiseRefBase other, ushort depth);
-            partial void SetSecondPrevious(PromiseRefBase other);
+            partial void SetSecondPrevious(PromiseRefBase secondPrevious);
 
 #if !PROMISE_PROGRESS && PROMISE_DEBUG
             [MethodImpl(InlineOption)]
-            partial void SetSecondPrevious(PromiseRefBase other)
+            partial void SetSecondPrevious(PromiseRefBase secondPrevious)
             {
-                _previous = other;
+                _previous = secondPrevious;
             }
 #endif
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/TestHelper.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/TestHelper.cs
@@ -79,7 +79,7 @@ namespace ProtoPromiseTests
         {
             if (Promise.Config.ForegroundContext != _foregroundContext)
             {
-#if PROMISE_DEBUG
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
                 Internal.TrackObjectsForRelease();
 #endif
 
@@ -147,15 +147,25 @@ namespace ProtoPromiseTests
             _backgroundContext.WaitForAllThreadsToComplete();
 
             ExecuteForegroundCallbacks();
+            GcCollectAndWaitForFinalizers();
+        }
+
+        public static void GcCollectAndWaitForFinalizers()
+        {
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();
-
         }
 
         public static void ExecuteForegroundCallbacks()
         {
             _foregroundContext.Execute();
+        }
+
+        public static void ExecuteForegroundCallbacksAndWaitForThreadsToComplete()
+        {
+            _foregroundContext.Execute();
+            _backgroundContext.WaitForAllThreadsToComplete();
         }
 
         public static float Lerp(float a, float b, float t)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/CancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/CancelationTests.cs
@@ -892,7 +892,8 @@ namespace ProtoPromiseTests.APIs
                 cancelationSource.Dispose();
             }
 
-#if !PROMISE_DEBUG && !PROTO_PROMISE_DEVELOPER_MODE // Nulled out fields aren't garbage collected in Debug mode until the end of the scope.
+// Nulled out fields aren't garbage collected in Debug mode until the end of the scope.
+#if !PROMISE_DEBUG && !PROTO_PROMISE_DEVELOPER_MODE && !DEBUG
             [MethodImpl(MethodImplOptions.NoInlining)]
             void ConvertToken(CancellationTokenSource source)
             {
@@ -915,8 +916,6 @@ namespace ProtoPromiseTests.APIs
 
                 Assert.IsFalse(weakReference.IsAlive);
             }
-
-            // TODO: test cancelationSource.Dispose().
 
 #if NET6_0_OR_GREATER
             [Test]


### PR DESCRIPTION
Fixes #87 (Attempt number 2 after #88).

Fixes callbacks not being invoked after they are registered after the original source has been reset.

<s>This uses a finalizer in a wrapper to re-register the cancelation callback if `CancellationTokenSource.TryReset()` is called. The downside is it is tied to the timing of the GC, so if the original source is canceled before the finalizer is able to hook up the callback again, the cancelation propagation will be delayed.</s>

[Edit] This re-registers to the token when a new callback is added. If `TryReset` was called on the original source, the existing callbacks will not be invoked.