### PR TITLE
Improve progress performance

### DIFF
--- a/ProtoPromise.sln
+++ b/ProtoPromise.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.30523.141
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProtoPromiseTests", "ProtoPromiseTests\ProtoPromiseTests.csproj", "{27C1B5AC-2E73-4B91-8258-C67B4B064569}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProtoPromise", "ProtoPromise\ProtoPromise.csproj", "{2A0BBD14-FA01-467C-8A42-55C5C287F66D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProtoPromise", "ProtoPromise\ProtoPromise.csproj", "{2A0BBD14-FA01-467C-8A42-55C5C287F66D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProtoPromiseUnityHelpers", "ProtoPromiseUnityHelpers\ProtoPromiseUnityHelpers.csproj", "{5B1E6550-0342-4240-AF91-F8059F84BF67}"
 EndProject
@@ -33,12 +33,12 @@ Global
 		{2A0BBD14-FA01-467C-8A42-55C5C287F66D}.Release_NoProgress|Any CPU.Build.0 = Release_NoProgress|Any CPU
 		{2A0BBD14-FA01-467C-8A42-55C5C287F66D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A0BBD14-FA01-467C-8A42-55C5C287F66D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5B1E6550-0342-4240-AF91-F8059F84BF67}.Debug_NoProgress|Any CPU.ActiveCfg = Debug_NoProgress|Any CPU
-		{5B1E6550-0342-4240-AF91-F8059F84BF67}.Debug_NoProgress|Any CPU.Build.0 = Debug_NoProgress|Any CPU
+		{5B1E6550-0342-4240-AF91-F8059F84BF67}.Debug_NoProgress|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B1E6550-0342-4240-AF91-F8059F84BF67}.Debug_NoProgress|Any CPU.Build.0 = Debug|Any CPU
 		{5B1E6550-0342-4240-AF91-F8059F84BF67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5B1E6550-0342-4240-AF91-F8059F84BF67}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5B1E6550-0342-4240-AF91-F8059F84BF67}.Release_NoProgress|Any CPU.ActiveCfg = Release_NoProgress|Any CPU
-		{5B1E6550-0342-4240-AF91-F8059F84BF67}.Release_NoProgress|Any CPU.Build.0 = Release_NoProgress|Any CPU
+		{5B1E6550-0342-4240-AF91-F8059F84BF67}.Release_NoProgress|Any CPU.ActiveCfg = Release|Any CPU
+		{5B1E6550-0342-4240-AF91-F8059F84BF67}.Release_NoProgress|Any CPU.Build.0 = Release|Any CPU
 		{5B1E6550-0342-4240-AF91-F8059F84BF67}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5B1E6550-0342-4240-AF91-F8059F84BF67}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -86,7 +86,7 @@ namespace Proto.Promises
                 // Set _userRetainIncrementor to 0 so _userRetainCounter will never overflow.
                 s_canceledSentinel = new CancelationRef(0) { _state = State.CanceledComplete, _internalRetainCounter = 1, _tokenId = -1 };
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-                // If we don't suppress, the finalizer can run when the ApplicationDomain is unloaded, causing a NullReferenceException. This happens in Unity when switching between editmode and playmode.
+                // If we don't suppress, the finalizer can run when the AppDomain is unloaded, causing a NullReferenceException. This happens in Unity when switching between editmode and playmode.
                 GC.SuppressFinalize(s_canceledSentinel);
 #pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
@@ -340,15 +340,6 @@ namespace Proto.Promises
                         }
                     }
                 }
