### PR TITLE
WaitAsync with CancelationToken

### DIFF
--- a/ProtoPromiseTests/ProtoPromiseTests.csproj
+++ b/ProtoPromiseTests/ProtoPromiseTests.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0-alpha-net7.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
   </ItemGroup>
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -119,12 +119,12 @@ namespace Proto.Promises
             private readonly CancelationCallbackNode _registeredCallbacksHead = CancelationCallbackNode.CreateLinkedListSentinel();
             internal SpinLocker _locker = new SpinLocker();
             // Start with Id 1 instead of 0 to reduce risk of false positives.
-            private int _sourceId = 1;
-            private int _tokenId = 1;
+            volatile private int _sourceId = 1;
+            volatile private int _tokenId = 1;
             private uint _userRetainCounter;
             private byte _internalRetainCounter;
             private bool _linkedToBclToken;
-            internal State _state;
+            volatile internal State _state;
 
             internal int SourceId
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
@@ -38,13 +38,7 @@ namespace Proto.Promises
 
         private static void ScheduleForHandle(HandleablePromiseBase handleable, SynchronizationContext context)
         {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
             if (context == null)
-            {
-                throw new InvalidOperationException("context cannot be null");
-            }
-#endif
-            if (context == BackgroundSynchronizationContextSentinel.s_instance)
             {
                 ThreadPool.QueueUserWorkItem(s_threadPoolHandleCallback, handleable);
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
@@ -38,7 +38,13 @@ namespace Proto.Promises
 
         private static void ScheduleForHandle(HandleablePromiseBase handleable, SynchronizationContext context)
         {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
             if (context == null)
+            {
+                throw new InvalidOperationException("context cannot be null");
+            }
+#endif
+            if (context == BackgroundSynchronizationContextSentinel.s_instance)
             {
                 ThreadPool.QueueUserWorkItem(s_threadPoolHandleCallback, handleable);
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -760,7 +760,7 @@ namespace Proto.Promises
                         }
                         case SynchronizationOption.Background:
                         {
-                            synchronizationContext = Promise.Config.BackgroundContext ?? BackgroundSynchronizationContextSentinel.s_instance;
+                            synchronizationContext = Promise.Config.BackgroundContext;
                             goto default;
                         }
                         default: // SynchronizationOption.Explicit
@@ -795,7 +795,7 @@ namespace Proto.Promises
                         }
                         case SynchronizationOption.Background:
                         {
-                            synchronizationContext = Promise.Config.BackgroundContext ?? BackgroundSynchronizationContextSentinel.s_instance;
+                            synchronizationContext = Promise.Config.BackgroundContext;
                             goto default;
                         }
                         default: // SynchronizationOption.Explicit
@@ -1076,7 +1076,7 @@ namespace Proto.Promises
                         }
                         case SynchronizationOption.Background:
                         {
-                            synchronizationContext = Promise.Config.BackgroundContext ?? BackgroundSynchronizationContextSentinel.s_instance;
+                            synchronizationContext = Promise.Config.BackgroundContext;
                             goto default;
                         }
                         default: // SynchronizationOption.Explicit
@@ -1167,7 +1167,7 @@ namespace Proto.Promises
                         }
                         case SynchronizationOption.Background:
                         {
-                            synchronizationContext = Promise.Config.BackgroundContext ?? BackgroundSynchronizationContextSentinel.s_instance;
+                            synchronizationContext = Promise.Config.BackgroundContext;
                             goto default;
                         }
                         default: // SynchronizationOption.Explicit

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -746,10 +746,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, _this.Depth)
                             : _this;
                     }
-                    var newRef = cancelationToken.CanBeCanceled
-                        ? PromiseDuplicateCancel<VoidResult>.GetOrCreate(_this.Depth, cancelationToken)
-                        : _this._ref.GetDuplicate(_this._id, _this.Depth);
-                    return new Promise(newRef, newRef.Id, _this.Depth);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        promise = PromiseDuplicateCancel<VoidResult>.GetOrCreate(_this.Depth, cancelationToken);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
+                    else
+                    {
+                        promise = _this._ref.GetDuplicate(_this._id, _this.Depth);
+                    }
+                    return new Promise(promise, promise.Id, _this.Depth);
                 }
 
                 internal static Promise<TResult> WaitAsync<TResult>(Promise<TResult> _this, CancelationToken cancelationToken)
@@ -760,10 +767,17 @@ namespace Proto.Promises
                             ? CallbackHelperResult<TResult>.Canceled(_this._ref, _this._id, _this.Depth)
                             : _this;
                     }
-                    var newRef = cancelationToken.CanBeCanceled
-                        ? PromiseDuplicateCancel<TResult>.GetOrCreate(_this.Depth, cancelationToken)
-                        : _this._ref.GetDuplicateT(_this._id, _this.Depth);
-                    return new Promise<TResult>(newRef, newRef.Id, _this.Depth, _this._result);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        promise = PromiseDuplicateCancel<TResult>.GetOrCreate(_this.Depth, cancelationToken);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
+                    else
+                    {
+                        promise = _this._ref.GetDuplicateT(_this._id, _this.Depth);
+                    }
+                    return new Promise<TResult>(promise, promise.Id, _this.Depth, _this._result);
                 }
 
                 internal static Promise WaitAsync(Promise _this, SynchronizationOption continuationOption, SynchronizationContext synchronizationContext, CancelationToken cancelationToken)
@@ -797,10 +811,21 @@ namespace Proto.Promises
                             {
                                 synchronizationContext = BackgroundSynchronizationContextSentinel.s_instance;
                             }
-                            var newRef = _this._ref == null
-                                ? PromiseConfigured<VoidResult>.GetOrCreateFromResolved(synchronizationContext, new VoidResult(), _this.Depth, cancelationToken)
-                                : _this._ref.GetConfigured(_this._id, synchronizationContext, _this.Depth, cancelationToken);
-                            return new Promise(newRef, newRef.Id, _this.Depth);
+                            PromiseRefBase promise;
+                            if (_this._ref == null)
+                            {
+                                promise = PromiseConfigured<VoidResult>.GetOrCreateFromResolved(synchronizationContext, new VoidResult(), _this.Depth, cancelationToken);
+                            }
+                            else if (cancelationToken.CanBeCanceled)
+                            {
+                                promise = PromiseConfigured<VoidResult>.GetOrCreate(synchronizationContext, _this.Depth, cancelationToken);
+                                _this._ref.HookupNewPromise(_this._id, promise);
+                            }
+                            else
+                            {
+                                promise = _this._ref.GetConfigured(_this._id, synchronizationContext, _this.Depth, cancelationToken);
+                            }
+                            return new Promise(promise, promise.Id, _this.Depth);
                         }
                     }
                 }
@@ -836,10 +861,21 @@ namespace Proto.Promises
                             {
                                 synchronizationContext = BackgroundSynchronizationContextSentinel.s_instance;
                             }
