### PR TITLE
Fix PromiseYielder with custom runners

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -75,11 +75,22 @@ namespace Proto.Promises
 #endif
         internal sealed partial class CancelationRef : HandleablePromiseBase, ICancelable, ITraceable
         {
-            internal static readonly CancelationRef s_canceledSentinel = new CancelationRef() { _state = State.CanceledComplete, _internalRetainCounter = 1, _tokenId = -1 };
+            internal static readonly CancelationRef s_canceledSentinel;
 
 #if PROMISE_DEBUG
             CausalityTrace ITraceable.Trace { get; set; }
 #endif
+
+            static CancelationRef()
+            {
+                s_canceledSentinel = new CancelationRef() { _state = State.CanceledComplete, _internalRetainCounter = 1, _tokenId = -1 };
+#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
+                // If we don't suppress, the finalizer can run when the ApplicationDomain is unloaded, causing a NullReferenceException. This happens in Unity when switching between editmode and playmode.
+                GC.SuppressFinalize(s_canceledSentinel);
+#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
+            }
+
+            private CancelationRef() { }
 
             ~CancelationRef()
             {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/PromiseYielderTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/PromiseYielderTests.cs
@@ -1,0 +1,105 @@
+﻿#if UNITY_5_5_OR_NEWER
+
+using NUnit.Framework;
+using Proto.Promises;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace ProtoPromiseTests.APIs
+{
+    public class PromiseYielderTestBehaviour : MonoBehaviour
+    {
+
+    }
+
+    public class PromiseYielderTests
+    {
+        public enum RunnerType
+        {
+            Default,
+            Custom
+        }
+
+        private class MoveNextCounterInstruction : CustomYieldInstruction
+        {
+            public int count;
+
+            public override bool keepWaiting
+            {
+                get
+                {
+                    ++count;
+                    return false;
+                }
+            }
+        }
+
+        private PromiseYielderTestBehaviour behaviour;
+
+        [SetUp]
+        public void Setup()
+        {
+            TestHelper.Setup();
+
+            behaviour = new GameObject("PromiseYielderTestBehaviour").AddComponent<PromiseYielderTestBehaviour>();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            Object.Destroy(behaviour);
+
+            TestHelper.Cleanup();
+        }
+
+        private MonoBehaviour GetRunner(RunnerType runnerType)
+        {
+            return runnerType == RunnerType.Default ? null : behaviour;
+        }
+
+        [UnityTest]
+        public IEnumerator PromiseYielderWaitOneFrame_WaitsOneFrame([Values] RunnerType runnerType)
+        {
+            int currentFrame = Time.frameCount;
+            int continuedFrame = -1;
+
+            var promise = PromiseYielder.WaitOneFrame(GetRunner(runnerType))
+                .Then(() => continuedFrame = Time.frameCount);
+            using (var yieldInstruction = promise.ToYieldInstruction())
+            {
+                yield return yieldInstruction;
+            }
+            Assert.AreEqual(currentFrame + 1, continuedFrame);
+        }
+
+        [UnityTest]
+        public IEnumerator PromiseYielderWaitFor_WaitsOnce([Values] RunnerType runnerType)
+        {
+            var instruction = new MoveNextCounterInstruction();
+
+            var promise = PromiseYielder.WaitFor(instruction, GetRunner(runnerType));
+            using (var yieldInstruction = promise.ToYieldInstruction())
+            {
+                yield return yieldInstruction;
+            }
+            Assert.AreEqual(1, instruction.count);
+        }
+
+        [UnityTest]
+        public IEnumerator PromiseYielderWaitFor_WaitsOnceOnEachRunner()
+        {
+            var instruction = new MoveNextCounterInstruction();
+
+            var promise = PromiseYielder.WaitFor(instruction)
+                .Then(() => PromiseYielder.WaitFor(instruction, behaviour));
+            using (var yieldInstruction = promise.ToYieldInstruction())
+            {
+                yield return yieldInstruction;
+            }
+            Assert.AreEqual(2, instruction.count);
+        }
+    }
+}
+
+#endif // UNITY_5_5_OR_NEWER

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/PromiseYielderTests.cs.meta
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/PromiseYielderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04c353342f0c84345aff04cf46425390
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixed PromiseYielder when different runners are used on a re-used routine.
No longer prevent MonoBehaviour runners from being collected when routines are pooled.
Fixed a NullReferenceException when the ApplicationDomain is reloaded.
Added PromiseYielder tests.