### PR TITLE
`CancelationRegistration` disposable

### DIFF
--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -63,4 +63,10 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
+      <Version>6.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/ProtoPromise/nuget/ProtoPromise.nuspec
+++ b/ProtoPromise/nuget/ProtoPromise.nuspec
@@ -20,14 +20,21 @@
     <dependencies>
       <group targetFramework="net35" />
       <group targetFramework="net40" />
-      <group targetFramework="net45" />
-      <group targetFramework="net47" />
-      
-      <group targetFramework="netstandard2.0" />
+      <group targetFramework="net45">
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net47">
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="netstandard2.0">
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
+      </group>
       <group targetFramework="netstandard2.1" />
-      
-      <group targetFramework="netcoreapp2.1" />
-      
+      <group targetFramework="netcoreapp2.1">
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
       <group targetFramework="net5.0" />
       <group targetFramework="net6.0" />
     </dependencies>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/CancelationToken.cs
@@ -58,7 +58,10 @@ namespace Proto.Promises
         /// <summary>
         /// Gets whether this token is capable of being in the canceled state.
         /// </summary>
-        /// <remarks>A <see cref="CancelationToken"/> is capable of being in the canceled state when the <see cref="CancelationSource"/> it is attached to is valid, or if the token has been retained and not yet released.</remarks>
+        /// <remarks>
+        /// A <see cref="CancelationToken"/> is capable of being in the canceled state when the <see cref="CancelationSource"/> it is attached to has not been disposed,
+        /// or if the token is already canceled and it has been retained and not yet released.
+        /// </remarks>
         public bool CanBeCanceled
         {
             get

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -205,7 +205,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal static bool CanTokenBeCanceled(CancelationRef _this, int tokenId)
             {
-                return _this != null && _this.TokenId == tokenId;
+                return _this != null && (_this.TokenId == tokenId & _this._state != State.Disposed);
             }
 
             [MethodImpl(InlineOption)]
@@ -810,8 +810,7 @@ namespace Proto.Promises
                 }
 
                 parent._smallFields._locker.Enter();
-                bool isRegistered = _this.GetIsRegisteredAndIsCanceled(parent, nodeId, tokenId, out isCanceled);
-                if (!isRegistered)
+                if (!_this.GetIsRegisteredAndIsCanceled(parent, nodeId, tokenId, out isCanceled))
                 {
                     parent._smallFields._locker.Exit();
                     return false;
@@ -820,7 +819,7 @@ namespace Proto.Promises
                 _this.RemoveFromLinkedList();
                 parent._smallFields._locker.Exit();
                 _this.Dispose();
-                return isRegistered;
+                return true;
             }
 
             [MethodImpl(InlineOption)]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -75,7 +75,7 @@ namespace Proto.Promises
 #endif
         internal sealed partial class CancelationRef : HandleablePromiseBase, ICancelable, ITraceable
         {
-            internal static readonly CancelationRef s_canceledSentinel = new CancelationRef() { _state = State.Canceled, _internalRetainCounter = 1, _tokenId = -1 };
+            internal static readonly CancelationRef s_canceledSentinel = new CancelationRef() { _state = State.CanceledComplete, _internalRetainCounter = 1, _tokenId = -1 };
 
 #if PROMISE_DEBUG
             CausalityTrace ITraceable.Trace { get; set; }
@@ -108,8 +108,9 @@ namespace Proto.Promises
             internal enum State : int
             {
                 Pending,
+                Disposed,
                 Canceled,
-                Disposed
+                CanceledComplete,
             }
 
             // Wrapping struct fields smaller than 64-bits in another struct fixes issue with extra padding
@@ -140,7 +141,7 @@ namespace Proto.Promises
             [ThreadStatic]
             private static bool ts_isLinkingToBclToken;
 #endif
-
+            internal Thread _executingThread;
             private ValueLinkedStackZeroGC<CancelationRegistration> _links = ValueLinkedStackZeroGC<CancelationRegistration>.Create();
             // Use a sentinel for the linked list so we don't need to null check.
             private readonly CancelationCallbackNode _registeredCallbacksHead = CancelationCallbackNode.CreateLinkedListSentinel();
@@ -198,7 +199,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             private bool IsSourceCanceled(int sourceId)
             {
-                return sourceId == SourceId & _state == State.Canceled;
+                return sourceId == SourceId & _state >= State.Canceled;
             }
 
             [MethodImpl(InlineOption)]
@@ -216,16 +217,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             private bool IsTokenCanceled(int tokenId)
             {
-                return tokenId == TokenId & _state == State.Canceled;
-            }
-
-            [MethodImpl(InlineOption)]
-            internal static void ThrowIfCanceled(CancelationRef _this, int tokenId)
-            {
-                if (_this != null && _this.IsTokenCanceled(tokenId))
-                {
-                    throw CanceledExceptionInternal.GetOrCreate();
-                }
+                return tokenId == TokenId & _state >= State.Canceled;
             }
 
             internal void MaybeLinkToken(CancelationToken token)
@@ -339,11 +331,7 @@ namespace Proto.Promises
                             int oldNodeId = node.NodeId;
                             _registeredCallbacksHead.InsertPrevious(node);
 
-                            _state = State.Canceled;
-                            ++_internalRetainCounter;
-                            _smallFields._locker.Exit();
-
-                            InvokeCallbacks();
+                            InvokeCallbacksAlreadyLocked();
                             registration = new CancelationRegistration(this, node, oldNodeId, tokenId);
                             return true;
                         }