-                            var newRef = _this._ref == null
-                                ? PromiseConfigured<TResult>.GetOrCreateFromResolved(synchronizationContext, _this._result, _this.Depth, cancelationToken)
-                                : _this._ref.GetConfiguredT(_this._id, synchronizationContext, _this.Depth, cancelationToken);
-                            return new Promise<TResult>(newRef, newRef.Id, _this.Depth, _this._result);
+                            PromiseRef<TResult> promise;
+                            if (_this._ref == null)
+                            {
+                                promise = PromiseConfigured<TResult>.GetOrCreateFromResolved(synchronizationContext, _this._result, _this.Depth, cancelationToken);
+                            }
+                            else if (cancelationToken.CanBeCanceled)
+                            {
+                                promise = PromiseConfigured<TResult>.GetOrCreate(synchronizationContext, _this.Depth, cancelationToken);
+                                _this._ref.HookupNewPromise(_this._id, promise);
+                            }
+                            else
+                            {
+                                promise = _this._ref.GetConfiguredT(_this._id, synchronizationContext, _this.Depth, cancelationToken);
+                            }
+                            return new Promise<TResult>(promise, promise.Id, _this.Depth, _this._result);
                         }
                     }
                 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -788,11 +788,15 @@ namespace Proto.Promises
                         }
                         case SynchronizationOption.Background:
                         {
-                            synchronizationContext = Promise.Config.BackgroundContext ?? BackgroundSynchronizationContextSentinel.s_instance;
+                            synchronizationContext = Promise.Config.BackgroundContext;
                             goto default;
                         }
                         default: // SynchronizationOption.Explicit
                         {
+                            if (synchronizationContext == null)
+                            {
+                                synchronizationContext = BackgroundSynchronizationContextSentinel.s_instance;
+                            }
                             var newRef = _this._ref == null
                                 ? PromiseConfigured<VoidResult>.GetOrCreateFromResolved(synchronizationContext, new VoidResult(), _this.Depth, cancelationToken)
                                 : _this._ref.GetConfigured(_this._id, synchronizationContext, _this.Depth, cancelationToken);
@@ -823,11 +827,15 @@ namespace Proto.Promises
                         }
                         case SynchronizationOption.Background:
                         {
-                            synchronizationContext = Promise.Config.BackgroundContext ?? BackgroundSynchronizationContextSentinel.s_instance;
+                            synchronizationContext = Promise.Config.BackgroundContext;
                             goto default;
                         }
                         default: // SynchronizationOption.Explicit
                         {
+                            if (synchronizationContext == null)
+                            {
+                                synchronizationContext = BackgroundSynchronizationContextSentinel.s_instance;
+                            }
                             var newRef = _this._ref == null
                                 ? PromiseConfigured<TResult>.GetOrCreateFromResolved(synchronizationContext, _this._result, _this.Depth, cancelationToken)
                                 : _this._ref.GetConfiguredT(_this._id, synchronizationContext, _this.Depth, cancelationToken);
@@ -1105,11 +1113,15 @@ namespace Proto.Promises
                         }
                         case SynchronizationOption.Background:
                         {
-                            synchronizationContext = Promise.Config.BackgroundContext ?? BackgroundSynchronizationContextSentinel.s_instance;
+                            synchronizationContext = Promise.Config.BackgroundContext;
                             goto default;
                         }
                         default: // SynchronizationOption.Explicit
                         {
+                            if (synchronizationContext == null)
+                            {
+                                synchronizationContext = BackgroundSynchronizationContextSentinel.s_instance;
+                            }
                             if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
                             {
                                 if (_this._ref != null)
@@ -1197,11 +1209,15 @@ namespace Proto.Promises
                         }
                         case SynchronizationOption.Background:
                         {
-                            synchronizationContext = Promise.Config.BackgroundContext ?? BackgroundSynchronizationContextSentinel.s_instance;
+                            synchronizationContext = Promise.Config.BackgroundContext;
                             goto default;
                         }
                         default: // SynchronizationOption.Explicit
                         {
+                            if (synchronizationContext == null)
+                            {
+                                synchronizationContext = BackgroundSynchronizationContextSentinel.s_instance;
+                            }
                             if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
                             {
                                 TResult result = GetResultFromResolved(_this);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -788,7 +788,7 @@ namespace Proto.Promises
                         }
                         case SynchronizationOption.Background:
                         {
-                            synchronizationContext = Promise.Config.BackgroundContext;
+                            synchronizationContext = Promise.Config.BackgroundContext ?? BackgroundSynchronizationContextSentinel.s_instance;
                             goto default;
                         }
                         default: // SynchronizationOption.Explicit
@@ -823,7 +823,7 @@ namespace Proto.Promises
                         }
                         case SynchronizationOption.Background:
                         {
-                            synchronizationContext = Promise.Config.BackgroundContext;
+                            synchronizationContext = Promise.Config.BackgroundContext ?? BackgroundSynchronizationContextSentinel.s_instance;
                             goto default;
                         }
                         default: // SynchronizationOption.Explicit
@@ -1105,7 +1105,7 @@ namespace Proto.Promises
                         }
                         case SynchronizationOption.Background:
                         {
-                            synchronizationContext = Promise.Config.BackgroundContext;
+                            synchronizationContext = Promise.Config.BackgroundContext ?? BackgroundSynchronizationContextSentinel.s_instance;
                             goto default;
                         }
                         default: // SynchronizationOption.Explicit
@@ -1197,7 +1197,7 @@ namespace Proto.Promises
                         }
                         case SynchronizationOption.Background:
                         {
-                            synchronizationContext = Promise.Config.BackgroundContext;
+                            synchronizationContext = Promise.Config.BackgroundContext ?? BackgroundSynchronizationContextSentinel.s_instance;
                             goto default;
                         }
                         default: // SynchronizationOption.Explicit

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -488,6 +488,12 @@ namespace Proto.Promises
                     return promise;
                 }
 
+                [MethodImpl(InlineOption)]
+                private bool ShouldInvokeSynchronous()
+                {
+                    return _isSynchronous | _synchronizationContext == ts_currentContext;
+                }
+
                 protected override void MaybeDispose()
                 {
                     if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
@@ -534,7 +540,7 @@ namespace Proto.Promises
                     }
                     InterlockedAddWithOverflowCheck(ref _retainCounter, 1, -1);
                     // Even though it's scheduled synchronous, we still have to let the stack unwind to prevent a deadlock in case user code tries to complete the promise.