-                
-                new protected void Dispose()
-                {
-                    base.Dispose();
-                    lock (_previousPromises)
-                    {
-                        _previousPromises.Clear();
-                    }
-                }
             }
         }
 #else // PROMISE_DEBUG

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ValueCollectionsInternal.cs
@@ -189,6 +189,14 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
+            internal ValueLinkedStack<T> TakeAndClear()
+            {
+                T temp = _head;
+                _head = null;
+                return new ValueLinkedStack<T>(temp);
+            }
+
+            [MethodImpl(InlineOption)]
             internal void Push(T item)
             {
                 AssertNotInCollection(item);
@@ -415,12 +423,9 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
-        internal struct ValueList<T> where T : class, ILinked<T>
+        internal struct ValueList<T>
         {
             // This structure is a specialized version of List<T> without the extra object overhead and unused methods.
-            // Individual elements cannot be removed or modified, only all elements can be cleared at once.
-            // This specialization is made use of in PromiseMultiAwait for increasing concurrency while invoking progress,
-            // so threads may iterate over the data while new data is being added.
 
             private T[] _storage;
             private int _count;
@@ -435,6 +440,8 @@ namespace Proto.Promises
             {
                 [MethodImpl(InlineOption)]
                 get { return _storage[index]; }
+                [MethodImpl(InlineOption)]
+                set { _storage[index] = value; }
             }
 
             [MethodImpl(InlineOption)]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Config.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Config.cs
@@ -62,18 +62,19 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
-        public static partial class Config
+        public static class Config
         {
             [Obsolete("Use ProgressPrecision to get the precision of progress reports."), EditorBrowsable(EditorBrowsableState.Never)]
-            public static readonly int ProgressDecimalBits = Internal.PromiseRefBase.Fixed32.DecimalBits;
+            public static readonly int ProgressDecimalBits = 32;
 
             /// <summary>
-            /// The maximum precision of progress reports.
+            /// The distance between 1 and the largest value smaller than 1. Progress reports use full 32-bit float precision.
             /// </summary>
 #if !PROMISE_PROGRESS
             [Obsolete(Internal.ProgressDisabledMessage, false)]
 #endif
-            public static readonly float ProgressPrecision = (float) (1d / Math.Pow(2d, Internal.PromiseRefBase.Fixed32.DecimalBits));
+            [EditorBrowsable(EditorBrowsableState.Never)] // Not obsolete, but not really necessary to use, either.
+            public static readonly float ProgressPrecision = 1f - 0.99999994f;
 
             [Obsolete("Use ObjectPoolingEnabled instead."), EditorBrowsable(EditorBrowsableState.Never)]
             public static PoolType ObjectPooling 
@@ -181,7 +182,7 @@ namespace Proto.Promises
                 {
                     if (!value)
                     {
-                        ThrowCannotDisableAsyncLocal();
+                        ThrowCannotDisableAsyncFlow();
                     }
                     s_asyncFlowExecutionContextEnabled = true;
                 }
@@ -189,9 +190,9 @@ namespace Proto.Promises
             private static bool s_asyncFlowExecutionContextEnabled;
 
             [MethodImpl(MethodImplOptions.NoInlining)]
-            private static void ThrowCannotDisableAsyncLocal()
+            private static void ThrowCannotDisableAsyncFlow()
             {
-                throw new InvalidOperationException("Cannot disable AsyncLocal. It may only be enabled.");
+                throw new InvalidOperationException("Cannot disable AsyncFlowExecutionContext. It may only be enabled.");
             }
 
             [Obsolete, EditorBrowsable(EditorBrowsableState.Never)]

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -84,10 +84,17 @@ namespace Proto.Promises
                             ? CallbackHelperVoid.Canceled(_this._ref, _this._id, _this.Depth)
                             : InvokeCallbackDirect(resolver, _this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolve<TArg, TDelegate>.GetOrCreate(resolver, cancelationToken, _this.Depth)
-                        : (PromiseRefBase) PromiseResolve<TArg, TDelegate>.GetOrCreate(resolver, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolve<TArg, TDelegate>.GetOrCreate(resolver, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolve<TArg, TDelegate>.GetOrCreate(resolver, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, _this.Depth);
                 }
 
@@ -102,10 +109,17 @@ namespace Proto.Promises
                             ? CallbackHelperVoid.Canceled(_this._ref, _this._id, nextDepth)
                             : InvokeCallbackAndAdoptDirect(resolver, _this, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolvePromise<VoidResult, TDelegate>.GetOrCreate(resolver, cancelationToken, nextDepth)
-                        : (PromiseRefBase) PromiseResolvePromise<VoidResult, TDelegate>.GetOrCreate(resolver, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolvePromise<VoidResult, TDelegate>.GetOrCreate(resolver, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolvePromise<VoidResult, TDelegate>.GetOrCreate(resolver, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, nextDepth);
                 }
 
@@ -123,10 +137,17 @@ namespace Proto.Promises
                             ? CallbackHelperVoid.Canceled(_this._ref, _this._id, _this.Depth)
                             : InvokeCallbackDirect(resolver, _this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolveReject<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, _this.Depth)
-                        : (PromiseRefBase) PromiseResolveReject<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolveReject<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolveReject<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, _this.Depth);
                 }
 
@@ -145,10 +166,17 @@ namespace Proto.Promises
                             ? CallbackHelperVoid.Canceled(_this._ref, _this._id, nextDepth)
                             : InvokeCallbackAndAdoptDirect(resolver, _this, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolveRejectPromise<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth)
-                        : (PromiseRefBase) PromiseResolveRejectPromise<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolveRejectPromise<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolveRejectPromise<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, nextDepth);
                 }
 
@@ -162,10 +190,17 @@ namespace Proto.Promises
                             ? CallbackHelperVoid.Canceled(_this._ref, _this._id, _this.Depth)
                             : InvokeCallbackDirect(continuer, _this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseContinue<VoidResult, TDelegateContinue>.GetOrCreate(continuer, cancelationToken, _this.Depth)
-                        : (PromiseRefBase) PromiseContinue<VoidResult, TDelegateContinue>.GetOrCreate(continuer, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseContinue<VoidResult, TDelegateContinue>.GetOrCreate(continuer, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseContinue<VoidResult, TDelegateContinue>.GetOrCreate(continuer, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, _this.Depth);
                 }
 
@@ -180,10 +215,17 @@ namespace Proto.Promises
                             ? CallbackHelperVoid.Canceled(_this._ref, _this._id, nextDepth)
                             : InvokeCallbackAndAdoptDirect(continuer, _this, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseContinuePromise<VoidResult, TDelegateContinue>.GetOrCreate(continuer, cancelationToken, nextDepth)
-                        : (PromiseRefBase) PromiseContinuePromise<VoidResult, TDelegateContinue>.GetOrCreate(continuer, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseContinuePromise<VoidResult, TDelegateContinue>.GetOrCreate(continuer, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseContinuePromise<VoidResult, TDelegateContinue>.GetOrCreate(continuer, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, nextDepth);
                 }
             }
@@ -263,10 +305,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, _this.Depth)
                             : InvokeCallbackDirect(resolver, _this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolvePromise<TResult, TDelegate>.GetOrCreate(resolver, cancelationToken, _this.Depth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseResolvePromise<TResult, TDelegate>.GetOrCreate(resolver, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolvePromise<TResult, TDelegate>.GetOrCreate(resolver, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolvePromise<TResult, TDelegate>.GetOrCreate(resolver, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 
@@ -281,10 +330,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, nextDepth)
                             : InvokeCallbackAndAdoptDirect(resolver, _this, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolvePromise<TResult, TDelegate>.GetOrCreate(resolver, cancelationToken, nextDepth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseResolvePromise<TResult, TDelegate>.GetOrCreate(resolver, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolvePromise<TResult, TDelegate>.GetOrCreate(resolver, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolvePromise<TResult, TDelegate>.GetOrCreate(resolver, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
 
@@ -302,10 +358,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, _this.Depth)
                             : InvokeCallbackDirect(resolver, _this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolveReject<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, _this.Depth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseResolveReject<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolveReject<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolveReject<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 
@@ -324,10 +387,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, nextDepth)
                             : InvokeCallbackAndAdoptDirect(resolver, _this, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolveRejectPromise<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseResolveRejectPromise<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolveRejectPromise<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolveRejectPromise<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
 
@@ -341,10 +411,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, _this.Depth)
                             : InvokeCallbackDirect(continuer, _this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseContinue<TResult, TDelegateContinue>.GetOrCreate(continuer, cancelationToken, _this.Depth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseContinue<TResult, TDelegateContinue>.GetOrCreate(continuer, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseContinue<TResult, TDelegateContinue>.GetOrCreate(continuer, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseContinue<TResult, TDelegateContinue>.GetOrCreate(continuer, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 
@@ -359,10 +436,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, nextDepth)
                             : InvokeCallbackAndAdoptDirect(continuer, _this, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseContinuePromise<TResult, TDelegateContinue>.GetOrCreate(continuer, cancelationToken, nextDepth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseContinuePromise<TResult, TDelegateContinue>.GetOrCreate(continuer, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseContinuePromise<TResult, TDelegateContinue>.GetOrCreate(continuer, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseContinuePromise<TResult, TDelegateContinue>.GetOrCreate(continuer, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
 
@@ -376,10 +460,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, _this.Depth)
                             : CallbackHelperVoid.Duplicate(_this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseCancel<TResult, TDelegateCancel>.GetOrCreate(canceler, cancelationToken, _this.Depth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseCancel<TResult, TDelegateCancel>.GetOrCreate(canceler, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseCancel<TResult, TDelegateCancel>.GetOrCreate(canceler, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseCancel<TResult, TDelegateCancel>.GetOrCreate(canceler, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 
@@ -394,10 +485,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, nextDepth)
                             : new Promise<TResult>(_this._ref, _this._id, nextDepth, _this._result);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseCancelPromise<TResult, TDelegateCancel>.GetOrCreate(canceler, cancelationToken, nextDepth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseCancelPromise<TResult, TDelegateCancel>.GetOrCreate(canceler, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseCancelPromise<TResult, TDelegateCancel>.GetOrCreate(canceler, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseCancelPromise<TResult, TDelegateCancel>.GetOrCreate(canceler, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
             }
@@ -453,10 +551,17 @@ namespace Proto.Promises
                             ? CallbackHelperResult<TResult>.Canceled(_this._ref, _this._id, _this.Depth)
                             : InvokeCallbackDirect(resolver, _this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolve<TResult, TDelegate>.GetOrCreate(resolver, cancelationToken, _this.Depth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseResolve<TResult, TDelegate>.GetOrCreate(resolver, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolve<TResult, TDelegate>.GetOrCreate(resolver, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolve<TResult, TDelegate>.GetOrCreate(resolver, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 
@@ -471,10 +576,17 @@ namespace Proto.Promises
                             ? CallbackHelperResult<TResult>.Canceled(_this._ref, _this._id, nextDepth)
                             : InvokeCallbackAndAdoptDirect(resolver, _this, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolvePromise<TResult, TDelegate>.GetOrCreate(resolver, cancelationToken, nextDepth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseResolvePromise<TResult, TDelegate>.GetOrCreate(resolver, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolvePromise<TResult, TDelegate>.GetOrCreate(resolver, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolvePromise<TResult, TDelegate>.GetOrCreate(resolver, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
 
@@ -492,10 +604,17 @@ namespace Proto.Promises
                             ? CallbackHelperResult<TResult>.Canceled(_this._ref, _this._id, _this.Depth)
                             : InvokeCallbackDirect(resolver, _this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolveReject<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, _this.Depth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseResolveReject<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolveReject<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolveReject<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 
@@ -514,10 +633,17 @@ namespace Proto.Promises
                             ? CallbackHelperResult<TResult>.Canceled(_this._ref, _this._id, nextDepth)
                             : InvokeCallbackAndAdoptDirect(resolver, _this, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolveRejectPromise<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseResolveRejectPromise<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolveRejectPromise<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolveRejectPromise<TResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
 
@@ -531,10 +657,17 @@ namespace Proto.Promises
                             ? CallbackHelperResult<TResult>.Canceled(_this._ref, _this._id, _this.Depth)
                             : InvokeCallbackDirect(continuer, _this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseContinue<TResult, TDelegateContinue>.GetOrCreate(continuer, cancelationToken, _this.Depth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseContinue<TResult, TDelegateContinue>.GetOrCreate(continuer, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseContinue<TResult, TDelegateContinue>.GetOrCreate(continuer, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseContinue<TResult, TDelegateContinue>.GetOrCreate(continuer, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 
@@ -549,10 +682,17 @@ namespace Proto.Promises
                             ? CallbackHelperResult<TResult>.Canceled(_this._ref, _this._id, nextDepth)
                             : InvokeCallbackAndAdoptDirect(continuer, _this, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseContinuePromise<TResult, TDelegateContinue>.GetOrCreate(continuer, cancelationToken, nextDepth)
-                        : (PromiseRefBase.PromiseRef<TResult>) PromiseContinuePromise<TResult, TDelegateContinue>.GetOrCreate(continuer, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRef<TResult> promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseContinuePromise<TResult, TDelegateContinue>.GetOrCreate(continuer, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseContinuePromise<TResult, TDelegateContinue>.GetOrCreate(continuer, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise<TResult>(promise, promise.Id, nextDepth);
                 }
             }
@@ -655,7 +795,7 @@ namespace Proto.Promises
                     Promise<TResult> promise, ushort nextDepth)
                 {
 #if !PROMISE_PROGRESS
-                    return promise;
+                    return new Promise<TResult>(promise._ref, promise._id, nextDepth, promise._result);
 #else
                     var _ref = promise._ref;
                     if (_ref == null)
@@ -668,7 +808,7 @@ namespace Proto.Promises
                     }
                     // Normalize progress. Passing a default resolver makes the Execute method adopt the promise's state without attempting to invoke.
                     var newRef = PromiseResolvePromise<TResult, DelegateResolvePassthrough<TResult>>.GetOrCreate(default(DelegateResolvePassthrough<TResult>), nextDepth);
-                    newRef.WaitForWithProgress(_ref, promise._id);
+                    newRef.SetSecondPreviousAndWaitFor(_ref, promise._id, null);
                     return new Promise<TResult>(newRef, newRef.Id, nextDepth);
 #endif
                 }
@@ -683,7 +823,7 @@ namespace Proto.Promises
                     Promise promise, ushort nextDepth)
                 {
 #if !PROMISE_PROGRESS
-                    return promise;
+                    return new Promise(promise._ref, promise._id, nextDepth);
 #else
                     var _ref = promise._ref;
                     if (_ref == null)
@@ -697,7 +837,7 @@ namespace Proto.Promises
                     }
                     // Normalize progress. Passing a default resolver makes the Execute method adopt the promise's state without attempting to invoke.
                     var newRef = PromiseResolvePromise<VoidResult, DelegateResolvePassthrough<VoidResult>>.GetOrCreate(default(DelegateResolvePassthrough<VoidResult>), nextDepth);
-                    newRef.WaitForWithProgress(_ref, promise._id);
+                    newRef.SetSecondPreviousAndWaitFor(_ref, promise._id, null);
                     return new Promise(newRef, newRef.Id, nextDepth);
 #endif
                 }
@@ -749,8 +889,8 @@ namespace Proto.Promises
                     PromiseRefBase promise;
                     if (cancelationToken.CanBeCanceled)
                     {
-                        promise = PromiseDuplicateCancel<VoidResult>.GetOrCreate(_this.Depth, cancelationToken);
-                        _this._ref.HookupNewPromise(_this._id, promise);
+                        var p = PromiseDuplicateCancel<VoidResult>.GetOrCreate(_this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
                     }
                     else
                     {
@@ -770,8 +910,8 @@ namespace Proto.Promises
                     PromiseRef<TResult> promise;
                     if (cancelationToken.CanBeCanceled)
                     {
-                        promise = PromiseDuplicateCancel<TResult>.GetOrCreate(_this.Depth, cancelationToken);
-                        _this._ref.HookupNewPromise(_this._id, promise);
+                        var p = PromiseDuplicateCancel<TResult>.GetOrCreate(_this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
                     }
                     else
                     {
@@ -811,15 +951,16 @@ namespace Proto.Promises
                             {
                                 synchronizationContext = BackgroundSynchronizationContextSentinel.s_instance;
                             }
-                            PromiseRefBase promise;
+                            PromiseConfigured<VoidResult> promise;
                             if (_this._ref == null)
                             {
-                                promise = PromiseConfigured<VoidResult>.GetOrCreateFromResolved(synchronizationContext, new VoidResult(), _this.Depth, forceAsync, cancelationToken);
+                                promise = PromiseConfigured<VoidResult>.GetOrCreateFromResolved(synchronizationContext, new VoidResult(), _this.Depth, forceAsync);
+                                promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
                             }
                             else
                             {
-                                promise = PromiseConfigured<VoidResult>.GetOrCreate(synchronizationContext, _this.Depth, forceAsync, cancelationToken);
-                                _this._ref.HookupNewPromise(_this._id, promise);
+                                promise = PromiseConfigured<VoidResult>.GetOrCreate(synchronizationContext, _this.Depth, forceAsync);
+                                _this._ref.HookupCancelablePromise(promise, _this._id, cancelationToken, ref promise._cancelationHelper);
                             }
                             return new Promise(promise, promise.Id, _this.Depth);
                         }
@@ -857,15 +998,16 @@ namespace Proto.Promises
                             {
                                 synchronizationContext = BackgroundSynchronizationContextSentinel.s_instance;
                             }
-                            PromiseRef<TResult> promise;
+                            PromiseConfigured<TResult> promise;
                             if (_this._ref == null)
                             {
-                                promise = PromiseConfigured<TResult>.GetOrCreateFromResolved(synchronizationContext, _this._result, _this.Depth, forceAsync, cancelationToken);
+                                promise = PromiseConfigured<TResult>.GetOrCreateFromResolved(synchronizationContext, _this._result, _this.Depth, forceAsync);
+                                promise._cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
                             }
                             else
                             {
-                                promise = PromiseConfigured<TResult>.GetOrCreate(synchronizationContext, _this.Depth, forceAsync, cancelationToken);
-                                _this._ref.HookupNewPromise(_this._id, promise);
+                                promise = PromiseConfigured<TResult>.GetOrCreate(synchronizationContext, _this.Depth, forceAsync);
+                                _this._ref.HookupCancelablePromise(promise, _this._id, cancelationToken, ref promise._cancelationHelper);
                             }
                             return new Promise<TResult>(promise, promise.Id, _this.Depth, _this._result);
                         }
@@ -882,10 +1024,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, _this.Depth)
                             : InvokeCallbackDirect(resolver, _this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolve<VoidResult, TDelegate>.GetOrCreate(resolver, cancelationToken, _this.Depth)
-                        : (PromiseRefBase) PromiseResolve<VoidResult, TDelegate>.GetOrCreate(resolver, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolve<VoidResult, TDelegate>.GetOrCreate(resolver, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolve<VoidResult, TDelegate>.GetOrCreate(resolver, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, _this.Depth);
                 }
 
@@ -900,10 +1049,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, nextDepth)
                             : InvokeCallbackAndAdoptDirect(resolver, _this, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolvePromise<VoidResult, TDelegate>.GetOrCreate(resolver, cancelationToken, nextDepth)
-                        : (PromiseRefBase) PromiseResolvePromise<VoidResult, TDelegate>.GetOrCreate(resolver, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolvePromise<VoidResult, TDelegate>.GetOrCreate(resolver, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolvePromise<VoidResult, TDelegate>.GetOrCreate(resolver, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, nextDepth);
                 }
 
@@ -921,10 +1077,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, _this.Depth)
                             : InvokeCallbackDirect(resolver, _this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolveReject<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, _this.Depth)
-                        : (PromiseRefBase) PromiseResolveReject<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolveReject<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolveReject<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, _this.Depth);
                 }
 
@@ -943,10 +1106,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, nextDepth)
                             : InvokeCallbackAndAdoptDirect(resolver, _this, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseResolveRejectPromise<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, cancelationToken, nextDepth)
-                        : (PromiseRefBase) PromiseResolveRejectPromise<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseResolveRejectPromise<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseResolveRejectPromise<VoidResult, TDelegateResolve, TDelegateReject>.GetOrCreate(resolver, rejecter, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, nextDepth);
                 }
 
@@ -960,10 +1130,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, _this.Depth)
                             : InvokeCallbackDirect(continuer, _this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseContinue<VoidResult, TDelegateContinue>.GetOrCreate(continuer, cancelationToken, _this.Depth)
-                        : (PromiseRefBase) PromiseContinue<VoidResult, TDelegateContinue>.GetOrCreate(continuer, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseContinue<VoidResult, TDelegateContinue>.GetOrCreate(continuer, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseContinue<VoidResult, TDelegateContinue>.GetOrCreate(continuer, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, _this.Depth);
                 }
 
@@ -978,10 +1155,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, nextDepth)
                             : InvokeCallbackAndAdoptDirect(continuer, _this, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseContinuePromise<VoidResult, TDelegateContinue>.GetOrCreate(continuer, cancelationToken, nextDepth)
-                        : (PromiseRefBase) PromiseContinuePromise<VoidResult, TDelegateContinue>.GetOrCreate(continuer, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseContinuePromise<VoidResult, TDelegateContinue>.GetOrCreate(continuer, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseContinuePromise<VoidResult, TDelegateContinue>.GetOrCreate(continuer, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, nextDepth);
                 }
 
@@ -1030,10 +1214,17 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, _this.Depth)
                             : Duplicate(_this);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseCancel<VoidResult, TDelegateCancel>.GetOrCreate(canceler, cancelationToken, _this.Depth)
-                        : (PromiseRefBase) PromiseCancel<VoidResult, TDelegateCancel>.GetOrCreate(canceler, _this.Depth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseCancel<VoidResult, TDelegateCancel>.GetOrCreate(canceler, _this.Depth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseCancel<VoidResult, TDelegateCancel>.GetOrCreate(canceler, _this.Depth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, _this.Depth);
                 }
 
@@ -1048,27 +1239,37 @@ namespace Proto.Promises
                             ? Canceled(_this._ref, _this._id, nextDepth)
                             : new Promise(_this._ref, _this._id, nextDepth);
                     }
-                    var promise = cancelationToken.CanBeCanceled
-                        ? CancelablePromiseCancelPromise<VoidResult, TDelegateCancel>.GetOrCreate(canceler, cancelationToken, nextDepth)
-                        : (PromiseRefBase) PromiseCancelPromise<VoidResult, TDelegateCancel>.GetOrCreate(canceler, nextDepth);
-                    _this._ref.HookupNewPromise(_this._id, promise);
+                    PromiseRefBase promise;
+                    if (cancelationToken.CanBeCanceled)
+                    {
+                        var p = CancelablePromiseCancelPromise<VoidResult, TDelegateCancel>.GetOrCreate(canceler, nextDepth);
+                        promise = _this._ref.HookupCancelablePromise(p, _this._id, cancelationToken, ref p._cancelationHelper);
+                    }
+                    else
+                    {
+                        promise = PromiseCancelPromise<VoidResult, TDelegateCancel>.GetOrCreate(canceler, nextDepth);
+                        _this._ref.HookupNewPromise(_this._id, promise);
+                    }
                     return new Promise(promise, promise.Id, nextDepth);
                 }
 
                 [MethodImpl(InlineOption)]
                 internal static ushort GetNextDepth(ushort depth)
                 {
-#if PROMISE_PROGRESS
-                    return Fixed32.GetNextDepth(depth);
-#elif PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    // Depth is unused, but it can help with debugging.
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    // We allow ushort.MaxValue to rollover for progress normalization purposes, but we don't allow overflow for regular user chains.
+                    // This restriction only exists for Promise.Then() chains, async/await has no depth limit.
+                    // Technically, we don't need to restrict this if progress is disabled, but we keep the check for consistency.
+                    const ushort maxDepthAllowed = ushort.MaxValue - 2;
+                    if (depth == maxDepthAllowed)
+                    {
+                        throw new OverflowException("Promise chain length exceeded maximum of " + maxDepthAllowed);
+                    }
+#endif
                     unchecked
                     {
-                        return (ushort) (depth + 1);
+                        return (ushort) (depth + 1u);
                     }
-#else
-                    return 0;
-#endif
                 }
 
 #if PROMISE_PROGRESS
@@ -1165,31 +1366,8 @@ namespace Proto.Promises
                         }
                     }
 
-                    promise = PromiseProgress<VoidResult, TProgress>.GetOrCreate(progress, _this.Depth, invokeOption == SynchronizationOption.Synchronous, synchronizationContext, forceAsync, cancelationToken);
-#if PROMISE_DEBUG
-                    promise._previous = _this._ref;
-#endif
-                    promise._smallFields._currentProgress = _this._ref._smallFields._currentProgress;
-                    _this._ref.InterlockedIncrementProgressReportingCount();
-                    HandleablePromiseBase previousWaiter;
-                    PromiseRefBase promiseSingleAwait = _this._ref.AddWaiter(_this._id, promise, out previousWaiter);
-                    if (previousWaiter == null)
-                    {
-                        promise.MaybeScheduleProgress();
-                        _this._ref.InterlockedDecrementProgressReportingCount();
-                        StackUnwindHelper.InvokeProgressors();
-                    }
-                    else
-                    {
-                        _this._ref.InterlockedDecrementProgressReportingCount();
-                        if (!VerifyWaiter(promiseSingleAwait))
-                        {
-                            // We're throwing InvalidOperationException here, so we don't want the new object to also add exceptions from its finalizer.
-                            Discard(promise);
-                            throw new InvalidOperationException("Cannot await or forget a forgotten promise or a non-preserved promise more than once.", GetFormattedStacktrace(2));
-                        }
-                        _this._ref.HandleNext(promise);
-                    }
+                    promise = PromiseProgress<VoidResult, TProgress>.GetOrCreate(progress, _this.Depth, invokeOption == SynchronizationOption.Synchronous, synchronizationContext, forceAsync);
+                    promise.HookupProgress(_this._ref, _this._id, cancelationToken);
                     return new Promise(promise, promise.Id, _this.Depth);
                 }
 
@@ -1259,31 +1437,8 @@ namespace Proto.Promises
                         }
                     }
 
-                    promise = PromiseProgress<TResult, TProgress>.GetOrCreate(progress, _this.Depth, invokeOption == SynchronizationOption.Synchronous, synchronizationContext, forceAsync, cancelationToken);
-#if PROMISE_DEBUG
-                    promise._previous = _this._ref;
-#endif
-                    promise._smallFields._currentProgress = _this._ref._smallFields._currentProgress;
-                    _this._ref.InterlockedIncrementProgressReportingCount();
-                    HandleablePromiseBase previousWaiter;
-                    PromiseRefBase promiseSingleAwait = _this._ref.AddWaiter(_this._id, promise, out previousWaiter);
-                    if (previousWaiter == null)
-                    {
-                        promise.MaybeScheduleProgress();
-                        _this._ref.InterlockedDecrementProgressReportingCount();
-                        StackUnwindHelper.InvokeProgressors();
-                    }
-                    else
-                    {
-                        _this._ref.InterlockedDecrementProgressReportingCount();
-                        if (!VerifyWaiter(promiseSingleAwait))
-                        {
-                            // We're throwing InvalidOperationException here, so we don't want the new object to also add exceptions from its finalizer.
-                            Discard(promise);
-                            throw new InvalidOperationException("Cannot await or forget a forgotten promise or a non-preserved promise more than once.", GetFormattedStacktrace(2));
-                        }
-                        _this._ref.HandleNext(promise);
-                    }
+                    promise = PromiseProgress<TResult, TProgress>.GetOrCreate(progress, _this.Depth, invokeOption == SynchronizationOption.Synchronous, synchronizationContext, forceAsync);
+                    promise.HookupProgress(_this._ref, _this._id, cancelationToken);
                     return new Promise<TResult>(promise, promise.Id, _this.Depth);
                 }
 #endif

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/MergeInternal.cs
@@ -17,6 +17,7 @@
 #pragma warning disable 0420 // A reference to a volatile field will not be treated as volatile
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Proto.Promises
@@ -30,13 +31,66 @@ namespace Proto.Promises
 #endif
             internal abstract partial class MultiHandleablePromiseBase<TResult> : PromiseSingleAwait<TResult>
             {
-                internal override void Handle(PromiseRefBase handler) { throw new System.InvalidOperationException(); }
+                internal override void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state) { throw new System.InvalidOperationException(); }
 
-                new protected void Reset(ushort depth)
+                // When each promise is completed, we decrement the wait count until it reaches zero before we handle the next waiter.
+                // If a promise completes with a state that should complete this promise before all the other promises were complete,
+                // we instead swap the count to 0 so that it will be marked complete early, and future completions will decrement into negative and never read 0 again.
+                // (Merge reject/cancel, or First resolve, Race always tries to set complete).
+                [MethodImpl(InlineOption)]
+                protected bool TrySetComplete()
                 {
-                    base.Reset(depth);
-#if PROMISE_PROGRESS
-                    _smallFields._currentProgress = default(Fixed32);
+                    return InterlockedExchange(ref _waitCount, 0) > 0;
+                }
+
+                [MethodImpl(InlineOption)]
+                protected bool RemoveWaiterAndGetIsComplete()
+                {
+                    // No overflow check as we expect the count to be able to go negative.
+                    return Interlocked.Add(ref _waitCount, -1) == 0;
+                }
+
+                protected void ReleaseAndHandleNext(PromiseRefBase handler)
+                {
+                    // Decrement retain counter instead of calling MaybeDispose, since we know the next handler will call MaybeDispose.
+                    InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
+                    HandleNextFromHandler(handler);
+                }
+
+                protected void Setup(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits, ushort depth)
+                {
+                    _waitCount = pendingAwaits;
+                    unchecked
+                    {
+                        _retainCounter = pendingAwaits + 1;
+                    }
+                    Reset(depth);
+
+                    _passThroughs = promisePassThroughs;
+                    foreach (var passThrough in promisePassThroughs)
+                    {
+#if PROMISE_DEBUG
+                        lock (_previousPromises)
+                        {
+                            _previousPromises.Push(passThrough.Owner);
+                        }
+#endif
+                        passThrough.SetTargetAndAddToOwner(this);
+                    }
+                }
+
+                new protected void Dispose()
+                {
+                    base.Dispose();
+                    while (_passThroughs.IsNotEmpty)
+                    {
+                        _passThroughs.Pop().Dispose();
+                    }
+#if PROMISE_DEBUG
+                    lock (_previousPromises)
+                    {
+                        _previousPromises.Clear();
+                    }
 #endif
                 }
             }
@@ -55,99 +109,57 @@ namespace Proto.Promises
 
                 private void MaybeDisposeNonVirt()
                 {
-                    if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
+                    if (InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1) == 0)
                     {
                         Dispose();
                         ObjectPool.MaybeRepool(this);
                     }
                 }
 
-                internal static MergePromise<TResult> GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits, ulong completedProgress, ulong totalProgress, ushort depth)
+                internal static MergePromise<TResult> GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits, ulong completedProgress, ushort depth)
                 {
                     var promise = ObjectPool.TryTake<MergePromise<TResult>>()
                         ?? new MergePromise<TResult>();
-                    promise.Setup(promisePassThroughs, pendingAwaits, completedProgress, totalProgress, depth);
+                    promise.Setup(promisePassThroughs, pendingAwaits, completedProgress, depth);
                     return promise;
                 }
 
                 internal static MergePromise<TResult> GetOrCreate(
                     ValueLinkedStack<PromisePassThrough> promisePassThroughs,
-
 #if CSHARP_7_3_OR_NEWER
                     in
 #endif
                     TResult value,
                     PromiseResolvedDelegate<TResult> onPromiseResolved,
-                    int pendingAwaits, ulong completedProgress, ulong totalProgress, ushort depth)
+                    int pendingAwaits, ulong completedProgress, ushort depth)
                 {
                     var promise = MergePromiseT.GetOrCreate(value, onPromiseResolved);
-                    promise.Setup(promisePassThroughs, pendingAwaits, completedProgress, totalProgress, depth);
+                    promise.Setup(promisePassThroughs, pendingAwaits, completedProgress, depth);
                     return promise;
                 }
 
-                private void Setup(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits, ulong completedProgress, ulong totalProgress, ushort depth)
+                private void Setup(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits, ulong completedProgress, ushort depth)
                 {
-                    _waitCount = pendingAwaits;
-                    unchecked
-                    {
-                        _retainCounter = pendingAwaits + 1;
-                    }
-                    Reset(depth);
-                    SetupProgress(completedProgress, totalProgress);
-
-                    while (promisePassThroughs.IsNotEmpty)
-                    {
-                        var passThrough = promisePassThroughs.Pop();
-#if PROMISE_DEBUG
-                        lock (_previousPromises)
-                        {
-                            _previousPromises.Push(passThrough.Owner);
-                        }
+#if PROMISE_PROGRESS
+                    _completeProgress = completedProgress;
 #endif
-                        passThrough.SetTargetAndAddToOwner(this);
-                        if (_rejectContainer != null)
-                        {
-                            // This was rejected or canceled potentially before all passthroughs were hooked up. Release all remaining passthroughs.
-                            while (promisePassThroughs.IsNotEmpty)
-                            {
-                                var p = promisePassThroughs.Pop();
-                                p.Owner.MaybeMarkAwaitedAndDispose(p.Id);
-                                p.Dispose();
-                                MaybeDispose();
-                            }
-                        }
-                    }
+                    Setup(promisePassThroughs, pendingAwaits, depth);
                 }
 
-                protected override void Handle(PromisePassThrough passThrough)
+                internal override void Handle(PromiseRefBase handler, int index)
                 {
-                    var handler = passThrough.Owner;
-                    var state = handler.State;
-                    if (state != Promise.State.Resolved) // Rejected/Canceled
+                    bool isComplete = handler.State == Promise.State.Resolved
+                        ? RemoveWaiterAndGetIsComplete()
+                        : TrySetComplete();
+                    if (isComplete)
                     {
-                        if (Interlocked.CompareExchange(ref _rejectContainer, handler._rejectContainer, null) == null)
-                        {
-                            handler.SuppressRejection = true;
-                            State = state;
-                            HandleNextInternal();
-                        }
-                        InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
+                        ReleaseAndHandleNext(handler);
+                        return;
                     }
-                    else // Resolved
-                    {
-                        IncrementProgress(passThrough);
-                        if (InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0) == 0
-                            && Interlocked.CompareExchange(ref _rejectContainer, RejectContainer.s_completionSentinel, null) == null)
-                        {
-                            State = state;
-                            HandleNextInternal();
-                        }
-                    }
+                    handler.SuppressRejection = true;
+                    handler.MaybeDispose();
                     MaybeDisposeNonVirt();
                 }
-
-                partial void IncrementProgress(PromisePassThrough passThrough);
-                partial void SetupProgress(ulong completedProgress, ulong totalProgress);
 
                 private sealed partial class MergePromiseT : MergePromise<TResult>
                 {
@@ -155,7 +167,7 @@ namespace Proto.Promises
 
                     internal override void MaybeDispose()
                     {
-                        if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
+                        if (InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1) == 0)
                         {
                             Dispose();
                             _onPromiseResolved = null;
@@ -176,80 +188,29 @@ namespace Proto.Promises
                         return promise;
                     }
 
-                    protected override void Handle(PromisePassThrough passThrough)
+                    internal override void Handle(PromiseRefBase handler, int index)
                     {
-                        var handler = passThrough.Owner;
-                        var state = handler.State;
-                        if (state != Promise.State.Resolved) // Rejected/Canceled
+                        bool isComplete;
+                        if (handler.State == Promise.State.Resolved)
                         {
-                            if (Interlocked.CompareExchange(ref _rejectContainer, handler._rejectContainer, null) == null)
-                            {
-                                handler.SuppressRejection = true;
-                                State = state;
-                                HandleNextInternal();
-                            }
-                            InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0);
+                            _onPromiseResolved.Invoke(handler, ref _result, index);
+                            isComplete = RemoveWaiterAndGetIsComplete();
                         }
-                        else // Resolved
+                        else
                         {
-                            IncrementProgress(passThrough);
-                            _onPromiseResolved.Invoke(handler, ref _result, passThrough.Index);
-                            if (InterlockedAddWithOverflowCheck(ref _waitCount, -1, 0) == 0
-                                && Interlocked.CompareExchange(ref _rejectContainer, RejectContainer.s_completionSentinel, null) == null)
-                            {
-                                State = state;
-                                HandleNextInternal();
-                            }
+                            isComplete = TrySetComplete();
                         }
-                        MaybeDispose();
+                        if (isComplete)
+                        {
+                            ReleaseAndHandleNext(handler);
+                            return;
+                        }
+                        handler.SuppressRejection = true;
+                        handler.MaybeDispose();
+                        MaybeDisposeNonVirt();
                     }
                 }
             }
-
-#if PROMISE_PROGRESS
-            partial class MergePromise<TResult>
-            {
-                partial void SetupProgress(ulong completedProgress, ulong totalProgress)
-                {
-                    _unscaledProgress = new UnsignedFixed64(completedProgress);
-                    _progressScaler = (double) (Depth + 1u) / (double) totalProgress;
-                }
-
-                partial void IncrementProgress(PromisePassThrough passThrough)
-                {
-                    var wasReportingPriority = Fixed32.ts_reportingPriority;
-                    Fixed32.ts_reportingPriority = true;
-
-                    uint dif = passThrough.GetProgressDifferenceToCompletion();
-                    var progress = IncrementProgress(dif);
-                    ReportProgress(progress, Depth);
-
-                    Fixed32.ts_reportingPriority = wasReportingPriority;
-                }
-
-                private Fixed32 NormalizeProgress(UnsignedFixed64 unscaledProgress)
-                {
-                    ThrowIfInPool(this);
-                    var scaledProgress = Fixed32.GetScaled(unscaledProgress, _progressScaler);
-                    _smallFields._currentProgress = scaledProgress;
-                    return scaledProgress;
-                }
-
-                protected override PromiseRefBase IncrementProgress(long amount, ref Fixed32 progress, ushort depth)
-                {
-                    ThrowIfInPool(this);
-                    // This essentially acts as a pass-through to normalize the progress.
-                    progress = IncrementProgress(amount);
-                    return this;
-                }
-
-                private Fixed32 IncrementProgress(long amount)
-                {
-                    var unscaledProgress = _unscaledProgress.InterlockedIncrement(amount);
-                    return NormalizeProgress(unscaledProgress);
-                }
-            }
-#endif
         }
     }
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/ProgressInternal.cs
@@ -14,8 +14,10 @@
 #endif
 
 #pragma warning disable IDE0016 // Use 'throw' expression
+#pragma warning disable IDE0019 // Use pattern matching
 #pragma warning disable IDE0018 // Inline variable declaration
 #pragma warning disable IDE0034 // Simplify 'default' expression
+#pragma warning disable CA1507 // Use nameof to express symbol names
 #pragma warning disable 0420 // A reference to a volatile field will not be treated as volatile
 
 using System;
@@ -75,368 +77,388 @@ namespace Proto.Promises
             }
         }
 
-        partial struct StackUnwindHelper
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        internal abstract partial class ProgressPassThrough : HandleablePromiseBase, ILinked<ProgressPassThrough>
         {
-            [ThreadStatic]
-            private static Queue<HandleablePromiseBase> ts_progressors;
-
-            [MethodImpl(InlineOption)]
-            internal static void AddProgressor(HandleablePromiseBase progressor)
+            ProgressPassThrough ILinked<ProgressPassThrough>.Next
             {
-                if (ts_progressors == null)
-                {
-                    ts_progressors = new Queue<HandleablePromiseBase>();
-                }
-                ts_progressors.Enqueue(progressor);
+                [MethodImpl(InlineOption)]
+                get { return _next.UnsafeAs<ProgressPassThrough>(); }
+                [MethodImpl(InlineOption)]
+                set { _next = value; }
             }
 
-            internal static void InvokeProgressors()
+            internal virtual void ExitLock()
             {
-                if (ts_progressors != null)
+                Monitor.Exit(this);
+            }
+
+            internal virtual void HookupToRoots(ref ProgressHookupValues progressHookupValues) { throw new System.InvalidOperationException(); }
+            // This is only overridden by ProgressMultiAwait.
+            internal virtual void ReportProgress(ref ProgressReportValues progressReportValues) { throw new System.InvalidOperationException(); }
+        }
+
+        internal
+#if CSHARP_7_3_OR_NEWER
+            ref // Don't allow on the heap.
+#endif
+            struct ProgressReportValues
+        {
+            internal HandleablePromiseBase _progressListener;
+            internal HandleablePromiseBase _reporter;
+            internal object _lockedObject;
+            internal double _progress;
+            internal ValueLinkedStack<ProgressPassThrough> _passthroughs;
+
+            internal ProgressReportValues(HandleablePromiseBase progressListener, HandleablePromiseBase reporter, object lockedObject, double progress)
+            {
+                _progressListener = progressListener;
+                _reporter = reporter;
+                _lockedObject = lockedObject;
+                _progress = progress;
+                _passthroughs = new ValueLinkedStack<ProgressPassThrough>();
+            }
+
+            internal void ReportProgressToSingularListeners()
+            {
+                while (_progressListener != null)
                 {
-                    while (ts_progressors.Count > 0)
+                    _progressListener.MaybeReportProgress(ref this);
+                }
+            }
+
+            internal void ReportProgressToAllListeners()
+            {
+                while (true)
+                {
+                    ReportProgressToSingularListeners();
+                    if (_passthroughs.IsEmpty)
                     {
-                        ts_progressors.Dequeue().InvokeProgressFromContext();
+                        break;
                     }
+                    _passthroughs.Pop().ReportProgress(ref this);
                 }
             }
         }
 
-        partial class PromiseSynchronousWaiter : HandleablePromiseBase
+        internal
+#if CSHARP_7_3_OR_NEWER
+            ref // Don't allow on the heap.
+#endif
+            struct ProgressHookupValues
         {
-            internal override PromiseRefBase SetProgress(ref PromiseRefBase.Fixed32 progress, ref ushort depth)
+            private HandleablePromiseBase _registeredPromisesHead;
+            private HandleablePromiseBase _currentReporter;
+            private HandleablePromiseBase _progressListener;
+            internal HandleablePromiseBase _expectedWaiter;
+            internal PromiseRefBase _previous;
+            // Even though progress is reported with single float, we use double for better precision when calculating the normalized progress.
+            internal double _min;
+            internal double _max;
+            // 1 / (depth of progress + 1), since it's faster to multiply the reciprocal than divide.
+            private double _divisorReciprocal;
+            internal double _currentProgress;
+            private ValueLinkedStack<ProgressPassThrough> _pendingPassthroughs;
+            internal uint _pendingPassthroughCount;
+            // Passthrough listeners are locked when they are created, and the lock is held while they're being hooked up to their roots,
+            // so we have to store them until all roots are hooked up to release the locks.
+            internal ValueLinkedStack<ProgressPassThrough> _lockedPassthroughs;
+            internal int _retainCounter;
+
+            internal HandleablePromiseBase ProgressListener
             {
-                return null;
+                get { return _progressListener; }
+                set
+                {
+                    _progressListener = value;
+                    _registeredPromisesHead = value;
+                }
             }
+
+            internal HandleablePromiseBase CurrentReporter
+            {
+                set { _currentReporter = value; }
+            }
+
+            internal ProgressHookupValues(HandleablePromiseBase progressListener, HandleablePromiseBase expectedWaiter, ushort depth, double min, double max, HandleablePromiseBase registeredPromisesHead)
+            {
+                _registeredPromisesHead = registeredPromisesHead;
+                _currentReporter = null;
+                _progressListener = progressListener;
+                _expectedWaiter = expectedWaiter;
+                _previous = null;
+                _min = min;
+                _max = max;
+                _divisorReciprocal = 1d / (depth + 1u);
+                _currentProgress = depth;
+                _pendingPassthroughs = new ValueLinkedStack<ProgressPassThrough>();
+                _pendingPassthroughCount = 0;
+                _lockedPassthroughs = new ValueLinkedStack<ProgressPassThrough>();
+                _retainCounter = 0;
+            }
+
+            internal void AddPassthrough(ProgressPassThrough progressPassthrough)
+            {
+                CurrentReporter = progressPassthrough;
+                ++_pendingPassthroughCount;
+                _pendingPassthroughs.Push(progressPassthrough);
+            }
+
+            internal ProgressPassThrough TakePassthrough()
+            {
+                --_pendingPassthroughCount;
+                return _pendingPassthroughs.Pop();
+            }
+
+            internal void SetMinMaxAndDivisorReciprocal(double min, double max, double divisorReciprocal)
+            {
+                SetMinAndMax(min, max);
+                _divisorReciprocal = divisorReciprocal;
+            }
+
+            internal void SetMinMaxAndDivisorFromDepth(double min, double max, ushort depth)
+            {
+                SetMinAndMax(min, max);
+                SetDivisorFromDepth(depth);
+            }
+
+            internal void SetDivisorFromDepth(ushort depth)
+            {
+                _divisorReciprocal = 1d / (depth + 1u);
+            }
+
+            internal void SetMinAndMaxFromDepth(uint depth)
+            {
+                SetMinAndMaxFromLocalProgress(depth, depth + 1u);
+            }
+
+            private void SetMinAndMax(double min, double max)
+            {
+                _min = min;
+                _max = max;
+            }
+
+            internal void SetMinAndMaxFromLocalProgress(double min, double max)
+            {
+                SetMinAndMax(
+                    GetLerpedProgressFromLocalProgress(min),
+                    GetLerpedProgressFromLocalProgress(max));
+            }
+
+            internal double GetLerpedProgressFromLocalProgress(double localProgress)
+            {
+                // localProgress is deferred's progress (0-1), or depth.
+                return Lerp(_min, _max, localProgress * _divisorReciprocal);
+            }
+
+            internal void SetListenerFields(ref PromiseRefBase.ProgressListenerFields fields)
+            {
+                fields._current = (float) (_currentProgress * _divisorReciprocal);
+                fields._min = (float) _min;
+                fields._max = (float) _max;
+
+                // There may already be some initial retains, so we add instead of overwrite.
+                InterlockedAddWithUnsignedOverflowCheck(ref fields._retainCounter, _retainCounter);
+
+                // Don't overwrite _unregisteredPromises.
+                fields._registeredPromisesHead = _registeredPromisesHead;
+                fields._currentReporter = _currentReporter;
+
+                _registeredPromisesHead = null;
+                _currentReporter = null;
+            }
+
+            internal void RegisterHandler(PromiseRefBase handler)
+            {
+                // Interlocked exchange instead of simple write to resolve race condition with await promise.
+                InterlockedExchange(ref handler._rejectContainerOrPreviousOrLink, _registeredPromisesHead);
+                _registeredPromisesHead = handler;
+                IncrementRetainCounter();
+            }
+
+            internal void IncrementRetainCounter()
+            {
+                // int is treated as uint, we just use int because Interlocked does not support uint on old runtimes.
+                unchecked
+                {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    uint current = (uint) _retainCounter;
+                    checked
+                    {
+                        ++current;
+                    }
+                    _retainCounter = (int) current;
+#else
+                    ++_retainCounter;
+#endif
+                }
+            }
+
+            internal void ListenForProgressOnRoots(ref PromiseRefBase.ProgressListenerFields progressFields)
+            {
+                // Users can forceAsync for very long promise chains to prevent stack overflow,
+                // but we have to prevent stack overflow while iterating over the entire promise tree to hook up progress.
+                // This algorithm allows the stack to unwind after visiting each promise, so we won't overflow, no matter how long the promise chain is.
+
+                while (_previous != null)
+                {
+                    _previous.TryHookupProgressListenerAndGetPrevious(ref this);
+                }
+                SetListenerFields(ref progressFields);
+
+                while (_pendingPassthroughCount > 0)
+                {
+                    TakePassthrough().HookupToRoots(ref this);
+                }
+
+                // Release the lock on all branched passthrough listeners.
+                while (_lockedPassthroughs.IsNotEmpty)
+                {
+                    _lockedPassthroughs.Pop().ExitLock();
+                }
+            }
+        }
+
+        [MethodImpl(InlineOption)]
+        private static double Lerp(double a, double b, double t)
+        {
+            return a + (b - a) * t;
         }
 
 #endif // !PROMISE_PROGRESS
 
         partial class PromiseRefBase
         {
-            // Calls to these get compiled away when PROGRESS is undefined.
-            partial void WaitWhileProgressReporting();
-            partial void InterlockedIncrementProgressReportingCount();
-            partial void InterlockedDecrementProgressReportingCount();
-
-#if !PROTO_PROMISE_DEVELOPER_MODE
-            [DebuggerNonUserCode, StackTraceHidden]
-#endif
-            internal partial struct Fixed32
-            {
-                // 16 bits for decimal part gives us 1/2^16 or 0.0000152587890625 step size (nearly 5 digits of precision)
-                // and the remaining 16 bits for whole part/depth allows up to 2^16 - 2 or 65534 promise.Then(() => otherPromise) chains, which should be plenty for typical use cases.
-                // Also, SmallFields._depth is a ushort with 16 bits, so this should not be smaller than 16 (though it can be larger, as long as it leaves some bits for the whole part).
-                internal const int DecimalBits = 16;
-            }
-
 #if PROMISE_PROGRESS
-            [MethodImpl(InlineOption)]
-            partial void WaitWhileProgressReporting()
-            {
-                Thread.MemoryBarrier(); // Make sure any writes happen before we read.
-                // This is used to make sure progress reports are complete before the next handler is handled.
-                if (_smallFields._reportingProgressCount != 0)
-                {
-                    WaitWhileProgressReportingCore();
-                }
-            }
+            internal virtual PromiseRefBase AddProgressWaiter(short promiseId, out HandleablePromiseBase previousWaiter, ref ProgressHookupValues progressHookupValues) { throw new System.InvalidOperationException(); }
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            private void WaitWhileProgressReportingCore()
-            {
-                var spinner = new SpinWait();
-                do
-                {
-                    spinner.SpinOnce();
-                } while (_smallFields._reportingProgressCount != 0);
-            }
-
-            partial class PromiseCompletionSentinel : HandleablePromiseBase
-            {
-                internal override PromiseRefBase SetProgress(ref Fixed32 progress, ref ushort depth)
-                {
-                    return null;
-                }
-            }
-
-            partial class PromiseForgetSentinel : HandleablePromiseBase
-            {
-                internal override PromiseRefBase SetProgress(ref Fixed32 progress, ref ushort depth)
-                {
-                    return null;
-                }
-            }
-
-            partial class InvalidAwaitSentinel : PromiseRefBase
-            {
-                internal override PromiseRefBase SetProgress(ref Fixed32 progress, ref ushort depth)
-                {
-                    return null;
-                }
-            }
-
-            internal partial struct Fixed32
-            {
-                // Necessary to fix a race condition when hooking up a promise and the promise's deferred reports progress. Deferred report takes precedence.
-                [ThreadStatic]
-                internal static bool ts_reportingPriority;
-
-                private const double DecimalMax = 1 << DecimalBits;
-                private const int DecimalMask = (1 << DecimalBits) - 1;
-                private const int WholeMask = ~DecimalMask;
-
-                [MethodImpl(InlineOption)]
-                private Fixed32(int value)
-                {
-                    _value = value;
-                }
-
-                [MethodImpl(InlineOption)]
-                internal static Fixed32 FromWhole(ushort wholeValue)
-                {
-                    return new Fixed32(wholeValue << DecimalBits);
-                }
-
-                [MethodImpl(InlineOption)]
-                internal static Fixed32 FromWholePlusOne(ushort wholeValue)
-                {
-                    // We don't need to check for overflow here.
-                    return new Fixed32((wholeValue + 1) << DecimalBits);
-                }
-
-                [MethodImpl(InlineOption)]
-                internal static Fixed32 FromDecimalForResolve(double decimalValue)
-                {
-                    return new Fixed32(ConvertToValue(decimalValue));
-                }
-
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE // Useful for debugging, but not actually used.
-                internal ushort WholePart
-                {
-                    get { return (ushort) ((_value & WholeMask) >> DecimalBits); }
-                }
-#endif
-
-                internal double DecimalPart
-                {
-                    get { return (double) (_value & DecimalMask) / DecimalMax; }
-                }
-
-                [MethodImpl(InlineOption)]
-                internal static ushort GetNextDepth(ushort depth)
-                {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    // We allow ushort.MaxValue to rollover for progress normalization purposes, but we don't allow overflow for regular user chains.
-                    const int DepthBits = 32 - DecimalBits;
-                    const ushort MaxValue = (1 << DepthBits) - 2;
-                    if (depth == MaxValue)
-                    {
-                        throw new OverflowException("Promise chain length exceeded maximum of " + MaxValue);
-                    }
-#endif
-                    unchecked
-                    {
-                        return (ushort) (depth + 1);
-                    }
-                }
-
-                [MethodImpl(InlineOption)]
-                internal uint GetRawValue()
-                {
-                    unchecked
-                    {
-                        return (uint) _value;
-                    }
-                }
-
-                [MethodImpl(InlineOption)]
-                internal double ToDouble()
-                {
-                    return ConvertToDouble(_value);
-                }
-
-                private static double ConvertToDouble(int value)
-                {
-                    double wholePart = (value & WholeMask) >> DecimalBits;
-                    double decimalPart = (double) (value & DecimalMask) / DecimalMax;
-                    return wholePart + decimalPart;
-                }
-
-                [MethodImpl(InlineOption)]
-                internal static Fixed32 GetScaled(UnsignedFixed64 value, double scaler)
-                {
-                    unchecked
-                    {
-                        // Don't bother rounding, we don't want to accidentally round to 1.0.
-                        int newValue = (int) (value.ToDouble() * scaler * DecimalMax);
-                        return new Fixed32(newValue);
-                    }
-                }
-
-                internal bool InterlockedTrySetIfGreater(Fixed32 other)
-                {
-                    Thread.MemoryBarrier();
-                    int otherValue = other._value;
-                    int current;
-                    do
-                    {
-                        current = _value;
-                        unchecked
-                        {
-                            if ((uint) otherValue <= (uint) current)
-                            {
-                                return false;
-                            }
-                        }
-                    } while (Interlocked.CompareExchange(ref _value, otherValue, current) != current);
-                    return true;
-                }
-
-                [MethodImpl(InlineOption)]
-                internal bool InterlockedTrySet(Fixed32 other)
-                {
-                    int _;
-                    return InterlockedTrySet(other, out _);
-                }
-
-                [MethodImpl(InlineOption)]
-                internal long InterlockedSetAndGetDifference(Fixed32 other)
-                {
-                    int oldValue;
-                    if (InterlockedTrySet(other, out oldValue))
-                    {
-                        unchecked
-                        {
-                            return (long) (uint) other._value - (long) (uint) oldValue;
-                        }
-                    }
-                    return 0;
-                }
-
-                private bool InterlockedTrySet(Fixed32 other, out int oldValue)
-                {
-                    Thread.MemoryBarrier();
-                    int otherValue = other._value;
-                    bool isReportingPriority = ts_reportingPriority;
-                    int current;
-                    do
-                    {
-                        current = _value;
-                        // If value is greater, always set.
-                        // If value is equal, don't set.
-                        // if value is less, only set if progress is being reported with priority.
-                        unchecked
-                        {
-                            bool valueIsGreater = (uint) otherValue > (uint) current;
-                            bool valueIsLess = (uint) otherValue < (uint) current;
-                            bool isOkay = valueIsGreater | (valueIsLess & isReportingPriority);
-                            if (!isOkay)
-                            {
-                                oldValue = 0;
-                                return false;
-                            }
-                        }
-                    } while (Interlocked.CompareExchange(ref _value, otherValue, current) != current);
-                    oldValue = current;
-                    return true;
-                }
-
-                [MethodImpl(InlineOption)]
-                internal Fixed32 SetNewDecimalPartFromDeferred(double decimalPart)
-                {
-                    int newValue = ConvertToValue(decimalPart);
-                    _value = newValue;
-                    return new Fixed32(newValue);
-                }
-
-                [MethodImpl(InlineOption)]
-                internal bool TrySetNewDecimalPartFromAsync(double decimalPart, out Fixed32 result)
-                {
-                    int newValue = ConvertToValue(decimalPart);
-                    int _;
-                    bool success = InterlockedTrySet(new Fixed32(newValue), out _);
-                    result = new Fixed32(newValue);
-                    return success;
-                }
-
-                [MethodImpl(InlineOption)]
-                internal bool TrySetNewDecimalPartFromWaitPromise(double decimalPart, ushort wholePart, out Fixed32 result)
-                {
-                    int newValue = ConvertToValue(decimalPart) | (wholePart << DecimalBits);
-                    int _;
-                    bool success = InterlockedTrySet(new Fixed32(newValue), out _);
-                    result = new Fixed32(newValue);
-                    return success;
-                }
-
-                [MethodImpl(InlineOption)]
-                private static int ConvertToValue(double dValue)
-                {
-                    // Don't round.
-                    return (int) (dValue * DecimalMax);
-                }
-
-                // Using double for better precision.
-                internal Fixed32 MultiplyAndDivide(double multiplier, double divisor)
-                {
-                    double dValue = ConvertToDouble(_value) * multiplier / divisor;
-                    return new Fixed32(ConvertToValue(dValue));
-                }
-            }
-
-            /// <summary>
-            /// Max Whole Number: 2^(64-<see cref="Promise.Config.ProgressDecimalBits"/>)
-            /// Precision: 1/(2^<see cref="Promise.Config.ProgressDecimalBits"/>)
-            /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal partial struct UnsignedFixed64 // Simplified compared to Fixed32 to remove unused functions.
+            internal partial struct ProgressRange
             {
-                private const double DecimalMax = 1L << Fixed32.DecimalBits;
-                private const long DecimalMask = (1L << Fixed32.DecimalBits) - 1L;
-                private const long WholeMask = ~DecimalMask;
-
                 [MethodImpl(InlineOption)]
-                internal UnsignedFixed64(ulong wholePart)
+                internal ProgressRange(float min, float max)
                 {
-                    unchecked
+                    _min = min;
+                    _max = max;
+                }
+            }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            internal partial struct ProgressListenerFields
+            {
+                // Detached count is negative because we use it to decrement the listener's retain counter via Interlocked.Add.
+                internal bool UnregisterHandlerAndGetShouldComplete(PromiseRefBase handler, HandleablePromiseBase progressListener, out HandleablePromiseBase target, out int negativeDetachedCount)
+                {
+                    // The lock is already held when this is called.
+
+                    if (_unregisteredPromises != null && _unregisteredPromises.Remove(handler, out target))
                     {
-                        _value = (long) (wholePart << Fixed32.DecimalBits);
+                        negativeDetachedCount = -1;
+                        return false;
                     }
-                }
 
-                [MethodImpl(InlineOption)]
-                private UnsignedFixed64(long value)
-                {
-                    _value = value;
-                }
+                    // We only null the current reporter if the handler was not already detached.
+                    // This stops any further progress reports from that reporter.
+                    _currentReporter = null;
 
-                internal double ToDouble()
-                {
-                    unchecked
+                    // The progress listener is attached as the tail element in the linked-list,
+                    // but we don't remove it since we only check if it's linked from the handler,
+                    // and we use it to stop iterating while we're detaching handlers (this is cheaper than adding an extra branch to remove it).
+                    bool shouldComplete = handler._rejectContainerOrPreviousOrLink == progressListener;
+                    
+                    if (_registeredPromisesHead == handler)
                     {
-                        long val = Interlocked.Read(ref _value);
-                        double wholePart = (val & WholeMask) >> Fixed32.DecimalBits;
-                        double decimalPart = (double) (val & DecimalMask) / DecimalMax;
-                        return wholePart + decimalPart;
+                        // Common case, the handler was the first element.
+                        _registeredPromisesHead = _registeredPromisesHead.UnsafeAs<PromiseRefBase>()._rejectContainerOrPreviousOrLink.UnsafeAs<HandleablePromiseBase>();
+                        target = _registeredPromisesHead;
+                        negativeDetachedCount = -1;
+                        return shouldComplete;
                     }
+
+                    // Uncommon case, the handler was canceled from a CancelationToken and broke the promise chain,
+                    // so we iterate over the chain to unregister the handlers and try to restore the old waiters.
+                    UnregisterHandlers(handler, progressListener, out target, out negativeDetachedCount);
+                    return shouldComplete;
                 }
 
-                [MethodImpl(InlineOption)]
-                internal UnsignedFixed64 InterlockedIncrement(long increment)
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                private void UnregisterHandlers(PromiseRefBase handler, HandleablePromiseBase progressListener, out HandleablePromiseBase target, out int negativeDetachedCount)
                 {
-                    Thread.MemoryBarrier();
-                    long current;
-                    long newValue;
-                    do
+                    int detachCounter = 0;
+                    // The progress listener is the tail, so we check for it instead of null.
+                    while (_registeredPromisesHead != progressListener)
                     {
-                        current = Interlocked.Read(ref _value);
-                        newValue = current + increment;
-                    } while (Interlocked.CompareExchange(ref _value, newValue, current) != current);
-                    return new UnsignedFixed64(newValue);
+                        var current = _registeredPromisesHead.UnsafeAs<PromiseRefBase>();
+                        var next = current._rejectContainerOrPreviousOrLink.UnsafeAs<HandleablePromiseBase>();
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                        // progressListener should be the tail, we should never get null.
+                        if (next == null)
+                        {
+                            throw new System.InvalidOperationException("next is null in UnregisterHandlers. current: " + current + ", progressListener: " + progressListener);
+                        }
+#endif
+                        _registeredPromisesHead = next;
+                        if (current == handler)
+                        {
+                            // Found the handler.
+                            target = next;
+                            negativeDetachedCount = detachCounter - 1;
+                            return;
+                        }
+                        if (current.TryRestoreWaiter(next, progressListener))
+                        {
+                            --detachCounter;
+                            continue;
+                        }
+                        // Very rare, this will only happen if the promise was completed on another thread while this was running.
+                        AddDetachedHandler(current, next);
+                    }
+                    throw new ArgumentException("Handler { " + handler + " } not found registered on progress listener { " + progressListener + " }.", "handler");
                 }
+
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                private void AddDetachedHandler(PromiseRefBase handler, HandleablePromiseBase target)
+                {
+                    // We lazy initialize the dictionary since this is a rare occurrence.
+                    if (_unregisteredPromises == null)
+                    {
+                        _unregisteredPromises = new Dictionary<PromiseRefBase, HandleablePromiseBase>();
+                    }
+                    _unregisteredPromises.Add(handler, target);
+                }
+            }
+
+            internal virtual bool TryRestoreWaiter(HandleablePromiseBase waiter, HandleablePromiseBase expected)
+            {
+                return CompareExchangeWaiter(waiter, expected) == expected;
+            }
+
+            private void SetProgressValuesAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+            {
+                ThrowIfInPool(this);
+                progressHookupValues._currentProgress = Depth;
+                progressHookupValues._expectedWaiter = this;
+                progressHookupValues._previous = _rejectContainerOrPreviousOrLink as PromiseRefBase;
+                progressHookupValues.RegisterHandler(this);
+            }
+
+            internal virtual bool TryHookupProgressListenerAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+            {
+                // Promises that aren't normalizing progress technically don't need to hook up the listener,
+                // but we still do it anyway so that the linked-list of registered promises can just use the links to get the old waiter (this implementation saves allocations).
+                if (CompareExchangeWaiter(progressHookupValues.ProgressListener, progressHookupValues._expectedWaiter) != progressHookupValues._expectedWaiter)
+                {
+                    progressHookupValues._previous = null;
+                    return false;
+                }
+                SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                return true;
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
@@ -470,10 +492,10 @@ namespace Proto.Promises
                     base.Reset(depth);
                     // _retainCounter is necessary to make sure the promise is disposed after the cancelation has invoked or unregistered,
                     // and the next awaited promise has been handled, and this is not invoking progress.
-                    _retainCounter = 2;
+                    _progressFields._retainCounter = 2;
                 }
 
-                internal static PromiseProgress<TResult, TProgress> GetOrCreate(TProgress progress, ushort depth, bool isSynchronous, SynchronizationContext synchronizationContext, bool forceAsync, CancelationToken cancelationToken)
+                internal static PromiseProgress<TResult, TProgress> GetOrCreate(TProgress progress, ushort depth, bool isSynchronous, SynchronizationContext synchronizationContext, bool forceAsync)
                 {
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
                     if (!isSynchronous && synchronizationContext == null)
@@ -490,7 +512,6 @@ namespace Proto.Promises
                     promise._previousState = Promise.State.Pending;
                     promise._synchronizationContext = synchronizationContext;
                     promise._forceAsync = forceAsync;
-                    cancelationToken.TryRegister(promise, out promise._cancelationRegistration); // Very important, must register after promise is fully setup.
                     return promise;
                 }
 
@@ -499,7 +520,7 @@ namespace Proto.Promises
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
                     if (synchronizationContext == null)
                     {
-                        throw new InvalidOperationException("synchronizationContext cannot be null");
+                        throw new System.InvalidOperationException("synchronizationContext cannot be null");
                     }
 #endif
                     var promise = ObjectPool.TryTake<PromiseProgress<TResult, TProgress>>()
@@ -524,28 +545,223 @@ namespace Proto.Promises
 
                 internal override void MaybeDispose()
                 {
-                    if (InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0) == 0)
+                    MaybeDispose(-1);
+                }
+
+                private void MaybeDispose(int retainAddCount)
+                {
+                    if (InterlockedAddWithUnsignedOverflowCheck(ref _progressFields._retainCounter, retainAddCount) == 0)
                     {
                         Dispose();
-                        _cancelationRegistration = default(CancelationRegistration);
                         _progress = default(TProgress);
+                        _synchronizationContext = null;
+                        _cancelationRegistration = default(CancelationRegistration);
+                        _previousRejectContainer = null;
                         ObjectPool.MaybeRepool(this);
+                    }
+                }
+
+                internal void HookupProgress(PromiseRefBase current, short promiseId, CancelationToken cancelationToken)
+                {
+#if PROMISE_DEBUG
+                    _previous = current;
+#endif
+                    _rejectContainerOrPreviousOrLink = current;
+                    cancelationToken.TryRegister(this, out _cancelationRegistration); // Very important, must register after promise is fully setup (previous is already assigned).
+
+                    TProgress callback;
+                    double reportProgress;
+                    PromiseRefBase promiseSingleAwait;
+                    lock (this)
+                    {
+                        _hookingUp = true;
+                        try
+                        {
+                            HandleablePromiseBase previousWaiter;
+                            _progressFields._registeredPromisesHead = this;
+                            var progressHookupValues = new ProgressHookupValues(this, current, Depth, 0d, 1d, this);
+                            promiseSingleAwait = current.AddProgressWaiter(promiseId, out previousWaiter, ref progressHookupValues);
+                            if (previousWaiter == PendingAwaitSentinel.s_instance)
+                            {
+                                progressHookupValues.ListenForProgressOnRoots(ref _progressFields);
+
+                                if (ShouldInvokeSynchronous())
+                                {
+                                    callback = _progress;
+                                    reportProgress = Lerp(_progressFields._min, _progressFields._max, _progressFields._current);
+                                    // Exit the lock before invoking so we're not holding the lock while user code runs.
+                                    goto InvokeProgressSynchronous;
+                                }
+
+                                ScheduleProgress();
+                                return;
+                            }
+                        }
+                        finally
+                        {
+                            _hookingUp = false;
+                        }
+                    }
+
+                    VerifyAwaitAndHandle(current, promiseSingleAwait);
+                    return;
+
+                InvokeProgressSynchronous:
+                    if (!IsInvoking1 & !IsCanceled & !_cancelationRegistration.Token.IsCancelationRequested)
+                    {
+                        CallbackHelperVoid.InvokeAndCatchProgress(callback, (float) reportProgress, this);
+                    }
+                }
+
+                // This is rare, only happens when the promise already completed (usually an already completed promise is not backed by a reference), or if a promise is incorrectly awaited twice.
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                private void VerifyAwaitAndHandle(PromiseRefBase current, PromiseRefBase promiseSingleAwait)
+                {
+                    if (!VerifyWaiter(promiseSingleAwait))
+                    {
+                        // We're already throwing InvalidOperationException here, so we don't want to also add exceptions from its finalizer.
+                        Discard(this);
+                        throw new InvalidOperationException("Cannot await or forget a forgotten promise or a non-preserved promise more than once.", GetFormattedStacktrace(3));
+                    }
+
+                    current.WaitUntilStateIsNotPending();
+                    // Call HandleCompletion instead of Handle so we don't have to worry about unregistering promises that were never registered.
+                    HandleCompletion(current, current._rejectContainerOrPreviousOrLink, current.State);
+                }
+
+                internal override void MaybeHookupProgressToAwaited(PromiseRefBase current, PromiseRefBase awaited, ref ProgressRange userProgressRange, ref ProgressRange listenerProgressRange)
+                {
+                    if (awaited == null)
+                    {
+                        // The awaited promise is already complete, do nothing.
+                        return;
+                    }
+
+                    TProgress callback;
+                    float reportMin, reportMax, reportT;
+                    HandleablePromiseBase reporter;
+                    lock (this)
+                    {
+                        // In case of promise completion on another thread,
+                        // make sure this is still hooked up to current, and another registered promise has not broken the chain.
+                        if (current._next != this | _progressFields._registeredPromisesHead != current)
+                        {
+                            return;
+                        }
+                        // We only check this is not in the pool after we verified the promise is still registered, otherwise it is valid for this to be in the pool.
+                        ThrowIfInPool(this);
+
+                        _hookingUp = true;
+                        double min = Lerp(listenerProgressRange._min, listenerProgressRange._max, userProgressRange._min);
+                        double max = Lerp(listenerProgressRange._min, listenerProgressRange._max, userProgressRange._max);
+                        var progressHookupValues = new ProgressHookupValues(this, current, awaited.Depth, min, max, _progressFields._registeredPromisesHead);
+                        if (!awaited.TryHookupProgressListenerAndGetPrevious(ref progressHookupValues))
+                        {
+                            // The awaited promise is already complete, or this was already registered to it on another thread, do nothing else.
+                            _hookingUp = false;
+                            return;
+                        }
+
+                        progressHookupValues.ListenForProgressOnRoots(ref _progressFields);
+                        reporter = _progressFields._currentReporter;
+                        _hookingUp = false;
+
+                        reportMin = _progressFields._min;
+                        reportMax = _progressFields._max;
+                        reportT = _progressFields._current;
+
+                        if (!ShouldInvokeSynchronous())
+                        {
+                            MaybeScheduleProgress();
+
+                            goto PropagateProgress;
+                        }
+
+                        callback = _progress;
+                        // Exit the lock before invoking so we're not holding the lock while user code runs.
+                    }
+
+                    if (!IsInvoking1 & !IsCanceled & !_cancelationRegistration.Token.IsCancelationRequested)
+                    {
+                        var reportProgress = (float) Lerp(reportMin, reportMax, reportT);
+                        CallbackHelperVoid.InvokeAndCatchProgress(callback, reportProgress, this);
+                    }
+
+                PropagateProgress:
+
+                    Monitor.Enter(this);
+                    // Because we exited the lock and re-entered, some values may have changed on another thread (or even on the same thread from user code).
+                    // We must make sure the values are still the same before continuing.
+                    if (current._next != this | _progressFields._currentReporter != reporter
+                        | _progressFields._current != reportT
+                        | IsInvoking1 | IsCanceled | _cancelationRegistration.Token.IsCancelationRequested)
+                    {
+                        Monitor.Exit(this);
+                        return;
+                    }
+
+                    // Report progress to next PromiseProgress listeners.
+                    var progress = Lerp(reportMin, reportMax, reportT);
+                    var progressReportValues = new ProgressReportValues(_next, this, this, progress);
+                    progressReportValues.ReportProgressToAllListeners();
+                }
+
+                internal override PromiseRefBase AddProgressWaiter(short promiseId, out HandleablePromiseBase previousWaiter, ref ProgressHookupValues progressHookupValues)
+                {
+                    var promiseSingleAwait = AddWaiter(promiseId, progressHookupValues.ProgressListener, out previousWaiter);
+                    if (previousWaiter == PendingAwaitSentinel.s_instance)
+                    {
+                        lock (this)
+                        {
+                            ThrowIfInPool(this);
+                            SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                        }
+                    }
+                    return promiseSingleAwait;
+                }
+
+                new private void SetProgressValuesAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+                {
+                    progressHookupValues._previous = null;
+                    progressHookupValues.SetMinAndMaxFromLocalProgress(0u, Depth + 1u);
+                    progressHookupValues._currentProgress = Lerp(_progressFields._min, _progressFields._max, _progressFields._current);
+                    progressHookupValues.CurrentReporter = this;
+                    progressHookupValues.RegisterHandler(this);
+                }
+
+                internal override bool TryHookupProgressListenerAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+                {
+                    lock (this)
+                    {
+                        ThrowIfInPool(this);
+                        if (CompareExchangeWaiter(progressHookupValues.ProgressListener, progressHookupValues._expectedWaiter) != progressHookupValues._expectedWaiter)
+                        {
+                            progressHookupValues._previous = null;
+                            return false;
+                        }
+                        SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                        return true;
                     }
                 }
 
                 internal override void InvokeProgressFromContext()
                 {
-                    ThrowIfInPool(this);
+                    float min, max, t;
+                    lock (this)
+                    {
+                        ThrowIfInPool(this);
+
+                        min = _progressFields._min;
+                        max = _progressFields._max;
+                        t = _progressFields._current;
+                        _isProgressScheduled = false;
+                        // Exit the lock before invoking so we're not holding the lock while user code runs.
+                    }
+
                     var currentContext = ts_currentContext;
                     ts_currentContext = _synchronizationContext;
 
-                    Thread.MemoryBarrier(); // Make sure we're reading fresh progress (since the field cannot be marked volatile).
-                    var progress = _smallFields._currentProgress;
-                    _isProgressScheduled = 0;
-                    // Calculate the normalized progress for the depth that the listener was added.
-                    // Use double for better precision.
-                    double expected = Depth + 1u;
-                    float value = (float) (progress.ToDouble() / expected);
+                    float value = (float) Lerp(min, max, t);
                     if (!IsInvoking1 & !IsCanceled & !_cancelationRegistration.Token.IsCancelationRequested)
                     {
                         CallbackHelperVoid.InvokeAndCatchProgress(_progress, value, this);
@@ -555,36 +771,95 @@ namespace Proto.Promises
                     ts_currentContext = currentContext;
                 }
 
-                internal void MaybeScheduleProgress()
+                private void MaybeScheduleProgress()
                 {
-#if NET_LEGACY // Interlocked.Exchange doesn't seem to work properly in Unity's old runtime. So use CompareExchange instead
-                    bool isProgressScheduled = Interlocked.CompareExchange(ref _isProgressScheduled, 1, 0) != 0;
-#else
-                    bool isProgressScheduled = Interlocked.Exchange(ref _isProgressScheduled, 1) != 0;
-#endif
-                    if (isProgressScheduled)
+                    if (!_isProgressScheduled)
                     {
-                        return;
+                        ScheduleProgress();
                     }
-                    InterlockedAddWithOverflowCheck(ref _retainCounter, 1, -1);
-                    // Even though it's scheduled synchronous, we still have to let the stack unwind to prevent a deadlock in case user code tries to complete the promise.
-                    if (ShouldInvokeSynchronous())
-                    {
-                        StackUnwindHelper.AddProgressor(this);
-                        return;
-                    }
+                }
+
+                private void ScheduleProgress()
+                {
+                    _isProgressScheduled = true;
+                    InterlockedAddWithUnsignedOverflowCheck(ref _progressFields._retainCounter, 1);
                     ScheduleForProgress(this, _synchronizationContext);
                 }
 
-                internal override PromiseRefBase SetProgress(ref Fixed32 progress, ref ushort depth)
+                internal override void MaybeReportProgress(PromiseRefBase reporter, double progress)
+                {
+                    // Manually enter the lock so the next listener can enter its lock before unlocking this.
+                    // This is necessary for race conditions so a progress report won't get ahead of another on a separate thread.
+                    Monitor.Enter(this);
+                    var progressReportValues = new ProgressReportValues(null, reporter, this, progress);
+                    MaybeReportProgressImpl(ref progressReportValues);
+                    progressReportValues.ReportProgressToAllListeners();
+                }
+
+                internal override void MaybeReportProgress(ref ProgressReportValues progressReportValues)
+                {
+                    // Manually enter this lock before exiting previous lock.
+                    Monitor.Enter(this);
+                    Monitor.Exit(progressReportValues._lockedObject);
+
+                    if (_hookingUp)
+                    {
+                        // Just set the current progress. This will be scheduled for invoke higher in the call stack.
+                        _progressFields._current = (float) progressReportValues._progress;
+                        Monitor.Exit(this);
+                        progressReportValues._progressListener = null;
+                        return;
+                    }
+
+                    progressReportValues._lockedObject = this;
+                    MaybeReportProgressImpl(ref progressReportValues);
+                }
+
+                private void MaybeReportProgressImpl(ref ProgressReportValues progressReportValues)
                 {
                     ThrowIfInPool(this);
-                    if (_smallFields._currentProgress.InterlockedTrySet(progress) & !IsCanceled)
+
+                    var reporter = progressReportValues._reporter;
+                    progressReportValues._reporter = this;
+                    float castedProgress = (float) progressReportValues._progress;
+                    if (_progressFields._currentReporter != reporter
+                        | _progressFields._current == castedProgress
+                        | IsInvoking1 | IsCanceled | _cancelationRegistration.Token.IsCancelationRequested)
+                    {
+                        Monitor.Exit(this);
+                        progressReportValues._progressListener = null;
+                        return;
+                    }
+
+                    _progressFields._current = castedProgress;
+                    progressReportValues._progress = Lerp(_progressFields._min, _progressFields._max, progressReportValues._progress);
+
+                    if (!ShouldInvokeSynchronous())
                     {
                         MaybeScheduleProgress();
-                        return this;
+
+                        progressReportValues._progressListener = _next;
+                        return;
                     }
-                    return null;
+
+                    TProgress callback = _progress;
+                    // Exit the lock before invoking so we're not holding the lock while user code runs.
+                    Monitor.Exit(this);
+
+                    CallbackHelperVoid.InvokeAndCatchProgress(callback, (float) progressReportValues._progress, this);
+
+                    Monitor.Enter(this);
+                    // Because we exited the lock and re-entered, some values may have changed on another thread (or even on the same thread from user code).
+                    // We must make sure the values are still the same before continuing.
+                    if (_progressFields._currentReporter != reporter
+                        | _progressFields._current != castedProgress
+                        | IsInvoking1 | IsCanceled | _cancelationRegistration.Token.IsCancelationRequested)
+                    {
+                        Monitor.Exit(this);
+                        progressReportValues._progressListener = null;
+                        return;
+                    }
+                    progressReportValues._progressListener = _next;
                 }
 
                 internal override void HandleFromContext()
@@ -598,14 +873,38 @@ namespace Proto.Promises
                     ts_currentContext = currentContext;
                 }
 
-                internal override void Handle(PromiseRefBase handler)
+                internal override void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state)
                 {
                     ThrowIfInPool(this);
+
+                    // We lock on this to resolve race condition with progress hookup and progress report.
+                    bool shouldComplete;
+                    HandleablePromiseBase target;
+                    int negativeDetachedCount;
+                    lock (this)
+                    {
+                        shouldComplete = _progressFields.UnregisterHandlerAndGetShouldComplete(handler, this, out target, out negativeDetachedCount);
+                    }
+
+                    if (!shouldComplete)
+                    {
+                        MaybeDispose(negativeDetachedCount);
+                        target.Handle(handler, rejectContainer, state);
+                        return;
+                    }
+
+                    // Release the amount of unregistered promises without checking the return (because we know we aren't fully released at this point).
+                    InterlockedAddWithUnsignedOverflowCheck(ref _progressFields._retainCounter, negativeDetachedCount);
+                    HandleCompletion(handler, rejectContainer, state);
+                }
+
+                private void HandleCompletion(PromiseRefBase handler, object rejectContainer, Promise.State state)
+                {
+                    handler.SetCompletionState(rejectContainer, state);
                     handler.SuppressRejection = true;
                     _result = handler.GetResult<TResult>();
-                    _rejectContainer = handler._rejectContainer;
                     handler.MaybeDispose();
-                    var state = handler.State;
+                    _previousRejectContainer = rejectContainer;
                     _previousState = state;
 
                     if (ShouldInvokeSynchronous())
@@ -626,11 +925,10 @@ namespace Proto.Promises
                             CallbackHelperVoid.InvokeAndCatchProgress(_progress, 1f, this);
                         }
                         // Release since Cancel() will not be invoked.
-                        InterlockedAddWithOverflowCheck(ref _retainCounter, -1, 0);
+                        InterlockedAddWithUnsignedOverflowCheck(ref _progressFields._retainCounter, -1);
                     }
 
-                    State = state;
-                    HandleNextInternal();
+                    HandleNextInternal(_previousRejectContainer, _previousState);
                 }
 
                 void ICancelable.Cancel()
@@ -644,7 +942,7 @@ namespace Proto.Promises
                 {
                     if (ShouldInvokeSynchronous())
                     {
-                        return AddWaiterImpl(promiseId, waiter, out previousWaiter, Depth);
+                        return AddWaiterImpl(promiseId, waiter, out previousWaiter);
                     }
 
                     if (promiseId != Id)
@@ -655,29 +953,38 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
                     WasAwaitedOrForgotten = true;
 
-                    var previous = CompareExchangeWaiter(waiter, null);
-                    if (previous != null)
+                    var previous = CompareExchangeWaiter(waiter, PendingAwaitSentinel.s_instance);
+                    if (previous != PendingAwaitSentinel.s_instance)
                     {
-                        // We do the verification process here instead of in the caller, because we need to handle continuations on the synchronization context.
-                        if (CompareExchangeWaiter(waiter, PromiseCompletionSentinel.s_instance) != PromiseCompletionSentinel.s_instance)
-                        {
-                            previousWaiter = InvalidAwaitSentinel.s_instance;
-                            return InvalidAwaitSentinel.s_instance;
-                        }
-
-                        // If this was configured to execute progress on a SynchronizationContext or the ThreadPool, force the waiter to execute on the same context for consistency.
-                        if (_synchronizationContext == null)
-                        {
-                            // If there is no context, send it to the ThreadPool.
-                            ThreadPool.QueueUserWorkItem(s_threadPoolCallback, this);
-                        }
-                        else
-                        {
-                            _synchronizationContext.Post(s_synchronizationContextCallback, this);
-                        }
+                        return VerifyAndHandleWaiter(waiter, out previousWaiter);
                     }
-                    previousWaiter = null;
-                    return this; // It doesn't matter what we return since previousWaiter is set to null.
+                    previousWaiter = PendingAwaitSentinel.s_instance;
+                    return this; // It doesn't matter what we return since previousWaiter is set to PendingAwaitSentinel.s_instance.
+                }
+
+                // This is rare, only happens when the promise already completed (usually an already completed promise is not backed by a reference), or if a promise is incorrectly awaited twice.
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                private PromiseRefBase VerifyAndHandleWaiter(HandleablePromiseBase waiter, out HandleablePromiseBase previousWaiter)
+                {
+                    // We do the verification process here instead of in the caller, because we need to handle continuations on the synchronization context.
+                    if (CompareExchangeWaiter(waiter, PromiseCompletionSentinel.s_instance) != PromiseCompletionSentinel.s_instance)
+                    {
+                        previousWaiter = InvalidAwaitSentinel.s_instance;
+                        return InvalidAwaitSentinel.s_instance;
+                    }
+
+                    // If this was configured to execute progress on a SynchronizationContext or the ThreadPool, force the waiter to execute on the same context for consistency.
+                    if (_synchronizationContext == null)
+                    {
+                        // If there is no context, send it to the ThreadPool.
+                        ThreadPool.QueueUserWorkItem(s_threadPoolCallback, this);
+                    }
+                    else
+                    {
+                        _synchronizationContext.Post(s_synchronizationContextCallback, this);
+                    }
+                    previousWaiter = PendingAwaitSentinel.s_instance;
+                    return null; // It doesn't matter what we return since previousWaiter is set to PendingAwaitSentinel.s_instance.
                 }
 
                 private static void ExecuteFromContext(object state)
@@ -688,10 +995,8 @@ namespace Proto.Promises
                         // This handles the waiter that was added after this was already complete.
                         var _this = state.UnsafeAs<PromiseProgress<TResult, TProgress>>();
                         ThrowIfInPool(_this);
-                        _this.State = _this._previousState;
                         // We don't need to synchronize access here because this is only called when the waiter is added after Invoke1 has completed, so there are no race conditions.
-                        // _this._next is guaranteed to be non-null here, so we can call HandleNext instead of MaybeHandleNext.
-                        _this.HandleNext(_this._next);
+                        _this.HandleNext(_this._next, _this._previousRejectContainer, _this._previousState);
                     }
                     catch (Exception e)
                     {
@@ -705,7 +1010,7 @@ namespace Proto.Promises
                     ValidateId(promiseId, this, 2);
                     ThrowIfInPool(this);
                     // Make sure the continuation happens on the synchronization context.
-                    if ((ShouldInvokeSynchronous())
+                    if (ShouldInvokeSynchronous()
                         && CompareExchangeWaiter(InvalidAwaitSentinel.s_instance, PromiseCompletionSentinel.s_instance) == PromiseCompletionSentinel.s_instance)
                     {
                         WasAwaitedOrForgotten = true;
@@ -716,274 +1021,1460 @@ namespace Proto.Promises
                 }
             } // PromiseProgress<TProgress>
 
-            [MethodImpl(InlineOption)]
-            partial void InterlockedIncrementProgressReportingCount()
-            {
-                InterlockedAddWithOverflowCheck(ref _smallFields._reportingProgressCount, 1, -1);
-            }
-
-            [MethodImpl(InlineOption)]
-            partial void InterlockedDecrementProgressReportingCount()
-            {
-                InterlockedAddWithOverflowCheck(ref _smallFields._reportingProgressCount, -1, 0);
-            }
-
-            [MethodImpl(InlineOption)]
-            internal void ReportProgress(Fixed32 progress, ushort depth)
-            {
-                InterlockedIncrementProgressReportingCount();
-                ReportProgressAlreadyIncremented(progress, depth);
-            }
-
-            internal void ReportProgressAlreadyIncremented(Fixed32 progress, ushort depth)
-            {
-                PromiseRefBase current = this;
-                while (true)
-                {
-                    var progressListener = current._next;
-                    if (progressListener == null)
-                    {
-                        break;
-                    }
-                    var next = progressListener.SetProgress(ref progress, ref depth);
-                    if (next == null)
-                    {
-                        break;
-                    }
-                    next.InterlockedIncrementProgressReportingCount();
-                    current.InterlockedDecrementProgressReportingCount();
-                    current = next;
-                }
-                current.InterlockedDecrementProgressReportingCount();
-
-                StackUnwindHelper.InvokeProgressors();
-            }
-
             partial class PromiseSingleAwait<TResult>
             {
-                internal override PromiseRefBase SetProgress(ref Fixed32 progress, ref ushort depth)
+                internal override PromiseRefBase AddProgressWaiter(short promiseId, out HandleablePromiseBase previousWaiter, ref ProgressHookupValues progressHookupValues)
                 {
-                    return _smallFields._currentProgress.InterlockedTrySet(progress) ? this : null;
+                    var promiseSingleAwait = AddWaiter(promiseId, progressHookupValues.ProgressListener, out previousWaiter);
+                    if (previousWaiter == PendingAwaitSentinel.s_instance)
+                    {
+                        SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                    }
+                    return promiseSingleAwait;
                 }
-            } // PromiseSingleAwait
+            }
 
-            // Used to increase concurrency when invoking progress in PromiseMultiAwait. The cost is slower single-threaded invoke.
-            [ThreadStatic]
-            private static List<ValueTuple<PromiseRefBase, Fixed32, ushort>> ts_progressListenersForMultiAwait;
-
-            partial class PromiseMultiAwait<TResult>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            private sealed partial class IndividualPromisePassThrough<TResult> : PromiseRef<TResult>
             {
-                internal override PromiseRefBase SetProgress(ref Fixed32 progress, ref ushort depth)
+                // This type is used to hook up each waiter in PromiseMultiAwait to its progress listener.
+                // This is necessary because the _rejectContainerOrPreviousOrLink field is used to hook up the registered promises chain,
+                // and it would not be possible to do that for multiple progress listeners with a single promise object. So we have to create dummy objects to register multiple.
+
+                internal static IndividualPromisePassThrough<TResult> GetOrCreateAndRegister(PromiseMultiAwait<TResult> owner, ref ProgressHookupValues progressHookupValues)
                 {
-                    lock (this)
+                    var passthrough = ObjectPool.TryTake<IndividualPromisePassThrough<TResult>>()
+                        ?? new IndividualPromisePassThrough<TResult>();
+                    passthrough._owner = owner;
+                    passthrough._next = progressHookupValues.ProgressListener;
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    passthrough._disposed = false;
+#endif
+                    progressHookupValues.RegisterHandler(passthrough);
+                    return passthrough;
+                }
+
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                ~IndividualPromisePassThrough()
+                {
+                    if (!_disposed)
                     {
-                        ThrowIfInPool(this);
-                        if (_smallFields._currentProgress.InterlockedTrySet(progress))
-                        {
-                            if (!_isProgressScheduled)
-                            {
-                                _isProgressScheduled = true;
-                                Retain(); // Retain until InvokeProgressFromContext is complete.
-                                StackUnwindHelper.AddProgressor(this);
-                            }
-                        }
-                        return null;
+                        // For debugging. This should never happen.
+                        string message = "A IndividualPromisePassThrough was garbage collected without it being released.";
+                        ReportRejection(new UnreleasedObjectException(message), _owner);
+                    }
+                }
+#endif
+
+                internal override void MaybeDispose()
+                {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    _disposed = true;
+#endif
+                    _owner = null;
+                    _result = default(TResult);
+                    _rejectContainerOrPreviousOrLink = null;
+                    ObjectPool.MaybeRepool(this);
+                }
+
+                internal override void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state)
+                {
+                    _result = handler.GetResult<TResult>();
+                    // Don't bother to call handler.SetCompletionState, since we know the handler is the owner which is PromiseMultiAwait that already set its completion state.
+                    _next.Handle(this, rejectContainer, state);
+                    if (SuppressRejection)
+                    {
+                        handler.SuppressRejection = true;
+                    }
+                    handler.MaybeDispose();
+                }
+
+                internal override bool TryRestoreWaiter(HandleablePromiseBase waiter, HandleablePromiseBase expected)
+                {
+                    if (_owner.TryRestoreWaiter(waiter, expected))
+                    {
+                        MaybeDispose();
+                        return true;
+                    }
+                    return false;
+                }
+
+                internal override void MaybeReportProgress(ref ProgressReportValues progressReportValues)
+                {
+                    _next.MaybeReportProgress(ref progressReportValues);
+                }
+
+                internal override PromiseRefBase AddProgressWaiter(short promiseId, out HandleablePromiseBase previousWaiter, ref ProgressHookupValues progressHookupValues) { throw new System.InvalidOperationException(); }
+                protected override void OnForget(short promiseId) { throw new System.InvalidOperationException(); }
+                internal override PromiseRefBase AddWaiter(short promiseId, HandleablePromiseBase waiter, out HandleablePromiseBase previousWaiter) { throw new System.InvalidOperationException(); }
+                internal override PromiseRefBase GetDuplicate(short promiseId, ushort depth) { throw new System.InvalidOperationException(); }
+                internal override PromiseRef<TResult> GetDuplicateT(short promiseId, ushort depth) { throw new System.InvalidOperationException(); }
+                internal override bool GetIsCompleted(short promiseId) { throw new System.InvalidOperationException(); }
+                internal override bool GetIsValid(short promiseId) { throw new System.InvalidOperationException(); }
+                internal override void MaybeMarkAwaitedAndDispose(short promiseId) { throw new System.InvalidOperationException(); }
+            }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            private sealed partial class ProgressMultiAwait<TResult> : ProgressPassThrough
+            {
+                private static ProgressMultiAwait<TResult> GetOrCreate(PromiseMultiAwait<TResult> owner)
+                {
+                    var passthrough = ObjectPool.TryTake<ProgressMultiAwait<TResult>>()
+                        ?? new ProgressMultiAwait<TResult>();
+                    passthrough._owner = owner;
+                    // Retain the owner so we can continue to lock on it until this is disposed.
+                    owner.Retain();
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    passthrough._disposed = false;
+#endif
+                    return passthrough;
+                }
+
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                ~ProgressMultiAwait()
+                {
+                    if (!_disposed)
+                    {
+                        // For debugging. This should never happen.
+                        string message = "A ProgressMultiAwait was garbage collected without it being released."
+                            + ", _currentReporter: " + _progressFields._currentReporter + ", _current: " + _progressFields._current
+                            + ", _min: " + _progressFields._min + ", _max: " + _progressFields._max
+                            ;
+                        ReportRejection(new UnreleasedObjectException(message), _owner);
+                    }
+                }
+#endif
+
+                private void Dispose()
+                {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    _disposed = true;
+#endif
+                    _owner.MaybeDispose();
+                    _progressListeners.Clear();
+                    // We don't nullify _owner here, since it is used to lock. If the lock is taken after this has already been disposed, the further checks will ensure no harm is done.
+                    ObjectPool.MaybeRepool(this);
+                }
+
+                private void MaybeDispose(int retainAddCount)
+                {
+                    if (InterlockedAddWithUnsignedOverflowCheck(ref _progressFields._retainCounter, retainAddCount) == 0)
+                    {
+                        Dispose();
                     }
                 }
 
-                internal override void InvokeProgressFromContext()
+                internal static void Hookup(PromiseMultiAwait<TResult> owner, ref ProgressHookupValues progressHookupValues)
                 {
-                    ThrowIfInPool(this);
-                    InterlockedIncrementProgressReportingCount();
-                    Fixed32 progress;
-                    ValueList<HandleablePromiseBase> branches;
-                    lock (this)
+                    progressHookupValues._previous = null;
+                    var passthrough = owner._next as ProgressMultiAwait<TResult>;
+                    if (passthrough != null)
                     {
-                        progress = _smallFields._currentProgress;
-                        _isProgressScheduled = false;
-                        // cache _nextBranches in a local because another thread can modify it in Handle.
-                        branches = _nextBranches;
-                    }
-                    if (State != Promise.State.Pending | branches.Count == 0)
-                    {
-                        InterlockedDecrementProgressReportingCount();
-                        MaybeDispose();
+                        passthrough._progressListeners.Add(progressHookupValues.ProgressListener);
+                        progressHookupValues.CurrentReporter = passthrough;
+                        progressHookupValues._currentProgress = Lerp(passthrough._progressFields._min, passthrough._progressFields._max, passthrough._progressFields._current);
                         return;
                     }
 
-                    var nextListeners = ts_progressListenersForMultiAwait;
-                    if (nextListeners == null)
+                    passthrough = GetOrCreate(owner);
+                    // The lock is held until progress is hooked up to all the roots.
+                    // We lock on owner instead of passthrough to resolve race conditions with further progress listeners being added while this is being hooked up.
+                    Monitor.Enter(owner);
+
+                    passthrough._progressListeners.Add(progressHookupValues.ProgressListener);
+                    progressHookupValues._currentProgress = owner.Depth;
+                    progressHookupValues.AddPassthrough(passthrough);
+                }
+
+                internal override void HookupToRoots(ref ProgressHookupValues progressHookupValues)
+                {
+                    progressHookupValues._retainCounter = 0;
+                    progressHookupValues.ProgressListener = this;
+                    progressHookupValues._expectedWaiter = _owner;
+                    progressHookupValues._currentProgress = _owner.Depth;
+                    progressHookupValues.SetMinMaxAndDivisorFromDepth(0d, 1d, _owner.Depth);
+
+                    var previous = _owner._rejectContainerOrPreviousOrLink as PromiseRefBase;
+                    if (previous == null || !previous.TryHookupProgressListenerAndGetPrevious(ref progressHookupValues))
                     {
-                        nextListeners = new List<ValueTuple<PromiseRefBase, Fixed32, ushort>>(branches.Count);
-                        ts_progressListenersForMultiAwait = nextListeners;
+                        ExitLock();
+                        Dispose();
+                        return;
                     }
 
-                    // New waiters could be added on another thread while this is looping. That is fine.
-                    // This will only iterate over the items that were captured for the snapshot in the branches local copy.
-                    // Items will not be removed until all threads invoking progress are complete.
+                    _owner._next = this;
+                    var passthroughCount = progressHookupValues._pendingPassthroughCount;
+                    while (progressHookupValues._previous != null)
+                    {
+                        progressHookupValues._previous.TryHookupProgressListenerAndGetPrevious(ref progressHookupValues);
+                    }
+
+                    progressHookupValues.SetListenerFields(ref _progressFields);
+                    if (passthroughCount != progressHookupValues._pendingPassthroughCount)
+                    {
+                        // The passthrough had further root branches, so we need to continue to hold the lock until all of those branches are hooked up.
+                        // The caller will release the lock when all branches are hooked up.
+                        progressHookupValues._lockedPassthroughs.Push(this);
+                        return;
+                    }
+                    // The passthrough has finished hooking up to all of its roots.
+                    PropagateProgress();
+                }
+
+                internal override void MaybeHookupProgressToAwaited(PromiseRefBase current, PromiseRefBase awaited, ref ProgressRange userProgressRange, ref ProgressRange listenerProgressRange)
+                {
+                    if (awaited == null)
+                    {
+                        // The awaited promise is already complete, do nothing.
+                        return;
+                    }
+
+                    Monitor.Enter(_owner);
+                    // In case of promise completion on another thread,
+                    // make sure this is still hooked up to current, and another registered promise has not broken the chain.
+                    if (current._next != this | _progressFields._registeredPromisesHead != current)
+                    {
+                        ExitLock();
+                        return;
+                    }
+                    // We only check this is not in the pool after we verified the promise is still registered, otherwise it is valid for this to be in the pool.
+                    ThrowIfInPool(this);
+
+                    _hookingUp = true;
+                    double min = Lerp(listenerProgressRange._min, listenerProgressRange._max, userProgressRange._min);
+                    double max = Lerp(listenerProgressRange._min, listenerProgressRange._max, userProgressRange._max);
+                    var progressHookupValues = new ProgressHookupValues(this, current, awaited.Depth, min, max, _progressFields._registeredPromisesHead);
+                    if (!awaited.TryHookupProgressListenerAndGetPrevious(ref progressHookupValues))
+                    {
+                        // The awaited promise is already complete, or this was already registered to it on another thread, do nothing else.
+                        _hookingUp = false;
+                        ExitLock();
+                        return;
+                    }
+
+                    progressHookupValues.ListenForProgressOnRoots(ref _progressFields);
+                    _hookingUp = false;
+
+                    PropagateProgress();
+                }
+
+                private void PropagateProgress()
+                {
+                    // Report progress to propagate up to the PromiseProgress listener.
+                    var progressReportValues = new ProgressReportValues(null, this, _owner, 0d);
+                    ReportProgress(ref progressReportValues);
+                    progressReportValues.ReportProgressToAllListeners();
+                }
+
+                internal override void ExitLock()
+                {
+                    Monitor.Exit(_owner);
+                }
+
+                internal override void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state)
+                {
+                    // We lock on owner to resolve race condition with progress hookup and progress report.
+                    Monitor.Enter(_owner);
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    try
+                    {
+                        ThrowIfInPool(this);
+                    }
+                    catch
+                    {
+                        ExitLock();
+                        throw;
+                    }
+#endif
+                    HandleablePromiseBase target;
+                    int negativeDetachedCount;
+                    if (_progressFields.UnregisterHandlerAndGetShouldComplete(handler, this, out target, out negativeDetachedCount))
+                    {
+                        HandleOwner(handler, rejectContainer, state, negativeDetachedCount);
+                        return;
+                    }
+
+                    ExitLock();
+                    MaybeDispose(negativeDetachedCount);
+                    target.Handle(handler, rejectContainer, state);
+                }
+
+                private void HandleOwner(PromiseRefBase handler, object rejectContainer, Promise.State state, int negativeDetachedCount)
+                {
+                    ThrowIfInPool(_owner);
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    if (_owner.State != Promise.State.Pending)
+                    {
+                        throw new System.InvalidOperationException("ProgressMultiAwait: Cannot handle owner more than once.");
+                    }
+#endif
+                    handler.SetCompletionState(rejectContainer, state);
+                    handler.SuppressRejection = true;
+                    _owner._result = handler.GetResult<TResult>();
+                    handler.MaybeDispose();
+                    _owner.SetCompletionState(rejectContainer, state);
+
+                    var branches = _owner._nextBranches;
+                    // Remove the branches so progress won't try to hook up.
+                    _owner._nextBranches = default(ValueList<HandleablePromiseBase>);
+                    // Detach this.
+                    _owner._next = null;
+                    ExitLock();
+
                     for (int i = 0, max = branches.Count; i < max; ++i)
                     {
-                        var progressListener = branches[i];
-                        Fixed32 progressCopy = progress;
-                        ushort depth = Depth;
-                        PromiseRefBase nextRef = progressListener.SetProgress(ref progressCopy, ref depth);
-                        if (nextRef != null)
+                        _owner.Retain(); // Retain since Handle will call MaybeDispose indiscriminately.
+                        branches[i].Handle(_owner, rejectContainer, state);
+                    }
+                    branches.Clear();
+                    _owner._nextBranches = branches;
+                    _owner.MaybeDispose();
+
+                    MaybeDispose(negativeDetachedCount);
+                }
+
+                internal override void MaybeReportProgress(PromiseRefBase reporter, double progress)
+                {
+                    // Manually enter the lock so the next listener can enter its lock before unlocking this.
+                    // This is necessary for race conditions so a progress report won't get ahead of another on a separate thread.
+                    Monitor.Enter(_owner);
+                    var progressReportValues = new ProgressReportValues(null, reporter, _owner, progress);
+                    MaybeReportProgressImpl(ref progressReportValues);
+                    progressReportValues.ReportProgressToAllListeners();
+                }
+
+                internal override void MaybeReportProgress(ref ProgressReportValues progressReportValues)
+                {
+                    // Manually enter this lock before exiting previous lock.
+                    Monitor.Enter(_owner);
+                    Monitor.Exit(progressReportValues._lockedObject);
+
+                    if (_hookingUp)
+                    {
+                        // Just set the current progress. This will be scheduled for invoke higher in the call stack.
+                        _progressFields._current = (float) progressReportValues._progress;
+                        Monitor.Exit(this);
+                        progressReportValues._progressListener = null;
+                        return;
+                    }
+
+                    progressReportValues._lockedObject = this;
+                    MaybeReportProgressImpl(ref progressReportValues);
+                }
+
+                private void MaybeReportProgressImpl(ref ProgressReportValues progressReportValues)
+                {
+                    ThrowIfInPool(this);
+                    progressReportValues._progressListener = null;
+
+                    if (_progressFields._currentReporter != progressReportValues._reporter)
+                    {
+                        ExitLock();
+                        return;
+                    }
+
+                    progressReportValues._reporter = this;
+                    _progressFields._current = (float) progressReportValues._progress;
+                    progressReportValues._passthroughs.Push(this);
+                }
+
+                internal override void ReportProgress(ref ProgressReportValues progressReportValues)
+                {
+                    double normalizedProgress = Lerp(_progressFields._min, _progressFields._max, _progressFields._current);
+                    for (int i = 0, max = _progressListeners.Count; i < max; ++i)
+                    {
+                        progressReportValues._reporter = this;
+                        progressReportValues._progress = normalizedProgress;
+                        progressReportValues._lockedObject = _owner;
+                        // We have to hold the lock until all branches have been reported.
+                        // We enter the lock again for each listener because each one exits the lock indiscriminately.
+                        Monitor.Enter(_owner);
+                        _progressListeners[i].MaybeReportProgress(ref progressReportValues);
+                        progressReportValues.ReportProgressToSingularListeners();
+                    }
+                    ExitLock();
+                }
+            }
+
+            partial class PromiseMultiAwait<TResult>
+            {
+                internal override PromiseRefBase AddProgressWaiter(short promiseId, out HandleablePromiseBase previousWaiter, ref ProgressHookupValues progressHookupValues)
+                {
+                    lock (this)
+                    {
+                        if (promiseId != Id | WasAwaitedOrForgotten)
                         {
-                            nextRef.InterlockedIncrementProgressReportingCount();
-                            nextListeners.Add(ValueTuple.Create(nextRef, progressCopy, depth));
+                            previousWaiter = InvalidAwaitSentinel.s_instance;
+                            return InvalidAwaitSentinel.s_instance;
+                        }
+                        ThrowIfInPool(this);
+
+                        if (State == Promise.State.Pending)
+                        {
+                            var passthrough = IndividualPromisePassThrough<TResult>.GetOrCreateAndRegister(this, ref progressHookupValues);
+                            _nextBranches.Add(passthrough);
+                            ProgressMultiAwait<TResult>.Hookup(this, ref progressHookupValues);
+                            previousWaiter = PendingAwaitSentinel.s_instance;
+                            return null;
+                        }
+                        Retain(); // Retain since Handle will be called higher in the stack which will call MaybeDispose indiscriminately.
+                    }
+                    previousWaiter = progressHookupValues.ProgressListener;
+                    return null;
+                }
+
+                internal override bool TryHookupProgressListenerAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+                {
+                    lock (this)
+                    {
+                        for (int i = 0, max = _nextBranches.Count; i < max; ++i)
+                        {
+                            if (_nextBranches[i] == progressHookupValues._expectedWaiter)
+                            {
+                                _nextBranches[i] = IndividualPromisePassThrough<TResult>.GetOrCreateAndRegister(this, ref progressHookupValues);
+                                ProgressMultiAwait<TResult>.Hookup(this, ref progressHookupValues);
+                                return true;
+                            }
                         }
                     }
-                    InterlockedDecrementProgressReportingCount();
-                    MaybeDispose();
+                    return false;
+                }
 
-                    foreach (var tuple in nextListeners)
+                internal override bool TryRestoreWaiter(HandleablePromiseBase waiter, HandleablePromiseBase expected)
+                {
+                    lock (this)
                     {
-                        tuple.Item1.ReportProgressAlreadyIncremented(tuple.Item2, tuple.Item3);
+                        for (int i = 0, max = _nextBranches.Count; i < max; ++i)
+                        {
+                            if (_nextBranches[i] == expected)
+                            {
+                                _nextBranches[i] = waiter;
+                                goto DisposePassthrough;
+                            }
+                        }
                     }
-                    nextListeners.Clear();
+                    return false;
+
+                DisposePassthrough:
+                    expected.UnsafeAs<IndividualPromisePassThrough<TResult>>().MaybeDispose();
+                    return true;
                 }
             } // PromiseMultiAwait
+
+            partial struct DeferredIdAndProgress
+            {
+                internal bool TrySetProgress(int deferredId, float progress)
+                {
+                    Thread.MemoryBarrier(); // Make sure we're reading fresh values and other instructions are executed before this.
+                    DeferredIdAndProgress comparand = this;
+                    comparand._id = deferredId;
+                    DeferredIdAndProgress newValue = comparand;
+                    newValue._currentProgress = progress;
+                    comparand._interlocker = Interlocked.CompareExchange(ref _interlocker, newValue._interlocker, comparand._interlocker);
+                    // We could run this in a loop if it failed due to the progress changing and the id remaining the same,
+                    // but it's fine if another thread set progress concurrently. In that case, we just need to know if the call was valid.
+                    return comparand._id == deferredId;
+                }
+            }
 
             partial class DeferredPromiseBase<TResult>
             {
                 [MethodImpl(InlineOption)]
-                public bool TryReportProgress(int deferredId, float progress)
+                new protected void Reset()
                 {
-                    // It is possible this is called concurrently on another thread after this object has been repooled.
-                    // User code really shouldn't use this in that manner, which the deferredId protects against accidental usage.
-                    // But in case that does happen (like in unit tests for stress testing), calling SetProgress on the progressListener will be a no-op.
+                    base.Reset();
+                    _idAndProgress._currentProgress = 0f;
+                }
 
-                    var progressListener = _next;
-                    InterlockedIncrementProgressReportingCount();
-                    if (deferredId != DeferredId)
+                internal sealed override PromiseRefBase AddProgressWaiter(short promiseId, out HandleablePromiseBase previousWaiter, ref ProgressHookupValues progressHookupValues)
+                {
+                    var promiseSingleAwait = AddWaiterImpl(promiseId, progressHookupValues.ProgressListener, out previousWaiter);
+                    if (previousWaiter == PendingAwaitSentinel.s_instance)
                     {
-                        InterlockedDecrementProgressReportingCount();
+                        SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                    }
+                    return promiseSingleAwait;
+                }
+
+                new private void SetProgressValuesAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+                {
+                    ThrowIfInPool(this);
+                    progressHookupValues._currentProgress = _idAndProgress._currentProgress;
+                    progressHookupValues.SetMinAndMaxFromDepth(0u);
+                    progressHookupValues._expectedWaiter = this;
+                    progressHookupValues._previous = null;
+                    progressHookupValues.CurrentReporter = this;
+                    progressHookupValues.RegisterHandler(this);
+                }
+
+                internal sealed override bool TryHookupProgressListenerAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+                {
+                    if (CompareExchangeWaiter(progressHookupValues.ProgressListener, progressHookupValues._expectedWaiter) != progressHookupValues._expectedWaiter)
+                    {
+                        progressHookupValues._previous = null;
                         return false;
                     }
-
-                    // Don't report progress 1.0, that will be reported automatically when the promise is resolved.
-                    if (progress >= 0 & progress < 1f)
-                    {
-                        Fixed32 newProgress = _smallFields._currentProgress.SetNewDecimalPartFromDeferred(progress);
-                        var wasReportingPriority = Fixed32.ts_reportingPriority;
-                        Fixed32.ts_reportingPriority = true;
-
-                        ReportProgressAlreadyIncremented(newProgress, progressListener);
-
-                        Fixed32.ts_reportingPriority = wasReportingPriority;
-                    }
-                    else
-                    {
-                        InterlockedDecrementProgressReportingCount();
-                    }
+                    SetProgressValuesAndGetPrevious(ref progressHookupValues);
                     return true;
                 }
 
-                private void ReportProgressAlreadyIncremented(Fixed32 progress, HandleablePromiseBase progressListener)
+                [MethodImpl(InlineOption)]
+                public bool TryReportProgress(int deferredId, float progress)
                 {
-                    if (progressListener == null)
+                    // 1.0 is a valid value, but we don't report it here, as that will be reported automatically when the promise is resolved.
+                    // We also protect against other values outside of the 0 to 1 range.
+                    bool shouldReportProgress = progress >= 0 & progress < 1f;
+                    if (!shouldReportProgress)
                     {
-                        InterlockedDecrementProgressReportingCount();
-                        return;
+                        return deferredId == DeferredId;
                     }
-                    ushort depth = 0;
-                    var next = progressListener.SetProgress(ref progress, ref depth);
-                    if (next == null)
+
+                    // It is possible this is called concurrently on another thread after this object has been repooled.
+                    // User code really shouldn't use this in that manner, which the deferredId protects against accidental usage.
+                    // But in case that does happen (like in unit tests for stress testing), calling MaybeReportProgress will be a no-op.
+
+                    if (!_idAndProgress.TrySetProgress(deferredId, progress))
                     {
-                        InterlockedDecrementProgressReportingCount();
-                        StackUnwindHelper.InvokeProgressors();
-                        return;
+                        return false;
                     }
-                    next.InterlockedIncrementProgressReportingCount();
-                    InterlockedDecrementProgressReportingCount();
-                    next.ReportProgressAlreadyIncremented(progress, depth);
+
+                    Thread.MemoryBarrier(); // Make sure we read _next after we write progress to handle race condition of a progress listener being hooked up on another thread.
+                    _next.MaybeReportProgress(this, progress);
+                    return true;
                 }
-            }
-
-            [MethodImpl(InlineOption)]
-            partial void SetSecondPrevious(PromiseRefBase secondPrevious)
-            {
-#if PROMISE_DEBUG
-                _previous = secondPrevious;
-#endif
-                _smallFields._secondPrevious = true;
-            }
-
-            partial void ReportProgressFromWaitFor(PromiseRefBase other, ushort depth)
-            {
-                var wasReportingPriority = Fixed32.ts_reportingPriority;
-                Fixed32.ts_reportingPriority = false;
-
-                Fixed32 progress;
-                if (TryNormalizeProgress(other._smallFields._currentProgress, depth, out progress))
-                {
-                    InterlockedIncrementProgressReportingCount();
-                    other.InterlockedDecrementProgressReportingCount();
-                    ReportProgressAlreadyIncremented(progress, Depth);
-                }
-                else
-                {
-                    other.InterlockedDecrementProgressReportingCount();
-                }
-
-                Fixed32.ts_reportingPriority = wasReportingPriority;
-            }
-
-            [MethodImpl(InlineOption)]
-            private bool TryNormalizeProgress(Fixed32 progress, ushort depth, out Fixed32 result)
-            {
-                // Calculate the normalized progress for this and previous depth.
-                double normalizedProgress = progress.ToDouble() / (depth + 1d);
-                return _smallFields._currentProgress.TrySetNewDecimalPartFromWaitPromise(normalizedProgress, Depth, out result);
             }
 
             partial class PromiseWaitPromise<TResult>
             {
-
                 [MethodImpl(InlineOption)]
                 new protected void Reset(ushort depth)
                 {
                     base.Reset(depth);
-                    _smallFields._secondPrevious = false;
+                    _smallFields._waitState = WaitState.First;
                 }
 
                 [MethodImpl(InlineOption)]
-                internal void WaitForWithProgress(PromiseRefBase _ref, short promiseId)
+                partial void SetSecondPreviousAndMaybeHookupProgress(PromiseRefBase secondPrevious, PromiseRefBase handler)
                 {
-                    ThrowIfInPool(this);
-                    SetSecondPrevious(_ref);
-                    _smallFields._currentProgress = Fixed32.FromWhole(Depth);
-                    _ref.HookupNewWaiter(promiseId, this);
+                    SetSecondPrevious(secondPrevious, handler);
+                    var listenerProgressRange = new ProgressRange(0f, 1f);
+                    _next.MaybeHookupProgressToAwaited(this, secondPrevious, ref _progressRange, ref listenerProgressRange);
                 }
 
-                internal override sealed PromiseRefBase SetProgress(ref Fixed32 progress, ref ushort depth)
+                [MethodImpl(InlineOption)]
+                private void SetSecondPrevious(PromiseRefBase secondPrevious, PromiseRefBase handler)
                 {
-                    // This acts as a pass-through to normalize the progress.
+                    // These are volatile writes, so their write order will not be changed.
+                    // This looks superfluous, but is necessary for progress hookup on another thread.
+                    _smallFields._waitState = WaitState.SettingSecond;
+#if PROMISE_DEBUG
+                    _previous = secondPrevious;
+#endif
+                    // Resolve race condition with progress hookup.
+                    // Only set _rejectContainerOrPreviousOrLink if it's the same as the handler,
+                    // otherwise it could break the registered promise chain.
+                    Interlocked.CompareExchange(ref _rejectContainerOrPreviousOrLink, secondPrevious, handler);
+                    _smallFields._waitState = WaitState.Second;
+                }
+
+                internal sealed override PromiseRefBase AddProgressWaiter(short promiseId, out HandleablePromiseBase previousWaiter, ref ProgressHookupValues progressHookupValues)
+                {
+                    var promiseSingleAwait = AddWaiterImpl(promiseId, progressHookupValues.ProgressListener, out previousWaiter);
+                    if (previousWaiter == PendingAwaitSentinel.s_instance)
+                    {
+                        SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                    }
+                    return promiseSingleAwait;
+                }
+
+                new private void SetProgressValuesAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+                {
                     ThrowIfInPool(this);
-                    bool didSet = _smallFields._secondPrevious
-                        ? TryNormalizeProgress(progress, depth, out progress)
-                        : _smallFields._currentProgress.InterlockedTrySet(progress);
-                    depth = Depth;
-                    return didSet ? this : null;
+                    uint depth = Depth;
+                    progressHookupValues._currentProgress = depth;
+                    progressHookupValues._expectedWaiter = this;
+                    var previous = _rejectContainerOrPreviousOrLink;
+                    // We read wait state after previous. These are both volatile reads, so we don't need a full memory barrier.
+                    if (_smallFields._waitState == WaitState.First)
+                    {
+                        _progressRange._min = (float) progressHookupValues.GetLerpedProgressFromLocalProgress(depth);
+                        _progressRange._max = (float) progressHookupValues.GetLerpedProgressFromLocalProgress(depth + 1u);
+                        progressHookupValues._previous = previous as PromiseRefBase;
+                        progressHookupValues.RegisterHandler(this);
+                        return;
+                    }
+
+                    progressHookupValues.SetMinAndMaxFromDepth(depth);
+                    WaitForSecondPreviousAssignment();
+                    // We read _rejectContainerOrPreviousOrLink again instead of using the cached previous, as another thread may have changed it.
+                    // This is a volatile read, so we don't need a memory barrier.
+                    var prev = _rejectContainerOrPreviousOrLink as PromiseRefBase;
+                    if (prev != null)
+                    {
+                        progressHookupValues.SetDivisorFromDepth(prev.Depth);
+                    }
+                    progressHookupValues._previous = prev;
+                    progressHookupValues.RegisterHandler(this);
+                }
+
+                [MethodImpl(InlineOption)]
+                private void WaitForSecondPreviousAssignment()
+                {
+                    if (_smallFields._waitState == WaitState.SettingSecond)
+                    {
+                        // Very rare, this should almost never happen.
+                        WaitForSecondPreviousAssignmentCore();
+                    }
+                }
+
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                private void WaitForSecondPreviousAssignmentCore()
+                {
+                    var spinner = new SpinWait();
+                    while (_smallFields._waitState == WaitState.SettingSecond)
+                    {
+                        spinner.SpinOnce();
+                    }
+                }
+
+                internal override bool TryHookupProgressListenerAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+                {
+                    if (CompareExchangeWaiter(progressHookupValues.ProgressListener, progressHookupValues._expectedWaiter) != progressHookupValues._expectedWaiter)
+                    {
+                        progressHookupValues._previous = null;
+                        return false;
+                    }
+                    SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                    return true;
                 }
             } // PromiseWaitPromise
 
-            partial class PromisePassThrough
+            // Even though interfaces are slower than abstract classes, it doesn't matter for this case since this will rarely be called,
+            // and it's cleaner to just add the interface for this specific case, rather than adding more clutter to the base class.
+            internal interface IMultiHandleablePromise
             {
-                internal override PromiseRefBase SetProgress(ref Fixed32 progress, ref ushort depth)
+                void ReturnPassthroughs(ValueLinkedStack<PromisePassThrough> passThroughs);
+            }
+
+            partial class MultiHandleablePromiseBase<TResult> : IMultiHandleablePromise
+            {
+                void IMultiHandleablePromise.ReturnPassthroughs(ValueLinkedStack<PromisePassThrough> passThroughs)
+                {
+                    _passThroughs = passThroughs;
+                }
+            }
+
+            partial class MergePromise<TResult>
+            {
+                internal sealed override PromiseRefBase AddProgressWaiter(short promiseId, out HandleablePromiseBase previousWaiter, ref ProgressHookupValues progressHookupValues)
+                {
+                    var promiseSingleAwait = AddWaiterImpl(promiseId, progressHookupValues.ProgressListener, out previousWaiter);
+                    if (previousWaiter == PendingAwaitSentinel.s_instance)
+                    {
+                        SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                    }
+                    return promiseSingleAwait;
+                }
+
+                new private void SetProgressValuesAndGetPrevious(ref ProgressHookupValues progressHookupValues)
                 {
                     ThrowIfInPool(this);
-                    depth = _ownerOrTarget.Depth;
-                    long dif = _smallFields._currentProgress.InterlockedSetAndGetDifference(progress);
-                    return _ownerOrTarget.IncrementProgress(dif, ref progress, _smallFields._depth);
+                    // Retain this until we've hooked up progress to the passthroughs. This is necessary because we take the passthroughs, then put back the ones that are unable to be hooked up.
+                    InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, 1);
+                    progressHookupValues.RegisterHandler(this);
+                    ProgressMerger.MaybeHookup(this, _completeProgress, _passThroughs.TakeAndClear(), ref progressHookupValues);
+                }
+
+                internal override sealed bool TryHookupProgressListenerAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+                {
+                    if (CompareExchangeWaiter(progressHookupValues.ProgressListener, progressHookupValues._expectedWaiter) != progressHookupValues._expectedWaiter)
+                    {
+                        progressHookupValues._previous = null;
+                        return false;
+                    }
+                    SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                    return true;
+                }
+            }
+
+            partial class RacePromise<TResult>
+            {
+                internal sealed override PromiseRefBase AddProgressWaiter(short promiseId, out HandleablePromiseBase previousWaiter, ref ProgressHookupValues progressHookupValues)
+                {
+                    var promiseSingleAwait = AddWaiterImpl(promiseId, progressHookupValues.ProgressListener, out previousWaiter);
+                    if (previousWaiter == PendingAwaitSentinel.s_instance)
+                    {
+                        SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                    }
+                    return promiseSingleAwait;
+                }
+
+                new private void SetProgressValuesAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+                {
+                    ThrowIfInPool(this);
+                    // Retain this until we've hooked up progress to the passthroughs. This is necessary because we take the passthroughs, then put back the ones that are unable to be hooked up.
+                    InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, 1);
+                    progressHookupValues.RegisterHandler(this);
+                    ProgressRacer.MaybeHookup(this, _passThroughs.TakeAndClear(), ref progressHookupValues);
+                }
+
+                internal override sealed bool TryHookupProgressListenerAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+                {
+                    if (CompareExchangeWaiter(progressHookupValues.ProgressListener, progressHookupValues._expectedWaiter) != progressHookupValues._expectedWaiter)
+                    {
+                        progressHookupValues._previous = null;
+                        return false;
+                    }
+                    SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                    return true;
+                }
+            }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            private sealed partial class ProgressMerger : ProgressPassThrough
+            {
+                private ProgressMerger() { }
+
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                ~ProgressMerger()
+                {
+                    try
+                    {
+                        if (!_disposed)
+                        {
+                            // For debugging. This should never happen.
+                            string message = "A MergeProgressPassThrough was garbage collected without it being released."
+                                + " _targetMergePromise: " + _targetMergePromise + ", _currentProgress: " + _currentProgress + ", _divisorReciprocal: " + _divisorReciprocal
+                                ;
+                            ReportRejection(new UnreleasedObjectException(message), _targetMergePromise);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        // This should never happen.
+                        ReportRejection(e, _targetMergePromise);
+                    }
+                }
+#endif
+
+                private static ProgressMerger GetOrCreate(PromiseRefBase targetMergePromise, ulong completedProgress, ulong expectedProgress, ValueLinkedStack<PromisePassThrough> passThroughs)
+                {
+                    var merger = ObjectPool.TryTake<ProgressMerger>()
+                        ?? new ProgressMerger();
+                    merger._targetMergePromise = targetMergePromise;
+                    merger._passThroughs = passThroughs;
+                    merger._currentProgress = completedProgress;
+                    merger._divisorReciprocal = 1d / expectedProgress;
+                    merger._retainCounter = 1; // We have 1 retain during hookup in case of promise completions on other threads.
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    merger._disposed = false;
+#endif
+                    return merger;
+                }
+
+                private void Dispose()
+                {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    _disposed = true;
+#endif
+                    // Don't nullify target, if it is accessed after this is disposed, the checks on it will ensure nothing happens.
+                    ObjectPool.MaybeRepool(this);
+                }
+
+                internal static void MaybeHookup(PromiseRefBase targetMergePromise, ulong completedProgress, ValueLinkedStack<PromisePassThrough> passThroughs, ref ProgressHookupValues progressHookupValues)
+                {
+                    progressHookupValues._previous = null;
+                    ushort depth = targetMergePromise.Depth;
+                    progressHookupValues.SetMinAndMaxFromLocalProgress(0u, depth + 1u);
+                    if (passThroughs.IsEmpty)
+                    {
+                        progressHookupValues._currentProgress = depth;
+                        targetMergePromise.MaybeDispose();
+                        return;
+                    }
+
+                    ulong expectedProgress = completedProgress;
+                    foreach (var pt in passThroughs)
+                    {
+                        expectedProgress += pt.Depth + 1u;
+                    }
+                    var merger = GetOrCreate(targetMergePromise, completedProgress, expectedProgress, passThroughs);
+                    progressHookupValues._currentProgress = completedProgress * merger._divisorReciprocal;
+
+                    progressHookupValues.AddPassthrough(merger);
+                }
+
+                internal override void HookupToRoots(ref ProgressHookupValues progressHookupValues)
+                {
+                    ThrowIfInPool(this);
+
+                    var returnPassthroughs = new ValueLinkedStack<PromisePassThrough>();
+                    int afterHookedUpReleaseCount = -1; // This was created with 1 retain, so we must release it 1 extra.
+                    while (_passThroughs.IsNotEmpty)
+                    {
+                        var passthrough = _passThroughs.Pop();
+                        InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, 1);
+                        if (!MergeProgressPassThrough.TryHookup(this, passthrough, ref progressHookupValues))
+                        {
+                            unchecked
+                            {
+                                --afterHookedUpReleaseCount;
+                            }
+                            AddProgress(passthrough.Depth + 1u);
+                            returnPassthroughs.Push(passthrough);
+                            continue;
+                        }
+                        // We replaced the passthrough with the progress passthrough, so it is no longer needed.
+                        passthrough.Dispose();
+                    }
+
+                    if (returnPassthroughs.IsNotEmpty)
+                    {
+                        _targetMergePromise.UnsafeAs<IMultiHandleablePromise>().ReturnPassthroughs(returnPassthroughs);
+                    }
+                    _targetMergePromise.MaybeDispose();
+                    if (InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, afterHookedUpReleaseCount) == 0)
+                    {
+                        Dispose();
+                    }
+                }
+
+                private double AddProgress(double value)
+                {
+                    // There is no Interlocked.Add function for double, so we have to do it in a CompareExchange loop.
+                    double current;
+                    double newValue;
+                    do
+                    {
+                        current = _currentProgress;
+                        newValue = current + value;
+                    } while (Interlocked.CompareExchange(ref _currentProgress, newValue, current) != current);
+                    return newValue;
+                }
+
+                internal void ReportProgress(float oldProgress, ref ProgressReportValues progressReportValues)
+                {
+                    ThrowIfInPool(this);
+
+                    double dif = progressReportValues._progress - oldProgress;
+                    // Multiply by the divisor reciprocal to normalize the progress.
+                    progressReportValues._progress = AddProgress(dif) * _divisorReciprocal;
+                    progressReportValues._progressListener = _targetMergePromise._next;
+                    progressReportValues._reporter = this;
                 }
 
                 [MethodImpl(InlineOption)]
-                internal uint GetProgressDifferenceToCompletion()
+                internal void Handle(float oldProgress, float maxProgress, PromiseRefBase handler, int index, object lockedObject)
                 {
                     ThrowIfInPool(this);
-                    Fixed32 incrementedWhole = Fixed32.FromWholePlusOne(_smallFields._depth);
-                    return incrementedWhole.GetRawValue() - _smallFields._currentProgress.GetRawValue();
+
+                    var target = _targetMergePromise;
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    if (InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1) == 0)
+#else
+                    if (--_retainCounter == 0)
+#endif
+                    {
+                        Monitor.Exit(lockedObject);
+                        Dispose();
+                    }
+                    else
+                    {
+                        var progressReportValues = new ProgressReportValues(null, this, lockedObject, maxProgress);
+                        ReportProgress(oldProgress, ref progressReportValues);
+                        progressReportValues.ReportProgressToAllListeners();
+                    }
+                    target.Handle(handler, index);
+                }
+            } // ProgressMerger
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            private sealed partial class MergeProgressPassThrough : ProgressPassThrough
+            {
+                private MergeProgressPassThrough() { }
+
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                ~MergeProgressPassThrough()
+                {
+                    try
+                    {
+                        if (!_disposed)
+                        {
+                            // For debugging. This should never happen.
+                            string message = "A MergeProgressPassThrough was garbage collected without it being released."
+                                + ", _target: " + _target
+                                + ", _currentReporter: " + _progressFields._currentReporter + ", _current: " + _progressFields._current
+                                + ", _min: " + _progressFields._min + ", _max: " + _progressFields._max
+                                ;
+                            ReportRejection(new UnreleasedObjectException(message), null);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        // This should never happen.
+                        ReportRejection(e, null);
+                    }
+                }
+#endif
+
+                private static MergeProgressPassThrough GetOrCreate(ProgressMerger target, int index)
+                {
+                    var passThrough = ObjectPool.TryTake<MergeProgressPassThrough>()
+                        ?? new MergeProgressPassThrough();
+                    passThrough._target = target;
+                    passThrough._currentProgress = 0f;
+                    passThrough._index = index;
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    passThrough._disposed = false;
+#endif
+                    return passThrough;
+                }
+
+                internal void Dispose()
+                {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    _disposed = true;
+#endif
+                    _target = null;
+                    ObjectPool.MaybeRepool(this);
+                }
+
+                private void MaybeDispose(int retainAddCount)
+                {
+                    if (InterlockedAddWithUnsignedOverflowCheck(ref _progressFields._retainCounter, retainAddCount) == 0)
+                    {
+                        Dispose();
+                    }
+                }
+
+                internal static bool TryHookup(ProgressMerger target, PromisePassThrough oldPassThrough, ref ProgressHookupValues progressHookupValues)
+                {
+                    return GetOrCreate(target, oldPassThrough.Index).TryListenForProgressOnRoots(oldPassThrough, ref progressHookupValues);
+                }
+
+                private bool TryListenForProgressOnRoots(PromisePassThrough oldPassThrough, ref ProgressHookupValues progressHookupValues)
+                {
+                    progressHookupValues._retainCounter = 0;
+                    progressHookupValues.ProgressListener = this;
+                    progressHookupValues._expectedWaiter = oldPassThrough;
+                    // Instead of lerping the progress from 0 to 1 like the base listener, we lerp from 0 to depth + 1,
+                    // then that value gets added to the merger value before it is scaled back down to 0 to 1.
+                    progressHookupValues.SetMinMaxAndDivisorReciprocal(0d, 1d, 1d);
+                    progressHookupValues._currentProgress = oldPassThrough.Depth;
+                    uint passthroughCount = progressHookupValues._pendingPassthroughCount;
+
+                    // The lock is held until progress is hooked up to all the roots.
+                    Monitor.Enter(this);
+                    if (!oldPassThrough.Owner.TryHookupProgressListenerAndGetPrevious(ref progressHookupValues))
+                    {
+                        Monitor.Exit(this);
+                        Dispose();
+                        return false;
+                    }
+
+                    while (progressHookupValues._previous != null)
+                    {
+                        progressHookupValues._previous.TryHookupProgressListenerAndGetPrevious(ref progressHookupValues);
+                    }
+                    progressHookupValues.SetListenerFields(ref _progressFields);
+                    if (passthroughCount == progressHookupValues._pendingPassthroughCount)
+                    {
+                        // The passthrough has finished hooking up to all of its roots.
+                        PropagateProgress();
+                    }
+                    else
+                    {
+                        // The passthrough had further root branches, so we need to continue to hold the lock until all of those branches are hooked up.
+                        // The caller will release the lock when all branches are hooked up.
+                        progressHookupValues._lockedPassthroughs.Push(this);
+                    }
+                    return true;
+                }
+
+                internal override void MaybeHookupProgressToAwaited(PromiseRefBase current, PromiseRefBase awaited, ref ProgressRange userProgressRange, ref ProgressRange listenerProgressRange)
+                {
+                    Monitor.Enter(this);
+                    // In case of promise completion on another thread,
+                    // make sure this is still hooked up to current, and another registered promise has not broken the chain.
+                    if (current._next != this | _progressFields._registeredPromisesHead != current)
+                    {
+                        Monitor.Exit(this);
+                        return;
+                    }
+                    // We only check this is not in the pool after we verified the promise is still registered, otherwise it is valid for this to be in the pool.
+                    ThrowIfInPool(this);
+
+                    _hookingUp = true;
+                    double min = Lerp(listenerProgressRange._min, listenerProgressRange._max, userProgressRange._min);
+                    double max = Lerp(listenerProgressRange._min, listenerProgressRange._max, userProgressRange._max);
+                    var progressHookupValues = new ProgressHookupValues(this, current, 0, min, max, _progressFields._registeredPromisesHead);
+                    if (awaited == null || !awaited.TryHookupProgressListenerAndGetPrevious(ref progressHookupValues))
+                    {
+                        // The awaited promise is already complete, or this was already registered to it on another thread, do nothing else.
+                        progressHookupValues.SetListenerFields(ref _progressFields);
+                        _hookingUp = false;
+                        Monitor.Exit(this);
+                        return;
+                    }
+
+                    progressHookupValues.ListenForProgressOnRoots(ref _progressFields);
+                    _hookingUp = false;
+
+                    PropagateProgress();
+                }
+
+                private void PropagateProgress()
+                {
+                    // Report progress to propagate up to the PromiseProgress listener.
+                    float oldProgress = _currentProgress;
+                    _currentProgress = (float) Lerp(_progressFields._min, _progressFields._max, _progressFields._current);
+                    var progressReportValues = new ProgressReportValues(null, _target, this, _currentProgress);
+                    _target.ReportProgress(oldProgress, ref progressReportValues);
+                    progressReportValues.ReportProgressToAllListeners();
+                }
+
+                internal override void MaybeReportProgress(PromiseRefBase reporter, double progress)
+                {
+                    // Manually enter the lock so the next listener can enter its lock before unlocking this.
+                    // This is necessary for race conditions so a progress report won't get ahead of another on a separate thread.
+                    Monitor.Enter(this);
+                    var progressReportValues = new ProgressReportValues(null, reporter, this, progress);
+                    MaybeReportProgressImpl(ref progressReportValues);
+                    progressReportValues.ReportProgressToAllListeners();
+                }
+
+                internal override void MaybeReportProgress(ref ProgressReportValues progressReportValues)
+                {
+                    // Manually enter this lock before exiting previous lock.
+                    Monitor.Enter(this);
+                    Monitor.Exit(progressReportValues._lockedObject);
+
+                    if (_hookingUp)
+                    {
+                        // Just set the current progress. This will be scheduled for invoke higher in the call stack.
+                        _progressFields._current = (float) progressReportValues._progress;
+                        Monitor.Exit(this);
+                        progressReportValues._progressListener = null;
+                        return;
+                    }
+
+                    progressReportValues._lockedObject = this;
+                    MaybeReportProgressImpl(ref progressReportValues);
+                }
+
+                private void MaybeReportProgressImpl(ref ProgressReportValues progressReportValues)
+                {
+                    if (_progressFields._currentReporter != progressReportValues._reporter)
+                    {
+                        Monitor.Exit(this);
+                        progressReportValues._progressListener = null;
+                        return;
+                    }
+                    float oldProgress = _currentProgress;
+                    _progressFields._current = (float) progressReportValues._progress;
+                    float newProgress = (float) Lerp(_progressFields._min, _progressFields._max, _progressFields._current);
+                    _currentProgress = newProgress;
+                    progressReportValues._progress = newProgress;
+                    _target.ReportProgress(oldProgress, ref progressReportValues);
+                }
+
+                internal override void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state)
+                {
+                    ThrowIfInPool(this);
+
+                    // We lock to resolve race condition with progress hookup and progress report.
+                    Monitor.Enter(this);
+                    HandleablePromiseBase target;
+                    int negativeDetachedCount;
+                    bool shouldComplete = _progressFields.UnregisterHandlerAndGetShouldComplete(handler, this, out target, out negativeDetachedCount);
+
+                    if (!shouldComplete)
+                    {
+                        Monitor.Exit(this);
+                        MaybeDispose(negativeDetachedCount);
+                        target.Handle(handler, rejectContainer, state);
+                        return;
+                    }
+
+                    handler.SetCompletionState(rejectContainer, state);
+                    // We continue to hold the lock until the target has been handled.
+                    _target.Handle(_currentProgress, _progressFields._max, handler, _index, this);
+                    MaybeDispose(negativeDetachedCount);
+                }
+            } // MergeProgressPassThrough
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            private sealed partial class ProgressRacer : ProgressPassThrough
+            {
+                private ProgressRacer() { }
+
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                ~ProgressRacer()
+                {
+                    try
+                    {
+                        if (!_disposed)
+                        {
+                            // For debugging. This should never happen.
+                            string message = "A RaceProgressPassThrough was garbage collected without it being released."
+                                + " _targetRacePromise: " + _targetRacePromise + ", _currentProgress: " + _currentProgress
+                                ;
+                            ReportRejection(new UnreleasedObjectException(message), _targetRacePromise);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        // This should never happen.
+                        ReportRejection(e, _targetRacePromise);
+                    }
+                }
+#endif
+
+                private static ProgressRacer GetOrCreate(PromiseRefBase targetRacePromise, ValueLinkedStack<PromisePassThrough> passThroughs)
+                {
+                    var racer = ObjectPool.TryTake<ProgressRacer>()
+                        ?? new ProgressRacer();
+                    racer._targetRacePromise = targetRacePromise;
+                    racer._passThroughs = passThroughs;
+                    racer._currentProgress = 0f;
+                    racer._retainCounter = 1; // We have 1 retain during hookup in case of promise completions on other threads.
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    racer._disposed = false;
+#endif
+                    return racer;
+                }
+
+                private void Dispose()
+                {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    _disposed = true;
+#endif
+                    // Don't nullify target, if it is accessed after this is disposed, the checks on it will ensure nothing happens.
+                    ObjectPool.MaybeRepool(this);
+                }
+
+                internal static void MaybeHookup(PromiseRefBase targetRacePromise, ValueLinkedStack<PromisePassThrough> passThroughs, ref ProgressHookupValues progressHookupValues)
+                {
+                    progressHookupValues._previous = null;
+                    ushort depth = targetRacePromise.Depth;
+                    progressHookupValues.SetMinAndMaxFromLocalProgress(0u, depth + 1u);
+                    if (passThroughs.IsEmpty)
+                    {
+                        progressHookupValues._currentProgress = depth;
+                        targetRacePromise.MaybeDispose();
+                        return;
+                    }
+
+                    var racer = GetOrCreate(targetRacePromise, passThroughs);
+                    progressHookupValues._currentProgress = 0d;
+
+                    progressHookupValues.AddPassthrough(racer);
+                }
+
+                internal override void HookupToRoots(ref ProgressHookupValues progressHookupValues)
+                {
+                    ThrowIfInPool(this);
+
+                    var returnPassthroughs = new ValueLinkedStack<PromisePassThrough>();
+                    int afterHookedUpReleaseCount = -1; // This was created with 1 retain, so we must release it 1 extra.
+                    while (_passThroughs.IsNotEmpty)
+                    {
+                        var passthrough = _passThroughs.Pop();
+                        InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, 1);
+                        if (!RaceProgressPassThrough.TryHookup(this, passthrough, ref progressHookupValues))
+                        {
+                            unchecked
+                            {
+                                --afterHookedUpReleaseCount;
+                            }
+                            returnPassthroughs.Push(passthrough);
+                            continue;
+                        }
+                        // We replaced the passthrough with the progress passthrough, so it is no longer needed.
+                        passthrough.Dispose();
+                    }
+
+                    if (returnPassthroughs.IsNotEmpty)
+                    {
+                        _targetRacePromise.UnsafeAs<IMultiHandleablePromise>().ReturnPassthroughs(returnPassthroughs);
+                    }
+                    _targetRacePromise.MaybeDispose();
+                    if (InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, afterHookedUpReleaseCount) == 0)
+                    {
+                        Dispose();
+                    }
+                }
+
+                new internal void ReportProgress(ref ProgressReportValues progressReportValues)
+                {
+                    ThrowIfInPool(this);
+
+                    double current;
+                    do
+                    {
+                        current = _currentProgress;
+                        if (progressReportValues._progress <= current)
+                        {
+                            Monitor.Exit(progressReportValues._lockedObject);
+                            progressReportValues._progressListener = null;
+                            return;
+                        }
+                    } while (Interlocked.CompareExchange(ref _currentProgress, progressReportValues._progress, current) != current);
+
+                    progressReportValues._progressListener = _targetRacePromise._next;
+                    progressReportValues._reporter = this;
+                }
+
+                [MethodImpl(InlineOption)]
+                new internal void Handle(PromiseRefBase handler, int index)
+                {
+                    ThrowIfInPool(this);
+
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    if (InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1) == 0)
+#else
+                    if (--_retainCounter == 0)
+#endif
+                    {
+                        Dispose();
+                    }
+                    _targetRacePromise.Handle(handler, index);
+                }
+            } // ProgressRacer
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            private sealed partial class RaceProgressPassThrough : ProgressPassThrough
+            {
+                private RaceProgressPassThrough() { }
+
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                ~RaceProgressPassThrough()
+                {
+                    try
+                    {
+                        if (!_disposed)
+                        {
+                            // For debugging. This should never happen.
+                            string message = "A RaceProgressPassThrough was garbage collected without it being released."
+                                + ", _target: " + _target + ", _index: " + _index
+                                + ", _currentReporter: " + _progressFields._currentReporter + ", _current: " + _progressFields._current
+                                + ", _min: " + _progressFields._min + ", _max: " + _progressFields._max
+                                ;
+                            ReportRejection(new UnreleasedObjectException(message), null);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        // This should never happen.
+                        ReportRejection(e, null);
+                    }
+                }
+#endif
+
+                private static RaceProgressPassThrough GetOrCreate(ProgressRacer target, int index)
+                {
+                    var passThrough = ObjectPool.TryTake<RaceProgressPassThrough>()
+                        ?? new RaceProgressPassThrough();
+                    passThrough._target = target;
+                    passThrough._index = index;
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    passThrough._disposed = false;
+#endif
+                    return passThrough;
+                }
+
+                internal void Dispose()
+                {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    _disposed = true;
+#endif
+                    _target = null;
+                    ObjectPool.MaybeRepool(this);
+                }
+
+                private void MaybeDispose(int retainAddCount)
+                {
+                    if (InterlockedAddWithUnsignedOverflowCheck(ref _progressFields._retainCounter, retainAddCount) == 0)
+                    {
+                        Dispose();
+                    }
+                }
+
+                internal static bool TryHookup(ProgressRacer target, PromisePassThrough oldPassThrough, ref ProgressHookupValues progressHookupValues)
+                {
+                    return GetOrCreate(target, oldPassThrough.Index).TryListenForProgressOnRoots(oldPassThrough, ref progressHookupValues);
+                }
+
+                private bool TryListenForProgressOnRoots(PromisePassThrough oldPassThrough, ref ProgressHookupValues progressHookupValues)
+                {
+                    progressHookupValues._retainCounter = 0;
+                    progressHookupValues.ProgressListener = this;
+                    progressHookupValues._expectedWaiter = oldPassThrough;
+                    progressHookupValues.SetMinMaxAndDivisorFromDepth(0d, 1d, oldPassThrough.Depth);
+                    progressHookupValues._currentProgress = oldPassThrough.Depth;
+                    uint passthroughCount = progressHookupValues._pendingPassthroughCount;
+
+                    // The lock is held until progress is hooked up to all the roots.
+                    Monitor.Enter(this);
+                    if (!oldPassThrough.Owner.TryHookupProgressListenerAndGetPrevious(ref progressHookupValues))
+                    {
+                        Monitor.Exit(this);
+                        Dispose();
+                        return false;
+                    }
+
+                    while (progressHookupValues._previous != null)
+                    {
+                        progressHookupValues._previous.TryHookupProgressListenerAndGetPrevious(ref progressHookupValues);
+                    }
+                    progressHookupValues.SetListenerFields(ref _progressFields);
+                    if (passthroughCount == progressHookupValues._pendingPassthroughCount)
+                    {
+                        // The passthrough has finished hooking up to all of its roots.
+                        PropagateProgress();
+                    }
+                    else
+                    {
+                        // The passthrough had further root branches, so we need to continue to hold the lock until all of those branches are hooked up.
+                        // The caller will release the lock when all branches are hooked up.
+                        progressHookupValues._lockedPassthroughs.Push(this);
+                    }
+                    return true;
+                }
+
+                internal override void MaybeHookupProgressToAwaited(PromiseRefBase current, PromiseRefBase awaited, ref ProgressRange userProgressRange, ref ProgressRange listenerProgressRange)
+                {
+                    if (awaited == null)
+                    {
+                        // The awaited promise is already complete, do nothing.
+                        return;
+                    }
+
+                    Monitor.Enter(this);
+                    // In case of promise completion on another thread,
+                    // make sure this is still hooked up to current, and another registered promise has not broken the chain.
+                    if (current._next != this | _progressFields._registeredPromisesHead != current)
+                    {
+                        Monitor.Exit(this);
+                        return;
+                    }
+                    // We only check this is not in the pool after we verified the promise is still registered, otherwise it is valid for this to be in the pool.
+                    ThrowIfInPool(this);
+
+                    _hookingUp = true;
+                    double min = Lerp(listenerProgressRange._min, listenerProgressRange._max, userProgressRange._min);
+                    double max = Lerp(listenerProgressRange._min, listenerProgressRange._max, userProgressRange._max);
+                    var progressHookupValues = new ProgressHookupValues(this, current, awaited.Depth, min, max, _progressFields._registeredPromisesHead);
+                    if (!awaited.TryHookupProgressListenerAndGetPrevious(ref progressHookupValues))
+                    {
+                        // The awaited promise is already complete, or this was already registered to it on another thread, do nothing else.
+                        _hookingUp = false;
+                        Monitor.Exit(this);
+                        return;
+                    }
+
+                    progressHookupValues.ListenForProgressOnRoots(ref _progressFields);
+                    _hookingUp = false;
+
+                    PropagateProgress();
+                }
+
+                private void PropagateProgress()
+                {
+                    // Report progress to propagate up to the PromiseProgress listener.
+                    var reportProgress = Lerp(_progressFields._min, _progressFields._max, _progressFields._current);
+                    var progressReportValues = new ProgressReportValues(null, _target, this, reportProgress);
+                    _target.ReportProgress(ref progressReportValues);
+                    progressReportValues.ReportProgressToAllListeners();
+                }
+
+                internal override void MaybeReportProgress(PromiseRefBase reporter, double progress)
+                {
+                    // Manually enter the lock so the next listener can enter its lock before unlocking this.
+                    // This is necessary for race conditions so a progress report won't get ahead of another on a separate thread.
+                    Monitor.Enter(this);
+                    var progressReportValues = new ProgressReportValues(null, reporter, this, progress);
+                    MaybeReportProgressImpl(ref progressReportValues);
+                    progressReportValues.ReportProgressToAllListeners();
+                }
+
+                internal override void MaybeReportProgress(ref ProgressReportValues progressReportValues)
+                {
+                    // Manually enter this lock before exiting previous lock.
+                    Monitor.Enter(this);
+                    Monitor.Exit(progressReportValues._lockedObject);
+
+                    if (_hookingUp)
+                    {
+                        // Just set the current progress. This will be scheduled for invoke higher in the call stack.
+                        _progressFields._current = (float) progressReportValues._progress;
+                        Monitor.Exit(this);
+                        progressReportValues._progressListener = null;
+                        return;
+                    }
+
+                    progressReportValues._lockedObject = this;
+                    MaybeReportProgressImpl(ref progressReportValues);
+                }
+
+                private void MaybeReportProgressImpl(ref ProgressReportValues progressReportValues)
+                {
+                    float castedProgress = (float) progressReportValues._progress;
+                    if (_progressFields._currentReporter != progressReportValues._reporter)
+                    {
+                        Monitor.Exit(this);
+                        progressReportValues._progressListener = null;
+                        return;
+                    }
+                    _progressFields._current = castedProgress; // We don't actually need to store the current, but it could be useful for debugging.
+                    progressReportValues._progress = Lerp(_progressFields._min, _progressFields._max, progressReportValues._progress);
+                    _target.ReportProgress(ref progressReportValues);
+                }
+
+                internal override void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state)
+                {
+                    ThrowIfInPool(this);
+
+                    // We lock on this to resolve race condition with progress hookup and progress report.
+                    Monitor.Enter(this);
+                    HandleablePromiseBase target;
+                    int negativeDetachedCount;
+                    bool shouldComplete = _progressFields.UnregisterHandlerAndGetShouldComplete(handler, this, out target, out negativeDetachedCount);
+
+                    if (!shouldComplete)
+                    {
+                        Monitor.Exit(this);
+                        MaybeDispose(negativeDetachedCount);
+                        target.Handle(handler, rejectContainer, state);
+                        return;
+                    }
+
+                    Monitor.Exit(this);
+                    handler.SetCompletionState(rejectContainer, state);
+                    var racer = _target;
+                    MaybeDispose(negativeDetachedCount);
+                    racer.Handle(handler, _index);
+                }
+            } // RaceProgressPassThrough
+
+            partial class PromisePassThrough
+            {
+                internal ushort Depth
+                {
+                    [MethodImpl(InlineOption)]
+                    get { return _smallFields._depth; }
                 }
 
                 [MethodImpl(InlineOption)]
@@ -991,111 +2482,90 @@ namespace Proto.Promises
                 {
                     _smallFields._depth = depth;
                 }
-
-                partial void SetInitialProgress(PromiseRefBase owner, PromiseRefBase target)
-                {
-                    var progress = owner._smallFields._currentProgress;
-                    _smallFields._currentProgress = progress;
-                    uint increment = progress.GetRawValue();
-                    target.IncrementProgress(increment, ref progress, _smallFields._depth);
-                }
             } // PromisePassThrough
 
             partial class AsyncPromiseRef<TResult>
             {
+                internal sealed override PromiseRefBase AddProgressWaiter(short promiseId, out HandleablePromiseBase previousWaiter, ref ProgressHookupValues progressHookupValues)
+                {
+                    var promiseSingleAwait = AddWaiterImpl(promiseId, progressHookupValues.ProgressListener, out previousWaiter);
+                    if (previousWaiter == PendingAwaitSentinel.s_instance)
+                    {
+                        SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                    }
+                    return promiseSingleAwait;
+                }
+
+                new private void SetProgressValuesAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+                {
+                    ThrowIfInPool(this);
+                    _listenerProgressRange = new ProgressRange(
+                        (float) progressHookupValues._min,
+                        (float) progressHookupValues._max
+                    );
+
+                    // Read previous before read range to resolve race condition with .AwaitWithProgress.
+                    // This is a volatile read, so we don't need a full memory barrier.
+                    progressHookupValues._previous = _rejectContainerOrPreviousOrLink as PromiseRefBase;
+                    progressHookupValues._expectedWaiter = this;
+                    progressHookupValues.SetMinAndMaxFromLocalProgress(_userProgressRange._min, _userProgressRange._max);
+                    if (progressHookupValues._previous != null)
+                    {
+                        progressHookupValues.SetDivisorFromDepth(progressHookupValues._previous.Depth);
+                    }
+                    progressHookupValues.RegisterHandler(this);
+                }
+
+                internal sealed override bool TryHookupProgressListenerAndGetPrevious(ref ProgressHookupValues progressHookupValues)
+                {
+                    if (CompareExchangeWaiter(progressHookupValues.ProgressListener, progressHookupValues._expectedWaiter) != progressHookupValues._expectedWaiter)
+                    {
+                        progressHookupValues._previous = null;
+                        return false;
+                    }
+                    SetProgressValuesAndGetPrevious(ref progressHookupValues);
+                    return true;
+                }
+
                 [MethodImpl(InlineOption)]
                 new private void Reset()
                 {
-                    _minProgress = _maxProgress = float.NaN;
+                    _userProgressRange._min = 0f;
+                    _userProgressRange._max = 0f;
                     base.Reset();
                 }
 
                 [MethodImpl(InlineOption)]
-                private static double Lerp(double a, double b, double t)
-                {
-                    return a + (b - a) * t;
-                }
-
-                private double LerpProgress(Fixed32 progress, ushort depth)
-                {
-                    ThrowIfInPool(this);
-                    double normalizedProgress = progress.ToDouble() / (depth + 1d);
-                    double newValue = Lerp(_minProgress, _maxProgress, normalizedProgress);
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    if (newValue < 0 || newValue >= 1)
-                    {
-                        throw new ArithmeticException("Async progress calculated outside allowed bounds of [0, 1), value: " + newValue
-                            + ", progress: " + progress.ToDouble() + ", depth: " + depth
-                            + ", _minProgress: " + _minProgress + ", _maxProgress: " + _maxProgress);
-                    }
-#endif
-                    return newValue;
-                }
-
-                internal override PromiseRefBase SetProgress(ref Fixed32 progress, ref ushort depth)
-                {
-                    if (float.IsNaN(_minProgress))
-                    {
-                        return null;
-                    }
-                    bool didSet = TryLerpAndSetProgress(ref progress, depth);
-                    depth = 0;
-                    return didSet ? this : null;
-                }
-
-                private bool TryLerpAndSetProgress(ref Fixed32 progress, ushort depth)
-                {
-                    var lerpedProgress = LerpProgress(progress, depth);
-                    return _smallFields._currentProgress.TrySetNewDecimalPartFromAsync(lerpedProgress, out progress);
-                }
-
                 partial void SetAwaitedComplete(PromiseRefBase handler)
                 {
-                    ThrowIfInPool(this);
-#if PROMISE_DEBUG
-                    _previous = null;
-#endif
-                    // Don't report progress if it's 1 or NaN. 1 will be reported when the async promise is resolved.
-                    // Also don't report if the awaited promise was rejected or canceled.
-                    if (handler.State == Promise.State.Resolved & _maxProgress < 1f)
-                    {
-                        var progress = Fixed32.FromDecimalForResolve(_maxProgress);
-                        _smallFields._currentProgress = progress;
-                        ReportProgress(progress, 0);
-                    }
-                    _minProgress = _maxProgress = float.NaN;
+                    // Resolve race condition with progress hookup.
+                    // Only nullify _rejectContainerOrPreviousOrLink if it's the same as the handler,
+                    // otherwise it could break the registered promise chain.
+                    Interlocked.CompareExchange(ref _rejectContainerOrPreviousOrLink, null, handler);
                 }
 
                 [MethodImpl(InlineOption)]
-                private void SetPreviousAndProgress(PromiseRefBase waiter, float minProgress, float maxProgress)
+                private void SetPreviousAndMaybeHookupProgress(PromiseRefBase waiter, float minProgress, float maxProgress)
                 {
 #if PROMISE_DEBUG
                     _previous = waiter;
 #endif
-                    _minProgress = float.IsNaN(minProgress)
-                        ? (float) _smallFields._currentProgress.DecimalPart
-                        : minProgress;
-                    _maxProgress = maxProgress;
-                }
-
-                private void ReportProgressFromHookupWaiterWithProgress(PromiseRefBase other, ushort depth)
-                {
-                    var wasReportingPriority = Fixed32.ts_reportingPriority;
-                    Fixed32.ts_reportingPriority = false;
-
-                    Fixed32 progress = other._smallFields._currentProgress;
-                    if (TryLerpAndSetProgress(ref progress, depth))
+                    if (float.IsNaN(minProgress))
                     {
-                        InterlockedIncrementProgressReportingCount();
-                        other.InterlockedDecrementProgressReportingCount();
-                        ReportProgressAlreadyIncremented(progress, 0);
+                        // We have to set min to previous max instead of current, since we can't know what the current would be if the previous awaited promise was rejected or canceled, and a progress listener was never hooked up.
+                        // Technically, we could hook up a progress listener just to tell this what its current progress would be, but that would be extremely inefficient for the common case where it doesn't matter.
+                        minProgress = _userProgressRange._max;
                     }
-                    else
-                    {
-                        other.InterlockedDecrementProgressReportingCount();
-                    }
+                    // Write range before write previous to resolve race condition with progress listener hooking up to this.
+                    _userProgressRange._min = minProgress;
+                    _userProgressRange._max = maxProgress;
 
-                    Fixed32.ts_reportingPriority = wasReportingPriority;
+                    // Resolve race condition with progress hookup.
+                    // Only write _rejectContainerOrPreviousOrLink if it's null,
+                    // otherwise it could break the registered promise chain.
+                    Interlocked.CompareExchange(ref _rejectContainerOrPreviousOrLink, waiter, null);
+
+                    _next.MaybeHookupProgressToAwaited(this, waiter, ref _userProgressRange, ref _listenerProgressRange);
                 }
             } // AsyncPromiseRef
 #endif // PROMISE_PROGRESS

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RejectContainersInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/RejectContainersInternal.cs
@@ -48,16 +48,6 @@ namespace Proto.Promises
 #endif
         internal abstract class RejectContainer : IRejectContainer, ITraceable
         {
-            // This is used with Interlocked in Merge/Race/First to handle completion race conditions.
-            // It's also used as a placeholder for cancelations.
-            internal static readonly RejectContainer s_completionSentinel = new CompletionSentinel();
-
-            private class CompletionSentinel : RejectContainer
-            {
-                public override void ReportUnhandled() { }
-                public override ExceptionDispatchInfo GetExceptionDispatchInfo() { throw new System.InvalidOperationException(); }
-            }
-
 #if PROMISE_DEBUG
             CausalityTrace ITraceable.Trace { get; set; }
 #endif

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
@@ -34,7 +34,7 @@ namespace Proto.Promises
 
                 private PromiseCompletionSentinel() { }
 
-                internal override void Handle(PromiseRefBase handler)
+                internal override void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state)
                 {
                     throw new System.InvalidOperationException("PromiseCompletionSentinel handled from " + handler);
                 }
@@ -50,8 +50,9 @@ namespace Proto.Promises
 
                 private PromiseForgetSentinel() { }
 
-                internal override void Handle(PromiseRefBase handler)
+                internal override void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state)
                 {
+                    handler.SetCompletionState(rejectContainer, state);
                     handler.MaybeDispose();
                 }
             }
@@ -66,15 +67,59 @@ namespace Proto.Promises
 
                 private InvalidAwaitSentinel()
                 {
-                    _next = this; // Set _next to this so that CompareExchangeWaiter will always fail.
+                    _next = this; // Set _next to this so that CompareExchangeWaiter will always fail. This is also used in the object pool so that the _next field will never be null.
                     _smallFields = new SmallFields(-5); // Set an id that is unlikely to match (though this should never be used in a Promise struct).
-                    // If we don't suppress, the finalizer can run when the ApplicationDomain is unloaded, causing a NullReferenceException. This happens in Unity when switching between editmode and playmode.
+                    // If we don't suppress, the finalizer can run when the AppDomain is unloaded, causing a NullReferenceException. This happens in Unity when switching between editmode and playmode.
                     System.GC.SuppressFinalize(this);
                 }
 
-                internal override void Handle(PromiseRefBase handler)
+                internal override void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state)
                 {
                     throw new System.InvalidOperationException("InvalidAwaitSentinel handled from " + handler);
+                }
+
+                internal override void MaybeDispose() { throw new System.InvalidOperationException(); }
+                protected override void OnForget(short promiseId) { throw new System.InvalidOperationException(); }
+                internal override PromiseRefBase AddWaiter(short promiseId, HandleablePromiseBase waiter, out HandleablePromiseBase previousWaiter) { throw new System.InvalidOperationException(); }
+                internal override PromiseRefBase GetDuplicate(short promiseId, ushort depth) { throw new System.InvalidOperationException(); }
+                internal override bool GetIsCompleted(short promiseId) { throw new System.InvalidOperationException(); }
+                internal override bool GetIsValid(short promiseId) { throw new System.InvalidOperationException(); }
+                internal override PromiseRefBase GetPreserved(short promiseId, ushort depth) { throw new System.InvalidOperationException(); }
+                internal override void MaybeMarkAwaitedAndDispose(short promiseId) { throw new System.InvalidOperationException(); }
+            }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            internal sealed partial class PendingAwaitSentinel : PromiseRefBase
+            {
+                // A singleton instance indicating that a promise has not yet been awaited. This is used so that we never have to check for null when handling the next promise.
+                internal static readonly PendingAwaitSentinel s_instance = new PendingAwaitSentinel();
+
+                private PendingAwaitSentinel()
+                {
+                    _smallFields = new SmallFields(-5); // Set an id that is unlikely to match (though this should never be used in a Promise struct).
+                    // If we don't suppress, the finalizer can run when the AppDomain is unloaded, causing a NullReferenceException. This happens in Unity when switching between editmode and playmode.
+                    System.GC.SuppressFinalize(this);
+                }
+
+                internal override void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state)
+                {
+                    // This will only be called if the handler was completed before it was awaited (rare).
+                    var waiter = handler.ReadNextWaiterAndMaybeSetCompleted();
+                    // If waiter is not this, it means the handler was awaited before it was set complete on another thread, so we need to handle it here.
+                    if (waiter != this)
+                    {
+#if PROMISE_PROGRESS
+                        // Exchange waiter to read latest and set to InvalidAwaitSentinel to solve race condition with progress.
+                        waiter = handler.ExchangeWaiter(InvalidAwaitSentinel.s_instance);
+#endif
+                        waiter.Handle(handler, rejectContainer, state);
+                    }
+                    else
+                    {
+                        handler.SetCompletionState(rejectContainer, state);
+                    }
                 }
 
                 internal override void MaybeDispose() { throw new System.InvalidOperationException(); }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStaticMerge.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStaticMerge.cs
@@ -24,19 +24,18 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
                 return Internal.CreateResolved(maxDepth);
             }
-            var promise = Internal.PromiseRefBase.MergePromise<Internal.VoidResult>.GetOrCreate(passThroughs, pendingCount, completedProgress, totalProgress, maxDepth);
+            var promise = Internal.PromiseRefBase.MergePromise<Internal.VoidResult>.GetOrCreate(passThroughs, pendingCount, completedProgress, maxDepth);
             return new Promise(promise, promise.Id, maxDepth);
         }
 
@@ -49,21 +48,20 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
                 return Internal.CreateResolved(maxDepth);
             }
-            var promise = Internal.PromiseRefBase.MergePromise<Internal.VoidResult>.GetOrCreate(passThroughs, pendingCount, completedProgress, totalProgress, maxDepth);
+            var promise = Internal.PromiseRefBase.MergePromise<Internal.VoidResult>.GetOrCreate(passThroughs, pendingCount, completedProgress, maxDepth);
             return new Promise(promise, promise.Id, maxDepth);
         }
 
@@ -76,23 +74,22 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
                 return Internal.CreateResolved(maxDepth);
             }
-            var promise = Internal.PromiseRefBase.MergePromise<Internal.VoidResult>.GetOrCreate(passThroughs, pendingCount, completedProgress, totalProgress, maxDepth);
+            var promise = Internal.PromiseRefBase.MergePromise<Internal.VoidResult>.GetOrCreate(passThroughs, pendingCount, completedProgress, maxDepth);
             return new Promise(promise, promise.Id, maxDepth);
         }
 
@@ -127,7 +124,6 @@ namespace Proto.Promises
                 var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
                 int pendingCount = 0;
                 ulong completedProgress = 0;
-                ulong totalProgress = 0;
                 ushort maxDepth = 0;
 
                 int index = -1;
@@ -135,14 +131,14 @@ namespace Proto.Promises
                 {
                     var p = promises.Current;
                     ValidateElement(p, "promises", 1);
-                    Internal.PrepareForMerge(p, ref passThroughs, ++index, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+                    Internal.PrepareForMerge(p, ref passThroughs, ++index, ref pendingCount, ref completedProgress, ref maxDepth);
                 }
 
                 if (pendingCount == 0)
                 {
                     return Internal.CreateResolved(maxDepth);
                 }
-                var promise = Internal.PromiseRefBase.MergePromise<Internal.VoidResult>.GetOrCreate(passThroughs, pendingCount, completedProgress, totalProgress, maxDepth);
+                var promise = Internal.PromiseRefBase.MergePromise<Internal.VoidResult>.GetOrCreate(passThroughs, pendingCount, completedProgress, maxDepth);
                 return new Promise(promise, promise.Id, maxDepth);
             }
         }
