### PR TITLE
Add optional `forceAsync` flag to APIs

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/HelperFunctionsInternal.cs
@@ -31,7 +31,7 @@ namespace Proto.Promises
     {
         // This is used to detect if we're currently executing on the context we're going to schedule to, so we can just invoke synchronously instead.
         [ThreadStatic]
-        private static SynchronizationContext ts_currentContext;
+        internal static SynchronizationContext ts_currentContext;
 
         private static readonly SendOrPostCallback s_synchronizationContextHandleCallback = HandleFromContext;
         private static readonly WaitCallback s_threadPoolHandleCallback = HandleFromContext;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -228,6 +228,7 @@ namespace Proto.Promises
                 private int _isScheduling; // Flag used so that only Cancel() or Handle() will call CompareExchangeWaiter and schedule the continuation. Int for Interlocked.
                 volatile private bool _wasCanceled;
                 volatile private Promise.State _previousState;
+                private bool _forceAsync;
             }
 
             partial class PromiseMultiAwait<TResult> : PromiseRef<TResult>
@@ -476,6 +477,7 @@ namespace Proto.Promises
                 volatile private bool _canceled;
                 volatile private Promise.State _previousState;
                 private bool _isSynchronous;
+                private bool _forceAsync;
             }
 #endif
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -169,25 +169,28 @@ namespace Proto.Promises
 
         /// <summary>
         /// Mark this as awaited and schedule the next continuation to execute on the context of the provided <paramref name="continuationOption"/>.
-        /// Returns a new <see cref="Promise{T}"/> that inherits the state of this, or will be canceled if/when the <paramref name="cancelationToken"/> is canceled before the continuation is invoked.
-        /// If the <paramref name="cancelationToken"/> is canceled before this is complete, the cancelation will propagate on the context of the provided <paramref name="continuationOption"/>.
+        /// Returns a new <see cref="Promise{T}"/> that inherits the state of this, or will be canceled if/when the <paramref name="cancelationToken"/> is canceled before this is complete.
         /// </summary>
-        public Promise<T> WaitAsync(SynchronizationOption continuationOption, CancelationToken cancelationToken = default(CancelationToken))
+        /// <param name="continuationOption">Indicates on which context the next continuation will be executed.</param>
+        /// <param name="forceAsync">If true, forces the next continuation to be invoked asynchronously. If <paramref name="continuationOption"/> is <see cref="SynchronizationOption.Synchronous"/>, this value will be ignored.</param>
+        /// <param name="cancelationToken">If canceled before this is complete, the returned <see cref="Promise{T}"/> will be canceled, and the cancelation will propagate on the context of the provided <paramref name="continuationOption"/>.</param>
+        public Promise<T> WaitAsync(SynchronizationOption continuationOption, bool forceAsync = false, CancelationToken cancelationToken = default(CancelationToken))
         {
             ValidateOperation(1);
-            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, (Internal.SynchronizationOption) continuationOption, null, cancelationToken);
+            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, (Internal.SynchronizationOption) continuationOption, null, forceAsync, cancelationToken);
         }
 
         /// <summary>
         /// Mark this as awaited and schedule the next continuation to execute on <paramref name="continuationContext"/>.
-        /// Returns a new <see cref="Promise{T}"/> that inherits the state of this, or will be canceled if/when the <paramref name="cancelationToken"/> is canceled before the continuation is invoked.
-        /// If the <paramref name="cancelationToken"/> is canceled before this is complete, the cancelation will propagate on the <paramref name="continuationContext"/>.
-        /// <para/>If <paramref name="continuationContext"/> is null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.
+        /// Returns a new <see cref="Promise{T}"/> that inherits the state of this, or will be canceled if/when the <paramref name="cancelationToken"/> is canceled before this is complete.
         /// </summary>