-                    if (_isSynchronous | _synchronizationContext == ts_currentContext)
+                    if (ShouldInvokeSynchronous())
                     {
                         StackUnwindHelper.AddProgressor(this);
                         return;
@@ -576,7 +582,7 @@ namespace Proto.Promises
                     var state = handler.State;
                     _previousState = state;
 
-                    if (_isSynchronous | _synchronizationContext == ts_currentContext)
+                    if (ShouldInvokeSynchronous())
                     {
                         handler = this;
                         Invoke1(state, out nextHandler);
@@ -612,7 +618,7 @@ namespace Proto.Promises
 
                 internal override PromiseRefBase AddWaiter(short promiseId, HandleablePromiseBase waiter, out HandleablePromiseBase previousWaiter)
                 {
-                    if (_isSynchronous | _synchronizationContext == ts_currentContext)
+                    if (ShouldInvokeSynchronous())
                     {
                         return AddWaiterImpl(promiseId, waiter, out previousWaiter, Depth);
                     }
@@ -660,7 +666,7 @@ namespace Proto.Promises
                         ThrowIfInPool(_this);
                         _this.State = _this._previousState;
                         // We don't need to synchronize access here because this is only called when the waiter is added after Invoke1 has completed, so there are no race conditions.
-                        // _this._waiter is guaranteed to be non-null here, so we can call HandleNext instead of MaybeHandleNext.
+                        // _this._next is guaranteed to be non-null here, so we can call HandleNext instead of MaybeHandleNext.
                         _this.HandleNext(_this._next);
                     }
                     catch (Exception e)
@@ -675,7 +681,7 @@ namespace Proto.Promises
                     ValidateId(promiseId, this, 2);
                     ThrowIfInPool(this);
                     // Make sure the continuation happens on the synchronization context.
-                    if ((_isSynchronous | _synchronizationContext == ts_currentContext)
+                    if ((ShouldInvokeSynchronous())
                         && CompareExchangeWaiter(InvalidAwaitSentinel.s_instance, PromiseCompletionSentinel.s_instance) == PromiseCompletionSentinel.s_instance)
                     {
                         WasAwaitedOrForgotten = true;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -45,13 +45,7 @@ namespace Proto.Promises
 
         private static void ScheduleForProgress(HandleablePromiseBase progressable, SynchronizationContext context)
         {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
             if (context == null)
-            {
-                throw new InvalidOperationException("context cannot be null");
-            }
-#endif
-            if (context == BackgroundSynchronizationContextSentinel.s_instance)
             {
                 ThreadPool.QueueUserWorkItem(s_threadPoolProgressCallback, progressable);
             }
@@ -467,12 +461,6 @@ namespace Proto.Promises
 
                 internal static PromiseProgress<TResult, TProgress> GetOrCreate(TProgress progress, CancelationToken cancelationToken, ushort depth, bool isSynchronous, SynchronizationContext synchronizationContext)
                 {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    if (!isSynchronous && synchronizationContext == null)
-                    {
-                        throw new InvalidOperationException("synchronizationContext cannot be null");
-                    }
-#endif
                     var promise = ObjectPool.TryTake<PromiseProgress<TResult, TProgress>>()
                         ?? new PromiseProgress<TResult, TProgress>();
                     promise.Reset(depth);
@@ -487,12 +475,6 @@ namespace Proto.Promises
 
                 internal static PromiseProgress<TResult, TProgress> GetOrCreateFromResolved(TProgress progress, CancelationToken cancelationToken, ushort depth, SynchronizationContext synchronizationContext, TResult result)
                 {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    if (synchronizationContext == null)
-                    {
-                        throw new InvalidOperationException("synchronizationContext cannot be null");
-                    }
-#endif
                     var promise = ObjectPool.TryTake<PromiseProgress<TResult, TProgress>>()
                         ?? new PromiseProgress<TResult, TProgress>();
                     promise.Reset(depth);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -45,7 +45,13 @@ namespace Proto.Promises
 
         private static void ScheduleForProgress(HandleablePromiseBase progressable, SynchronizationContext context)
         {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
             if (context == null)
+            {
+                throw new InvalidOperationException("context cannot be null");
+            }
+#endif
+            if (context == BackgroundSynchronizationContextSentinel.s_instance)
             {
                 ThreadPool.QueueUserWorkItem(s_threadPoolProgressCallback, progressable);
             }
@@ -461,6 +467,12 @@ namespace Proto.Promises
 
                 internal static PromiseProgress<TResult, TProgress> GetOrCreate(TProgress progress, CancelationToken cancelationToken, ushort depth, bool isSynchronous, SynchronizationContext synchronizationContext)
                 {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    if (!isSynchronous && synchronizationContext == null)
+                    {
+                        throw new InvalidOperationException("synchronizationContext cannot be null");
+                    }
+#endif
                     var promise = ObjectPool.TryTake<PromiseProgress<TResult, TProgress>>()
                         ?? new PromiseProgress<TResult, TProgress>();
                     promise.Reset(depth);
@@ -475,6 +487,12 @@ namespace Proto.Promises
 
                 internal static PromiseProgress<TResult, TProgress> GetOrCreateFromResolved(TProgress progress, CancelationToken cancelationToken, ushort depth, SynchronizationContext synchronizationContext, TResult result)
                 {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    if (synchronizationContext == null)
+                    {
+                        throw new InvalidOperationException("synchronizationContext cannot be null");
+                    }
+#endif
                     var promise = ObjectPool.TryTake<PromiseProgress<TResult, TProgress>>()
                         ?? new PromiseProgress<TResult, TProgress>();
                     promise.Reset(depth);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -212,9 +212,21 @@ namespace Proto.Promises
             {
             }
 
+            partial class PromiseDuplicate<TResult> : PromiseSingleAwait<TResult>
+            {
+            }
+
+            partial class PromiseDuplicateCancel<TResult> : PromiseSingleAwait<TResult>
+            {
+                private CancelationHelper _cancelationHelper;
+            }
+
             partial class PromiseConfigured<TResult> : PromiseSingleAwait<TResult>
             {
                 private SynchronizationContext _synchronizationContext;
+                private CancelationHelper _cancelationHelper;
+                private int _isScheduling; // Flag used so that only Cancel() or Handle() will call CompareExchangeWaiter and schedule the continuation. Int for Interlocked.
+                volatile private bool _wasCanceled;
                 volatile private Promise.State _previousState;
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -210,16 +210,9 @@ namespace Proto.Promises
                 }
 
                 internal abstract PromiseRef<TResult> GetDuplicateT(short promiseId, ushort depth);
-                internal virtual PromiseRef<TResult> GetConfiguredT(short promiseId, SynchronizationContext synchronizationContext, ushort depth)
+                internal PromiseRef<TResult> GetConfiguredT(short promiseId, SynchronizationContext synchronizationContext, ushort depth, CancelationToken cancelationToken)
                 {
-                    var newPromise = PromiseConfigured<TResult>.GetOrCreate(synchronizationContext, depth);
-                    HookupNewPromise(promiseId, newPromise);
-                    return newPromise;
-                }
-
-                internal override PromiseRefBase GetConfigured(short promiseId, SynchronizationContext synchronizationContext, ushort depth)
-                {
-                    var newPromise = PromiseConfigured<TResult>.GetOrCreate(synchronizationContext, depth);
+                    var newPromise = PromiseConfigured<TResult>.GetOrCreate(synchronizationContext, depth, cancelationToken);
                     HookupNewPromise(promiseId, newPromise);
                     return newPromise;
                 }
@@ -245,7 +238,6 @@ namespace Proto.Promises
             internal abstract PromiseRefBase AddWaiter(short promiseId, HandleablePromiseBase waiter, out HandleablePromiseBase previousWaiter);
             internal abstract bool GetIsValid(short promiseId);
             internal abstract PromiseRefBase GetPreserved(short promiseId, ushort depth);
-            internal abstract PromiseRefBase GetConfigured(short promiseId, SynchronizationContext synchronizationContext, ushort depth);
 
             internal short Id
             {
@@ -306,6 +298,12 @@ namespace Proto.Promises
                     // This should never happen.
                     ReportRejection(e, this);
                 }
+            }
+            internal PromiseRefBase GetConfigured(short promiseId, SynchronizationContext synchronizationContext, ushort depth, CancelationToken cancelationToken)
+            {
+                var newPromise = PromiseConfigured<VoidResult>.GetOrCreate(synchronizationContext, depth, cancelationToken);
+                HookupNewPromise(promiseId, newPromise);
+                return newPromise;
             }
 
             internal void Forget(short promiseId)
@@ -447,7 +445,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             private HandleablePromiseBase CompareExchangeWaiter(HandleablePromiseBase waiter, HandleablePromiseBase comparand)
             {
-                Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _waiter.
+                Thread.MemoryBarrier(); // Make sure previous writes are done before swapping _next.
                 return Interlocked.CompareExchange(ref _next, waiter, comparand);
             }
 
@@ -717,7 +715,9 @@ namespace Proto.Promises
 
                 internal override PromiseRefBase GetDuplicate(short promiseId, ushort depth)
                 {
-                    return GetDuplicateT(promiseId, depth);
+                    var newPromise = PromiseDuplicate<VoidResult>.GetOrCreate(depth);
+                    HookupNewPromise(promiseId, newPromise);
+                    return newPromise;
                 }
 
                 internal override PromiseRef<TResult> GetDuplicateT(short promiseId, ushort depth)
@@ -844,7 +844,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal sealed class PromiseDuplicate<TResult> : PromiseSingleAwait<TResult>
+            internal sealed partial class PromiseDuplicate<TResult> : PromiseSingleAwait<TResult>
             {
                 private PromiseDuplicate() { }
 
@@ -873,74 +873,183 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal sealed partial class PromiseConfigured<TResult> : PromiseSingleAwait<TResult>
+            internal sealed partial class PromiseDuplicateCancel<TResult> : PromiseSingleAwait<TResult>, ICancelable
             {
-                private PromiseConfigured() { }
+                private PromiseDuplicateCancel() { }
 
                 protected override void MaybeDispose()
                 {
-                    // TODO: handle properly when Promise.WaitAsync(CancelationToken) is added.
-                    Dispose();
-                    ObjectPool.MaybeRepool(this);
-                }
-
-                internal static PromiseConfigured<TResult> GetOrCreate(SynchronizationContext synchronizationContext, ushort depth)
-                {
-                    var promise = ObjectPool.TryTake<PromiseConfigured<TResult>>()
-                        ?? new PromiseConfigured<TResult>();
-                    promise.Reset(depth);
-                    promise._synchronizationContext = synchronizationContext;
-                    return promise;
+                    if (_cancelationHelper.TryRelease())
+                    {
+                        Dispose();
+                        ObjectPool.MaybeRepool(this);
+                    }
                 }
 
                 [MethodImpl(InlineOption)]
-                internal static PromiseConfigured<TResult> GetOrCreateFromResolved(SynchronizationContext synchronizationContext,
-#if CSHARP_7_3_OR_NEWER
-                    in
-#endif
-                    TResult result, ushort depth)
+                internal static PromiseDuplicateCancel<TResult> GetOrCreate(ushort depth, CancelationToken cancelationToken)
                 {
-                    var promise = GetOrCreate(synchronizationContext, depth);
-                    promise._result = result;
-                    promise._previousState = Promise.State.Resolved;
-                    promise._next = PromiseCompletionSentinel.s_instance;
+                    var promise = ObjectPool.TryTake<PromiseDuplicateCancel<TResult>>()
+                        ?? new PromiseDuplicateCancel<TResult>();
+                    promise.Reset(depth);
+                    promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
                     return promise;
-                }
-
-                internal override PromiseRefBase GetConfigured(short promiseId, SynchronizationContext synchronizationContext, ushort depth)
-                {
-                    return GetConfiguredT(promiseId, synchronizationContext, depth);
-                }
-
-                internal override PromiseRef<TResult> GetConfiguredT(short promiseId, SynchronizationContext synchronizationContext, ushort depth)
-                {
-                    // This isn't strictly thread-safe, but when the next promise is awaited, the CompareExchange should catch it if this is used improperly.
-                    ValidateIdAndNotAwaited(promiseId);
-                    _smallFields.IncrementPromiseId();
-                    _synchronizationContext = synchronizationContext;
-                    return this;
                 }
 
                 internal override void Handle(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler)
                 {
                     ThrowIfInPool(this);
-                    // TODO: when cancelations are added, don't suppress rejection if this is canceled.
+                    if (_cancelationHelper.TryUnregister(this))
+                    {
+                        _cancelationHelper.TryRelease();
+                        HandleSelf(ref handler, out nextHandler);
+                    }
+                    else
+                    {
+                        MaybeDispose();
+                        CancelationHelper.SetNextAfterCanceled(ref handler, out nextHandler);
+                    }
+                }
+
+                void ICancelable.Cancel()
+                {
+                    HandleFromCancelation();
+                }
+            }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            internal sealed partial class PromiseConfigured<TResult> : PromiseSingleAwait<TResult>, ICancelable
+            {
+                private PromiseConfigured() { }
+
+                protected override void MaybeDispose()
+                {
+                    if (_cancelationHelper.TryRelease())
+                    {
+                        Dispose();
+                        ObjectPool.MaybeRepool(this);
+                    }
+                }
+
+                private static PromiseConfigured<TResult> GetOrCreateBase(SynchronizationContext synchronizationContext, ushort depth, CancelationToken cancelationToken)
+                {
+                    var promise = ObjectPool.TryTake<PromiseConfigured<TResult>>()
+                        ?? new PromiseConfigured<TResult>();
+                    promise.Reset(depth);
+                    promise._synchronizationContext = synchronizationContext;
+                    promise._isScheduling = 0;
+                    promise._wasCanceled = false;
+                    return promise;
+                }
+
+                internal static PromiseConfigured<TResult> GetOrCreate(SynchronizationContext synchronizationContext, ushort depth, CancelationToken cancelationToken)
+                {
+                    var promise = GetOrCreateBase(synchronizationContext, depth, cancelationToken);
+                    promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
+                    return promise;
+                }
+
+                internal static PromiseConfigured<TResult> GetOrCreateFromResolved(SynchronizationContext synchronizationContext,
+#if CSHARP_7_3_OR_NEWER
+                    in
+#endif
+                    TResult result, ushort depth, CancelationToken cancelationToken)
+                {
+                    var promise = GetOrCreateBase(synchronizationContext, depth, cancelationToken);
+                    promise._result = result;
+                    promise._previousState = Promise.State.Resolved;
+                    promise._next = PromiseCompletionSentinel.s_instance;
+                    promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
+                    return promise;
+                }
+
+                [MethodImpl(InlineOption)]
+                private bool ShouldContinueSynchronous()
+                {
+                    return _synchronizationContext == ts_currentContext;
+                }
+
+                internal override void Handle(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler)
+                {
+                    ThrowIfInPool(this);
+                    nextHandler = null;
+
+#if NET_LEGACY // Interlocked.Exchange doesn't seem to work properly in Unity's old runtime. So use CompareExchange instead
+                    if (Interlocked.CompareExchange(ref _isScheduling, 1, 0) != 0)
+#else
+                    if (Interlocked.Exchange(ref _isScheduling, 1) != 0)
+#endif
+                    {
+                        handler.MaybeDispose();
+                        _cancelationHelper.TryRelease();
+                        return;
+                    }
+
                     handler.SuppressRejection = true;
                     _result = handler.GetResult<TResult>();
                     _rejectContainer = handler._rejectContainer;
                     _previousState = handler.State;
                     handler.MaybeDispose();
-                    nextHandler = null;
+
                     // Leave pending until this is awaited.
                     if (CompareExchangeWaiter(PromiseCompletionSentinel.s_instance, null) != null)
                     {
-                        if (_synchronizationContext == ts_currentContext)
+                        if (!ShouldContinueSynchronous())
                         {
-                            State = _previousState;
-                            nextHandler = _next;
+                            ScheduleForHandle(this, _synchronizationContext);
                             return;
                         }
+
+                        SetCompletionState();
+                        handler = this;
+                        nextHandler = _next;
+                    }
+                }
+
+                void ICancelable.Cancel()
+                {
+                    _wasCanceled = true;
+#if NET_LEGACY // Interlocked.Exchange doesn't seem to work properly in Unity's old runtime. So use CompareExchange instead
+                    if (Interlocked.CompareExchange(ref _isScheduling, 1, 0) != 0)
+#else
+                    if (Interlocked.Exchange(ref _isScheduling, 1) != 0)
+#endif
+                    {
+                        MaybeDispose();
+                        return;
+                    }
+
+                    _rejectContainer = RejectContainer.s_completionSentinel;
+
+                    if (!ShouldContinueSynchronous())
+                    {
+                        _previousState = Promise.State.Canceled;
                         ScheduleForHandle(this, _synchronizationContext);
+                        return;
+                    }
+
+                    State = Promise.State.Canceled;
+                    HandleNextInternal();
+                }
+
+                private void SetCompletionState()
+                {
+                    if (_cancelationHelper.TryUnregister(this) & !_wasCanceled)
+                    {
+                        _cancelationHelper.TryRelease();
+                        State = _previousState;
+                    }
+                    else
+                    {
+                        var rejectContainer = _rejectContainer;
+                        if (rejectContainer != null)
+                        {
+                            rejectContainer.AddToUnhandledStack();
+                        }
+                        _rejectContainer = RejectContainer.s_completionSentinel;
+                        State = Promise.State.Canceled;
                     }
                 }
 
@@ -949,9 +1058,9 @@ namespace Proto.Promises
                     var currentContext = ts_currentContext;
                     ts_currentContext = _synchronizationContext;
 
-                    State = _previousState;
-                    // We don't need to synchronize access here because this is only called when the previous promise completed and the waiter has already been added, so there are no race conditions.
-                    // _waiter is guaranteed to be non-null here, so we can call HandleNext instead of MaybeHandleNext.
+                    SetCompletionState();
+                    // We don't need to synchronize access here because this is only called when the previous promise completed or the token canceled, and the waiter has already been added, so there are no race conditions.
+                    // _next is guaranteed to be non-null here, so we can call HandleNext instead of MaybeHandleNext.
                     HandleNext(_next);
 
                     ts_currentContext = currentContext;
@@ -977,16 +1086,16 @@ namespace Proto.Promises
                             return InvalidAwaitSentinel.s_instance;
                         }
 
-                        if (_synchronizationContext == ts_currentContext)
+                        if (ShouldContinueSynchronous())
                         {
-                            State = _previousState;
+                            SetCompletionState();
                             previousWaiter = waiter;
                             return null;
                         }
                         ScheduleForHandle(this, _synchronizationContext);
                     }
                     previousWaiter = null;
-                    return this; // It doesn't matter what we return since previousWaiter is set to null.
+                    return null; // It doesn't matter what we return since previousWaiter is set to null.
                 }
 
                 internal override bool GetIsCompleted(short promiseId)
@@ -994,11 +1103,11 @@ namespace Proto.Promises
                     ValidateId(promiseId, this, 2);
                     ThrowIfInPool(this);
                     // Make sure the continuation happens on the synchronization context.
-                    if (_synchronizationContext == ts_currentContext
+                    if (ShouldContinueSynchronous()
                         && CompareExchangeWaiter(InvalidAwaitSentinel.s_instance, PromiseCompletionSentinel.s_instance) == PromiseCompletionSentinel.s_instance)
                     {
                         WasAwaitedOrForgotten = true;
-                        State = _previousState;
+                        SetCompletionState();
                         return true;
                     }
                     return false;
@@ -1658,9 +1767,9 @@ namespace Proto.Promises
             {
                 if (promise != null)
                 {
-                    // TODO: suppress rejection before dispose.
-                    promise.MaybeMarkAwaitedAndDispose(id);
+                    // Suppress rejection before dispose, since the dispose checks the flag. This may still set the flag if the id doesn't match, but that's not a big deal if it happens.
                     promise.SuppressRejection = suppressRejection;
+                    promise.MaybeMarkAwaitedAndDispose(id);
                 }
             }
         } // PromiseRefBase

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -945,7 +945,6 @@ namespace Proto.Promises
                         ?? new PromiseConfigured<TResult>();
                     promise.Reset(depth);
                     promise._synchronizationContext = synchronizationContext;
-                    promise._isScheduling = 0;
                     promise._wasCanceled = false;
                     return promise;
                 }
@@ -953,6 +952,7 @@ namespace Proto.Promises
                 internal static PromiseConfigured<TResult> GetOrCreate(SynchronizationContext synchronizationContext, ushort depth, CancelationToken cancelationToken)
                 {
                     var promise = GetOrCreateBase(synchronizationContext, depth, cancelationToken);
+                    promise._isScheduling = 0;
                     promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
                     return promise;
                 }
@@ -964,6 +964,7 @@ namespace Proto.Promises
                     TResult result, ushort depth, CancelationToken cancelationToken)
                 {
                     var promise = GetOrCreateBase(synchronizationContext, depth, cancelationToken);
+                    promise._isScheduling = 1;
                     promise._result = result;
                     promise._previousState = Promise.State.Resolved;
                     promise._next = PromiseCompletionSentinel.s_instance;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -935,6 +935,12 @@ namespace Proto.Promises
 
                 private static PromiseConfigured<TResult> GetOrCreateBase(SynchronizationContext synchronizationContext, ushort depth, CancelationToken cancelationToken)
                 {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    if (synchronizationContext == null)
+                    {
+                        throw new InvalidOperationException("synchronizationContext cannot be null");
+                    }
+#endif
                     var promise = ObjectPool.TryTake<PromiseConfigured<TResult>>()
                         ?? new PromiseConfigured<TResult>();
                     promise.Reset(depth);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -886,12 +886,6 @@ namespace Proto.Promises
 
                 internal static PromiseConfigured<TResult> GetOrCreate(SynchronizationContext synchronizationContext, ushort depth)
                 {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    if (synchronizationContext == null)
-                    {
-                        throw new InvalidOperationException("synchronizationContext cannot be null");
-                    }
-#endif
                     var promise = ObjectPool.TryTake<PromiseConfigured<TResult>>()
                         ?? new PromiseConfigured<TResult>();
                     promise.Reset(depth);
@@ -920,12 +914,6 @@ namespace Proto.Promises
 
                 internal override PromiseRef<TResult> GetConfiguredT(short promiseId, SynchronizationContext synchronizationContext, ushort depth)
                 {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    if (synchronizationContext == null)
-                    {
-                        throw new InvalidOperationException("synchronizationContext cannot be null");
-                    }
-#endif
                     // This isn't strictly thread-safe, but when the next promise is awaited, the CompareExchange should catch it if this is used improperly.
                     ValidateIdAndNotAwaited(promiseId);
                     _smallFields.IncrementPromiseId();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
@@ -88,14 +88,5 @@ namespace Proto.Promises
                 internal override void MaybeMarkAwaitedAndDispose(short promiseId) { throw new System.InvalidOperationException(); }
             }
         } // PromiseRefBase
-
-        internal class BackgroundSynchronizationContextSentinel : SynchronizationContext
-        {
-            internal static readonly BackgroundSynchronizationContextSentinel s_instance = new BackgroundSynchronizationContextSentinel();
-
-            public override void Post(SendOrPostCallback d, object state) { throw new System.InvalidOperationException(); }
-            public override void Send(SendOrPostCallback d, object state) { throw new System.InvalidOperationException(); }
-            public override SynchronizationContext CreateCopy() { throw new System.InvalidOperationException(); }
-        }
     } // Internal
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
@@ -87,5 +87,14 @@ namespace Proto.Promises
                 internal override void MaybeMarkAwaitedAndDispose(short promiseId) { throw new System.InvalidOperationException(); }
             }
         } // PromiseRefBase
+
+        internal class BackgroundSynchronizationContextSentinel : SynchronizationContext
+        {
+            internal static readonly BackgroundSynchronizationContextSentinel s_instance = new BackgroundSynchronizationContextSentinel();
+
+            public override void Post(SendOrPostCallback d, object state) { throw new System.InvalidOperationException(); }
+            public override void Send(SendOrPostCallback d, object state) { throw new System.InvalidOperationException(); }
+            public override SynchronizationContext CreateCopy() { throw new System.InvalidOperationException(); }
+        }
     } // Internal
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
@@ -68,7 +68,7 @@ namespace Proto.Promises
 
                 private InvalidAwaitSentinel()
                 {
-                    _next = this; // Set _waiter to this so that CompareExchangeWaiter will always fail.
+                    _next = this; // Set _next to this so that CompareExchangeWaiter will always fail.
                     _smallFields = new SmallFields(-5); // Set an id that is unlikely to match (though this should never be used in a Promise struct).
                 }
 
@@ -80,7 +80,6 @@ namespace Proto.Promises
                 protected override void MaybeDispose() { throw new System.InvalidOperationException(); }
                 protected override void OnForget(short promiseId) { throw new System.InvalidOperationException(); }
                 internal override PromiseRefBase AddWaiter(short promiseId, HandleablePromiseBase waiter, out HandleablePromiseBase previousWaiter) { throw new System.InvalidOperationException(); }
-                internal override PromiseRefBase GetConfigured(short promiseId, SynchronizationContext synchronizationContext, ushort depth) { throw new System.InvalidOperationException(); }
                 internal override PromiseRefBase GetDuplicate(short promiseId, ushort depth) { throw new System.InvalidOperationException(); }
                 internal override bool GetIsCompleted(short promiseId) { throw new System.InvalidOperationException(); }
                 internal override bool GetIsValid(short promiseId) { throw new System.InvalidOperationException(); }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
@@ -127,24 +127,36 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Mark this as awaited and schedule the next continuation to execute on the context of the provided option. Returns a new <see cref="Promise"/>.
+        /// Mark this as awaited and schedule the next continuation to execute on the context of the provided option.
+        /// Returns a new <see cref="Promise"/> that inherits the state of this, or will be canceled if/when the <paramref name="cancelationToken"/> is canceled before the continuation is invoked.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
-        public Promise WaitAsync(SynchronizationOption continuationOption)
+        public Promise WaitAsync(SynchronizationOption continuationOption, CancelationToken cancelationToken = default(CancelationToken))
         {
             ValidateOperation(1);
-            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, (Internal.SynchronizationOption) continuationOption, null);
+            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, (Internal.SynchronizationOption) continuationOption, null, cancelationToken);
         }
 
         /// <summary>
-        /// Mark this as awaited and schedule the next continuation to execute on <paramref name="continuationContext"/>. Returns a new <see cref="Promise"/>.
+        /// Mark this as awaited and schedule the next continuation to execute on <paramref name="continuationContext"/>.
+        /// Returns a new <see cref="Promise"/> that inherits the state of this, or will be canceled if/when the <paramref name="cancelationToken"/> is canceled before the continuation is invoked.
         /// <para/>If <paramref name="continuationContext"/> is null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
-        public Promise WaitAsync(SynchronizationContext continuationContext)
+        public Promise WaitAsync(SynchronizationContext continuationContext, CancelationToken cancelationToken = default(CancelationToken))
         {
             ValidateOperation(1);
-            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, Internal.SynchronizationOption.Explicit, continuationContext);
+            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, Internal.SynchronizationOption.Explicit, continuationContext, cancelationToken);
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="Promise"/> that inherits the state of this, or will be canceled if/when the <paramref name="cancelationToken"/> is canceled before the continuation is invoked.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise WaitAsync(CancelationToken cancelationToken)
+        {
+            ValidateOperation(1);
+            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, cancelationToken);
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
@@ -1,4 +1,10 @@
-﻿#pragma warning disable IDE0034 // Simplify 'default' expression
+﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+#pragma warning disable IDE0034 // Simplify 'default' expression
 #pragma warning disable CA1507 // Use nameof to express symbol names
 #pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -168,22 +168,36 @@ namespace Proto.Promises
         }
 
         /// <summary>
