### PR TITLE
Include IL2CPP workarounds in nuget package

### DIFF
--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net35;net40;net45;net47;netstandard2.0;netstandard2.1;netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
-    <DefineConstants>CSHARP_7_3_OR_NEWER</DefineConstants>
     <Configurations>Release;Debug;Release_NoProgress;Debug_NoProgress</Configurations>
     <Version>2.2.0</Version>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <!--Only for function pointers in await override implementation. All other code should be C# 4 compatible for old Unity versions.-->
-    <LangVersion>9</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!--Set true to help debug internal promise code (allows the debugger to step into the code and includes internal stacktraces).-->
     <DeveloperMode>false</DeveloperMode>
@@ -19,17 +16,39 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!--Unity uses NET_LEGACY for old runtime prior to .Net 4.6, so we will do the same here.-->
-  <PropertyGroup Condition="'$(TargetFramework)'=='net35' OR '$(TargetFramework)'=='net40'">
-    <DefineConstants>$(DefineConstants);NET_LEGACY</DefineConstants>
-  </PropertyGroup>
-
-  <!--Unity's IL2CPP runtime had a lot of issues that we had to work around, most of which were fixed when they added .Net Standard 2.1 support.
+  <Choose>
+    <!--Unity's IL2CPP runtime had a lot of issues that we had to work around, most of which were fixed when they added .Net Standard 2.1 support.
       If someone chooses to use the Nuget package instead of the Unity package, and builds with IL2CPP in an older Unity version, we must make sure everything still works with those workarounds.
       To keep things simple, we just define ENABLE_IL2CPP in all build targets older than netstandard2.1, so all build targets that older Unity versions can possibly consume will have the workarounds baked in.-->
-  <PropertyGroup Condition="'$(TargetFramework)'=='net35' OR '$(TargetFramework)'=='net40' OR '$(TargetFramework)'=='net47' OR '$(TargetFramework)'=='netstandard2.0'">
-    <DefineConstants>$(DefineConstants);ENABLE_IL2CPP</DefineConstants>
-  </PropertyGroup>
+    <When Condition="'$(TargetFramework)'=='net35'">
+      <PropertyGroup>
+        <!--The newest language version Unity 5.5 supports (by default).-->
+        <LangVersion>4</LangVersion>
+        <!--Unity uses NET_LEGACY for old runtime prior to .Net 4.6, so we will do the same here.-->
+        <DefineConstants>$(DefineConstants);NET_LEGACY;ENABLE_IL2CPP</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetFramework)'=='net40'">
+      <PropertyGroup>
+        <LangVersion>7.3</LangVersion>
+        <!--Unity uses NET_LEGACY for old runtime prior to .Net 4.6, so we will do the same here.-->
+        <DefineConstants>$(DefineConstants);NET_LEGACY;ENABLE_IL2CPP;CSHARP_7_3_OR_NEWER</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetFramework)'=='net47' OR '$(TargetFramework)'=='netstandard2.0'">
+      <PropertyGroup>
+        <LangVersion>7.3</LangVersion>
+        <DefineConstants>$(DefineConstants);ENABLE_IL2CPP;CSHARP_7_3_OR_NEWER</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <!--For function pointers in await override implementation.-->
+        <LangVersion>9</LangVersion>
+        <DefineConstants>$(DefineConstants);CSHARP_7_3_OR_NEWER</DefineConstants>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoProgress|AnyCPU'">
     <DefineConstants>$(DefineConstants);RELEASE;PROTO_PROMISE_PROGRESS_DISABLE</DefineConstants>

--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -24,6 +24,13 @@
     <DefineConstants>$(DefineConstants);NET_LEGACY</DefineConstants>
   </PropertyGroup>
 
+  <!--Unity's IL2CPP runtime had a lot of issues that we had to work around, most of which were fixed when they added .Net Standard 2.1 support.
+      If someone chooses to use the Nuget package instead of the Unity package, and builds with IL2CPP in an older Unity version, we must make sure everything still works with those workarounds.
+      To keep things simple, we just define ENABLE_IL2CPP in all build targets older than netstandard2.1, so all build targets that older Unity versions can possibly consume will have the workarounds baked in.-->
+  <PropertyGroup Condition="'$(TargetFramework)'=='net35' OR '$(TargetFramework)'=='net40' OR '$(TargetFramework)'=='net47' OR '$(TargetFramework)'=='netstandard2.0'">
+    <DefineConstants>$(DefineConstants);ENABLE_IL2CPP</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoProgress|AnyCPU'">
     <DefineConstants>$(DefineConstants);RELEASE;PROTO_PROMISE_PROGRESS_DISABLE</DefineConstants>
     <DebugSymbols>false</DebugSymbols>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -908,7 +908,7 @@ namespace Proto.Promises
                     // callback to complete. While such polling isn't ideal, we expect this to be a rare case (disposing while
                     // the associated callback is running), and brief when it happens (so the polling will be minimal), and making
                     // this work with a callback mechanism will add additional cost to other more common cases.
