### PR TITLE
Don't hold onto references past a promise's lifetime

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -203,6 +203,12 @@ namespace Proto.Promises
                     HookupNewPromise(promiseId, newPromise);
                     return newPromise;
                 }
+
+                new protected void Dispose()
+                {
+                    base.Dispose();
+                    _result = default(TResult);
+                }
             }
 
             internal abstract void MaybeMarkAwaitedAndDispose(short promiseId);


### PR DESCRIPTION
Set _result field to default when promise is disposed to release resources.