-        /// Mark this as awaited and schedule the next continuation to execute on the context of the provided option. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/>.
+        /// Mark this as awaited and schedule the next continuation to execute on the context of the provided <paramref name="continuationOption"/>.
+        /// Returns a new <see cref="Promise{T}"/> that inherits the state of this, or will be canceled if/when the <paramref name="cancelationToken"/> is canceled before the continuation is invoked.
+        /// If the <paramref name="cancelationToken"/> is canceled before this is complete, the cancelation will propagate on the context of the provided <paramref name="continuationOption"/>.
         /// </summary>
-        public Promise<T> WaitAsync(SynchronizationOption continuationOption)
+        public Promise<T> WaitAsync(SynchronizationOption continuationOption, CancelationToken cancelationToken = default(CancelationToken))
         {
             ValidateOperation(1);
-            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, (Internal.SynchronizationOption) continuationOption, null);
+            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, (Internal.SynchronizationOption) continuationOption, null, cancelationToken);
         }
 
         /// <summary>
-        /// Mark this as awaited and schedule the next continuation to execute on <paramref name="continuationContext"/>. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/>.
+        /// Mark this as awaited and schedule the next continuation to execute on <paramref name="continuationContext"/>.
+        /// Returns a new <see cref="Promise{T}"/> that inherits the state of this, or will be canceled if/when the <paramref name="cancelationToken"/> is canceled before the continuation is invoked.
+        /// If the <paramref name="cancelationToken"/> is canceled before this is complete, the cancelation will propagate on the <paramref name="continuationContext"/>.
         /// <para/>If <paramref name="continuationContext"/> is null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.
         /// </summary>