@@ -193,13 +189,12 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -211,7 +206,7 @@ namespace Proto.Promises
                 {
                     target = feed.GetResult<T1>();
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<T1>(promise, promise.Id, maxDepth);
         }
 
@@ -225,13 +220,12 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -247,7 +241,7 @@ namespace Proto.Promises
                 {
                     target.Item2 = feed.GetResult<T2>();
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<ValueTuple<T1, T2>>(promise, promise.Id, maxDepth);
         }
 
@@ -261,15 +255,14 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -286,7 +279,7 @@ namespace Proto.Promises
                         target.Item2 = feed.GetResult<T2>();
                         break;
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<ValueTuple<T1, T2>>(promise, promise.Id, maxDepth);
         }
 
@@ -300,15 +293,14 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -328,7 +320,7 @@ namespace Proto.Promises
                         target.Item3 = feed.GetResult<T3>();
                         break;
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<ValueTuple<T1, T2, T3>>(promise, promise.Id, maxDepth);
         }
 
@@ -342,17 +334,16 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -372,7 +363,7 @@ namespace Proto.Promises
                         target.Item3 = feed.GetResult<T3>();
                         break;
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<ValueTuple<T1, T2, T3>>(promise, promise.Id, maxDepth);
         }
 
@@ -386,17 +377,16 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -419,7 +409,7 @@ namespace Proto.Promises
                         target.Item4 = feed.GetResult<T4>();
                         break;
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<ValueTuple<T1, T2, T3, T4>>(promise, promise.Id, maxDepth);
         }
 
