### PR TITLE
Fix compilation errors in Unity 2017

### DIFF
--- a/.github/workflows/csproj-builds.yml
+++ b/.github/workflows/csproj-builds.yml
@@ -1,0 +1,33 @@
+# This builds in all configurations and runtimes so we will catch any compilation errors prior to releasing with the automatic publish-nuget action.
+
+name: CsProj Builds
+
+on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  dotnet-core-tests:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [Release, Release_NoProgress, Debug, Debug_NoProgress]
+        developerMode: [true, false]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v2
+        with:
+          global-json-file: global.json
+          
+      - name: Build
+        timeout-minutes: 180
+        run: |
+          dotnet build -c ${{ matrix.config }} -p:DeveloperMode=${{ matrix.developerMode }}

--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -5,7 +5,7 @@
     <Configurations>Release;Debug;Release_NoProgress;Debug_NoProgress</Configurations>
     <Version>2.3.0</Version>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <!--Set true to help debug internal promise code (allows the debugger to step into the code and includes internal stacktraces).-->
     <DeveloperMode>false</DeveloperMode>
   </PropertyGroup>
@@ -20,19 +20,12 @@
     <!--Unity's IL2CPP runtime had a lot of issues that we had to work around, most of which were fixed when they added .Net Standard 2.1 support.
       If someone chooses to use the Nuget package instead of the Unity package, and builds with IL2CPP in an older Unity version, we must make sure everything still works with those workarounds.
       To keep things simple, we just define ENABLE_IL2CPP in all build targets older than netstandard2.1, so all build targets that older Unity versions can possibly consume will have the workarounds baked in.-->
-    <When Condition="'$(TargetFramework)'=='net35'">
+    <When Condition="'$(TargetFramework)'=='net35' OR '$(TargetFramework)'=='net40'">
       <PropertyGroup>
         <!--The newest language version Unity 5.5 supports (by default).-->
         <LangVersion>4</LangVersion>
         <!--Unity uses NET_LEGACY for old runtime prior to .Net 4.6, so we will do the same here.-->
         <DefineConstants>$(DefineConstants);NET_LEGACY;ENABLE_IL2CPP</DefineConstants>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(TargetFramework)'=='net40'">
-      <PropertyGroup>
-        <LangVersion>7.3</LangVersion>
-        <!--Unity uses NET_LEGACY for old runtime prior to .Net 4.6, so we will do the same here.-->
-        <DefineConstants>$(DefineConstants);NET_LEGACY;ENABLE_IL2CPP;CSHARP_7_3_OR_NEWER</DefineConstants>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFramework)'=='net47' OR '$(TargetFramework)'=='netstandard2.0'">
@@ -45,6 +38,7 @@
       <PropertyGroup>
         <!--For function pointers in await override implementation.-->
         <LangVersion>9</LangVersion>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <DefineConstants>$(DefineConstants);CSHARP_7_3_OR_NEWER</DefineConstants>
       </PropertyGroup>
     </Otherwise>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Cancelations/Internal/CancelationInternal.cs
@@ -1035,7 +1035,8 @@ namespace Proto.Promises
                         return source.IsCancellationRequested ? CancelationToken.Canceled() : default(CancelationToken);
                     }
 
-                    if (s_tokenCache.TryGetValue(source, out var cancelationRef))
+                    CancelationRef cancelationRef;
+                    if (s_tokenCache.TryGetValue(source, out cancelationRef))
                     {
                         var tokenId = cancelationRef.TokenId;
                         Thread.MemoryBarrier();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/ExceptionDispatchInfo.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/ExceptionDispatchInfo.cs
@@ -13,6 +13,8 @@ namespace System.Runtime.ExceptionServices
     {
         private Exception _source;
 
+        public Exception SourceException { get { return _source; } }
+
         public static ExceptionDispatchInfo Capture(Exception source)
         {
             return new ExceptionDispatchInfo() { _source = source };

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/ValueTuple.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/ForOldRuntime/ValueTuple.cs
@@ -2,6 +2,10 @@
 #define NET_LEGACY
 #endif
 
+// ValueTuples are available in .Net 4.7 and Unity 2018.1 or newer.
+// Unity 2017 supported .Net 4.6 experimental, full support with ValueTuples wasn't added until 2018.1.
+#if NET_LEGACY || NET45 || UNITY_2017
+
 #pragma warning disable RECS0025 // Non-readonly field referenced in 'GetHashCode()'
 #pragma warning disable RECS0017 // Possible compare of value type with 'null'
 #pragma warning disable IDE0031 // Use null propagation
@@ -11,7 +15,6 @@
 #pragma warning disable 0436 // Type conflicts with imported type
 #pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
-#if NET_LEGACY || NET45 // ValueTuples are available in .Net 4.7 and newer.
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.
 
 namespace System.Collections

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Extensions.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Extensions.cs
@@ -24,7 +24,7 @@ namespace Proto.Promises
 #endif
     public static partial class Extensions
     {
-#if !NET_LEGACY
+#if CSHARP_7_3_OR_NEWER
         /// <summary>
         /// Convert the <paramref name="promise"/> to a <see cref="Task"/>.
         /// </summary>
@@ -56,7 +56,7 @@ namespace Proto.Promises
         {
             return await task;
         }
-#elif NET40
+#elif !NET_LEGACY || NET40
         /// <summary>
         /// Convert the <paramref name="promise"/> to a <see cref="Task"/>.
         /// </summary>
@@ -76,10 +76,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        if (!(resultContainer.RejectReason is System.Exception exception))
-                        {
-                            exception = Promise.RejectException(resultContainer.RejectReason);
-                        }
+                        System.Exception exception = resultContainer._target._rejectContainer.UnsafeAs<Internal.IRejectContainer>().GetExceptionDispatchInfo().SourceException;
                         source.SetException(exception);
                     }
                 })
@@ -106,10 +103,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        if (!(resultContainer.RejectReason is System.Exception exception))
-                        {
-                            exception = Promise.RejectException(resultContainer.RejectReason);
-                        }
+                        System.Exception exception = resultContainer._rejectContainer.UnsafeAs<Internal.IRejectContainer>().GetExceptionDispatchInfo().SourceException;
                         source.SetException(exception);
                     }
                 })
@@ -164,7 +158,7 @@ namespace Proto.Promises
             }, TaskContinuationOptions.ExecuteSynchronously);
             return deferred.Promise;
         }
-#endif // elif NET40
+#endif // elif !NET_LEGACY || NET40
 
 #if UNITY_2021_2_OR_NEWER || (!NET_LEGACY && !UNITY_5_5_OR_NEWER)
         /// <summary>


### PR DESCRIPTION
When the experimental .net 4.6 runtime is selected.