### PR TITLE
Report unhandled rejections in PromiseForgetSentinel

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -795,7 +795,7 @@ namespace Proto.Promises
                     Promise<TResult> promise, ushort nextDepth)
                 {
 #if !PROMISE_PROGRESS
-                    return new Promise<TResult>(promise._ref, promise._id, nextDepth, promise._result);
+                    return new Promise<TResult>(promise._ref, promise._id, nextDepth, promise._result).Duplicate();
 #else
                     var _ref = promise._ref;
                     if (_ref == null)
@@ -823,7 +823,7 @@ namespace Proto.Promises
                     Promise promise, ushort nextDepth)
                 {
 #if !PROMISE_PROGRESS
-                    return new Promise(promise._ref, promise._id, nextDepth);
+                    return new Promise(promise._ref, promise._id, nextDepth).Duplicate();
 #else
                     var _ref = promise._ref;
                     if (_ref == null)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CancelInternal.cs
@@ -26,6 +26,29 @@ namespace Proto.Promises
     {
         partial class PromiseRefBase
         {
+            internal virtual void ReportUnhandledAndMaybeDispose()
+            {
+                // PromiseSingleAwait
+
+                // Rejection maybe wasn't caught.
+                if (State == Promise.State.Rejected & !SuppressRejection)
+                {
+                    SuppressRejection = true;
+                    _rejectContainerOrPreviousOrLink.UnsafeAs<IRejectContainer>().ReportUnhandled();
+                }
+                MaybeDispose();
+            }
+
+            partial class PromiseMultiAwait<TResult>
+            {
+                internal override void ReportUnhandledAndMaybeDispose()
+                {
+                    // We don't report unhandled rejection here unless none of the waiters suppressed.
+                    // This way we only report it once in case multiple waiters were canceled.
+                    MaybeDispose();
+                }
+            }
+
             internal partial struct CancelationHelper
             {
                 [MethodImpl(InlineOption)]
@@ -114,7 +137,7 @@ namespace Proto.Promises
                     else
                     {
                         MaybeDispose();
-                        handler.MaybeDispose();
+                        handler.ReportUnhandledAndMaybeDispose();
                     }
                 }
 
@@ -184,7 +207,7 @@ namespace Proto.Promises
                     else
                     {
                         MaybeDispose();
-                        handler.MaybeDispose();
+                        handler.ReportUnhandledAndMaybeDispose();
                     }
                 }
 
@@ -245,7 +268,7 @@ namespace Proto.Promises
                     else if (!unregistered)
                     {
                         MaybeDispose();
-                        handler.MaybeDispose();
+                        handler.ReportUnhandledAndMaybeDispose();
                     }
                     else if (state == Promise.State.Rejected)
                     {
@@ -326,7 +349,7 @@ namespace Proto.Promises
                     else if (!unregistered)
                     {
                         MaybeDispose();
-                        handler.MaybeDispose();
+                        handler.ReportUnhandledAndMaybeDispose();
                     }
                     else if (state == Promise.State.Rejected)
                     {
@@ -394,7 +417,7 @@ namespace Proto.Promises
                     else
                     {
                         MaybeDispose();
-                        handler.MaybeDispose();
+                        handler.ReportUnhandledAndMaybeDispose();
                     }
                 }
 
@@ -459,7 +482,7 @@ namespace Proto.Promises
                     else
                     {
                         MaybeDispose();
-                        handler.MaybeDispose();
+                        handler.ReportUnhandledAndMaybeDispose();
                     }
                 }
 
@@ -521,7 +544,7 @@ namespace Proto.Promises
                     else
                     {
                         MaybeDispose();
-                        handler.MaybeDispose();
+                        handler.ReportUnhandledAndMaybeDispose();
                     }
                 }
 
@@ -591,7 +614,7 @@ namespace Proto.Promises
                     else
                     {
                         MaybeDispose();
-                        handler.MaybeDispose();
+                        handler.ReportUnhandledAndMaybeDispose();
                     }
                 }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -310,12 +310,6 @@ namespace Proto.Promises
 #if PROMISE_DEBUG
                 _previous = null;
 #endif