@@ -433,19 +423,18 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -468,7 +457,7 @@ namespace Proto.Promises
                         target.Item4 = feed.GetResult<T4>();
                         break;
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<ValueTuple<T1, T2, T3, T4>>(promise, promise.Id, maxDepth);
         }
 
@@ -482,19 +471,18 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref value.Item5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise5, ref value.Item5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -520,7 +508,7 @@ namespace Proto.Promises
                         target.Item5 = feed.GetResult<T5>();
                         break;
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<ValueTuple<T1, T2, T3, T4, T5>>(promise, promise.Id, maxDepth);
         }
 
@@ -534,21 +522,20 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref value.Item5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise5, ref value.Item5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -574,7 +561,7 @@ namespace Proto.Promises
                         target.Item5 = feed.GetResult<T5>();
                         break;
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<ValueTuple<T1, T2, T3, T4, T5>>(promise, promise.Id, maxDepth);
         }
 
@@ -588,21 +575,20 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref value.Item5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise5, ref value.Item5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref value.Item6, ref passThroughs, 5, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise6, ref value.Item6, ref passThroughs, 5, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -631,7 +617,7 @@ namespace Proto.Promises
                         target.Item6 = feed.GetResult<T6>();
                         break;
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<ValueTuple<T1, T2, T3, T4, T5, T6>>(promise, promise.Id, maxDepth);
         }
 
