### PR TITLE
Improve perf via recursion

### DIFF
--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -11,9 +11,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!--Set true to help debug internal promise code (allows the debugger to step into the code and includes internal stacktraces).-->
     <DeveloperMode>false</DeveloperMode>
-    <!--If true, the stack will unwind before invoking the next continuation. If false, stack traces will be longer, but it could cause a StackOverflowException if the promise chain is very long.
-        This value is ignored if DeveloperMode is false, and will default to true.-->
-    <AllowStackToUnwind>true</AllowStackToUnwind>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,10 +22,6 @@
   <!--Unity uses NET_LEGACY for old runtime prior to .Net 4.6, so we will do the same here.-->
   <PropertyGroup Condition="'$(TargetFramework)'=='net35' OR '$(TargetFramework)'=='net40'">
     <DefineConstants>$(DefineConstants);NET_LEGACY</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(AllowStackToUnwind)'=='false'">
-    <DefineConstants>$(DefineConstants);PROTO_PROMISE_STACK_UNWIND_DISABLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoProgress|AnyCPU'">

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/StackTraceHiddenAttribute.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/StackTraceHiddenAttribute.cs
@@ -1,7 +1,9 @@
 ﻿// TODO: Unity hasn't adopted .Net 6+ yet, and they usually use different compilation symbols than .Net SDK, so we'll have to update the compilation symbols here once Unity finally does adopt it.
 #if !NET6_0_OR_GREATER
 
-namespace System.Diagnostics
+using System;
+
+namespace Proto.Promises
 {
     // This doesn't actually do anything before .Net 6, this is just so make it so we don't need to #if NET6_0_OR_GREATER at every place the attribute is used.
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Struct, Inherited = false)]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -145,9 +145,8 @@ namespace Proto.Promises
 #endif
                 }
 
-                internal override void Handle(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler)
+                internal override void Handle(PromiseRefBase handler)
                 {
-                    nextHandler = null;
                     Invoke();
                 }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/InterfacesInternal.cs
@@ -37,7 +37,7 @@ namespace Proto.Promises
                 set { _next = value; }
             }
 
-            internal virtual void Handle(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler) { throw new System.InvalidOperationException(); }
+            internal virtual void Handle(PromiseRefBase handler) { throw new System.InvalidOperationException(); }
             // This is overridden in PromiseMultiAwait and PromiseProgress and PromiseConfigured.
             internal virtual void HandleFromContext() { throw new System.InvalidOperationException(); }
 #if PROMISE_PROGRESS