-        public Promise<T> WaitAsync(SynchronizationContext continuationContext)
+        public Promise<T> WaitAsync(SynchronizationContext continuationContext, CancelationToken cancelationToken = default(CancelationToken))
         {
             ValidateOperation(1);
-            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, Internal.SynchronizationOption.Explicit, continuationContext);
+            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, Internal.SynchronizationOption.Explicit, continuationContext, cancelationToken);
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="Promise{T}"/> that inherits the state of this, or will be canceled if/when the <paramref name="cancelationToken"/> is canceled before the continuation is invoked.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise<T> WaitAsync(CancelationToken cancelationToken)
+        {
+            ValidateOperation(1);
+            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, cancelationToken);
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
@@ -1,4 +1,10 @@
-﻿#pragma warning disable IDE0034 // Simplify 'default' expression
+﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+#pragma warning disable IDE0034 // Simplify 'default' expression
 #pragma warning disable CA1507 // Use nameof to express symbol names
 #pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/PromiseCancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/PromiseCancelationTests.cs
@@ -1970,166 +1970,150 @@ namespace ProtoPromiseTests.APIs
                 promise.Forget();
             }
 
-            private const string expectedRejection = "Reject";
-            private Action<UnhandledException> previousRejectionHandler;
-
-            private void SetupExpectedUncaughtRejections()
+            public class Reject
             {
-                // When a callback is canceled and the previous promise is rejected, the rejection is unhandled.
-                // So we need to suppress that here and make sure it's correct.
-                previousRejectionHandler = Promise.Config.UncaughtRejectionHandler;
-                Promise.Config.UncaughtRejectionHandler = e => Assert.AreEqual(expectedRejection, e.Value);
-            }
 