@@ -645,23 +631,22 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref value.Item5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise5, ref value.Item5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref value.Item6, ref passThroughs, 5, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise6, ref value.Item6, ref passThroughs, 5, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise7, "promise7", 1);
-            Internal.PrepareForMerge(promise7, ref passThroughs, 6, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise7, ref passThroughs, 6, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -690,7 +675,7 @@ namespace Proto.Promises
                         target.Item6 = feed.GetResult<T6>();
                         break;
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<ValueTuple<T1, T2, T3, T4, T5, T6>>(promise, promise.Id, maxDepth);
         }
 
@@ -704,23 +689,22 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref value.Item5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise5, ref value.Item5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref value.Item6, ref passThroughs, 5, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise6, ref value.Item6, ref passThroughs, 5, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise7, "promise7", 1);
-            Internal.PrepareForMerge(promise7, ref value.Item7, ref passThroughs, 6, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise7, ref value.Item7, ref passThroughs, 6, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -752,7 +736,7 @@ namespace Proto.Promises
                         target.Item7 = feed.GetResult<T7>();
                         break;
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>(promise, promise.Id, maxDepth);
         }
 
@@ -766,25 +750,24 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref value.Item1, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref value.Item2, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref value.Item3, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise4, ref value.Item4, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref value.Item5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise5, ref value.Item5, ref passThroughs, 4, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref value.Item6, ref passThroughs, 5, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise6, ref value.Item6, ref passThroughs, 5, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise7, "promise7", 1);
-            Internal.PrepareForMerge(promise7, ref value.Item7, ref passThroughs, 6, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise7, ref value.Item7, ref passThroughs, 6, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise8, "promise8", 1);
-            Internal.PrepareForMerge(promise8, ref passThroughs, 7, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise8, ref passThroughs, 7, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (pendingCount == 0)
             {
@@ -816,7 +799,7 @@ namespace Proto.Promises
                         target.Item7 = feed.GetResult<T7>();
                         break;
                 }
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>(promise, promise.Id, maxDepth);
         }
     }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