@@ -363,7 +351,7 @@ namespace Proto.Promises
 
                 _smallFields._locker.Exit();
                 registration = default(CancelationRegistration);
-                if (state == State.Canceled)
+                if (state >= State.Canceled)
                 {
                     cancelable.Cancel();
                     return true;
@@ -386,37 +374,38 @@ namespace Proto.Promises
                     _smallFields._locker.Exit();
                     return false;
                 }
+                InvokeCallbacksAlreadyLocked();
+                return true;
+            }
+
+            private void InvokeCallbacksAlreadyLocked()
+            {
+                ThrowIfInPool(this);
+
+                _executingThread = Thread.CurrentThread;
                 _state = State.Canceled;
                 ++_internalRetainCounter;
                 _smallFields._locker.Exit();
 
-                InvokeCallbacks();
-                return true;
-            }
-
-            private void InvokeCallbacks()
-            {
-                ThrowIfInPool(this);
                 Unlink();
 
                 // We call the delegates in LIFO order so that callbacks fire 'deepest first'.
                 // This is intended to help with nesting scenarios so that child enlisters cancel before their parents.
 
-                var previous = _registeredCallbacksHead._previous;
-                // If the previous references itself, then it is the sentinel and no registrations exist.
-                if (previous == _registeredCallbacksHead)
-                {
-                    MaybeResetAndRepool();
-                    return;
-                }
-                // Set the last node's previous to null since null check is faster than reference comparison.
-                _registeredCallbacksHead._next.UnsafeAs<CancelationCallbackNode>()._previous = null;
-                _registeredCallbacksHead.ResetSentinel();
                 List<Exception> exceptions = null;
-                do
+                while (true)
                 {
-                    var current = previous;
-                    previous = current._previous;
+                    _smallFields._locker.Enter();
+                    // If the sentinel's previous points to itself, no more registrations exist.
+                    var current = _registeredCallbacksHead._previous;
+                    if (current == _registeredCallbacksHead)
+                    {
+                        _smallFields._locker.Exit();
+                        break;
+                    }
+                    current.RemoveFromLinkedList();
+                    _smallFields._locker.Exit();
+
                     try
                     {
                         current.Invoke(this);
@@ -429,8 +418,10 @@ namespace Proto.Promises
                         }
                         exceptions.Add(e);
                     }
-                } while (previous != null);
+                }
 
+                _executingThread = null;
+                _state = State.CanceledComplete;
                 MaybeResetAndRepool();
                 if (exceptions != null)
                 {
@@ -455,7 +446,10 @@ namespace Proto.Promises
                     return false;
                 }
 