@@ -49,40 +49,40 @@ namespace Proto.Promises
         partial class PromiseRefBase
         {
             // For Merge/Race/First promises
-            protected virtual void Handle(PromisePassThrough passThrough, out HandleablePromiseBase nextHandler) { throw new System.InvalidOperationException(); }
+            protected virtual void Handle(PromisePassThrough passThrough) { throw new System.InvalidOperationException(); }
 #if PROMISE_PROGRESS
             protected virtual PromiseRefBase IncrementProgress(long increment, ref Fixed32 progress, ushort depth) { throw new System.InvalidOperationException(); }
 #endif
 
             internal interface IDelegateResolveOrCancel
             {
-                void InvokeResolver(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler, PromiseRefBase owner);
+                void InvokeResolver(PromiseRefBase handler, PromiseRefBase owner);
             }
 
             internal interface IDelegateResolveOrCancelPromise
             {
-                void InvokeResolver(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler, PromiseRefBase owner);
+                void InvokeResolver(PromiseRefBase handler, PromiseRefBase owner);
                 bool IsNull { get; }
             }
 
             internal interface IDelegateReject
             {
-                void InvokeRejecter(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler, PromiseRefBase owner);
+                void InvokeRejecter(PromiseRefBase handler, PromiseRefBase owner);
             }
 
             internal interface IDelegateRejectPromise
             {
-                void InvokeRejecter(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler, PromiseRefBase owner);
+                void InvokeRejecter(PromiseRefBase handler, PromiseRefBase owner);
             }
 
             internal interface IDelegateContinue
             {
-                void Invoke(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler, PromiseRefBase owner);
+                void Invoke(PromiseRefBase handler, PromiseRefBase owner);
             }
 
             internal interface IDelegateContinuePromise
             {
-                void Invoke(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler, PromiseRefBase owner);
+                void Invoke(PromiseRefBase handler, PromiseRefBase owner);
                 bool IsNull { get; }
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -585,14 +585,12 @@ namespace Proto.Promises
                     var currentContext = ts_currentContext;
                     ts_currentContext = _synchronizationContext;
 
-                    HandleablePromiseBase nextHandler;
-                    Invoke1(_previousState, out nextHandler);
-                    MaybeHandleNext(nextHandler);
+                    Invoke1(_previousState);
 
                     ts_currentContext = currentContext;
                 }
 
-                internal override void Handle(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler)
+                internal override void Handle(PromiseRefBase handler)
                 {
                     ThrowIfInPool(this);
                     handler.SuppressRejection = true;
@@ -604,16 +602,14 @@ namespace Proto.Promises
 
                     if (ShouldInvokeSynchronous())
                     {
-                        handler = this;
-                        Invoke1(state, out nextHandler);
+                        Invoke1(state);
                         return;
                     }
 
-                    nextHandler = null;
                     ScheduleForHandle(this, _synchronizationContext);
                 }
 
-                private void Invoke1(Promise.State state, out HandleablePromiseBase nextHandler)
+                private void Invoke1(Promise.State state)
                 {
                     if (TryUnregisterAndIsNotCanceling(ref _cancelationRegistration) & !IsCanceled)
                     {
@@ -626,7 +622,7 @@ namespace Proto.Promises
                     }
 
                     State = state;
-                    nextHandler = TakeOrHandleNextWaiter();
+                    HandleNextInternal();
                 }
 
                 void ICancelable.Cancel()

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -483,7 +483,6 @@ namespace Proto.Promises
 
             partial class AsyncPromiseRef<TResult> : AsyncPromiseBase<TResult>
             {
-                private HandleablePromiseBase _nextForComplete;
                 private ExecutionContext _executionContext;
 #if PROMISE_PROGRESS
                 private float _minProgress;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
@@ -89,7 +89,7 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void Handle(PromisePassThrough passThrough, out HandleablePromiseBase nextHandler)
+                protected override void Handle(PromisePassThrough passThrough)
                 {
                     var handler = passThrough.Owner;
                     if (Interlocked.CompareExchange(ref _rejectContainer, RejectContainer.s_completionSentinel, null) == null)
@@ -106,11 +106,7 @@ namespace Proto.Promises
                         // Very important, write State must come after write _result or _rejectContainer. This is a volatile write, so we don't need a full memory barrier.
                         // State is checked for completion, and if it is read not pending on another thread, _result and _rejectContainer must have already been written so the other thread can read them.
                         State = handler.State;
-                        nextHandler = TakeOrHandleNextWaiter();
-                    }
-                    else
-                    {
-                        nextHandler = null;
+                        HandleNextInternal();
                     }
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE // _waitCount isn't actually used in Race, but can be useful for debugging.
                     InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
@@ -202,10 +198,9 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void Handle(PromisePassThrough passThrough, out HandleablePromiseBase nextHandler)
+                protected override void Handle(PromisePassThrough passThrough)
                 {
                     var handler = passThrough.Owner;
-                    nextHandler = null;
                     var state = handler.State;
                     if (state != Promise.State.Resolved) // Rejected/Canceled
                     {
@@ -214,7 +209,7 @@ namespace Proto.Promises
                             && Interlocked.CompareExchange(ref _rejectContainer, handler._rejectContainer, null) == null)
                         {
                             State = state;
-                            nextHandler = TakeOrHandleNextWaiter();
+                            HandleNextInternal();
                         }
                     }
                     else // Resolved
@@ -222,7 +217,7 @@ namespace Proto.Promises
                         if (Interlocked.CompareExchange(ref _rejectContainer, RejectContainer.s_completionSentinel, null) == null)
                         {
                             SetResult(passThrough.Index);
-                            nextHandler = TakeOrHandleNextWaiter();
+                            HandleNextInternal();
                         }
                         InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
                     }
@@ -295,10 +290,9 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void Handle(PromisePassThrough passThrough, out HandleablePromiseBase nextHandler)
+                protected override void Handle(PromisePassThrough passThrough)
                 {
                     var handler = passThrough.Owner;
-                    nextHandler = null;
                     var state = handler.State;
                     if (state != Promise.State.Resolved) // Rejected/Canceled
                     {
@@ -307,7 +301,7 @@ namespace Proto.Promises
                             && Interlocked.CompareExchange(ref _rejectContainer, handler._rejectContainer, null) == null)
                         {
                             State = state;
-                            nextHandler = TakeOrHandleNextWaiter();
+                            HandleNextInternal();
                         }
                     }
                     else // Resolved
@@ -315,7 +309,7 @@ namespace Proto.Promises
                         if (Interlocked.CompareExchange(ref _rejectContainer, RejectContainer.s_completionSentinel, null) == null)
                         {
                             SetResult(new ValueTuple<int, TResult>(passThrough.Index, handler.GetResult<TResult>()));
-                            nextHandler = TakeOrHandleNextWaiter();
+                            HandleNextInternal();
                         }
                         InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
                     }
