### PR TITLE
Support scheduling continuations on the foreground context in Unity editmode

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
@@ -68,6 +68,8 @@ namespace Proto.Promises
                 {
                     _next = this; // Set _next to this so that CompareExchangeWaiter will always fail.
                     _smallFields = new SmallFields(-5); // Set an id that is unlikely to match (though this should never be used in a Promise struct).
+                    // If we don't suppress, the finalizer can run when the ApplicationDomain is unloaded, causing a NullReferenceException. This happens in Unity when switching between editmode and playmode.
+                    System.GC.SuppressFinalize(this);
                 }
 
                 internal override void Handle(PromiseRefBase handler)


### PR DESCRIPTION
Fixed a NullReferenceException when switching between editmode and playmode in Unity editor.
Added default support for scheduling continuations on the foreground context in editmode by using Unity's SynchronizationContext. Warn the user if it doesn't exist on old runtimes.
Added `Promise` static constructor in Unity since it no longer wraps `Promise<T>`.