-                // TODO: Can this check be moved to PromiseForgetSentinel?
-                // Rejection maybe wasn't caught.
-                if (State == Promise.State.Rejected & !SuppressRejection)
-                {
-                    _rejectContainerOrPreviousOrLink.UnsafeAs<IRejectContainer>().ReportUnhandled();
-                }
                 _rejectContainerOrPreviousOrLink = null;
             }
 
@@ -693,6 +687,13 @@ namespace Proto.Promises
                             throw new System.InvalidOperationException("PromiseMultiAwait was disposed completely without being forgotten.");
                         }
 #endif
+                        // Rejection maybe wasn't caught.
+                        // We handle this directly here because we don't add the PromiseForgetSentinel to this type when it is forgotten.
+                        if (State == Promise.State.Rejected & !SuppressRejection)
+                        {
+                            SuppressRejection = true;
+                            _rejectContainerOrPreviousOrLink.UnsafeAs<IRejectContainer>().ReportUnhandled();
+                        }
                         Dispose();
                     }
                     ObjectPool.MaybeRepool(this);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -880,7 +880,7 @@ namespace Proto.Promises
                     else
                     {
                         MaybeDispose();
-                        handler.MaybeDispose();
+                        handler.ReportUnhandledAndMaybeDispose();
                     }
                 }
 
@@ -965,8 +965,8 @@ namespace Proto.Promises
                     if (Interlocked.Exchange(ref _isScheduling, 1) != 0)
 #endif
                     {
-                        handler.MaybeDispose();
                         MaybeDispose();
+                        handler.ReportUnhandledAndMaybeDispose();
                         return;
                     }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
@@ -52,6 +52,12 @@ namespace Proto.Promises
 
                 internal override void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state)
                 {
+                    // Rejection maybe wasn't caught.
+                    if (state == Promise.State.Rejected & !handler.SuppressRejection)
+                    {
+                        handler.SuppressRejection = true;
+                        rejectContainer.UnsafeAs<IRejectContainer>().ReportUnhandled();
+                    }
                     handler.SetCompletionState(rejectContainer, state);
                     handler.MaybeDispose();
                 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/SentinelsInternal.cs
@@ -85,6 +85,7 @@ namespace Proto.Promises
                 }
 
                 internal override void MaybeDispose() { throw new System.InvalidOperationException(); }
+                internal override void ReportUnhandledAndMaybeDispose() { throw new System.InvalidOperationException(); }
                 protected override void OnForget(short promiseId) { throw new System.InvalidOperationException(); }
                 internal override PromiseRefBase AddWaiter(short promiseId, HandleablePromiseBase waiter, out HandleablePromiseBase previousWaiter) { throw new System.InvalidOperationException(); }
                 internal override PromiseRefBase GetDuplicate(short promiseId, ushort depth) { throw new System.InvalidOperationException(); }
@@ -129,6 +130,7 @@ namespace Proto.Promises
                 }
 
                 internal override void MaybeDispose() { throw new System.InvalidOperationException(); }
+                internal override void ReportUnhandledAndMaybeDispose() { throw new System.InvalidOperationException(); }
                 protected override void OnForget(short promiseId) { throw new System.InvalidOperationException(); }
                 internal override PromiseRefBase AddWaiter(short promiseId, HandleablePromiseBase waiter, out HandleablePromiseBase previousWaiter) { throw new System.InvalidOperationException(); }
                 internal override PromiseRefBase GetDuplicate(short promiseId, ushort depth) { throw new System.InvalidOperationException(); }


### PR DESCRIPTION
Report unhandled rejections in PromiseForgetSentinel instead of in Dispose to remove a branch in long promise chains.
Added tests to ensure unhandled rejections are actually sent to the UncaughtRejectionHandler.
Also fixed a bug when progress is disabled where a preserved promise was not duplicated, causing a `.Forget()` to dispose it prematurely.

I wasn't able to measure any performance difference, but I only was testing with 8 promise awaits. I would expect this to have a larger difference with more awaits.