@@ -388,10 +382,9 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void Handle(PromisePassThrough passThrough, out HandleablePromiseBase nextHandler)
+                protected override void Handle(PromisePassThrough passThrough)
                 {
                     var handler = passThrough.Owner;
-                    nextHandler = null;
                     var state = handler.State;
                     if (state != Promise.State.Resolved) // Rejected/Canceled
                     {
@@ -400,7 +393,7 @@ namespace Proto.Promises
                             && Interlocked.CompareExchange(ref _rejectContainer, handler._rejectContainer, null) == null)
                         {
                             State = state;
-                            nextHandler = TakeOrHandleNextWaiter();
+                            HandleNextInternal();
                         }
                     }
                     else // Resolved
@@ -408,7 +401,7 @@ namespace Proto.Promises
                         if (Interlocked.CompareExchange(ref _rejectContainer, RejectContainer.s_completionSentinel, null) == null)
                         {
                             SetResult(handler.GetResult<TResult>());
-                            nextHandler = TakeOrHandleNextWaiter();
+                            HandleNextInternal();
                         }
                         InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
                     }
@@ -481,10 +474,9 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void Handle(PromisePassThrough passThrough, out HandleablePromiseBase nextHandler)
+                protected override void Handle(PromisePassThrough passThrough)
                 {
                     var handler = passThrough.Owner;
-                    nextHandler = null;
                     var state = handler.State;
                     if (state != Promise.State.Resolved) // Rejected/Canceled
                     {
@@ -493,7 +485,7 @@ namespace Proto.Promises
                             && Interlocked.CompareExchange(ref _rejectContainer, handler._rejectContainer, null) == null)
                         {
                             State = state;
-                            nextHandler = TakeOrHandleNextWaiter();
+                            HandleNextInternal();
                         }
                     }
                     else // Resolved
@@ -501,7 +493,7 @@ namespace Proto.Promises
                         if (Interlocked.CompareExchange(ref _rejectContainer, RejectContainer.s_completionSentinel, null) == null)
                         {
                             SetResult(passThrough.Index);
-                            nextHandler = TakeOrHandleNextWaiter();
+                            HandleNextInternal();
                         }
                         InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
                     }