-                    return Promise.Run((parent, _this, nodeId, tokenId), static async cv =>
+                    return Promise.Run((parent, _this, nodeId, tokenId), async cv =>
                     {
                         var (source, node, nId, sId) = cv;
                         // _this._nodeId will be incremented when the callback is complete and this is disposed.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Extensions.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Extensions.cs
@@ -76,7 +76,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        if (resultContainer.RejectReason is not System.Exception exception)
+                        if (!(resultContainer.RejectReason is System.Exception exception))
                         {
                             exception = Promise.RejectException(resultContainer.RejectReason);
                         }
@@ -106,7 +106,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        if (resultContainer.RejectReason is not System.Exception exception)
+                        if (!(resultContainer.RejectReason is System.Exception exception))
                         {
                             exception = Promise.RejectException(resultContainer.RejectReason);
                         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/AwaitInternal.cs
@@ -152,7 +152,7 @@ namespace Proto.Promises
 
 #if !NETCOREAPP
         // Override AwaitOnCompleted implementation to prevent boxing in Unity.
-#if UNITY_2021_2_OR_NEWER || !UNITY_5_5_OR_NEWER // C# 9 added in 2021.2. We can also use this in non-Unity library since CIL has supported function pointers forever.
+#if UNITY_2021_2_OR_NEWER || NETSTANDARD2_1_OR_GREATER // Even though CIL has always had function pointers, Unity did not properly support the CIL instructions until C# 9/ .Net Standard 2.1 support was added.
         internal unsafe abstract class AwaitOverrider<T> where T : INotifyCompletion
         {
 #pragma warning disable IDE0044 // Add readonly modifier
@@ -193,7 +193,7 @@ namespace Proto.Promises
                 }
             }
         }
-#else // UNITY_2021_2_OR_NEWER || !UNITY_5_5_OR_NEWER
+#else // UNITY_2021_2_OR_NEWER || NETSTANDARD2_1_OR_GREATER
         internal abstract class AwaitOverrider<T> where T : INotifyCompletion
         {
             private static AwaitOverrider<T> s_awaitOverrider;
@@ -238,7 +238,7 @@ namespace Proto.Promises
                 }
             }
         }
-#endif // UNITY_2021_2_OR_NEWER || !UNITY_5_5_OR_NEWER
+#endif // UNITY_2021_2_OR_NEWER || NETSTANDARD2_1_OR_GREATER
 #endif // !NETCOREAPP
 
         internal static void ValidateId(short promiseId, PromiseRefBase _ref, int skipFrames)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
@@ -407,9 +407,8 @@ namespace Proto.Promises
             }
         }
 
-#if UNITY_2021_2_OR_NEWER || !UNITY_5_5_OR_NEWER
-        // Old IL2CPP runtime immediately crashes if these methods exist, even if they are not used. So we only include them if we're not in Unity, or in a newer Unity version with the fixed compiler.
-        // (Even though it would work with the Mono runtime, the API surface must be kept consistent.)
+#if UNITY_2021_2_OR_NEWER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP
+        // Old IL2CPP runtime immediately crashes if these methods exist, even if they are not used. So we only include them in newer build targets that old Unity versions cannot consume.
         // See https://github.com/timcassell/ProtoPromise/pull/106 for details.
 
         /// <summary>
@@ -519,8 +518,7 @@ namespace Proto.Promises
         {
             return Promise.FirstWithIndex<T, TEnumerator>(promises);
         }
-#endif // UNITY_2021_2_OR_NEWER || !UNITY_5_5_OR_NEWER
-
+#endif // UNITY_2021_2_OR_NEWER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP
         /// <summary>
         /// Returns a <see cref="Promise"/> that will resolve with a list of the promises' values in the same order when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be rejected or canceled with the same reason.


### PR DESCRIPTION
Followup to #127 to support nuget package consumption in Unity.

Include IL2CPP workarounds in nuget package build targets older than netstandard2.1.

This unfortunately removes `Promise<T>.{RaceWithIndex, FirstWithIndex}` in older build targets, but there is at least the workaround to use `Promise.{RaceWithIndex<T>, FirstWithIndex<T>}` instead.