-        public Promise<T> WaitAsync(SynchronizationContext continuationContext, CancelationToken cancelationToken = default(CancelationToken))
+        /// <param name="continuationContext">The context on which context the next continuation will be executed. If null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.</param>
+        /// <param name="forceAsync">If true, forces the next continuation to be invoked asynchronously.</param>
+        /// <param name="cancelationToken">If canceled before this is complete, the returned <see cref="Promise{T}"/> will be canceled, and the cancelation will propagate on the provided <paramref name="continuationContext"/>.</param>
+        public Promise<T> WaitAsync(SynchronizationContext continuationContext, bool forceAsync = false, CancelationToken cancelationToken = default(CancelationToken))
         {
             ValidateOperation(1);
-            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, Internal.SynchronizationOption.Explicit, continuationContext, cancelationToken);
+            return Internal.PromiseRefBase.CallbackHelperVoid.WaitAsync(this, Internal.SynchronizationOption.Explicit, continuationContext, forceAsync, cancelationToken);
         }
 
         /// <summary>
@@ -202,14 +205,15 @@ namespace Proto.Promises
 
         /// <summary>
         /// Add a progress listener. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/>.
-        /// <para/><paramref name="progressListener"/> will be reported with progress that is normalized between 0 and 1 on the context of the provided option.
         /// 
         /// <para/>If/when this is resolved, <paramref name="progressListener"/> will be invoked with 1.0, then the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
         /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
-        /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, progress will stop being reported.
         /// </summary>