@@ -531,15 +531,14 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
             T v0 = default(T);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
             T v1 = default(T);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (valueContainer == null)
             {
@@ -569,7 +568,7 @@ namespace Proto.Promises
             var promise = Internal.PromiseRefBase.MergePromise<IList<T>>.GetOrCreate(passThroughs, valueContainer, (Internal.PromiseRefBase feed, ref IList<T> target, int index) =>
             {
                 target[index] = feed.GetResult<T>();
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<IList<T>>(promise, promise.Id, maxDepth);
         }
 
@@ -586,18 +585,17 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
             T v0 = default(T);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
             T v1 = default(T);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
             T v2 = default(T);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (valueContainer == null)
             {
@@ -628,7 +626,7 @@ namespace Proto.Promises
             var promise = Internal.PromiseRefBase.MergePromise<IList<T>>.GetOrCreate(passThroughs, valueContainer, (Internal.PromiseRefBase feed, ref IList<T> target, int index) =>
             {
                 target[index] = feed.GetResult<T>();
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<IList<T>>(promise, promise.Id, maxDepth);
         }
 
@@ -646,21 +644,20 @@ namespace Proto.Promises
             var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
             int pendingCount = 0;
             ulong completedProgress = 0;
-            ulong totalProgress = 0;
             ushort maxDepth = 0;
 
             ValidateArgument(promise1, "promise1", 1);
             T v0 = default(T);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise2, "promise2", 1);
             T v1 = default(T);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise3, "promise3", 1);
             T v2 = default(T);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount, ref completedProgress, ref maxDepth);
             ValidateArgument(promise4, "promise4", 1);
             T v3 = default(T);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount, ref completedProgress, ref maxDepth);
 
             if (valueContainer == null)
             {
@@ -692,7 +689,7 @@ namespace Proto.Promises
             var promise = Internal.PromiseRefBase.MergePromise<IList<T>>.GetOrCreate(passThroughs, valueContainer, (Internal.PromiseRefBase feed, ref IList<T> target, int index) =>
             {
                 target[index] = feed.GetResult<T>();
-            }, pendingCount, completedProgress, totalProgress, maxDepth);
+            }, pendingCount, completedProgress, maxDepth);
             return new Promise<IList<T>>(promise, promise.Id, maxDepth);
         }
 