-                ++_sourceId;
+                unchecked
+                {
+                    ++_sourceId;
+                }
                 if (_state != State.Pending)
                 {
                     MaybeResetAndRepoolAlreadyLocked();
@@ -486,6 +480,7 @@ namespace Proto.Promises
                 {
                     var current = previous;
                     previous = current._previous;
+                    current._previous = null;
                     current.Dispose();
                 } while (previous != null);
             }
@@ -542,7 +537,10 @@ namespace Proto.Promises
                 {
                     if (--_userRetainCounter == 0 & _internalRetainCounter == 0)
                     {
-                        ++_tokenId;
+                        unchecked
+                        {
+                            ++_tokenId;
+                        }
                         _smallFields._locker.Exit();
                         ResetAndRepool();
                         return true;
@@ -577,7 +575,10 @@ namespace Proto.Promises
                         Thread.MemoryBarrier();
                     }
 #endif
-                    ++_tokenId;
+                    unchecked
+                    {
+                        ++_tokenId;
+                    }
                     _smallFields._locker.Exit();
                     ResetAndRepool();
                     return;
@@ -662,49 +663,30 @@ namespace Proto.Promises
                 internal override void Invoke(CancelationRef parent)
                 {
                     ThrowIfInPool(this);
-                    var canceler = _cancelable;
-#if PROMISE_DEBUG
                     SetCurrentInvoker(this);
                     try
                     {
-                        canceler.Cancel();
+                        _cancelable.Cancel();
                     }
                     finally
                     {
+                        Dispose();
                         ClearCurrentInvoker();
-                        parent._smallFields._locker.Enter();
-                        DisposeAlreadyLocked(parent);
                     }
-#else
-                    parent._smallFields._locker.Enter();
-                    DisposeAlreadyLocked(parent);
-                    canceler.Cancel();
-#endif
                 }
 
                 [MethodImpl(InlineOption)]
                 internal override void Dispose()
                 {
-                    ResetForDispose();
-                    ObjectPool.MaybeRepool(this);
-                }
-
-                [MethodImpl(InlineOption)]
-                private void ResetForDispose()
-                {
                     ThrowIfInPool(this);
-                    ++_nodeId;
-                    _previous = null;
+                    unchecked
+                    {
+                        ++_nodeId;
+                    }
                     _cancelable = default(TCancelable);
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
                     _disposed = true;
 #endif
-                }
-
-                protected override void DisposeAlreadyLocked(CancelationRef parent)
-                {
-                    ResetForDispose();
-                    parent._smallFields._locker.Exit();
                     ObjectPool.MaybeRepool(this);
                 }
             }
@@ -713,7 +695,7 @@ namespace Proto.Promises
         internal class CancelationCallbackNode : HandleablePromiseBase
         {
             internal CancelationCallbackNode _previous; // _next is HandleablePromiseBase which we just unsafe cast to CallbackNode.
-            protected int _nodeId = 1; // Start with id 1 instead of 0 to reduce risk of false positives.
+            volatile protected int _nodeId = 1; // Start with id 1 instead of 0 to reduce risk of false positives.
             protected int _parentId; // In case the CancelationRegistration is torn from threads.
 
             internal int NodeId
@@ -738,6 +720,13 @@ namespace Proto.Promises
                 _previous = this;
             }
 