+        /// <param name="progressListener">Will be reported with progress that is normalized between 0 and 1 on the context of the provided option.</param>
+        /// <param name="invokeOption">Indicates on which context <paramref name="progressListener"/> will be reported.</param>
+        /// <param name="forceAsync">If true, forces progress invoke to happen asynchronously. If <paramref name="invokeOption"/> is <see cref="SynchronizationOption.Synchronous"/>, this value will be ignored.</param>
+        /// <param name="cancelationToken">If canceled while this is pending, progress will stop being reported. This will not cancel the returned <see cref="Promise"/>.</param>
 #if !PROMISE_PROGRESS
         [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
@@ -218,7 +222,7 @@ namespace Proto.Promises
 #else
         public
 #endif
-            Promise<T> Progress<TProgress>(TProgress progressListener, SynchronizationOption invokeOption = SynchronizationOption.Foreground, CancelationToken cancelationToken = default(CancelationToken))
+            Promise<T> Progress<TProgress>(TProgress progressListener, SynchronizationOption invokeOption = SynchronizationOption.Foreground, CancelationToken cancelationToken = default(CancelationToken), bool forceAsync = false)
             where TProgress : IProgress<float>
         {
             ValidateArgument(progressListener, "progressListener", 1);
@@ -228,21 +232,21 @@ namespace Proto.Promises
 #else
             ValidateOperation(1);
 
-            return Internal.PromiseRefBase.CallbackHelperVoid.AddProgress(this, progressListener, cancelationToken, (Internal.SynchronizationOption) invokeOption, null);
+            return Internal.PromiseRefBase.CallbackHelperVoid.AddProgress(this, progressListener, (Internal.SynchronizationOption) invokeOption, null, forceAsync, cancelationToken);
 #endif
         }
 
         /// <summary>
         /// Add a progress listener. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/>.
-        /// <para/><paramref name="progressListener"/> will be reported with progress that is normalized between 0 and 1 on <paramref name="invokeContext"/>.
-        /// <para/>If <paramref name="invokeContext"/> is null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.
         /// 
         /// <para/>If/when this is resolved, <paramref name="progressListener"/> will be invoked with 1.0, then the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
         /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
-        /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, progress will stop being reported.
         /// </summary>
+        /// <param name="progressListener">Will be reported with progress that is normalized between 0 and 1 on the context of the provided option.</param>
+        /// <param name="invokeContext">The context on which <paramref name="progressListener"/> will be reported. If null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.</param>
+        /// <param name="forceAsync">If true, forces progress invoke to happen asynchronously.</param>
+        /// <param name="cancelationToken">If canceled while this is pending, progress will stop being reported. This will not cancel the returned <see cref="Promise"/>.</param>
 #if !PROMISE_PROGRESS
         [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
@@ -252,7 +256,7 @@ namespace Proto.Promises
 #else
         public
 #endif
-            Promise<T> Progress<TProgress>(TProgress progressListener, SynchronizationContext invokeContext, CancelationToken cancelationToken = default(CancelationToken))
+            Promise<T> Progress<TProgress>(TProgress progressListener, SynchronizationContext invokeContext, CancelationToken cancelationToken = default(CancelationToken), bool forceAsync = false)
             where TProgress : IProgress<float>
         {
             ValidateArgument(progressListener, "progressListener", 1);
@@ -262,51 +266,52 @@ namespace Proto.Promises
 #else
             ValidateOperation(1);
 
-            return Internal.PromiseRefBase.CallbackHelperVoid.AddProgress(this, progressListener, cancelationToken, Internal.SynchronizationOption.Explicit, invokeContext);
+            return Internal.PromiseRefBase.CallbackHelperVoid.AddProgress(this, progressListener, Internal.SynchronizationOption.Explicit, invokeContext, forceAsync, cancelationToken);
 #endif
         }
 
         /// <summary>
         /// Add a progress listener. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/>.
-        /// <para/><paramref name="onProgress"/> will be invoked with progress that is normalized between 0 and 1 on the context of the provided option.
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with 1.0, then the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
         /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
-        /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
+        /// <param name="onProgress">Will be invoked with progress that is normalized between 0 and 1 on the context of the provided option.</param>
+        /// <param name="invokeOption">Indicates on which context <paramref name="onProgress"/> will be invoked.</param>
+        /// <param name="forceAsync">If true, forces progress invoke to happen asynchronously. If <paramref name="invokeOption"/> is <see cref="SynchronizationOption.Synchronous"/>, this value will be ignored.</param>
+        /// <param name="cancelationToken">If canceled while this is pending, progress will stop being reported. This will not cancel the returned <see cref="Promise"/>.</param>
 #if !PROMISE_PROGRESS
         [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
-        public Promise<T> Progress(Action<float> onProgress, SynchronizationOption invokeOption = SynchronizationOption.Foreground, CancelationToken cancelationToken = default(CancelationToken))
+        public Promise<T> Progress(Action<float> onProgress, SynchronizationOption invokeOption = SynchronizationOption.Foreground, CancelationToken cancelationToken = default(CancelationToken), bool forceAsync = false)
         {
             ValidateArgument(onProgress, "onProgress", 1);
 
-            return Progress(new Internal.PromiseRefBase.DelegateProgress(onProgress), invokeOption, cancelationToken);
+            return Progress(new Internal.PromiseRefBase.DelegateProgress(onProgress), invokeOption, cancelationToken, forceAsync);
         }
 
         /// <summary>
         /// Add a progress listener. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/>.
-        /// <para/><paramref name="onProgress"/> will be invoked with progress that is normalized between 0 and 1 on <paramref name="invokeContext"/>.
-        /// <para/>If <paramref name="invokeContext"/> is null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with 1.0, then the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
         /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
-        /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
+        /// <param name="onProgress">Will be invoked with progress that is normalized between 0 and 1 on the context of the provided option.</param>
+        /// <param name="invokeContext">The context on which <paramref name="onProgress"/> will be invoked. If null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.</param>
+        /// <param name="forceAsync">If true, forces progress invoke to happen asynchronously.</param>
+        /// <param name="cancelationToken">If canceled while this is pending, progress will stop being reported. This will not cancel the returned <see cref="Promise"/>.</param>
 #if !PROMISE_PROGRESS
         [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
-        public Promise<T> Progress(Action<float> onProgress, SynchronizationContext invokeContext, CancelationToken cancelationToken = default(CancelationToken))
+        public Promise<T> Progress(Action<float> onProgress, SynchronizationContext invokeContext, CancelationToken cancelationToken = default(CancelationToken), bool forceAsync = false)
         {
             ValidateArgument(onProgress, "onProgress", 1);
 
-            return Progress(new Internal.PromiseRefBase.DelegateProgress(onProgress), invokeContext, cancelationToken);
+            return Progress(new Internal.PromiseRefBase.DelegateProgress(onProgress), invokeContext, cancelationToken, forceAsync);
         }
 
         /// <summary>
@@ -831,7 +836,7 @@ namespace Proto.Promises
                 .AddResolveRejectWait(this, Internal.PromiseRefBase.DelegateWrapper.Create(onResolved), Internal.PromiseRefBase.DelegateWrapper.Create(onRejected), cancelationToken);
         }
 #endregion
-
+        
 #region Continue Callbacks
         /// <summary>
         /// Add a continuation callback. Returns a new <see cref="Promise"/>.
@@ -893,51 +898,53 @@ namespace Proto.Promises
 
             return Internal.PromiseRefBase.CallbackHelper<T, TResult>.AddContinueWait(this, Internal.PromiseRefBase.DelegateWrapper.Create(onContinue), cancelationToken);
         }
-#endregion
+        #endregion
 
         // Capture values below.
 
         /// <summary>
         /// Capture a value and add a progress listener. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/>.
-        /// <para/><paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and progress that is normalized between 0 and 1 on the context of the provided option.
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
         /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
-        /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
+        /// <param name="onProgress">Will be invoked with progress that is normalized between 0 and 1 on the context of the provided option.</param>
+        /// <param name="invokeOption">Indicates on which context <paramref name="onProgress"/> will be invoked.</param>
+        /// <param name="forceAsync">If true, forces progress invoke to happen asynchronously. If <paramref name="invokeOption"/> is <see cref="SynchronizationOption.Synchronous"/>, this value will be ignored.</param>
+        /// <param name="cancelationToken">If canceled while this is pending, progress will stop being reported. This will not cancel the returned <see cref="Promise"/>.</param>
 #if !PROMISE_PROGRESS
         [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
-        public Promise<T> Progress<TCaptureProgress>(TCaptureProgress progressCaptureValue, Action<TCaptureProgress, float> onProgress, SynchronizationOption invokeOption = SynchronizationOption.Foreground, CancelationToken cancelationToken = default(CancelationToken))
+        public Promise<T> Progress<TCaptureProgress>(TCaptureProgress progressCaptureValue, Action<TCaptureProgress, float> onProgress,
+            SynchronizationOption invokeOption = SynchronizationOption.Foreground, CancelationToken cancelationToken = default(CancelationToken), bool forceAsync = false)
         {
             ValidateArgument(onProgress, "onProgress", 1);
 
-            return Progress(new Internal.PromiseRefBase.DelegateCaptureProgress<TCaptureProgress>(progressCaptureValue, onProgress), invokeOption, cancelationToken);
+            return Progress(new Internal.PromiseRefBase.DelegateCaptureProgress<TCaptureProgress>(progressCaptureValue, onProgress), invokeOption, cancelationToken, forceAsync);
         }
 
         /// <summary>
         /// Capture a value and add a progress listener. Returns a new <see cref="Promise{T}"/> of <typeparamref name="T"/>.
-        /// <para/><paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and progress that is normalized between 0 and 1 on <paramref name="invokeContext"/>.
-        /// <para/>If <paramref name="invokeContext"/> is null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.
         /// 
         /// <para/>If/when this is resolved, <paramref name="onProgress"/> will be invoked with <paramref name="progressCaptureValue"/> and 1.0, then the new <see cref="Promise{T}"/> will be resolved when it returns.
         /// <para/>If/when this is rejected with any reason, the new <see cref="Promise{T}"/> will be rejected with the same reason.
         /// <para/>If/when this is canceled, the new <see cref="Promise{T}"/> will be canceled.
-        /// 
-        /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, <paramref name="onProgress"/> will stop being invoked.
         /// </summary>
+        /// <param name="onProgress">Will be invoked with progress that is normalized between 0 and 1 on the context of the provided option.</param>
+        /// <param name="invokeContext">The context on which <paramref name="onProgress"/> will be invoked. If null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.</param>
+        /// <param name="forceAsync">If true, forces progress invoke to happen asynchronously.</param>
+        /// <param name="cancelationToken">If canceled while this is pending, progress will stop being reported. This will not cancel the returned <see cref="Promise"/>.</param>
 #if !PROMISE_PROGRESS
         [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
         [MethodImpl(Internal.InlineOption)]
-        public Promise<T> Progress<TCaptureProgress>(TCaptureProgress progressCaptureValue, Action<TCaptureProgress, float> onProgress, SynchronizationContext invokeContext, CancelationToken cancelationToken = default(CancelationToken))
+        public Promise<T> Progress<TCaptureProgress>(TCaptureProgress progressCaptureValue, Action<TCaptureProgress, float> onProgress, SynchronizationContext invokeContext, CancelationToken cancelationToken = default(CancelationToken), bool forceAsync = false)
         {
             ValidateArgument(onProgress, "onProgress", 1);
 
-            return Progress(new Internal.PromiseRefBase.DelegateCaptureProgress<TCaptureProgress>(progressCaptureValue, onProgress), invokeContext, cancelationToken);
+            return Progress(new Internal.PromiseRefBase.DelegateCaptureProgress<TCaptureProgress>(progressCaptureValue, onProgress), invokeContext, cancelationToken, forceAsync);
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
@@ -1100,7 +1100,10 @@ namespace Proto.Promises
         /// <para/>If <paramref name="resolver"/> throws an <see cref="Exception"/> and the <see cref="Deferred"/> is still pending, the new <see cref="Promise{T}"/> will be canceled if it is an <see cref="OperationCanceledException"/>,
         /// or rejected with that <see cref="Exception"/>
         /// </summary>
-        public static Promise<T> New(Action<Deferred> resolver, SynchronizationOption synchronizationOption = SynchronizationOption.Synchronous)
+        /// <param name="resolver">The resolver delegate that will control the completion of the returned <see cref="Promise"/> via the passed in <see cref="Deferred"/>.</param>
+        /// <param name="synchronizationOption">Indicates on which context the <paramref name="resolver"/> will be invoked.</param>
+        /// <param name="forceAsync">If true, forces the <paramref name="resolver"/> to be invoked asynchronously. If <paramref name="synchronizationOption"/> is <see cref="SynchronizationOption.Synchronous"/>, this value will be ignored.</param>
+        public static Promise<T> New(Action<Deferred> resolver, SynchronizationOption synchronizationOption = SynchronizationOption.Synchronous, bool forceAsync = false)
         {
             ValidateArgument(resolver, "resolver", 1);
 
@@ -1120,7 +1123,7 @@ namespace Proto.Promises
                 {
                     if (!def.TryReject(e)) throw;
                 }
-            }, synchronizationOption)
+            }, synchronizationOption, forceAsync)
                 .Forget();
             return deferred.Promise;
         }
@@ -1131,7 +1134,11 @@ namespace Proto.Promises
         /// <para/>If <paramref name="resolver"/> throws an <see cref="Exception"/> and the <see cref="Deferred"/> is still pending, the new <see cref="Promise{T}"/> will be canceled if it is an <see cref="OperationCanceledException"/>,
         /// or rejected with that <see cref="Exception"/>
         /// </summary>
-        public static Promise<T> New<TCapture>(TCapture captureValue, Action<TCapture, Deferred> resolver, SynchronizationOption synchronizationOption = SynchronizationOption.Synchronous)
+        /// <param name="captureValue">The value that will be passed to <paramref name="resolver"/>.</param>
+        /// <param name="resolver">The resolver delegate that will control the completion of the returned <see cref="Promise"/> via the passed in <see cref="Deferred"/>.</param>
+        /// <param name="synchronizationOption">Indicates on which context the <paramref name="resolver"/> will be invoked.</param>
+        /// <param name="forceAsync">If true, forces the <paramref name="resolver"/> to be invoked asynchronously. If <paramref name="synchronizationOption"/> is <see cref="SynchronizationOption.Synchronous"/>, this value will be ignored.</param>
+        public static Promise<T> New<TCapture>(TCapture captureValue, Action<TCapture, Deferred> resolver, SynchronizationOption synchronizationOption = SynchronizationOption.Synchronous, bool forceAsync = false)
         {
             ValidateArgument(resolver, "resolver", 1);
 
@@ -1151,7 +1158,7 @@ namespace Proto.Promises
                 {
                     if (!def.TryReject(e)) throw;
                 }
-            }, synchronizationOption)
+            }, synchronizationOption, forceAsync)
                 .Forget();
             return deferred.Promise;
         }