@@ -742,7 +739,6 @@ namespace Proto.Promises
                 var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
                 int pendingCount = 0;
                 ulong completedProgress = 0;
-                ulong totalProgress = 0;
                 ushort maxDepth = 0;
 
                 if (valueContainer == null)
@@ -757,7 +753,7 @@ namespace Proto.Promises
                     var p = promises.Current;
                     ValidateElement(p, "promises", 1);
                     T value = default(T);
-                    Internal.PrepareForMerge(p, ref value, ref passThroughs, i, ref pendingCount, ref completedProgress, ref totalProgress, ref maxDepth);
+                    Internal.PrepareForMerge(p, ref value, ref passThroughs, i, ref pendingCount, ref completedProgress, ref maxDepth);
                     // Make sure list has the same count as promises.
                     if (listSize < (i + 1))
                     {
@@ -784,7 +780,7 @@ namespace Proto.Promises
                 var promise = Internal.PromiseRefBase.MergePromise<IList<T>>.GetOrCreate(passThroughs, valueContainer, (Internal.PromiseRefBase feed, ref IList<T> target, int index) =>
                 {
                     target[index] = feed.GetResult<T>();
-                }, pendingCount, completedProgress, totalProgress, maxDepth);
+                }, pendingCount, completedProgress, maxDepth);
                 return new Promise<IList<T>>(promise, promise.Id, maxDepth);
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/ResultContainers.cs
@@ -126,7 +126,7 @@ namespace Proto.Promises
             /// FOR INTERNAL USE ONLY!
             /// </summary>
             [MethodImpl(Internal.InlineOption)]
