### PR TITLE
Preserve stacktrace in old runtimes

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
@@ -4,6 +4,7 @@
 #undef PROMISE_DEBUG
 # endif
 
+#pragma warning disable IDE0031 // Use null propagation
 #pragma warning disable IDE0034 // Simplify 'default' expression
 #pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
@@ -318,7 +319,8 @@ namespace Proto.Promises
                 get
                 {
                     ValidateCall();
-                    return _rejectContainer.Value;
+                    var container = _rejectContainer;
+                    return container == null ? null : container.Value;
                 }
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/ProgressHelper.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/ProgressHelper.cs
@@ -80,9 +80,9 @@ namespace ProtoPromiseTests
                     {
                         if (waitTimeout <= TimeSpan.Zero)
                         {
-                            waitTimeout = TimeSpan.FromSeconds(1);
+                            waitTimeout = TimeSpan.FromSeconds(2);
                         }
-                        if (!Monitor.Wait(_locker, waitTimeout))
+                        if (!Monitor.Wait(_locker, waitTimeout) && !_wasInvoked)
                         {
                             throw new TimeoutException("Progress was not invoked after " + waitTimeout + ", _currentProgress: " + _currentProgress + ", current thread is background: " + Thread.CurrentThread.IsBackground);
                         }
@@ -135,7 +135,7 @@ namespace ProtoPromiseTests
 
             if (timeout <= TimeSpan.Zero)
             {
-                timeout = TimeSpan.FromSeconds(1);
+                timeout = TimeSpan.FromSeconds(2);
             }
             float current = float.NaN;
             if (!SpinWait.SpinUntil(() => { current = _currentProgress; return current == expectedProgress; }, timeout))


### PR DESCRIPTION
Reverts the behavior that was changed in #114 to preserve stacktraces in old runtimes.