@@ -1161,7 +1168,10 @@ namespace Proto.Promises
         /// <para/>If <paramref name="resolver"/> throws an <see cref="Exception"/> and the <see cref="Deferred"/> is still pending, the new <see cref="Promise{T}"/> will be canceled if it is an <see cref="OperationCanceledException"/>,
         /// or rejected with that <see cref="Exception"/>
         /// </summary>
-		public static Promise<T> New(Action<Deferred> resolver, SynchronizationContext synchronizationContext)
+        /// <param name="resolver">The resolver delegate that will control the completion of the returned <see cref="Promise"/> via the passed in <see cref="Deferred"/>.</param>
+        /// <param name="synchronizationContext">The context on which the <paramref name="resolver"/> will be invoked. If null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.</param>
+        /// <param name="forceAsync">If true, forces the <paramref name="resolver"/> to be invoked asynchronously.</param>
+		public static Promise<T> New(Action<Deferred> resolver, SynchronizationContext synchronizationContext, bool forceAsync = false)
         {
             ValidateArgument(resolver, "resolver", 1);
 
@@ -1181,7 +1191,7 @@ namespace Proto.Promises
                 {
                     if (!def.TryReject(e)) throw;
                 }
-            }, synchronizationContext)
+            }, synchronizationContext, forceAsync)
                 .Forget();
             return deferred.Promise;
         }