-            internal ResultContainer(Internal.PromiseRefBase source) : this(source._rejectContainer, source.State)
+            internal ResultContainer(Internal.PromiseRefBase source) : this(source._rejectContainerOrPreviousOrLink.UnsafeAs<Internal.IRejectContainer>(), source.State)
             {
             }
 
@@ -251,7 +251,7 @@ namespace Proto.Promises
             /// FOR INTERNAL USE ONLY!
             /// </summary>
             [MethodImpl(Internal.InlineOption)]
-            internal ResultContainer(Internal.PromiseRefBase source) : this(source.GetResult<T>(), source._rejectContainer, source.State)
+            internal ResultContainer(Internal.PromiseRefBase source) : this(source.GetResult<T>(), source._rejectContainerOrPreviousOrLink.UnsafeAs<Internal.IRejectContainer>(), source.State)
             {
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/AsyncFunctionTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/AsyncFunctionTests.cs
@@ -1287,7 +1287,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void AsyncPromiseWillHaveProgressSetToMax_WhenAnotherAwaitableIsAwaitedWithoutProgress_MinMax_void()
+        public void AsyncPromiseWillReportProgress_WhenAnotherAwaitableIsAwaitedWithoutProgress_MinMax_void()
         {
             var deferred1 = Promise.NewDeferred();
             var deferred2 = Promise.NewDeferred();
@@ -1307,14 +1307,15 @@ namespace ProtoPromiseTests.APIs
                 .Forget();
 
             progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f));
-            progressHelper.ResolveAndAssertResult(deferred1, 0.5f);
-            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 0.5f, false);
-            progressHelper.ResolveAndAssertResult(deferred2, 1f, false);
+            // Implementation detail - progress is not reported after awaited promise is resolved, until another promise is awaited with progress.
+            progressHelper.ResolveAndAssertResult(deferred1, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ResolveAndAssertResult(deferred2, 1f, true);
             Assert.IsTrue(complete);
         }
 
         [Test]
-        public void AsyncPromiseWillHaveProgressSetToMax_WhenAnotherAwaitableIsAwaitedWithoutProgress_Max_void()
+        public void AsyncPromiseWillReportProgress_WhenAnotherAwaitableIsAwaitedWithoutProgress_Max_void()
         {
             var deferred1 = Promise.NewDeferred();
             var deferred2 = Promise.NewDeferred();
@@ -1334,14 +1335,15 @@ namespace ProtoPromiseTests.APIs
                 .Forget();
 
             progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f));
-            progressHelper.ResolveAndAssertResult(deferred1, 0.5f);
-            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 0.5f, false);
-            progressHelper.ResolveAndAssertResult(deferred2, 1f, false);
+            // Implementation detail - progress is not reported after awaited promise is resolved, until another promise is awaited with progress.
+            progressHelper.ResolveAndAssertResult(deferred1, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ResolveAndAssertResult(deferred2, 1f, true);
             Assert.IsTrue(complete);
         }
 
         [Test]
-        public void AsyncPromiseWillHaveProgressSetToMax_WhenAnotherAwaitableIsAwaitedWithoutProgress_MinMax_T()
+        public void AsyncPromiseWillReportProgress_WhenAnotherAwaitableIsAwaitedWithoutProgress_MinMax_T()
         {
             var deferred1 = Promise.NewDeferred<int>();
             var deferred2 = Promise.NewDeferred<int>();
@@ -1361,14 +1363,15 @@ namespace ProtoPromiseTests.APIs
                 .Forget();
 
             progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f));
-            progressHelper.ResolveAndAssertResult(deferred1, 1, 0.5f);
-            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 0.5f, false);
-            progressHelper.ResolveAndAssertResult(deferred2, 2, 1f, false);
+            // Implementation detail - progress is not reported after awaited promise is resolved, until another promise is awaited with progress.
+            progressHelper.ResolveAndAssertResult(deferred1, 1, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ResolveAndAssertResult(deferred2, 2, 1f, true);
             Assert.IsTrue(complete);
         }
 
         [Test]
-        public void AsyncPromiseWillHaveProgressSetToMax_WhenAnotherAwaitableIsAwaitedWithoutProgress_Max_T()
+        public void AsyncPromiseWillReportProgress_WhenAnotherAwaitableIsAwaitedWithoutProgress_Max_T()
         {
             var deferred1 = Promise.NewDeferred<int>();
             var deferred2 = Promise.NewDeferred<int>();
@@ -1388,9 +1391,10 @@ namespace ProtoPromiseTests.APIs
                 .Forget();
 
             progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f));
-            progressHelper.ResolveAndAssertResult(deferred1, 1, 0.5f);
-            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, 0.5f, false);
-            progressHelper.ResolveAndAssertResult(deferred2, 2, 1f, false);
+            // Implementation detail - progress is not reported after awaited promise is resolved, until another promise is awaited with progress.
+            progressHelper.ResolveAndAssertResult(deferred1, 1, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ResolveAndAssertResult(deferred2, 2, 1f, true);
             Assert.IsTrue(complete);
         }
 #endif // PROMISE_PROGRESS

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/NewAndRunTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/NewAndRunTests.cs
@@ -839,10 +839,6 @@ namespace ProtoPromiseTests.APIs
             if (isPending)
             {
 #if PROMISE_PROGRESS
-                // Wait a bit longer to make sure the promise is fully adopted before we report progress.
-                // Otherwise it results in a race condition where the progress may be reported as 0 immediately after we try to report 0.5 and spoils the result.
-                Thread.Sleep(System.TimeSpan.FromMilliseconds(500));
-
                 progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
                 if (completeType == CompleteType.Resolve)
                 {
@@ -955,10 +951,6 @@ namespace ProtoPromiseTests.APIs
             if (isPending)
             {
 #if PROMISE_PROGRESS
-                // Wait a bit longer to make sure the promise is fully adopted before we report progress.
-                // Otherwise it results in a race condition where the progress may be reported as 0 immediately after we try to report 0.5 and spoils the result.
-                Thread.Sleep(System.TimeSpan.FromMilliseconds(500));
-
                 progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
                 if (completeType == CompleteType.Resolve)
                 {
@@ -1071,10 +1063,6 @@ namespace ProtoPromiseTests.APIs
             if (isPending)
             {
 #if PROMISE_PROGRESS
-                // Wait a bit longer to make sure the promise is fully adopted before we report progress.
-                // Otherwise it results in a race condition where the progress may be reported as 0 immediately after we try to report 0.5 and spoils the result.
-                Thread.Sleep(System.TimeSpan.FromMilliseconds(500));
-
                 progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
                 if (completeType == CompleteType.Resolve)
                 {
@@ -1189,10 +1177,6 @@ namespace ProtoPromiseTests.APIs
             if (isPending)
             {
 #if PROMISE_PROGRESS
-                // Wait a bit longer to make sure the promise is fully adopted before we report progress.
-                // Otherwise it results in a race condition where the progress may be reported as 0 immediately after we try to report 0.5 and spoils the result.
-                Thread.Sleep(System.TimeSpan.FromMilliseconds(500));
-
                 progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
                 if (completeType == CompleteType.Resolve)
                 {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/AwaitConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/Threading/AwaitConcurrencyTests.cs
@@ -41,9 +41,9 @@ namespace ProtoPromiseTests.Threading
             threadHelper.ExecuteMultiActionParallel(
                 () =>
                 {
-                    Await();
+                    Await().Forget();
 
-                    async void Await()
+                    async Promise Await()
                     {
                         try
                         {
@@ -83,9 +83,9 @@ namespace ProtoPromiseTests.Threading
             threadHelper.ExecuteMultiActionParallel(
                 () =>
                 {
-                    Await();
+                    Await().Forget();
 
-                    async void Await()
+                    async Promise Await()
                     {
                         try
                         {
@@ -210,9 +210,9 @@ namespace ProtoPromiseTests.Threading
                 {
                     barrierAction =>
                     {
-                        Await();
+                        Await().Forget();
 
-                        async void Await()
+                        async Promise Await()
                         {
                             try
                             {


### PR DESCRIPTION
Resolves #115

Refactored progress to iterate over the promise tree when progress is subscribed instead of when progress is reported. This moves the heavy work to the 1-time hookup rather than every time progress is reported. Reporting progress is now much faster and scales better with longer promise chains (`O(n)` where `n` is now Merge/Race/Preserve promises instead of every promise). This also increases memory when progress is listened to, but decreases it when it is not (for `.Then` chains).

Progress now uses full 32-bit float precision instead of 16-bit fixed precision.

---

Without listening to progress or normalizing with `.AwaitWithProgress`. (8 awaits with max depth 3)

|       Method | Pending |     Mean | Allocated | Survived |
|------------- |-------- |---------:|----------:|---------:|
|   AsyncAwait |    True | 2.184 us |         - |    696 B |
| ContinueWith |    True | 2.594 us |         - |    400 B |

This PR:

|       Method | Pending |     Mean | Allocated | Survived |
|------------- |-------- |---------:|----------:|---------:|
|   AsyncAwait |    True | 2.075 us |         - |    696 B |
| ContinueWith |    True | 2.104 us |         - |    384 B |

---

Same setup, but with listening to progress, normalizing with `.AwaitWithProgress`, and reporting `0.5` progress before resolving.

Master:

|       Method | Pending |     Mean | Allocated | Survived |
|------------- |-------- |---------:|----------:|---------:|
|   AsyncAwait |    True | 5.138 us |         - |    896 B |
| ContinueWith |    True | 4.691 us |         - |    568 B |

This PR:

|       Method | Pending |     Mean | Allocated | Survived |
|------------- |-------- |---------:|----------:|---------:|
|   AsyncAwait |    True | 4.548 us |         - |    936 B |
| ContinueWith |    True | 4.222 us |         - |    592 B |

Longer promise chains would result in even larger speed differences due to the better scaling.

---

Same setup, but with normalizing with `.AwaitWithProgress`, and reporting `0.5` progress before resolving, and _without_ listening to progress.

Master:

|       Method | Pending |     Mean | Allocated | Survived |
|------------- |-------- |---------:|----------:|---------:|
|   AsyncAwait |    True | 3.885 us |         - |    728 B |
| ContinueWith |    True | 3.516 us |         - |    400 B |

This PR:

|       Method | Pending |     Mean | Allocated | Survived |
|------------- |-------- |---------:|----------:|---------:|
|   AsyncAwait |    True | 2.587 us |         - |    728 B |
| ContinueWith |    True | 2.270 us |         - |    384 B |

In this PR, reporting progress when there is no progress listener is an `O(1)` no-op. In master it has to iterate over the entire promise tree, so larger promise trees will take more time to report the progress, even without a listener.