### PR TITLE
Added `Promise.Wait()` and `Promise<T>.WaitForResult()` synchronous APIs.

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AsyncInternal.cs
@@ -679,7 +679,7 @@ namespace Proto.Promises
                     }
                 }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     Dispose();
                     if (_continuer != null)
@@ -726,7 +726,7 @@ namespace Proto.Promises
                         promise._stateMachine = stateMachine;
                     }
 
-                    protected override void MaybeDispose()
+                    internal override void MaybeDispose()
                     {
                         Dispose();
                         _stateMachine = default(TStateMachine);
@@ -782,7 +782,7 @@ namespace Proto.Promises
                     }
                 }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     Dispose();
                     _executionContext = null;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -85,6 +85,12 @@ namespace Proto.Promises
                 internal TResult GetResultForAwaiter(short promiseId)
                 {
                     ValidateId(promiseId, this, 2);
+                    return GetResultAndMaybeDispose();
+                }
+
+                [MethodImpl(InlineOption)]
+                internal TResult GetResultAndMaybeDispose()
+                {
                     TResult result = _result;
                     MaybeDispose();
                     return result;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
@@ -77,7 +77,7 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (_cancelationHelper.TryRelease())
                     {
@@ -139,7 +139,7 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (_cancelationHelper.TryRelease())
                     {
@@ -212,7 +212,7 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (_cancelationHelper.TryRelease())
                     {
@@ -287,7 +287,7 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (_cancelationHelper.TryRelease())
                     {
@@ -369,7 +369,7 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (_cancelationHelper.TryRelease())
                     {
@@ -426,7 +426,7 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (_cancelationHelper.TryRelease())
                     {
@@ -492,7 +492,7 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (_cancelationHelper.TryRelease())
                     {
@@ -554,7 +554,7 @@ namespace Proto.Promises
                     return promise;
                 }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (_cancelationHelper.TryRelease())
                     {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/DeferredInternal.cs
@@ -118,7 +118,7 @@ namespace Proto.Promises
             {
                 protected DeferredPromise() { }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     Dispose();
                     ObjectPool.MaybeRepool(this);
@@ -185,7 +185,7 @@ namespace Proto.Promises
             {
                 private DeferredPromiseCancel() { }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     Dispose();
                     _cancelationRegistration = default(CancelationRegistration);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
@@ -48,7 +48,7 @@ namespace Proto.Promises
             {
                 private MergePromise() { }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     MaybeDisposeNonVirt();
                 }
@@ -153,7 +153,7 @@ namespace Proto.Promises
                 {
                     private MergePromiseT() { }
 
-                    protected override void MaybeDispose()
+                    internal override void MaybeDispose()
                     {
                         if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
                         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -102,6 +102,14 @@ namespace Proto.Promises
             }
         }
 
+        partial class PromiseSynchronousWaiter : HandleablePromiseBase
+        {
+            internal override PromiseRefBase SetProgress(ref PromiseRefBase.Fixed32 progress, ref ushort depth)
+            {
+                return null;
+            }
+        }
+
 #endif // !PROMISE_PROGRESS
 
         partial class PromiseRefBase
@@ -514,7 +522,7 @@ namespace Proto.Promises
                     return _isSynchronous | (!_forceAsync & _synchronizationContext == ts_currentContext);
                 }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
                     {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -158,7 +158,9 @@ namespace Proto.Promises
 
         partial class PromiseSynchronousWaiter : HandleablePromiseBase
         {
-            private bool _isComplete;
+            private bool _isHookingUp;
+            private bool _didWaitSuccessfully;
+            private bool _didWait;
         }
 
         partial class PromiseRefBase : HandleablePromiseBase

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -156,6 +156,11 @@ namespace Proto.Promises
             volatile internal HandleablePromiseBase _next;
         }
 
+        partial class PromiseSynchronousWaiter : HandleablePromiseBase
+        {
+            private bool _isComplete;
+        }
+
         partial class PromiseRefBase : HandleablePromiseBase
         {
             [StructLayout(LayoutKind.Explicit)]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RaceInternal.cs
@@ -30,7 +30,7 @@ namespace Proto.Promises
             {
                 protected RacePromise() { }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
                     {
@@ -140,7 +140,7 @@ namespace Proto.Promises
             {
                 private RacePromiseWithIndexVoid() { }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
                     {
@@ -232,7 +232,7 @@ namespace Proto.Promises
             {
                 private RacePromiseWithIndex() { }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
                     {
@@ -324,7 +324,7 @@ namespace Proto.Promises
             {
                 protected FirstPromise() { }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
                     {
@@ -416,7 +416,7 @@ namespace Proto.Promises
             {
                 private FirstPromiseWithIndexVoid() { }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
                     {
@@ -508,7 +508,7 @@ namespace Proto.Promises
             {
                 private FirstPromiseWithIndex() { }
 
-                protected override void MaybeDispose()
+                internal override void MaybeDispose()
                 {
                     if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
                     {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
@@ -75,7 +75,7 @@ namespace Proto.Promises
                     throw new System.InvalidOperationException("InvalidAwaitSentinel handled from " + handler);
                 }
 
-                protected override void MaybeDispose() { throw new System.InvalidOperationException(); }
+                internal override void MaybeDispose() { throw new System.InvalidOperationException(); }
                 protected override void OnForget(short promiseId) { throw new System.InvalidOperationException(); }
                 internal override PromiseRefBase AddWaiter(short promiseId, HandleablePromiseBase waiter, out HandleablePromiseBase previousWaiter) { throw new System.InvalidOperationException(); }
                 internal override PromiseRefBase GetDuplicate(short promiseId, ushort depth) { throw new System.InvalidOperationException(); }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -168,11 +168,48 @@ namespace Proto.Promises
             {
                 return _result;
             }
-            Internal.PromiseSynchronousWaiter.WaitForCompletion(r, _id);
+            Internal.PromiseSynchronousWaiter.TryWaitForCompletion(r, _id, TimeSpan.FromMilliseconds(Timeout.Infinite));
             var state = r.State;
             if (state == Promise.State.Resolved)
             {
                 return r.GetResultAndMaybeDispose();
+            }
+#if NET_LEGACY
+            r.Throw(state, _id);
+#else
+            r.GetExceptionDispatchInfo(state, _id).Throw();
+#endif
+            throw null; // This will never be reached, but the compiler needs help understanding that.
+        }
+
+        /// <summary>
+        /// Mark this as awaited and wait for the operation to complete with a specified timeout.
+        /// <para/>If the operation completed successfully before the timeout expired, this will return true and <paramref name="result"/> will be assigned from the result of the operation. Otherwise, this will return false.
+        /// If the operation was rejected or canceled, the appropriate exception will be thrown.
+        /// </summary>
+        /// <remarks>
+        /// If a <see cref="TimeSpan"/> representing -1 millisecond is specified for the timeout parameter, this method blocks indefinitely until the operation is complete.
+        /// <para/>Warning: this may cause a deadlock if you are not careful. Make sure you know what you are doing!
+        /// </remarks>
+        public bool WaitForResult(TimeSpan timeout, out T result)
+        {
+            ValidateOperation(1);
+            var r = _ref;
+            if (r == null)
+            {
+                result = _result;
+                return true;
+            }
+            if (!Internal.PromiseSynchronousWaiter.TryWaitForCompletion(r, _id, timeout))
+            {
+                result = default(T);
+                return false;
+            }
+            var state = r.State;
+            if (state == Promise.State.Resolved)
+            {
+                result = r.GetResultAndMaybeDispose();
+                return true;
             }
 #if NET_LEGACY
             r.Throw(state, _id);


### PR DESCRIPTION
Resolves #109. Though I decided to change `GetResult` to `WaitForResult` for a more intuitive name (don't want users thinking they can call `GetResult` multiple times).