@@ -1191,7 +1201,11 @@ namespace Proto.Promises
         /// <para/>If <paramref name="resolver"/> throws an <see cref="Exception"/> and the <see cref="Deferred"/> is still pending, the new <see cref="Promise{T}"/> will be canceled if it is an <see cref="OperationCanceledException"/>,
         /// or rejected with that <see cref="Exception"/>
         /// </summary>
-        public static Promise<T> New<TCapture>(TCapture captureValue, Action<TCapture, Deferred> resolver, SynchronizationContext synchronizationContext)
+        /// <param name="captureValue">The value that will be passed to <paramref name="resolver"/>.</param>
+        /// <param name="resolver">The resolver delegate that will control the completion of the returned <see cref="Promise"/> via the passed in <see cref="Deferred"/>.</param>
+        /// <param name="synchronizationContext">The context on which the <paramref name="resolver"/> will be invoked. If null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.</param>
+        /// <param name="forceAsync">If true, forces the <paramref name="resolver"/> to be invoked asynchronously.</param>
+        public static Promise<T> New<TCapture>(TCapture captureValue, Action<TCapture, Deferred> resolver, SynchronizationContext synchronizationContext, bool forceAsync = false)
         {
             ValidateArgument(resolver, "resolver", 1);
 
@@ -1211,7 +1225,7 @@ namespace Proto.Promises
                 {
                     if (!def.TryReject(e)) throw;
                 }
-            }, synchronizationContext)
+            }, synchronizationContext, forceAsync)
                 .Forget();
             return deferred.Promise;
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/WaitAsyncConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/WaitAsyncConcurrencyTests.cs
@@ -153,13 +153,13 @@ namespace ProtoPromiseTests.Threading
             {
                 parallelActions.Add(() =>
                 {
-                    promise = promise.ConfigureAwait(waitType, cancelationToken);
+                    promise = promise.ConfigureAwait(waitType, false, cancelationToken);
                     SubscribeContinuation();
                 });
             }
             else if (waitAsyncSubscribePlace == ActionPlace.Parallel)
             {
-                parallelActions.Add(() => promise = promise.ConfigureAwait(waitType, cancelationToken));
+                parallelActions.Add(() => promise = promise.ConfigureAwait(waitType, false, cancelationToken));
             }
             else if (continuePlace == ActionPlace.Parallel)
             {
@@ -180,7 +180,7 @@ namespace ProtoPromiseTests.Threading
                     promise = deferred.Promise;
                     if (waitAsyncSubscribePlace == ActionPlace.InSetup)
                     {
-                        promise = promise.ConfigureAwait(waitType, cancelationToken);
+                        promise = promise.ConfigureAwait(waitType, false, cancelationToken);
                     }
                     if (continuePlace == ActionPlace.InSetup)
                     {
@@ -191,7 +191,7 @@ namespace ProtoPromiseTests.Threading
                 {
                     if (waitAsyncSubscribePlace == ActionPlace.InTeardown)
                     {
-                        promise = promise.ConfigureAwait(waitType, cancelationToken);
+                        promise = promise.ConfigureAwait(waitType, false, cancelationToken);
                     }
                     if (continuePlace == ActionPlace.InTeardown)
                     {
@@ -282,13 +282,13 @@ namespace ProtoPromiseTests.Threading
             {
                 parallelActions.Add(() =>
                 {
-                    promise = promise.ConfigureAwait(waitType, cancelationToken);
+                    promise = promise.ConfigureAwait(waitType, false, cancelationToken);
                     SubscribeContinuation();
                 });
             }
             else if (waitAsyncSubscribePlace == ActionPlace.Parallel)
             {
-                parallelActions.Add(() => promise = promise.ConfigureAwait(waitType, cancelationToken));
+                parallelActions.Add(() => promise = promise.ConfigureAwait(waitType, false, cancelationToken));
             }
             else if (continuePlace == ActionPlace.Parallel)
             {
@@ -309,7 +309,7 @@ namespace ProtoPromiseTests.Threading
                     promise = deferred.Promise;
                     if (waitAsyncSubscribePlace == ActionPlace.InSetup)
                     {
-                        promise = promise.ConfigureAwait(waitType, cancelationToken);
+                        promise = promise.ConfigureAwait(waitType, false, cancelationToken);
                     }
                     if (continuePlace == ActionPlace.InSetup)
                     {
@@ -320,7 +320,7 @@ namespace ProtoPromiseTests.Threading
                 {
                     if (waitAsyncSubscribePlace == ActionPlace.InTeardown)
                     {
-                        promise = promise.ConfigureAwait(waitType, cancelationToken);
+                        promise = promise.ConfigureAwait(waitType, false, cancelationToken);
                     }
                     if (continuePlace == ActionPlace.InTeardown)
                     {


### PR DESCRIPTION
Added optional `forceAsync` flag to APIs accepting `SynchronizationOption` or `SynchronizationContext`, and `Promise.{SwitchToForeground, SwitchToBackground}`.
Optimized `PromiseSynchronizationContext` to set the internal ts_currentContext to itself, and added a recursive check on `Execute()`.

Resolves #95.

WIP (needs tests).