+            internal void RemoveFromLinkedList()
+            {
+                _previous._next = _next;
+                _next.UnsafeAs<CancelationCallbackNode>()._previous = _previous;
+                _previous = null;
+            }
+
             internal void InsertPrevious(CancelationCallbackNode node)
             {
                 node._previous = _previous;
@@ -750,6 +739,54 @@ namespace Proto.Promises
             internal virtual void Dispose() { throw new System.InvalidOperationException(); }
 
             [MethodImpl(InlineOption)]
+            private bool GetIsRegistered(CancelationRef parent, int nodeId, int tokenId)
+            {
+                return parent._smallFields._instanceId == _parentId & parent.TokenId == tokenId
+                    & _nodeId == nodeId & _previous != null;
+            }
+
+            [MethodImpl(InlineOption)]
+            internal static bool GetIsRegistered(CancelationRef parent, CancelationCallbackNode _this, int nodeId, int tokenId)
+            {
+                if (_this == null | parent == null)
+                {
+                    return false;
+                }
+                return _this.GetIsRegistered(parent, nodeId, tokenId);
+            }
+
+            [MethodImpl(InlineOption)]
+            internal static bool TryUnregister(CancelationRef parent, CancelationCallbackNode _this, int nodeId, int tokenId)
+            {
+                if (_this == null | parent == null)
+                {
+                    return false;
+                }
+
+                parent._smallFields._locker.Enter();
+                if (!_this.GetIsRegistered(parent, nodeId, tokenId))
+                {
+                    parent._smallFields._locker.Exit();
+                    return false;
+                }
+
+                _this.RemoveFromLinkedList();
+                parent._smallFields._locker.Exit();
+                _this.Dispose();
+                return true;
+            }
+
+            [MethodImpl(InlineOption)]
+            private bool GetIsRegisteredAndIsCanceled(CancelationRef parent, int nodeId, int tokenId, out bool isCanceled)
+            {
+                bool canceled = parent._state >= CancelationRef.State.Canceled;
+                bool tokenIdMatches = parent._smallFields._instanceId == _parentId & parent.TokenId == tokenId;
+                bool isRegistered = tokenIdMatches & _nodeId == nodeId & _previous != null;
+                isCanceled = canceled & tokenIdMatches;
+                return isRegistered;
+            }
+
+            [MethodImpl(InlineOption)]
             internal static bool GetIsRegisteredAndIsCanceled(CancelationRef parent, CancelationCallbackNode _this, int nodeId, int tokenId, out bool isCanceled)
             {
                 if (_this == null | parent == null)
@@ -757,16 +794,10 @@ namespace Proto.Promises
                     isCanceled = false;
                     return false;
                 }
-                return _this.GetIsRegistered(parent, nodeId, tokenId, out isCanceled);
-            }
-
-            [MethodImpl(InlineOption)]
-            private bool GetIsRegistered(CancelationRef parent, int nodeId, int tokenId, out bool isCanceled)
-            {
-                bool canceled = parent._state == CancelationRef.State.Canceled;
-                bool tokenIdMatches = parent.TokenId == tokenId & parent._smallFields._instanceId == _parentId;
-                isCanceled = canceled & tokenIdMatches;
-                return !canceled & tokenIdMatches & _nodeId == nodeId;
+                parent._smallFields._locker.Enter();
+                bool isRegistered = _this.GetIsRegisteredAndIsCanceled(parent, nodeId, tokenId, out isCanceled);
+                parent._smallFields._locker.Exit();
+                return isRegistered;
             }
 
             [MethodImpl(InlineOption)]
@@ -777,31 +808,57 @@ namespace Proto.Promises
                     isCanceled = false;
                     return false;
                 }
-                return _this.TryUnregister(parent, nodeId, tokenId, out isCanceled);
-            }
 
-            [MethodImpl(InlineOption)]
-            private bool TryUnregister(CancelationRef parent, int nodeId, int tokenId, out bool isCanceled)
-            {
                 parent._smallFields._locker.Enter();
-                bool canceled;
-                bool isRegistered = GetIsRegistered(parent, nodeId, tokenId, out canceled);
+                bool isRegistered = _this.GetIsRegisteredAndIsCanceled(parent, nodeId, tokenId, out isCanceled);
                 if (!isRegistered)
                 {
                     parent._smallFields._locker.Exit();
-                    isCanceled = canceled;
                     return false;
                 }
 
-                _previous._next = _next;
-                _next.UnsafeAs<CancelationCallbackNode>()._previous = _previous;
-                DisposeAlreadyLocked(parent);
-
-                isCanceled = canceled;
-                return true;
+                _this.RemoveFromLinkedList();
+                parent._smallFields._locker.Exit();
+                _this.Dispose();
+                return isRegistered;
             }
 
