### PR TITLE
Added StackTradeHidden attribute to hide internal stack traces.

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
@@ -5,6 +5,7 @@
 #endif
 
 using System;
+using System.Diagnostics;
 
 namespace Proto.Promises
 {
@@ -12,7 +13,7 @@ namespace Proto.Promises
     /// Represents a callback delegate that has been registered with a <see cref="CancelationToken"/>.
     /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [System.Diagnostics.DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     public
 #if CSHARP_7_3_OR_NEWER

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationSource.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace Proto.Promises
 {
@@ -15,7 +16,7 @@ namespace Proto.Promises
     /// Cancelation source used to cancel operations.
     /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [System.Diagnostics.DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     public
 #if CSHARP_7_3_OR_NEWER

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace Proto.Promises
 {
@@ -21,7 +22,7 @@ namespace Proto.Promises
     /// Propagates notification that operations should be canceled.
     /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [System.Diagnostics.DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     public
 #if CSHARP_7_3_OR_NEWER

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -21,7 +21,7 @@ namespace Proto.Promises
     internal static partial class Internal
     {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal struct CancelDelegateTokenVoid : ICancelable
         {
@@ -41,7 +41,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal struct CancelDelegateToken<TCapture> : ICancelable
         {
@@ -67,7 +67,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal sealed partial class CancelationRef : HandleablePromiseBase, ICancelable, ITraceable
         {
@@ -559,7 +559,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed class CallbackNodeImpl<TCancelable> : CancelationCallbackNode, ITraceable
                 where TCancelable : ICancelable

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/StackTraceHiddenAttribute.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/StackTraceHiddenAttribute.cs
@@ -1,0 +1,14 @@
+﻿// TODO: Unity hasn't adopted .Net 6+ yet, and they usually use different compilation symbols than .Net SDK, so we'll have to update the compilation symbols here once Unity finally does adopt it.
+#if !NET6_0_OR_GREATER
+
+namespace System.Diagnostics
+{
+    // This doesn't actually do anything before .Net 6, this is just so make it so we don't need to #if NET6_0_OR_GREATER at every place the attribute is used.
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Struct, Inherited = false)]
+    internal sealed class StackTraceHiddenAttribute : Attribute
+    {
+
+    }
+}
+
+#endif

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/StackTraceHiddenAttribute.cs.meta
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/StackTraceHiddenAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c35331d4fb77d024f8212abd4f71f583
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
@@ -219,7 +219,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal class CausalityTrace
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ExceptionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ExceptionsInternal.cs
@@ -12,7 +12,7 @@ namespace Proto.Promises
     partial class Internal
     {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal sealed class UnhandledExceptionInternal : UnhandledException, IRejectionToContainer, ICantHandleException
         {
@@ -32,7 +32,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal sealed class CanceledExceptionInternal : CanceledException
         {
@@ -53,7 +53,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal sealed class RejectionException : Exception
         {
@@ -68,7 +68,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal sealed class RejectExceptionInternal<T> : RejectException, IRejectionToContainer, ICantHandleException
         {
@@ -95,7 +95,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal sealed class ForcedRethrowException : RethrowException
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
@@ -25,7 +25,7 @@ namespace Proto.Promises
     /// Members of this type are meant for INTERNAL USE ONLY! Do not use in user code! Use the documented public APIs.
     /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     internal static partial class Internal
     {
@@ -71,7 +71,7 @@ namespace Proto.Promises
         // This is used to facilitate stack unwinding in PromiseMultiAwaits to prevent StackOverflowExceptions in the case of very long promise chains.
         // Also used for synchronous progress invoke to prevent deadlocks.
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         private partial struct StackUnwindHelper
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/PoolInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/PoolInternal.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ProtoPromiseTests")]
@@ -32,12 +33,12 @@ namespace Proto.Promises
 
         // Using static generic classes to hold the pools allows direct pool access at runtime without doing a dictionary lookup.
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal static partial class ObjectPool
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private static class Type<T> where T : HandleablePromiseBase
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
@@ -113,7 +113,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal struct Enumerator<T> : IEnumerator<T> where T : class, ILinked<T>
         {
@@ -165,7 +165,7 @@ namespace Proto.Promises
 #if PROTO_PROMISE_DEVELOPER_MODE
         internal partial class ValueLinkedStack<T> : IEnumerable<T> where T : class, ILinked<T>
 #else
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
         internal struct ValueLinkedStack<T> : IEnumerable<T> where T : class, ILinked<T>
 #endif
         {
@@ -228,7 +228,7 @@ namespace Proto.Promises
         /// Must not be readonly.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal struct SpinLocker
         {
@@ -276,7 +276,7 @@ namespace Proto.Promises
 #if PROTO_PROMISE_DEVELOPER_MODE
         internal partial class ValueLinkedStackSafe<T> where T : HandleablePromiseBase
 #else
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
         internal struct ValueLinkedStackSafe<T> where T : HandleablePromiseBase
 #endif
         {
@@ -343,7 +343,7 @@ namespace Proto.Promises
 #if PROTO_PROMISE_DEVELOPER_MODE
         internal partial class ValueLinkedQueue<T> : IEnumerable<T> where T : class, ILinked<T>
 #else
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
         internal struct ValueLinkedQueue<T> : IEnumerable<T> where T : class, ILinked<T>
 #endif
         {
@@ -413,7 +413,7 @@ namespace Proto.Promises
         /// This structure is unsuitable for general purpose.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal struct ValueList<T> where T : class, ILinked<T>
         {
@@ -465,12 +465,12 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal struct ValueLinkedStackZeroGC<T> : IEnumerable<T>
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed class Node : HandleablePromiseBase, ILinked<Node>
             {
@@ -500,7 +500,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct Enumerator : IEnumerator<T>
             {
@@ -593,7 +593,7 @@ namespace Proto.Promises
     } // class Internal
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     internal static class ArrayExtensions
     {
@@ -601,7 +601,7 @@ namespace Proto.Promises
         /// Generic Array enumerator. Use this instead of the default <see cref="Array.GetEnumerator"/> for passing it around as an <see cref="IEnumerator{T}"/>.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal struct Enumerator<T> : IEnumerator<T>
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Config.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Config.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -59,7 +60,7 @@ namespace Proto.Promises
         /// Promise configuration. Configuration settings affect the global behaviour of promises.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public static partial class Config
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Proto.Promises
@@ -27,7 +28,7 @@ namespace Proto.Promises
         /// <para/>You must use <see cref="Deferred"/> or <see cref="Promise{T}.Deferred"/> to resolve the attached <see cref="Promise"/>.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public
 #if CSHARP_7_3_OR_NEWER
@@ -317,7 +318,7 @@ namespace Proto.Promises
         /// An instance of this is used to report progress and resolve, reject, or cancel the attached <see cref="Promise"/>.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public
 #if CSHARP_7_3_OR_NEWER
@@ -619,7 +620,7 @@ namespace Proto.Promises
         /// An instance of this is used to report progress and resolve, reject, or cancel the attached <see cref="Promise"/>.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public
 #if CSHARP_7_3_OR_NEWER

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Extensions.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Extensions.cs
@@ -12,13 +12,15 @@
 using System.Threading.Tasks;
 #endif
 
+using System.Diagnostics;
+
 namespace Proto.Promises
 {
     /// <summary>
     /// Helpful extensions to convert promises to and from other asynchronous types.
     /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [System.Diagnostics.DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     public static partial class Extensions
     {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -86,7 +86,7 @@ namespace Proto.Promises
         /// This type is intended for compiler use only.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public partial struct PromiseMethodBuilder
         {
@@ -142,7 +142,7 @@ namespace Proto.Promises
         /// This type is intended for compiler use only.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public partial struct PromiseMethodBuilder<T>
         {
@@ -427,7 +427,7 @@ namespace Proto.Promises
 #endif
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal partial class AsyncPromiseRef<TResult> : AsyncPromiseBase<TResult>
             {
@@ -598,7 +598,7 @@ namespace Proto.Promises
                 }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-                [DebuggerNonUserCode]
+                [DebuggerNonUserCode, StackTraceHidden]
 #endif
                 private abstract partial class PromiseMethodContinuer : HandleablePromiseBase, IDisposable
                 {
@@ -623,7 +623,7 @@ namespace Proto.Promises
                     internal abstract void MoveNextWithoutHandle();
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-                    [DebuggerNonUserCode]
+                    [DebuggerNonUserCode, StackTraceHidden]
 #endif
                     private sealed partial class Continuer<TStateMachine> : PromiseMethodContinuer where TStateMachine : IAsyncStateMachine
                     {
@@ -732,7 +732,7 @@ namespace Proto.Promises
             partial class AsyncPromiseRef<TResult>
             {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-                [DebuggerNonUserCode]
+                [DebuggerNonUserCode, StackTraceHidden]
 #endif
                 private sealed partial class AsyncPromiseRefMachine<TStateMachine> : AsyncPromiseRef<TResult> where TStateMachine : IAsyncStateMachine
                 {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -92,7 +92,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed class AwaiterRef<TContinuer> : HandleablePromiseBase, ITraceable
                 where TContinuer : IAction
@@ -348,7 +348,7 @@ namespace Proto.Promises
         /// </summary>
         /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public
 #if CSHARP_7_3_OR_NEWER
@@ -458,7 +458,7 @@ namespace Proto.Promises
         /// </summary>
         /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public
 #if CSHARP_7_3_OR_NEWER
@@ -569,7 +569,7 @@ namespace Proto.Promises
         /// </summary>
         /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public
 #if CSHARP_7_3_OR_NEWER
@@ -692,7 +692,7 @@ namespace Proto.Promises
         /// </summary>
         /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public
 #if CSHARP_7_3_OR_NEWER

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -13,6 +13,7 @@
 #pragma warning disable IDE0034 // Simplify 'default' expression
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -33,7 +34,7 @@ namespace Proto.Promises
             // These help reduce typed out generics.
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal static class CallbackHelperArg<TArg>
             {
@@ -188,7 +189,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal static class CallbackHelperResult<TResult>
             {
@@ -402,7 +403,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal static class CallbackHelper<TArg, TResult>
             {
@@ -557,7 +558,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal static class CallbackHelperVoid
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
@@ -17,6 +17,7 @@
 #pragma warning disable IDE0034 // Simplify 'default' expression
 #pragma warning disable 0420 // A reference to a volatile field will not be treated as volatile
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Proto.Promises
@@ -64,7 +65,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class CancelablePromiseResolve<TResult, TResolver> : PromiseSingleAwait<TResult>, ICancelable
                 where TResolver : IDelegateResolveOrCancel
@@ -126,7 +127,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class CancelablePromiseResolvePromise<TResult, TResolver> : PromiseWaitPromise<TResult>, ICancelable
                 where TResolver : IDelegateResolveOrCancelPromise
@@ -197,7 +198,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class CancelablePromiseResolveReject<TResult, TResolver, TRejecter> : PromiseSingleAwait<TResult>, ICancelable
                 where TResolver : IDelegateResolveOrCancel
@@ -272,7 +273,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class CancelablePromiseResolveRejectPromise<TResult, TResolver, TRejecter> : PromiseWaitPromise<TResult>, ICancelable
                 where TResolver : IDelegateResolveOrCancelPromise
@@ -356,7 +357,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class CancelablePromiseContinue<TResult, TContinuer> : PromiseSingleAwait<TResult>, ICancelable
                 where TContinuer : IDelegateContinue
@@ -413,7 +414,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class CancelablePromiseContinuePromise<TResult, TContinuer> : PromiseWaitPromise<TResult>, ICancelable
                 where TContinuer : IDelegateContinuePromise
@@ -479,7 +480,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class CancelablePromiseCancel<TResult, TCanceler> : PromiseSingleAwait<TResult>, ICancelable
                 where TCanceler : IDelegateResolveOrCancel
@@ -541,7 +542,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class CancelablePromiseCancelPromise<TResult, TCanceler> : PromiseWaitPromise<TResult>, ICancelable
                 where TCanceler : IDelegateResolveOrCancelPromise

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
@@ -8,6 +8,7 @@
 #pragma warning disable 0420 // A reference to a volatile field will not be treated as volatile
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -52,7 +53,7 @@ namespace Proto.Promises
         partial class PromiseRefBase
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal abstract partial class DeferredPromiseBase<TResult> : AsyncPromiseBase<TResult>, IDeferredPromise
             {
@@ -111,7 +112,7 @@ namespace Proto.Promises
             // The only purpose of this is to cast the ref when converting a DeferredBase to a Deferred(<T>) to avoid extra checks.
             // Otherwise, DeferredPromise<T> would be unnecessary and this would be implemented in the base class.
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal partial class DeferredPromise<TResult> : DeferredPromiseBase<TResult>
             {
@@ -178,7 +179,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal sealed partial class DeferredPromiseCancel<TResult> : DeferredPromise<TResult>, ICancelable
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DelegateWrappersInternal.cs
@@ -8,6 +8,7 @@
 #pragma warning disable IDE0034 // Simplify 'default' expression
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Proto.Promises
@@ -17,7 +18,7 @@ namespace Proto.Promises
         partial class PromiseRefBase
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal static class DelegateWrapper
             {
@@ -293,7 +294,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateResolvePassthrough : IAction, IFunc<Promise>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise
             {
@@ -348,7 +349,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateResolvePassthrough<TResult> : IFunc<TResult, TResult>, IFunc<TResult, Promise<TResult>>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise
             {
@@ -394,7 +395,7 @@ namespace Proto.Promises
             #region Regular Delegates
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateVoidVoid : IAction, IFunc<Promise>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
             {
@@ -466,7 +467,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateVoidResult<TResult> : IFunc<TResult>, IFunc<Promise<TResult>>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
             {
@@ -537,7 +538,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateArgVoid<TArg> : IAction<TArg>, IFunc<TArg, Promise>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
             {
@@ -620,7 +621,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateArgResult<TArg, TResult> : IFunc<TArg, TResult>, IFunc<TArg, Promise<TResult>>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
             {
@@ -702,7 +703,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegatePromiseVoidVoid : IFunc<Promise>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise
             {
@@ -743,7 +744,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegatePromiseVoidResult<TResult> : IFunc<Promise<TResult>>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise
             {
@@ -784,7 +785,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegatePromiseArgVoid<TArg> : IFunc<TArg, Promise>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise
             {
@@ -834,7 +835,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegatePromiseArgResult<TArg, TResult> : IFunc<TArg, Promise<TResult>>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise
             {
@@ -885,7 +886,7 @@ namespace Proto.Promises
 
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinueVoidVoid : IAction, IDelegateContinue
             {
@@ -921,7 +922,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinueVoidResult<TResult> : IFunc<TResult>, IDelegateContinue
             {
@@ -957,7 +958,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinueArgVoid<TArg> : IAction<TArg>, IDelegateContinue
             {
@@ -993,7 +994,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinueArgResult<TArg, TResult> : IFunc<TArg, TResult>, IDelegateContinue
             {
@@ -1029,7 +1030,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinuePromiseVoidVoid : IFunc<Promise>, IDelegateContinuePromise
             {
@@ -1069,7 +1070,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinuePromiseVoidResult<TResult> : IFunc<Promise<TResult>>, IDelegateContinuePromise
             {
@@ -1109,7 +1110,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinuePromiseArgVoid<TArg> : IFunc<TArg, Promise>, IDelegateContinuePromise
             {
@@ -1149,7 +1150,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinuePromiseArgResult<TArg, TResult> : IFunc<TArg, Promise<TResult>>, IDelegateContinuePromise
             {
@@ -1189,7 +1190,7 @@ namespace Proto.Promises
             }
 
 //#if !PROTO_PROMISE_DEVELOPER_MODE
-//            [System.Diagnostics.DebuggerNonUserCode]
+//            [DebuggerNonUserCode, StackTraceHidden]
 //#endif
 //            internal struct DelegateContinue<TArg, TResult> : IDelegateContinue
 //            {
@@ -1270,7 +1271,7 @@ namespace Proto.Promises
 //            }
 
 //#if !PROTO_PROMISE_DEVELOPER_MODE
-//            [System.Diagnostics.DebuggerNonUserCode]
+//            [DebuggerNonUserCode, StackTraceHidden]
 //#endif
 //            internal struct DelegateContinuePromise<TArg, TResult> : IDelegateContinuePromise
 //            {
@@ -1352,7 +1353,7 @@ namespace Proto.Promises
 
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateFinally : IAction
             {
@@ -1378,7 +1379,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateCancel : IAction
             {
@@ -1398,7 +1399,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateProgress : IProgress<float>
             {
@@ -1421,7 +1422,7 @@ namespace Proto.Promises
             #region Delegates with capture value
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateCaptureVoidVoid<TCapture> : IAction, IFunc<Promise>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
             {
@@ -1499,7 +1500,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateCaptureVoidResult<TCapture, TResult> : IFunc<TResult>, IFunc<Promise<TResult>>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
             {
@@ -1576,7 +1577,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateCaptureArgVoid<TCapture, TArg> : IAction<TArg>, IFunc<TArg, Promise>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
             {
@@ -1665,7 +1666,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateCaptureArgResult<TCapture, TArg, TResult> : IFunc<TArg, TResult>, IFunc<TArg, Promise<TResult>>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
             {
@@ -1753,7 +1754,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateCapturePromiseVoidVoid<TCapture> : IFunc<Promise>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise
             {
@@ -1800,7 +1801,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateCapturePromiseVoidResult<TCapture, TResult> : IFunc<Promise<TResult>>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise
             {
@@ -1847,7 +1848,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateCapturePromiseArgVoid<TCapture, TArg> : IFunc<TArg, Promise>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise
             {
@@ -1903,7 +1904,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateCapturePromiseArgResult<TCapture, TArg, TResult> : IFunc<TArg, Promise<TResult>>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise
             {
@@ -1960,7 +1961,7 @@ namespace Proto.Promises
 
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinueCaptureVoidVoid<TCapture> : IAction, IDelegateContinue
             {
@@ -2002,7 +2003,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinueCaptureVoidResult<TCapture, TResult> : IFunc<TResult>, IDelegateContinue
             {
@@ -2044,7 +2045,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinueCaptureArgVoid<TCapture, TArg> : IAction<TArg>, IDelegateContinue
             {
@@ -2086,7 +2087,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinueCaptureArgResult<TCapture, TArg, TResult> : IFunc<TArg, TResult>, IDelegateContinue
             {
@@ -2128,7 +2129,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinuePromiseCaptureVoidVoid<TCapture> : IFunc<Promise>, IDelegateContinuePromise
             {
@@ -2174,7 +2175,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinuePromiseCaptureVoidResult<TCapture, TResult> : IFunc<Promise<TResult>>, IDelegateContinuePromise
             {
@@ -2220,7 +2221,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinuePromiseCaptureArgVoid<TCapture, TArg> : IFunc<TArg, Promise>, IDelegateContinuePromise
             {
@@ -2266,7 +2267,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateContinuePromiseCaptureArgResult<TCapture, TArg, TResult> : IFunc<TArg, Promise<TResult>>, IDelegateContinuePromise
             {
@@ -2312,7 +2313,7 @@ namespace Proto.Promises
             }
 
 //#if !PROTO_PROMISE_DEVELOPER_MODE
-//            [System.Diagnostics.DebuggerNonUserCode]
+//            [DebuggerNonUserCode, StackTraceHidden]
 //#endif
 //            internal struct DelegateContinueCapture<TCapture, TArg, TResult> : IDelegateContinue
 //            {
@@ -2399,7 +2400,7 @@ namespace Proto.Promises
 //            }
 
 //#if !PROTO_PROMISE_DEVELOPER_MODE
-//            [System.Diagnostics.DebuggerNonUserCode]
+//            [DebuggerNonUserCode, StackTraceHidden]
 //#endif
 //            internal struct DelegateContinuePromiseCapture<TCapture, TArg, TResult> : IDelegateContinuePromise
 //            {
@@ -2487,7 +2488,7 @@ namespace Proto.Promises
 
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateCaptureFinally<TCapture> : IAction
             {
@@ -2519,7 +2520,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateCaptureCancel<TCapture> : IAction
             {
@@ -2545,7 +2546,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal struct DelegateCaptureProgress<TCapture> : IProgress<float>
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/FirstInternal.cs
@@ -13,6 +13,7 @@
 #pragma warning disable 0420 // A reference to a volatile field will not be treated as volatile
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -23,7 +24,7 @@ namespace Proto.Promises
         partial class PromiseRefBase
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal sealed partial class FirstPromise<TResult> : MultiHandleablePromiseBase<TResult>
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
@@ -9,6 +9,7 @@
 #endif
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Proto.Promises
@@ -24,7 +25,7 @@ namespace Proto.Promises
     {
         // Abstract classes are used instead of interfaces, because virtual calls on interfaces are twice as slow as virtual calls on classes.
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal abstract partial class HandleablePromiseBase : ILinked<HandleablePromiseBase>
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
@@ -16,6 +16,7 @@
 #pragma warning disable 0420 // A reference to a volatile field will not be treated as volatile
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 
 namespace Proto.Promises
@@ -25,7 +26,7 @@ namespace Proto.Promises
         partial class PromiseRefBase
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal abstract partial class MultiHandleablePromiseBase<TResult> : PromiseSingleAwait<TResult>
             {
@@ -41,7 +42,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal partial class MergePromise<TResult> : MultiHandleablePromiseBase<TResult>
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -20,6 +20,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -111,7 +112,7 @@ namespace Proto.Promises
             partial void InterlockedDecrementProgressReportingCount();
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal partial struct Fixed32
             {
@@ -381,7 +382,7 @@ namespace Proto.Promises
             /// Precision: 1/(2^<see cref="Promise.Config.ProgressDecimalBits"/>)
             /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal partial struct UnsignedFixed64 // Simplified compared to Fixed32 to remove unused functions.
             {
@@ -431,7 +432,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal sealed partial class PromiseProgress<TResult, TProgress> : PromiseSingleAwait<TResult>, ICancelable
                 where TProgress : IProgress<float>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -20,18 +20,19 @@
 #pragma warning disable 0420 // A reference to a volatile field will not be treated as volatile
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Proto.Promises
 {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [System.Diagnostics.DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     partial struct Promise { }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [System.Diagnostics.DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     partial struct Promise<T> { }
 
@@ -114,12 +115,12 @@ namespace Proto.Promises
 #endif
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal abstract partial class PromiseRefBase : HandleablePromiseBase, ITraceable
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal abstract partial class PromiseRef<TResult> : PromiseRefBase
             {
@@ -486,7 +487,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal abstract partial class PromiseSingleAwait<TResult> : PromiseRef<TResult>
             {
@@ -628,7 +629,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal sealed partial class PromiseMultiAwait<TResult> : PromiseRef<TResult>
             {
@@ -841,7 +842,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal sealed class PromiseDuplicate<TResult> : PromiseSingleAwait<TResult>
             {
@@ -870,7 +871,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal sealed partial class PromiseConfigured<TResult> : PromiseSingleAwait<TResult>
             {
@@ -1050,14 +1051,14 @@ namespace Proto.Promises
 #endif
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal abstract partial class PromiseWaitPromise<TResult> : PromiseSingleAwait<TResult>
             {
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal abstract partial class AsyncPromiseBase<TResult> : PromiseSingleAwait<TResult>
             {
@@ -1084,7 +1085,7 @@ namespace Proto.Promises
             // Resolve types for more common .Then(onResolved) calls to be more efficient (because the runtime does not allow 0-size structs).
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class PromiseResolve<TResult, TResolver> : PromiseSingleAwait<TResult>
                 where TResolver : IDelegateResolveOrCancel
@@ -1123,7 +1124,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class PromiseResolvePromise<TResult, TResolver> : PromiseWaitPromise<TResult>
                 where TResolver : IDelegateResolveOrCancelPromise
@@ -1170,7 +1171,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class PromiseResolveReject<TResult, TResolver, TRejecter> : PromiseSingleAwait<TResult>
                 where TResolver : IDelegateResolveOrCancel
@@ -1221,7 +1222,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class PromiseResolveRejectPromise<TResult, TResolver, TRejecter> : PromiseWaitPromise<TResult>
                 where TResolver : IDelegateResolveOrCancelPromise
@@ -1280,7 +1281,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class PromiseContinue<TResult, TContinuer> : PromiseSingleAwait<TResult>
                 where TContinuer : IDelegateContinue
@@ -1314,7 +1315,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class PromiseContinuePromise<TResult, TContinuer> : PromiseWaitPromise<TResult>
                 where TContinuer : IDelegateContinuePromise
@@ -1355,7 +1356,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class PromiseFinally<TResult, TFinalizer> : PromiseSingleAwait<TResult>
                 where TFinalizer : IAction
@@ -1402,7 +1403,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class PromiseCancel<TResult, TCanceler> : PromiseSingleAwait<TResult>
                 where TCanceler : IDelegateResolveOrCancel
@@ -1441,7 +1442,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private sealed partial class PromiseCancelPromise<TResult, TCanceler> : PromiseWaitPromise<TResult>
                 where TCanceler : IDelegateResolveOrCancelPromise
@@ -1488,7 +1489,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal sealed partial class PromisePassThrough : HandleablePromiseBase, ILinked<PromisePassThrough>
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
@@ -13,6 +13,7 @@
 #pragma warning disable 0420 // A reference to a volatile field will not be treated as volatile
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -23,7 +24,7 @@ namespace Proto.Promises
         partial class PromiseRefBase
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal sealed partial class RacePromise<TResult> : MultiHandleablePromiseBase<TResult>
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RejectContainersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RejectContainersInternal.cs
@@ -23,7 +23,7 @@ namespace Proto.Promises
     internal static partial class Internal
     {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal abstract class RejectContainer : ITraceable
         {
@@ -88,7 +88,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal sealed class RejectionContainer : RejectContainer, IRejectValueContainer, IRejectionToContainer, ICantHandleException
         {
@@ -166,7 +166,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal sealed class RejectionContainerException : RejectContainer, IRejectValueContainer, IRejectionToContainer, ICantHandleException
         {
@@ -268,7 +268,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal sealed class RethrownRejectionContainer : RejectContainer, IRejectValueContainer, IRejectionToContainer, ICantHandleException
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
@@ -15,6 +15,7 @@
 
 #pragma warning disable IDE0090 // Use 'new(...)'
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -25,7 +26,7 @@ namespace Proto.Promises
         internal abstract partial class PromiseRefBase : HandleablePromiseBase, ITraceable
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal sealed partial class PromiseCompletionSentinel : HandleablePromiseBase
             {
@@ -41,7 +42,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal sealed partial class PromiseForgetSentinel : HandleablePromiseBase
             {
@@ -58,7 +59,7 @@ namespace Proto.Promises
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             internal sealed partial class InvalidAwaitSentinel : PromiseRefBase
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Manager.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Manager.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace Proto.Promises
 {
@@ -11,7 +12,7 @@ namespace Proto.Promises
         /// Promise manager. This can be used to clear pooled objects (if enabled).
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public static class Manager
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Proto.Promises
@@ -18,7 +19,7 @@ namespace Proto.Promises
     /// An instance of <see cref="ReasonContainer"/> is only valid during the invocation of the delegate it is passed into.
     /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [System.Diagnostics.DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     public
 #if CSHARP_7_3_OR_NEWER
@@ -97,7 +98,7 @@ namespace Proto.Promises
         /// An instance of <see cref="ResultContainer"/> is only valid during the invocation of the onContinue delegate it is passed into.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public
 #if CSHARP_7_3_OR_NEWER
@@ -183,7 +184,7 @@ namespace Proto.Promises
         /// An instance of <see cref="ResultContainer"/> is only valid during the invocation of the onContinue delegate it is passed into.
         /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public
 #if CSHARP_7_3_OR_NEWER

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Unity/PromiseBehaviour.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Unity/PromiseBehaviour.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 
@@ -33,7 +34,7 @@ namespace Proto.Promises
     namespace Unity // I would have nested this within Internal, but you can only change the execution order of public, un-nested behaviours, so add a nested namespace instead.
     {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         public sealed class PromiseBehaviour : MonoBehaviour
         {
@@ -41,7 +42,7 @@ namespace Proto.Promises
             // UnityException: get_isPlayingOrWillChangePlaymode is not allowed to be called from a MonoBehaviour constructor (or instance field initializer),
             // call it in Awake or Start instead.
 #if !PROTO_PROMISE_DEVELOPER_MODE
-            [System.Diagnostics.DebuggerNonUserCode]
+            [DebuggerNonUserCode, StackTraceHidden]
 #endif
             private static class Dummy
             {
@@ -53,7 +54,7 @@ namespace Proto.Promises
                 {
 #pragma warning disable 0612 // Type or member is obsolete
                     // Set default warning handler to route to UnityEngine.Debug.
-                    Promise.Config.WarningHandler = Debug.LogWarning;
+                    Promise.Config.WarningHandler = UnityEngine.Debug.LogWarning;
 #pragma warning restore 0612 // Type or member is obsolete
 
 #if UNITY_EDITOR
@@ -97,7 +98,7 @@ namespace Proto.Promises
             {
                 if (_instance != null)
                 {
-                    Debug.LogWarning("There can only be one instance of PromiseBehaviour. Destroying new instance.");
+                    UnityEngine.Debug.LogWarning("There can only be one instance of PromiseBehaviour. Destroying new instance.");
                     Destroy(this);
                     return;
                 }
@@ -117,7 +118,7 @@ namespace Proto.Promises
                 {
                     if (_instance == this)
                     {
-                        Debug.LogWarning("PromiseBehaviour destroyed! Removing PromiseSynchronizationContext from Promise.Config.ForegroundContext.");
+                        UnityEngine.Debug.LogWarning("PromiseBehaviour destroyed! Removing PromiseSynchronizationContext from Promise.Config.ForegroundContext.");
                         _instance = null;
                         if (Promise.Config.ForegroundContext == _syncContext)
                         {
@@ -154,7 +155,7 @@ namespace Proto.Promises
                     // In case someone clears `Promise.Config.UncaughtRejectionHandler`, we catch the AggregateException here and log it so that the coroutine won't stop.
                     catch (AggregateException e)
                     {
-                        Debug.LogException(e);
+                        UnityEngine.Debug.LogException(e);
                     }
                 }
             }
@@ -174,7 +175,7 @@ namespace Proto.Promises
                 {
                     // Unfortunately, Unity does not provide a means to completely eliminate the stack trace at the point of calling `Debug.Log`, so the log will always have at least 1 extra stack frame.
                     // This implementation minimizes it to 1 extra stack frame always (because `Update()` is called from Unity's side, and they do not include their own internal stack traces).
-                    Debug.LogException(_currentlyReportingExceptions.Dequeue());
+                    UnityEngine.Debug.LogException(_currentlyReportingExceptions.Dequeue());
                 }
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Unity/PromiseYieldInstruction.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Unity/PromiseYieldInstruction.cs
@@ -11,6 +11,7 @@
 #pragma warning disable 0420 // A reference to a volatile field will not be treated as volatile
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using UnityEngine;
 
@@ -34,7 +35,7 @@ namespace Proto.Promises
     /// Yield instruction that can be yielded in a coroutine to wait until the <see cref="Promise"/> it came from has settled.
     /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [System.Diagnostics.DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     public abstract class PromiseYieldInstruction : CustomYieldInstruction, IDisposable
     {
@@ -134,7 +135,7 @@ namespace Proto.Promises
     /// An instance of this should be disposed when you are finished with it.
     /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [System.Diagnostics.DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     public abstract class PromiseYieldInstruction<T> : PromiseYieldInstruction
     {
@@ -181,7 +182,7 @@ namespace Proto.Promises
     partial class Internal
     {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal sealed class YieldInstructionVoid : PromiseYieldInstruction, ILinked<YieldInstructionVoid>
         {
@@ -253,7 +254,7 @@ namespace Proto.Promises
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         internal sealed class YieldInstruction<T> : PromiseYieldInstruction<T>, ILinked<YieldInstruction<T>>
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Unity/PromiseYielder.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Unity/PromiseYielder.cs
@@ -9,6 +9,7 @@
 #pragma warning disable 0420 // A reference to a volatile field will not be treated as volatile
 
 using System.Collections;
+using System.Diagnostics;
 using UnityEngine;
 
 namespace Proto.Promises
@@ -17,7 +18,7 @@ namespace Proto.Promises
     /// Yielder used to wait for a yield instruction to complete in the form of a Promise, using Unity's coroutines.
     /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [System.Diagnostics.DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     public sealed class PromiseYielder : MonoBehaviour
     {
@@ -41,7 +42,7 @@ namespace Proto.Promises
         {
             if (_instance != this)
             {
-                Debug.LogWarning("There can only be one instance of PromiseYielder. Destroying new instance.");
+                UnityEngine.Debug.LogWarning("There can only be one instance of PromiseYielder. Destroying new instance.");
                 Destroy(this);
                 return;
             }
@@ -57,14 +58,14 @@ namespace Proto.Promises
             {
                 if (_instance == this)
                 {
-                    Debug.LogWarning("PromiseYielder destroyed! Any pending PromiseYielder.WaitFor promises will not be resolved!");
+                    UnityEngine.Debug.LogWarning("PromiseYielder destroyed! Any pending PromiseYielder.WaitFor promises will not be resolved!");
                     _instance = null;
                 }
             }
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [System.Diagnostics.DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         private class Routine : Internal.HandleablePromiseBase, IEnumerator, Internal.ILinked<Routine>
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/PromiseSynchronizationContext.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/PromiseSynchronizationContext.cs
@@ -9,12 +9,12 @@ namespace Proto.Promises.Threading
     /// A <see cref="SynchronizationContext"/> used to schedule callbacks to the thread that it was created on.
     /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
-    [DebuggerNonUserCode]
+    [DebuggerNonUserCode, StackTraceHidden]
 #endif
     public sealed class PromiseSynchronizationContext : SynchronizationContext
     {
 #if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode]
+        [DebuggerNonUserCode, StackTraceHidden]
 #endif
         private sealed class SyncCallback : Internal.HandleablePromiseBase
         {


### PR DESCRIPTION
Resolves #43.

Master:

```
Proto.Promises.Internal+UnhandledExceptionInternal: An exception was not handled. -- This exception's Stacktrace contains the causality trace of all async callbacks that ran.
 ---> System.Exception: Exception of type 'System.Exception' was thrown.
   at ProtoPromiseTests.APIs.APlus_2_1_PromiseStates._2_1_1_WhenPendingAPromise.Func2() in C:\Users\Tim\Documents\git\ProtoPromise\ProtoPromise_Unity\Assets\Plugins\ProtoPromiseTests\Tests\APIs\APlus_2_1_PromiseStates.cs:line 40
   at Proto.Promises.Async.CompilerServices.PromiseAwaiterVoid.GetResult() in C:\Users\Tim\Documents\git\ProtoPromise\ProtoPromise_Unity\Assets\Plugins\ProtoPromise\Core\Promises\Internal\AwaitInternal.cs:line 410
   at ProtoPromiseTests.APIs.APlus_2_1_PromiseStates._2_1_1_WhenPendingAPromise.Func() in C:\Users\Tim\Documents\git\ProtoPromise\ProtoPromise_Unity\Assets\Plugins\ProtoPromiseTests\Tests\APIs\APlus_2_1_PromiseStates.cs:line 35
   --- End of inner exception stack trace ---
   at ProtoPromiseTests.APIs.APlus_2_1_PromiseStates._2_1_1_WhenPendingAPromise.Func()

   at ProtoPromiseTests.APIs.APlus_2_1_PromiseStates._2_1_1_WhenPendingAPromise.AAAAA() in C:\Users\Tim\Documents\git\ProtoPromise\ProtoPromise_Unity\Assets\Plugins\ProtoPromiseTests\Tests\APIs\APlus_2_1_PromiseStates.cs:line 30
```

This PR:

```
Proto.Promises.Internal+UnhandledExceptionInternal: An exception was not handled. -- This exception's Stacktrace contains the causality trace of all async callbacks that ran.
 ---> System.Exception: Exception of type 'System.Exception' was thrown.
   at ProtoPromiseTests.APIs.APlus_2_1_PromiseStates._2_1_1_WhenPendingAPromise.Func2() in C:\Users\Tim\Documents\git\ProtoPromise\ProtoPromise_Unity\Assets\Plugins\ProtoPromiseTests\Tests\APIs\APlus_2_1_PromiseStates.cs:line 40
   at ProtoPromiseTests.APIs.APlus_2_1_PromiseStates._2_1_1_WhenPendingAPromise.Func() in C:\Users\Tim\Documents\git\ProtoPromise\ProtoPromise_Unity\Assets\Plugins\ProtoPromiseTests\Tests\APIs\APlus_2_1_PromiseStates.cs:line 35
   --- End of inner exception stack trace ---
   at ProtoPromiseTests.APIs.APlus_2_1_PromiseStates._2_1_1_WhenPendingAPromise.Func()

   at ProtoPromiseTests.APIs.APlus_2_1_PromiseStates._2_1_1_WhenPendingAPromise.AAAAA() in C:\Users\Tim\Documents\git\ProtoPromise\ProtoPromise_Unity\Assets\Plugins\ProtoPromiseTests\Tests\APIs\APlus_2_1_PromiseStates.cs:line 30
```

With this code

```cs
public void AAAAA()
{
    Func().Forget();
}

async Promise Func()
{
    await Func2();
}

async Promise Func2()
{
    throw new System.Exception();
}
```