### PR TITLE
Fix a theoretical race condition

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -458,9 +458,9 @@ namespace Proto.Promises
             // This can be called instead of MaybeHandleNext when we know the nextHandler is not null.
             internal void HandleNext(HandleablePromiseBase nextHandler)
             {
-                WaitWhileProgressReporting();
                 // Set the waiter to InvalidAwaitSentinel to break the chain to stop progress reports.
                 _next = InvalidAwaitSentinel.s_instance;
+                WaitWhileProgressReporting();
                 nextHandler.Handle(this);
             }
 


### PR DESCRIPTION
Fixed a theoretical race condition from a possibly reused object when reporting progress.

The race condition is incredibly unlikely to happen, and can really only happen if a user reports progress and completes the deferred concurrently on separate threads (which is not recommended). So I don't think a patch update is necessary for it.