-            protected virtual void DisposeAlreadyLocked(CancelationRef parent) { throw new System.InvalidOperationException(); }
+            [MethodImpl(InlineOption)]
+            internal static void TryUnregisterOrWaitForCallbackToComplete(CancelationRef parent, CancelationCallbackNode _this, int nodeId, int tokenId)
+            {
+                if (_this == null | parent == null)
+                {
+                    return;
+                }
+
+                parent._smallFields._locker.Enter();
+                bool idsMatch = parent._smallFields._instanceId == _this._parentId
+                    & tokenId == parent.TokenId
+                    & nodeId == _this._nodeId;
+                if (idsMatch & _this._previous != null)
+                {
+                    _this.RemoveFromLinkedList();
+                    parent._smallFields._locker.Exit();
+                    _this.Dispose();
+                    return;
+                }
+
+                parent._smallFields._locker.Exit();
+                // If the source is executing callbacks on another thread, we must wait until this callback is complete.
+                if (idsMatch
+                    & parent._state == CancelationRef.State.Canceled
+                    & parent._executingThread != Thread.CurrentThread)
+                {
+                    var spinner = new SpinWait();
+                    // _this._nodeId will be incremented when the callback is complete and this is disposed.
+                    // parent.TokenId will be incremented when all callbacks are complete and it is disposed.
+                    // We really only need to compare the nodeId, the tokenId comparison is just for a little extra safety in case of thread starvation and node re-use.
+                    while (nodeId == _this._nodeId & tokenId == parent.TokenId)
+                    {
+                        spinner.SpinOnce(); // Spin, as we assume callback execution is fast and that this situation is rare.
+                    }
+                }
+            }
         } // class CancelationCallbackNode
 
         partial class CancelationRef
@@ -950,7 +1007,7 @@ namespace Proto.Promises
                     {
                         return default(CancellationToken);
                     }
-                    if (state == State.Canceled)
+                    if (state >= State.Canceled)
                     {
                         return new CancellationToken(true);
                     }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/CancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/CancelationTests.cs
@@ -470,7 +470,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource2 = CancelationSource.New();
                 cancelationSource2.Cancel();
                 CancelationSource cancelationSource3 = CancelationSource.New(new CancelationToken[] { cancelationSource1.Token, cancelationSource2.Token });
-                cancelationSource3.Token.Register(()  =>
+                cancelationSource3.Token.Register(() =>
                 {
                     invoked = true;
                 });
@@ -602,9 +602,9 @@ namespace ProtoPromiseTests.APIs
             public void CancelationTokenInvalidOperations()
             {
                 CancelationToken cancelationToken = new CancelationToken();
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => { cancelationToken.Register(() => { }); });
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => { cancelationToken.Register(1, i => { }); });
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.Throws<Proto.Promises.InvalidOperationException>(cancelationToken.Retain);
+#pragma warning restore CS0618 // Type or member is obsolete
                 Assert.Throws<Proto.Promises.InvalidOperationException>(cancelationToken.Release);
             }
 
@@ -650,7 +650,7 @@ namespace ProtoPromiseTests.APIs
             public void CancelationTokenCanceledMaybeBeRetainedAndReleased0()
             {
                 CancelationToken cancelationToken = CancelationToken.Canceled();
-                cancelationToken.Retain();
+                cancelationToken.TryRetain();
                 cancelationToken.Release();
             }
 
@@ -667,7 +667,7 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationToken.Retain();
+                cancelationToken.TryRetain();
                 cancelationSource.Dispose();
                 Assert.IsTrue(cancelationToken.CanBeCanceled);
                 cancelationToken.Release();
@@ -678,7 +678,7 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationToken.Retain();
+                cancelationToken.TryRetain();
                 cancelationSource.Dispose();
                 cancelationToken.Release();
                 Assert.IsFalse(cancelationToken.CanBeCanceled);
@@ -690,7 +690,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 cancelationSource.Cancel();
-                cancelationToken.Retain();
+                cancelationToken.TryRetain();
                 cancelationSource.Dispose();
                 Assert.IsTrue(cancelationToken.IsCancelationRequested);
                 cancelationToken.Release();
@@ -702,7 +702,7 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 cancelationSource.Cancel();
-                cancelationToken.Retain();
+                cancelationToken.TryRetain();
                 cancelationSource.Dispose();
                 cancelationToken.Release();
                 Assert.IsFalse(cancelationToken.IsCancelationRequested);