-            private void CleanupExpectedUncaughtRejections()
-            {
-                Promise.Config.UncaughtRejectionHandler = previousRejectionHandler;
-            }
+                private const string expectedRejection = "Reject";
 
-            [Test]
-            public void OnRejectedIsNotInvokedIfTokenIsCanceled_void()
-            {
-                SetupExpectedUncaughtRejections();
+                [SetUp]
+                public void Setup()
+                {
+                    // When a callback is canceled and the previous promise is rejected, the rejection is unhandled.
+                    // So we set the expected uncaught reject value.
+                    TestHelper.s_expectedUncaughtRejectValue = expectedRejection;
 
-                CancelationSource cancelationSource = CancelationSource.New();
+                    TestHelper.Setup();
+                }
 
-                var deferred = Promise.NewDeferred();
+                [TearDown]
+                public void Teardown()
+                {
+                    TestHelper.Cleanup();
 
-                TestHelper.AddCallbacksWithCancelation<float, object, string>(
-                    deferred.Promise,
-                    onReject: _ => Assert.Fail("OnRejected was invoked."),
-                    onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
-                    onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
-                    onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
-                    cancelationToken: cancelationSource.Token
-                );
+                    TestHelper.s_expectedUncaughtRejectValue = null;
+                }
 
-                cancelationSource.Cancel();
-                deferred.Reject(expectedRejection);
+                [Test]
+                public void OnRejectedIsNotInvokedIfTokenIsCanceled_void()
+                {
+                    CancelationSource cancelationSource = CancelationSource.New();
 
-                cancelationSource.Dispose();
+                    var deferred = Promise.NewDeferred();
 
-                CleanupExpectedUncaughtRejections();
-            }
+                    TestHelper.AddCallbacksWithCancelation<float, object, string>(
+                        deferred.Promise,
+                        onReject: _ => Assert.Fail("OnRejected was invoked."),
+                        onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
+                        onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
+                        onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
+                        cancelationToken: cancelationSource.Token
+                    );
 
-            [Test]
-            public void OnRejectedIsNotInvokedIfTokenIsCanceled_T()
-            {
-                SetupExpectedUncaughtRejections();
+                    cancelationSource.Cancel();
+                    deferred.Reject(expectedRejection);
 
-                CancelationSource cancelationSource = CancelationSource.New();
+                    cancelationSource.Dispose();
+                }
 
-                var deferred = Promise.NewDeferred<int>();
+                [Test]
+                public void OnRejectedIsNotInvokedIfTokenIsCanceled_T()
+                {
+                    CancelationSource cancelationSource = CancelationSource.New();
 
-                TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
-                    deferred.Promise,
-                    onReject: _ => Assert.Fail("OnRejected was invoked."),
-                    onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
-                    onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
-                    onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
-                    cancelationToken: cancelationSource.Token
-                );
+                    var deferred = Promise.NewDeferred<int>();
 
-                cancelationSource.Cancel();
-                deferred.Reject(expectedRejection);
+                    TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
+                        deferred.Promise,
+                        onReject: _ => Assert.Fail("OnRejected was invoked."),
+                        onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
+                        onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
+                        onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
+                        cancelationToken: cancelationSource.Token
+                    );
 
-                cancelationSource.Dispose();
+                    cancelationSource.Cancel();
+                    deferred.Reject(expectedRejection);
 
-                CleanupExpectedUncaughtRejections();
-            }
+                    cancelationSource.Dispose();
+                }
 
-            [Test]
-            public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_void0()
-            {
-                SetupExpectedUncaughtRejections();
+                [Test]
+                public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_void0()
+                {
+                    CancelationSource cancelationSource = CancelationSource.New();
+                    cancelationSource.Cancel();
 
-                CancelationSource cancelationSource = CancelationSource.New();
-                cancelationSource.Cancel();
+                    var deferred = Promise.NewDeferred();
 
-                var deferred = Promise.NewDeferred();
+                    TestHelper.AddCallbacksWithCancelation<float, object, string>(
+                        deferred.Promise,
+                        onReject: _ => Assert.Fail("OnRejected was invoked."),
+                        onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
+                        onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
+                        onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
+                        cancelationToken: cancelationSource.Token
+                    );
 
-                TestHelper.AddCallbacksWithCancelation<float, object, string>(
-                    deferred.Promise,
-                    onReject: _ => Assert.Fail("OnRejected was invoked."),
-                    onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
-                    onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
-                    onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
-                    cancelationToken: cancelationSource.Token
-                );
+                    deferred.Reject(expectedRejection);
 
-                deferred.Reject(expectedRejection);
+                    cancelationSource.Dispose();
+                }
 
-                cancelationSource.Dispose();
+                [Test]
+                public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_void1()
+                {
+                    var deferred = Promise.NewDeferred();
 
-                CleanupExpectedUncaughtRejections();
-            }
+                    TestHelper.AddCallbacksWithCancelation<float, object, string>(
+                        deferred.Promise,
+                        onReject: _ => Assert.Fail("OnRejected was invoked."),
+                        onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
+                        onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
+                        onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
+                        cancelationToken: Proto.Promises.CancelationToken.Canceled()
+                    );
 
-            [Test]
-            public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_void1()
-            {
-                SetupExpectedUncaughtRejections();
+                    deferred.Reject(expectedRejection);
+                }
 
-                var deferred = Promise.NewDeferred();
+                [Test]
+                public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_T0()
+                {
+                    CancelationSource cancelationSource = CancelationSource.New();
+                    cancelationSource.Cancel();
 
-                TestHelper.AddCallbacksWithCancelation<float, object, string>(
-                    deferred.Promise,
-                    onReject: _ => Assert.Fail("OnRejected was invoked."),
-                    onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
-                    onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
-                    onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
-                    cancelationToken: Proto.Promises.CancelationToken.Canceled()
-                );
+                    var deferred = Promise.NewDeferred<int>();
 
-                deferred.Reject(expectedRejection);
+                    TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
+                        deferred.Promise,
+                        onReject: _ => Assert.Fail("OnRejected was invoked."),
+                        onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
+                        onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
+                        onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
+                        cancelationToken: cancelationSource.Token
+                    );
 
-                CleanupExpectedUncaughtRejections();
-            }
+                    deferred.Reject(expectedRejection);
 
-            [Test]
-            public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_T0()
-            {
-                SetupExpectedUncaughtRejections();
+                    cancelationSource.Dispose();
+                }
 
-                CancelationSource cancelationSource = CancelationSource.New();
-                cancelationSource.Cancel();
+                [Test]
+                public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_T1()
+                {
+                    var deferred = Promise.NewDeferred<int>();
 
-                var deferred = Promise.NewDeferred<int>();
+                    TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
+                        deferred.Promise,
+                        onReject: _ => Assert.Fail("OnRejected was invoked."),
+                        onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
+                        onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
+                        onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
+                        cancelationToken: Proto.Promises.CancelationToken.Canceled()
+                    );
 
-                TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
-                    deferred.Promise,
-                    onReject: _ => Assert.Fail("OnRejected was invoked."),
-                    onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
-                    onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
-                    onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
-                    cancelationToken: cancelationSource.Token
-                );
-
-                deferred.Reject(expectedRejection);
-
-                cancelationSource.Dispose();
-
-                CleanupExpectedUncaughtRejections();
-            }
-
-            [Test]
-            public void OnRejectedIsNotInvokedIfTokenIsAlreadyCanceled_T1()
-            {
-                SetupExpectedUncaughtRejections();
-
-                var deferred = Promise.NewDeferred<int>();
-
-                TestHelper.AddCallbacksWithCancelation<int, float, object, string>(
-                    deferred.Promise,
-                    onReject: _ => Assert.Fail("OnRejected was invoked."),
-                    onUnknownRejection: () => Assert.Fail("OnRejected was invoked."),
-                    onRejectCapture: _ => Assert.Fail("OnRejected was invoked."),
-                    onUnknownRejectionCapture: _ => Assert.Fail("OnRejected was invoked."),
-                    cancelationToken: Proto.Promises.CancelationToken.Canceled()
-                );
-
-                deferred.Reject(expectedRejection);
-
-                CleanupExpectedUncaughtRejections();
+                    deferred.Reject(expectedRejection);
+                }
             }
 
             [Test]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/WaitAsyncTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/WaitAsyncTests.cs
@@ -25,25 +25,23 @@ namespace ProtoPromiseTests.APIs
         }
 
         const string rejectValue = "Fail";
