### PR TITLE
Validation to make `AsyncMonitor.WaitAsync` safer

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/ParallelForTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Tests/APIs/ParallelForTests.cs
@@ -8,13 +8,13 @@ using NUnit.Framework;
 using Proto.Promises;
 using Proto.Promises.Threading;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 
 namespace ProtoPromiseTests.APIs
 {
+#if !UNITY_WEBGL
     public sealed class ParallelForTests
     {
         [SetUp]
@@ -530,4 +530,5 @@ namespace ProtoPromiseTests.APIs
             }
         }
     }
+#endif // !UNITY_WEBGL
 }


### PR DESCRIPTION
Fixed `AsyncMonitor.WaitAsync` when the cancelation token is canceled outside of the lock.

The lock is now released when the `AsyncMonitor.WaitAsync` promise is awaited, rather than when it's created.
Added validation to make sure the key is not disposed before the `AsyncMonitor.WaitAsync` is complete.

These changes should make it harder to misuse. The promise should always be awaited within the lock body.