### PR TITLE
Use `SpinWait` instead of `Monitor.Wait` for synchronous waits.

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -159,8 +159,8 @@ namespace Proto.Promises
         partial class PromiseSynchronousWaiter : HandleablePromiseBase
         {
             private bool _isHookingUp;
-            private bool _didWaitSuccessfully;
-            private bool _didWait;
+            volatile private bool _didWaitSuccessfully;
+            volatile private bool _didWait;
         }
 
         partial class PromiseRefBase : HandleablePromiseBase


### PR DESCRIPTION
This should reduce the average time of waiting for completion, since the current method with `Monitor.Wait` causes more contention on the lock.