@@ -574,10 +566,9 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void Handle(PromisePassThrough passThrough, out HandleablePromiseBase nextHandler)
+                protected override void Handle(PromisePassThrough passThrough)
                 {
                     var handler = passThrough.Owner;
-                    nextHandler = null;
                     var state = handler.State;
                     if (state != Promise.State.Resolved) // Rejected/Canceled
                     {
@@ -586,7 +577,7 @@ namespace Proto.Promises
                             && Interlocked.CompareExchange(ref _rejectContainer, handler._rejectContainer, null) == null)
                         {
                             State = state;
-                            nextHandler = TakeOrHandleNextWaiter();
+                            HandleNextInternal();
                         }
                     }
                     else // Resolved
@@ -594,7 +585,7 @@ namespace Proto.Promises
                         if (Interlocked.CompareExchange(ref _rejectContainer, RejectContainer.s_completionSentinel, null) == null)
                         {
                             SetResult(new ValueTuple<int, TResult>(passThrough.Index, handler.GetResult<TResult>()));
-                            nextHandler = TakeOrHandleNextWaiter();
+                            HandleNextInternal();
                         }
                         InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
                     }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
@@ -16,7 +16,6 @@
 #pragma warning disable IDE0090 // Use 'new(...)'
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Proto.Promises
@@ -35,7 +34,7 @@ namespace Proto.Promises
 
                 private PromiseCompletionSentinel() { }
 
-                internal override void Handle(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler)
+                internal override void Handle(PromiseRefBase handler)
                 {
                     throw new System.InvalidOperationException("PromiseCompletionSentinel handled from " + handler);
                 }
@@ -51,9 +50,8 @@ namespace Proto.Promises
 
                 private PromiseForgetSentinel() { }
 
-                internal override void Handle(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler)
+                internal override void Handle(PromiseRefBase handler)
                 {
-                    nextHandler = null;
                     handler.MaybeDispose();
                 }
             }
@@ -72,7 +70,7 @@ namespace Proto.Promises
                     _smallFields = new SmallFields(-5); // Set an id that is unlikely to match (though this should never be used in a Promise struct).
                 }
 
-                internal override void Handle(ref PromiseRefBase handler, out HandleablePromiseBase nextHandler)
+                internal override void Handle(PromiseRefBase handler)
                 {
                     throw new System.InvalidOperationException("InvalidAwaitSentinel handled from " + handler);
                 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/PromiseSynchronizationContext.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/PromiseSynchronizationContext.cs
@@ -189,10 +189,12 @@ namespace Proto.Promises.Threading
                     : "Execute may only be called from the thread on which the PromiseSynchronizationContext was created.");
             }
 
-            var currentContext = Internal.ts_currentContext;
+            var currentContextInternal = Internal.ts_currentContext;
+            var currentContextGlobal = Current;
             try
             {
                 Internal.ts_currentContext = this;
+                SetSynchronizationContext(this);
                 _isInvoking = true;
 
                 while (true)
@@ -233,7 +235,8 @@ namespace Proto.Promises.Threading
             finally
             {
                 _isInvoking = false;
-                Internal.ts_currentContext = currentContext;
+                Internal.ts_currentContext = currentContextInternal;
+                SetSynchronizationContext(currentContextGlobal);
             }
         }
     }


### PR DESCRIPTION
Since #99 made it possible to force async continuations, we no longer need to unwind the stack before invoking continuations. If users have very deep async stacks, they can use the `forceAsync` flag on `WaitAsync` or `SwitchToContext` / `SwitchToForeground` / `SwitchToBackground` APIs to prevent stack overflows (or `Task.Yield()` in async functions). This gains us ~7% performance and slightly reduced memory.

Master:

|         Type | Pending |       Mean | Allocated | Survived |
|------------- |-------- |-----------:|----------:|---------:|
|   AsyncAwait |    True | 2,385.6 ns |         - |    720 B |
| ContinueWith |    True | 2,979.8 ns |         - |    400 B |

This PR:

|         Type | Pending |       Mean | Allocated | Survived |
|------------- |-------- |-----------:|----------:|---------:|
|   AsyncAwait |    True | 2,224.6 ns |         - |    696 B |
| ContinueWith |    True | 2,738.8 ns |         - |    400 B |