@@ -1177,56 +1177,54 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationRegistrationTryUnregisterCallbackIsInvoked2()
+            public void CancelationRegistrationTryUnregisterCallbackIsNotInvoked_0()
             {
+                // This is testing an implementation detail that a callback can be unregistered if it hasn't yet been invoked, even if the token is in the process of canceling.
+                // Callbacks are invoked in reverse order.
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 bool invoked = false;
-                CancelationRegistration cancelationRegistration = new CancelationRegistration();
-                // Can't unregister cancelation after token is canceled.
-                cancelationToken.Register(() => Assert.IsFalse(cancelationRegistration.TryUnregister()));
-                cancelationRegistration = cancelationToken.Register(() => invoked = true);
-                cancelationSource.Cancel();
-                Assert.IsTrue(invoked);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationRegistrationTryUnregisterCallbackIsInvoked3()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                bool invoked = false;
-                CancelationRegistration cancelationRegistration = new CancelationRegistration();
-                // Can't unregister cancelation after token is canceled.
-                cancelationToken.Register(() => Assert.IsFalse(cancelationRegistration.TryUnregister()));
-                cancelationRegistration = cancelationToken.Register(0, i => invoked = true);
-                cancelationSource.Cancel();
-                Assert.IsTrue(invoked);
-                cancelationSource.Dispose();
-            }
-
-            [Test]
-            public void CancelationRegistrationUnregisterCallbackIsNotInvoked0()
-            {
-                CancelationSource cancelationSource = CancelationSource.New();
-                CancelationToken cancelationToken = cancelationSource.Token;
-                bool invoked = false;
-                CancelationRegistration cancelationRegistration = cancelationToken.Register(() => invoked = true);
-                cancelationRegistration.Unregister();
+                var cancelationRegistration = cancelationToken.Register(() => invoked = true);
+                cancelationToken.Register(() => Assert.IsTrue(cancelationRegistration.TryUnregister()));
                 cancelationSource.Cancel();
                 Assert.IsFalse(invoked);
                 cancelationSource.Dispose();
             }
 
             [Test]
-            public void CancelationRegistrationUnregisterCallbackIsNotInvoked1()
+            public void CancelationRegistrationTryUnregisterCallbackIsNotInvoked_1()
+            {
+                CancelationSource cancelationSource = CancelationSource.New();
+                CancelationToken cancelationToken = cancelationSource.Token;
+                bool invoked = false;
+                var cancelationRegistration = cancelationToken.Register(0, i => invoked = true);
+                cancelationToken.Register(() => Assert.IsTrue(cancelationRegistration.TryUnregister()));
+                cancelationSource.Cancel();
+                Assert.IsFalse(invoked);
+                cancelationSource.Dispose();
+            }
+
+            [Test]
+            public void CancelationRegistrationTryUnregisterCallbackIsNotInvoked0()
+            {
+                CancelationSource cancelationSource = CancelationSource.New();
+                CancelationToken cancelationToken = cancelationSource.Token;
+                bool invoked = false;
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(() => invoked = true);
+                Assert.IsTrue(cancelationRegistration.TryUnregister());
+                cancelationSource.Cancel();
+                Assert.IsFalse(invoked);
+                cancelationSource.Dispose();
+            }
+
+            [Test]
+            public void CancelationRegistrationTryUnregisterCallbackIsNotInvoked1()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 bool invoked = false;
                 CancelationRegistration cancelationRegistration = cancelationToken.Register(0, i => invoked = true);
-                cancelationRegistration.Unregister();
+                Assert.IsTrue(cancelationRegistration.TryUnregister());
                 cancelationSource.Cancel();
                 Assert.IsFalse(invoked);
                 cancelationSource.Dispose();