-        Action<UnhandledException> currentHandler;
 
         [SetUp]
         public void Setup()
         {
-            TestHelper.Setup();
-
             // When a promise is canceled, the previous rejected promise is unhandled, so its rejection is sent to the UncaughtRejectionHandler.
-            // So we need to suppress that here and make sure it's correct.
-            currentHandler = Promise.Config.UncaughtRejectionHandler;
-            Promise.Config.UncaughtRejectionHandler = e => Assert.AreEqual(rejectValue, e.Value);
+            // So we set the expected uncaught reject value.
+            TestHelper.s_expectedUncaughtRejectValue = rejectValue;
+
+            TestHelper.Setup();
         }
 
         [TearDown]
         public void Teardown()
         {
-            Promise.Config.UncaughtRejectionHandler = currentHandler;
-
             TestHelper.Cleanup();
+
+            TestHelper.s_expectedUncaughtRejectValue = null;
         }
 
         private static IEnumerable<TestCaseData> GetArgs(CompleteType[] completeTypes)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/AllConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/AllConcurrencyTests.cs
@@ -17,25 +17,23 @@ namespace ProtoPromiseTests.Threading
     public class AllConcurrencyTests
     {
         const string rejectValue = "Fail";
-        Action<UnhandledException> currentHandler;
 
         [SetUp]
         public void Setup()
         {
-            TestHelper.Setup();
-
             // When 2 or more promises are rejected, the remaining rejects are sent to the UncaughtRejectionHandler.
-            // So we need to suppress that here and make sure it's correct.
-            currentHandler = Promise.Config.UncaughtRejectionHandler;
-            Promise.Config.UncaughtRejectionHandler = e => Assert.AreEqual(rejectValue, e.Value);
+            // So we set the expected uncaught reject value.
+            TestHelper.s_expectedUncaughtRejectValue = rejectValue;
+
+            TestHelper.Setup();
         }
 
         [TearDown]
         public void Teardown()
         {
-            Promise.Config.UncaughtRejectionHandler = currentHandler;
-
             TestHelper.Cleanup();
+
+            TestHelper.s_expectedUncaughtRejectValue = null;
         }
 
         [Test]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/ApiWithCancelationTokenConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/ApiWithCancelationTokenConcurrencyTests.cs
@@ -17,25 +17,23 @@ namespace ProtoPromiseTests.Threading
     public class ApiWithCancelationTokenConcurrencyTests
     {
         const int rejectValue = 1;
-        Action<UnhandledException> currentHandler;
 
         [SetUp]
         public void Setup()
         {
-            TestHelper.Setup();
-
             // When a callback is canceled and the previous promise is rejected, the rejection is unhandled.
-            // So we need to suppress that here and make sure it's correct.
-            currentHandler = Promise.Config.UncaughtRejectionHandler;
-            Promise.Config.UncaughtRejectionHandler = e => Assert.AreEqual(rejectValue, e.Value);
+            // So we set the expected uncaught reject value.
+            TestHelper.s_expectedUncaughtRejectValue = rejectValue;
+
+            TestHelper.Setup();
         }
 
         [TearDown]
         public void Teardown()
         {
-            TestHelper.WaitForAllThreadsAndReplaceRejectionHandler(currentHandler);
-
             TestHelper.Cleanup();
+
+            TestHelper.s_expectedUncaughtRejectValue = null;
         }
 
         [Test]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/FirstConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/FirstConcurrencyTests.cs
@@ -17,25 +17,23 @@ namespace ProtoPromiseTests.Threading
     public class FirstConcurrencyTests
     {
         const string rejectValue = "Fail";
-        Action<UnhandledException> currentHandler;
 
         [SetUp]
         public void Setup()
         {
-            TestHelper.Setup();
-
             // When 2 or more promises are rejected, the remaining rejects are sent to the UncaughtRejectionHandler.
-            // So we need to suppress that here and make sure it's correct.
-            currentHandler = Promise.Config.UncaughtRejectionHandler;
-            Promise.Config.UncaughtRejectionHandler = e => Assert.AreEqual(rejectValue, e.Value);
+            // So we set the expected uncaught reject value.
+            TestHelper.s_expectedUncaughtRejectValue = rejectValue;
+
+            TestHelper.Setup();
         }
 
         [TearDown]
         public void Teardown()
         {
-            TestHelper.WaitForAllThreadsAndReplaceRejectionHandler(currentHandler);
-
             TestHelper.Cleanup();
+
+            TestHelper.s_expectedUncaughtRejectValue = null;
         }
 
         [Test]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/MergeConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/MergeConcurrencyTests.cs
@@ -16,25 +16,23 @@ namespace ProtoPromiseTests.Threading
     public class MergeConcurrencyTests
     {
         const string rejectValue = "Fail";
-        Action<UnhandledException> currentHandler;
 
         [SetUp]
         public void Setup()
         {
-            TestHelper.Setup();
-
             // When 2 or more promises are rejected, the remaining rejects are sent to the UncaughtRejectionHandler.
-            // So we need to suppress that here and make sure it's correct.
-            currentHandler = Promise.Config.UncaughtRejectionHandler;
-            Promise.Config.UncaughtRejectionHandler = e => Assert.AreEqual(rejectValue, e.Value);
+            // So we set the expected uncaught reject value.
+            TestHelper.s_expectedUncaughtRejectValue = rejectValue;
+
+            TestHelper.Setup();
         }
 
         [TearDown]
         public void Teardown()
         {
-            TestHelper.WaitForAllThreadsAndReplaceRejectionHandler(currentHandler);
-
             TestHelper.Cleanup();
+
+            TestHelper.s_expectedUncaughtRejectValue = null;
         }
 
         [Test]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/RaceConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/RaceConcurrencyTests.cs
@@ -17,25 +17,23 @@ namespace ProtoPromiseTests.Threading
     public class RaceConcurrencyTests
     {
         const string rejectValue = "Fail";
-        Action<UnhandledException> currentHandler;
 
         [SetUp]
         public void Setup()
         {
-            TestHelper.Setup();
-
             // When 2 or more promises are rejected, the remaining rejects are sent to the UncaughtRejectionHandler.
-            // So we need to suppress that here and make sure it's correct.
-            currentHandler = Promise.Config.UncaughtRejectionHandler;
-            Promise.Config.UncaughtRejectionHandler = e => Assert.AreEqual(rejectValue, e.Value);
+            // So we set the expected uncaught reject value.
+            TestHelper.s_expectedUncaughtRejectValue = rejectValue;
+
+            TestHelper.Setup();
         }
 
         [TearDown]
         public void Teardown()
         {
-            TestHelper.WaitForAllThreadsAndReplaceRejectionHandler(currentHandler);
-
             TestHelper.Cleanup();
+
+            TestHelper.s_expectedUncaughtRejectValue = null;
         }
 
         [Test]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/WaitAsyncConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/WaitAsyncConcurrencyTests.cs
@@ -1,0 +1,339 @@
+﻿using NUnit.Framework;
+using Proto.Promises;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace ProtoPromiseTests.Threading
+{
+    public class WaitAsyncConcurrencyTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            TestHelper.Setup();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            TestHelper.Cleanup();
+        }
+
+        public enum ContinuationType
+        {
+            ContinueWith,
+            Await
+        }
+
+        private static IEnumerable<TestCaseData> GetArgs()
+        {
+            var waitTypes = new ConfigureAwaitType[]
+            {
+                ConfigureAwaitType.None,
+                ConfigureAwaitType.Synchronous,
+                ConfigureAwaitType.Foreground,
+#if !UNITY_WEBGL
+                ConfigureAwaitType.Background,
+#endif
+                // ConfigureAwaitType.Explicit // Skip explicit to reduce number of tests.
+            };
+            var waitAsyncPlaces = new ActionPlace[]
+            {
+                ActionPlace.InSetup,
+                ActionPlace.Parallel,
+                ActionPlace.InTeardown
+            };
+
+            var continuationTypes = new ContinuationType[]
+            {
+                ContinuationType.ContinueWith
+#if CSHARP_7_3_OR_NEWER
+                , ContinuationType.Await
+#endif
+            };
+
+            foreach (var waitType in waitTypes)
+            foreach (var waitAsyncPlace in waitAsyncPlaces)
+            foreach (var continuePlace in GetContinuePlace(waitAsyncPlace))
+            foreach (var continuationType in continuationTypes)
+            {
+                yield return new TestCaseData(waitType, waitAsyncPlace, continuePlace, true, continuationType);
+                yield return new TestCaseData(waitType, waitAsyncPlace, continuePlace, false, continuationType);
+            }
+        }
+
+        private static IEnumerable<ActionPlace> GetContinuePlace(ActionPlace waitAsyncPlace)
+        {
+            if (waitAsyncPlace == ActionPlace.InSetup)
+            {
+                yield return ActionPlace.InSetup;
+            }
+            if (waitAsyncPlace != ActionPlace.InTeardown)
+            {
+                yield return ActionPlace.Parallel;
+            }
+            yield return ActionPlace.InTeardown;
+        }
+
+        private readonly TimeSpan timeout = TimeSpan.FromSeconds(2);
+
+        [Test, TestCaseSource("GetArgs")]
+        public void WaitAsyncContinuationWillBeInvokedOnTheCorrectContext_Concurrent_void(
+            ConfigureAwaitType waitType,
+            ActionPlace waitAsyncSubscribePlace,
+            ActionPlace continuePlace,
+            bool withCancelation,
+            ContinuationType continuationType)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            
+            var cancelationSource = default(CancelationSource);
+            var cancelationToken = default(CancelationToken);
+            var deferred = default(Promise.Deferred);
+            var promise = default(Promise);
+
+            bool didContinue = false;
+
+            Action SubscribeContinuation = () =>
+            {
+#if CSHARP_7_3_OR_NEWER
+                if (continuationType == ContinuationType.Await)
+                {
+                    Await().Forget();
+
+                    async Promise Await()
+                    {
+                        try
+                        {
+                            await promise;
+                        }
+                        catch (OperationCanceledException) { }
+                        finally
+                        {
+                            // None and Synchronous don't care about the continuation context.
+                            if (waitType != ConfigureAwaitType.None && waitType != ConfigureAwaitType.Synchronous)
+                            {
+                                TestHelper.AssertCallbackContext((SynchronizationType) waitType, SynchronizationType.Background, foregroundThread);
+                            }
+                            didContinue = true;
+                        }
+                    }
+                }
+                else
+#endif
+                {
+                    promise
+                        .ContinueWith(_ =>
+                        {
+                            // None and Synchronous don't care about the continuation context.
+                            if (waitType != ConfigureAwaitType.None && waitType != ConfigureAwaitType.Synchronous)
+                            {
+                                TestHelper.AssertCallbackContext((SynchronizationType) waitType, SynchronizationType.Background, foregroundThread);
+                            }
+                            didContinue = true;
+                        })
+                        .Forget();
+                }
+            };
+
+            var parallelActions = new List<Action>(3)
+            {
+                () => deferred.Resolve()
+            };
+
+            if (withCancelation)
+            {
+                parallelActions.Add(() => cancelationSource.Cancel());
+            }
+
+            if (waitAsyncSubscribePlace == ActionPlace.Parallel && continuePlace == ActionPlace.Parallel)
+            {
+                parallelActions.Add(() =>
+                {
+                    promise = promise.ConfigureAwait(waitType, cancelationToken);
+                    SubscribeContinuation();
+                });
+            }
+            else if (waitAsyncSubscribePlace == ActionPlace.Parallel)
+            {
+                parallelActions.Add(() => promise = promise.ConfigureAwait(waitType, cancelationToken));
+            }
+            else if (continuePlace == ActionPlace.Parallel)
+            {
+                parallelActions.Add(SubscribeContinuation);
+            }
+                
+            var threadHelper = new ThreadHelper();
+            threadHelper.ExecuteParallelActionsWithOffsets(false,
+                setup: () =>
+                {
+                    didContinue = false;
+                    if (withCancelation)
+                    {
+                        cancelationSource = CancelationSource.New();
+                        cancelationToken = cancelationSource.Token;
+                    }
+                    deferred = Promise.NewDeferred();
+                    promise = deferred.Promise;
+                    if (waitAsyncSubscribePlace == ActionPlace.InSetup)
+                    {
+                        promise = promise.ConfigureAwait(waitType, cancelationToken);
+                    }
+                    if (continuePlace == ActionPlace.InSetup)
+                    {
+                        SubscribeContinuation();
+                    }
+                },
+                teardown: () =>
+                {
+                    if (waitAsyncSubscribePlace == ActionPlace.InTeardown)
+                    {
+                        promise = promise.ConfigureAwait(waitType, cancelationToken);
+                    }
+                    if (continuePlace == ActionPlace.InTeardown)
+                    {
+                        SubscribeContinuation();
+                    }
+
+                    TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                    if (!SpinWait.SpinUntil(() => didContinue, timeout))
+                    {
+                        Assert.Fail("Timed out after " + timeout + ", didContinue: " + didContinue);
+                    }
+                    cancelationSource.TryDispose();
+                },
+                actions: parallelActions.ToArray()
+            );
+        }
+
+        [Test, TestCaseSource("GetArgs")]
+        public void WaitAsyncContinuationWillBeInvokedOnTheCorrectContext_Concurrent_T(
+            ConfigureAwaitType waitType,
+            ActionPlace waitAsyncSubscribePlace,
+            ActionPlace continuePlace,
+            bool withCancelation,
+            ContinuationType continuationType)
+        {
+            var foregroundThread = Thread.CurrentThread;
+
+            var cancelationSource = default(CancelationSource);
+            var cancelationToken = default(CancelationToken);
+            var deferred = default(Promise<int>.Deferred);
+            var promise = default(Promise<int>);
+
+            bool didContinue = false;
+
+            Action SubscribeContinuation = () =>
+            {
+#if CSHARP_7_3_OR_NEWER
+                if (continuationType == ContinuationType.Await)
+                {
+                    Await().Forget();
+
+                    async Promise Await()
+                    {
+                        try
+                        {
+                            _ = await promise;
+                        }
+                        catch (OperationCanceledException) { }
+                        finally
+                        {
+                            // None and Synchronous don't care about the continuation context.
+                            if (waitType != ConfigureAwaitType.None && waitType != ConfigureAwaitType.Synchronous)
+                            {
+                                TestHelper.AssertCallbackContext((SynchronizationType) waitType, SynchronizationType.Background, foregroundThread);
+                            }
+                            didContinue = true;
+                        }
+                    }
+                }
+                else
+#endif
+                {
+                    promise
+                        .ContinueWith(_ =>
+                        {
+                            // None and Synchronous don't care about the continuation context.
+                            if (waitType != ConfigureAwaitType.None && waitType != ConfigureAwaitType.Synchronous)
+                            {
+                                TestHelper.AssertCallbackContext((SynchronizationType) waitType, SynchronizationType.Background, foregroundThread);
+                            }
+                            didContinue = true;
+                        })
+                        .Forget();
+                }
+            };
+
+            var parallelActions = new List<Action>(3)
+            {
+                () => deferred.Resolve(1)
+            };
+
+            if (withCancelation)
+            {
+                parallelActions.Add(() => cancelationSource.Cancel());
+            }
+
+            if (waitAsyncSubscribePlace == ActionPlace.Parallel && continuePlace == ActionPlace.Parallel)
+            {
+                parallelActions.Add(() =>
+                {
+                    promise = promise.ConfigureAwait(waitType, cancelationToken);
+                    SubscribeContinuation();
+                });
+            }
+            else if (waitAsyncSubscribePlace == ActionPlace.Parallel)
+            {
+                parallelActions.Add(() => promise = promise.ConfigureAwait(waitType, cancelationToken));
+            }
+            else if (continuePlace == ActionPlace.Parallel)
+            {
+                parallelActions.Add(SubscribeContinuation);
+            }
+
+            var threadHelper = new ThreadHelper();
+            threadHelper.ExecuteParallelActionsWithOffsets(false,
+                setup: () =>
+                {
+                    didContinue = false;
+                    if (withCancelation)
+                    {
+                        cancelationSource = CancelationSource.New();
+                        cancelationToken = cancelationSource.Token;
+                    }
+                    deferred = Promise<int>.NewDeferred();
+                    promise = deferred.Promise;
+                    if (waitAsyncSubscribePlace == ActionPlace.InSetup)
+                    {
+                        promise = promise.ConfigureAwait(waitType, cancelationToken);
+                    }
+                    if (continuePlace == ActionPlace.InSetup)
+                    {
+                        SubscribeContinuation();
+                    }
+                },
+                teardown: () =>
+                {
+                    if (waitAsyncSubscribePlace == ActionPlace.InTeardown)
+                    {
+                        promise = promise.ConfigureAwait(waitType, cancelationToken);
+                    }
+                    if (continuePlace == ActionPlace.InTeardown)
+                    {
+                        SubscribeContinuation();
+                    }
+
+                    TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                    if (!SpinWait.SpinUntil(() => didContinue, timeout))
+                    {
+                        Assert.Fail("Timed out after " + timeout + ", didContinue: " + didContinue);
+                    }
+                    cancelationSource.TryDispose();
+                },
+                actions: parallelActions.ToArray()
+            );
+        }
+    }
+}

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/WaitAsyncConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/WaitAsyncConcurrencyTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿#if !UNITY_WEBGL
+
+using NUnit.Framework;
 using Proto.Promises;
 using System;
 using System.Collections.Generic;
@@ -337,3 +339,5 @@ namespace ProtoPromiseTests.Threading
         }
     }
 }
+
+#endif // !UNITY_WEBGL

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/WaitAsyncConcurrencyTests.cs.meta
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/WaitAsyncConcurrencyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf7a5fe5da99fdb438b582de48279a5c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added `Promise(<T>).WaitAsync(CancelationToken)` APIs.
Added optional `CancelationToken` arguments to existing `WaitAsync` APIs.

Resolves #11.