### PR TITLE
Fix potential cancelation race conditions

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationRegistration.cs
@@ -129,7 +129,7 @@ namespace Proto.Promises
         /// <summary>Returns a value indicating whether two <see cref="CancelationRegistration"/> values are equal.</summary>
         public static bool operator ==(CancelationRegistration lhs, CancelationRegistration rhs)
         {
-            return lhs._node == rhs._node & lhs._nodeId == rhs._nodeId & lhs._tokenId == rhs._tokenId;
+            return lhs._ref == rhs._ref & lhs._node == rhs._node & lhs._nodeId == rhs._nodeId & lhs._tokenId == rhs._tokenId;
         }
 
         /// <summary>Returns a value indicating whether two <see cref="CancelationRegistration"/> values are not equal.</summary>


### PR DESCRIPTION
Added an extra check in case of a torn CancelationRegistration.
Removed dispose if the BCL source was disposed in case of a rare race condition causing issues.
Fixed CancelationRegistration operator ==.
Changed cancelation invoke order to LIFO and optimized the loop.