### PR TITLE
Fixed failing tests due to race condition.

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/NewAndRunTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/NewAndRunTests.cs
@@ -839,6 +839,10 @@ namespace ProtoPromiseTests.APIs
             if (isPending)
             {
 #if PROMISE_PROGRESS
+                // Wait a bit longer to make sure the promise is fully adopted before we report progress.
+                // Otherwise it results in a race condition where the progress may be reported as 0 immediately after we try to report 0.5 and spoils the result.
+                Thread.Sleep(System.TimeSpan.FromMilliseconds(500));
+
                 progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
                 if (completeType == CompleteType.Resolve)
                 {
@@ -951,6 +955,10 @@ namespace ProtoPromiseTests.APIs
             if (isPending)
             {
 #if PROMISE_PROGRESS
+                // Wait a bit longer to make sure the promise is fully adopted before we report progress.
+                // Otherwise it results in a race condition where the progress may be reported as 0 immediately after we try to report 0.5 and spoils the result.
+                Thread.Sleep(System.TimeSpan.FromMilliseconds(500));
+
                 progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
                 if (completeType == CompleteType.Resolve)
                 {
@@ -1063,6 +1071,10 @@ namespace ProtoPromiseTests.APIs
             if (isPending)
             {
 #if PROMISE_PROGRESS
+                // Wait a bit longer to make sure the promise is fully adopted before we report progress.
+                // Otherwise it results in a race condition where the progress may be reported as 0 immediately after we try to report 0.5 and spoils the result.
+                Thread.Sleep(System.TimeSpan.FromMilliseconds(500));
+
                 progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
                 if (completeType == CompleteType.Resolve)
                 {
@@ -1177,6 +1189,10 @@ namespace ProtoPromiseTests.APIs
             if (isPending)
             {
 #if PROMISE_PROGRESS
+                // Wait a bit longer to make sure the promise is fully adopted before we report progress.
+                // Otherwise it results in a race condition where the progress may be reported as 0 immediately after we try to report 0.5 and spoils the result.
+                Thread.Sleep(System.TimeSpan.FromMilliseconds(500));
+
                 progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
                 if (completeType == CompleteType.Resolve)
                 {


### PR DESCRIPTION
Fixes #134.

This is a band-aid, there exists still a real race condition between reporting progress from adopting the promise (`promise.Then()`), and reporting progress to the deferred. I will look at remedying this race condition with the refactor for #115. But it's not a huge issue, as the next progress report will be reported correctly.

Also, I had to run the test in a `while (true)` loop for 15 minutes on my computer before the failure surfaced. So it's super rare, and shouldn't harm anything.