@@ -1257,15 +1255,16 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void RegisteredCallbackIsNotRegisteredDuringInvocation()
+            public void RegisteredCallbackIsRegisteredDuringInvocationOfOtherCallback()
             {
+                // This is testing an implementation detail that a callback is still registered if it hasn't yet been invoked, even if the token is in the process of canceling.
+                // Callbacks are invoked in reverse order.
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
-                CancelationRegistration cancelationRegistration = new CancelationRegistration();
-                cancelationToken.Register(() => Assert.IsFalse(cancelationRegistration.IsRegistered));
-                cancelationRegistration = cancelationToken.Register(() => { });
+                var cancelationRegistration = cancelationToken.Register(() => { });
+                cancelationToken.Register(() => Assert.IsTrue(cancelationRegistration.IsRegistered));
                 cancelationSource.Cancel();
-                    cancelationSource.Dispose();
+                cancelationSource.Dispose();
             }
 
             [Test]
@@ -1308,7 +1307,7 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationToken.Retain();
+                cancelationToken.TryRetain();
                 cancelationSource.Cancel();
                 cancelationSource.Dispose();
                 cancelationToken.Register(() => { });
@@ -1320,17 +1319,19 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void RetainedCancelationTokenMayNotBeRegisteredToAfterCancelationSourceIsDisposedWithoutCancel()
+            public void RetainedCancelationTokenAfterCancelationSourceIsDisposedWithoutCancel_RegisterDoesNothing()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
-                cancelationToken.Retain();
+                cancelationToken.TryRetain();
                 cancelationSource.Dispose();
+                bool wasInvoked = false;
+                Assert.IsFalse(cancelationToken.Register(() => wasInvoked = true).IsRegistered);
+                Assert.IsFalse(cancelationToken.Register(1, cv => wasInvoked = true).IsRegistered);
                 CancelationRegistration cancelationRegistration;
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => cancelationToken.Register(() => { }));
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => cancelationToken.Register(1, cv => { }));
-                Assert.IsFalse(cancelationToken.TryRegister(() => { }, out cancelationRegistration));
-                Assert.IsFalse(cancelationToken.TryRegister(1, cv => { }, out cancelationRegistration));
+                Assert.IsFalse(cancelationToken.TryRegister(() => wasInvoked = true, out cancelationRegistration));
+                Assert.IsFalse(cancelationToken.TryRegister(1, cv => wasInvoked = true, out cancelationRegistration));
+                Assert.IsFalse(wasInvoked);
                 cancelationToken.Release();
             }
 
@@ -1399,6 +1400,75 @@ namespace ProtoPromiseTests.APIs
                 cancelationSource.Cancel();
                 cancelationSource.Dispose();
             }
+
+            [Test]
+            public void CancelationRegistrationDisposeUnregistersCallback_0()
+            {
+                CancelationSource cancelationSource = CancelationSource.New();
+                CancelationToken cancelationToken = cancelationSource.Token;
+                bool invoked = false;
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(() => invoked = true);
+                cancelationRegistration.Dispose();
+                cancelationSource.Cancel();
+                Assert.IsFalse(invoked);
+                cancelationSource.Dispose();
+            }
+
+            [Test]
+            public void CancelationRegistrationDisposeUnregistersCallback_1()
+            {
+                CancelationSource cancelationSource = CancelationSource.New();
+                CancelationToken cancelationToken = cancelationSource.Token;
+                bool invoked = false;
+                using (cancelationToken.Register(1, cv => invoked = true)) { }
+                cancelationSource.Cancel();
+                Assert.IsFalse(invoked);
+                cancelationSource.Dispose();
+            }
+
+#if !UNITY_WEBGL
+
+            [Test]
+            public void CancelationRegistrationDisposeWaitsForCallbackToComplete_0()
+            {
+                CancelationSource cancelationSource = CancelationSource.New();
+                CancelationToken cancelationToken = cancelationSource.Token;
+                bool startedInvoke = false;
+                bool invoked = false;
+                CancelationRegistration cancelationRegistration = cancelationToken.Register(() =>
+                {
+                    startedInvoke = true;
+                    Thread.Sleep(TimeSpan.FromSeconds(1));
+                    invoked = true;
+                });
+                Promise.Run(() => cancelationSource.Cancel()).Forget();
+                SpinWait.SpinUntil(() => startedInvoke);
+                cancelationRegistration.Dispose();
+                Assert.IsTrue(invoked);
+                cancelationSource.Dispose();
+            }
+
+            [Test]
+            public void CancelationRegistrationDisposeWaitsForCallbackToComplete_1()
+            {
+                CancelationSource cancelationSource = CancelationSource.New();
+                CancelationToken cancelationToken = cancelationSource.Token;
+                bool startedInvoke = false;
+                bool invoked = false;
+                using (cancelationToken.Register(() =>
+                    {
+                        startedInvoke = true;
+                        Thread.Sleep(TimeSpan.FromSeconds(1));
+                        invoked = true;
+                    }))
+                {
+                    Promise.Run(() => cancelationSource.Cancel()).Forget();
+                    SpinWait.SpinUntil(() => startedInvoke);
+                }
+                Assert.IsTrue(invoked);
+                cancelationSource.Dispose();
+            }
+#endif // !UNITY_WEBGL
         }
     }
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/CancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/CancelationTests.cs
@@ -618,10 +618,20 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationTokenFromSourceCannotBeCanceledAfterSourceIsDisposed()
+            public void CancelationTokenFromSourceCannotBeCanceledAfterSourceIsDisposed_0()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
+                cancelationSource.Dispose();
+                Assert.IsFalse(cancelationToken.CanBeCanceled);
+            }
+
+            [Test]
+            public void CancelationTokenFromSourceCannotBeCanceledAfterSourceIsDisposed_1()
+            {
+                CancelationSource cancelationSource = CancelationSource.New();
+                CancelationToken cancelationToken = cancelationSource.Token;
+                cancelationSource.Cancel();
                 cancelationSource.Dispose();
                 Assert.IsFalse(cancelationToken.CanBeCanceled);
             }
