### PR TITLE
Fix UnreleasedObjectException from cancelation registration.

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
@@ -44,10 +44,7 @@ namespace Proto.Promises
         {
             get
             {
-                var node = _node;
-                return node == null
-                    ? new CancelationToken()
-                    : new CancelationToken(_ref, _tokenId);
+                return new CancelationToken(_ref, _tokenId);
             }
         }
 


### PR DESCRIPTION
Don't check for node disposed if the token was hooked up to BCL token.
Also removed null check in `CancelationRegistration.Token` property.