@@ -647,15 +657,7 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void CancelationTokenCanceledMaybeBeRetainedAndReleased0()
-            {
-                CancelationToken cancelationToken = CancelationToken.Canceled();
-                cancelationToken.TryRetain();
-                cancelationToken.Release();
-            }
-
-            [Test]
-            public void CancelationTokenCanceledMaybeBeRetainedAndReleased1()
+            public void CancelationTokenCanceledMaybeBeRetainedAndReleased()
             {
                 CancelationToken cancelationToken = CancelationToken.Canceled();
                 Assert.IsTrue(cancelationToken.TryRetain());
@@ -663,11 +665,23 @@ namespace ProtoPromiseTests.APIs
             }
 
             [Test]
-            public void RetainedCancelationTokenFromSourceCanBeCanceledAfterSourceIsDisposed()
+            public void RetainedCancelationTokenFromSourceCanNotBeCanceledAfterSourceIsDisposedWithoutCancel()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
                 CancelationToken cancelationToken = cancelationSource.Token;
                 cancelationToken.TryRetain();
+                cancelationSource.Dispose();
+                Assert.IsFalse(cancelationToken.CanBeCanceled);
+                cancelationToken.Release();
+            }
+
+            [Test]
+            public void RetainedCancelationTokenFromSourceCanBeCanceledAfterSourceIsCanceledThenDisposed()
+            {
+                CancelationSource cancelationSource = CancelationSource.New();
+                CancelationToken cancelationToken = cancelationSource.Token;
+                cancelationToken.TryRetain();
+                cancelationSource.Cancel();
                 cancelationSource.Dispose();
                 Assert.IsTrue(cancelationToken.CanBeCanceled);
                 cancelationToken.Release();


### PR DESCRIPTION
- Added `CancelationRegistration` implements `IDisposable`. `CancelationRegistration.Dispose()` tries to unregister the callback, or waits for the callback to complete.
- Added `CancelationRegistration` implements `IAsyncDisposable` in supported build targets. `CancelationRegistration.DisposeAsync()` tries to unregister the callback, or returns a `ValueTask` that will complete after the callback is complete.
- A callback now may be unregistered if the token is currently canceling, as long as the callback has not yet been invoked.
- `CancelationToken.Register(callback)` now returns a default registration if it failed to register instead of throwing.
- Deprecated `CancelationToken.Retain()` and `CancelationRegistration.Unregister()`.
- Added unchecked scopes so that ids can wrap around for infinite reuse.
- Changed `CancelationToken.CanBeCanceled` to return false if the source was disposed without being canceled.

Resolves #97.