### PR TITLE
Simplify `AsyncLazy`

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/AsyncLazyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/AsyncLazyTests.cs
@@ -81,7 +81,7 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void AsyncLazy_WithSynchronousOption_CallsFuncDirectly_Then()
+        public void AsyncLazy_CallsFuncDirectly_Then()
         {
             var testThread = Thread.CurrentThread;
             Thread funcThread = null;
@@ -89,7 +89,7 @@ namespace ProtoPromiseTests.APIs
             {
                 funcThread = Thread.CurrentThread;
                 return Promise.Resolved(13);
-            }, SynchronizationOption.Synchronous);
+            });
 
             bool isComplete = false;
             lazy.Promise
@@ -266,15 +266,15 @@ namespace ProtoPromiseTests.APIs
 
 #if !UNITY_WEBGL
         [Test]
-        public void AsyncLazy_WithBackgroundOption_CallsFuncOnBackgroundContext_Then()
+        public void AsyncLazy_WithPromiseRun_CallsFuncOnBackgroundContext_Then()
         {
             var testThread = Thread.CurrentThread;
             Thread funcThread = null;
-            var lazy = new AsyncLazy<int>(() =>
+            var lazy = new AsyncLazy<int>(() => Promise.Run(() =>
             {
                 funcThread = Thread.CurrentThread;
                 return Promise.Resolved(13);
-            }, SynchronizationOption.Background);
+            }, SynchronizationOption.Background));
 
             Assert.AreEqual(13, lazy.Promise.WaitWithTimeout(TimeSpan.FromSeconds(1)));
 
@@ -284,13 +284,13 @@ namespace ProtoPromiseTests.APIs
 
 #if CSHARP_7_3_OR_NEWER
         [Test]
-        public void AsyncLazy_WithSynchronousOption_CallsFuncDirectly_Async()
+        public void AsyncLazy_CallsFuncDirectly_Async()
         {
-            AsyncLazy_WithSynchronousOption_CallsFuncDirectly_Core()
+            AsyncLazy_CallsFuncDirectly_Core()
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }
 
-        private async Promise AsyncLazy_WithSynchronousOption_CallsFuncDirectly_Core()
+        private async Promise AsyncLazy_CallsFuncDirectly_Core()
         {
             var testThread = Thread.CurrentThread;
             Thread funcThread = null;
@@ -298,7 +298,7 @@ namespace ProtoPromiseTests.APIs
             {
                 funcThread = Thread.CurrentThread;
                 return Promise.Resolved(13);
-            }, SynchronizationOption.Synchronous);
+            });
 
             await lazy;
 
@@ -485,21 +485,22 @@ namespace ProtoPromiseTests.APIs
 
 #if !UNITY_WEBGL
         [Test]
-        public void AsyncLazy_WithBackgroundOption_CallsFuncOnBackgroundContext_Async()
+        public void AsyncLazy_SwitchToBackground_CallsFuncOnBackgroundContext_Async()
         {
-            AsyncLazy_WithBackgroundOption_CallsFuncOnBackgroundContext_Core()
+            AsyncLazy_SwitchToBackground_CallsFuncOnBackgroundContext_Core()
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }
 
-        private async Promise AsyncLazy_WithBackgroundOption_CallsFuncOnBackgroundContext_Core()
+        private async Promise AsyncLazy_SwitchToBackground_CallsFuncOnBackgroundContext_Core()
         {
             var testThread = Thread.CurrentThread;
             Thread funcThread = null;
-            var lazy = new AsyncLazy<int>(() =>
+            var lazy = new AsyncLazy<int>(async () =>
             {
+                await Promise.SwitchToBackground(true);
                 funcThread = Thread.CurrentThread;
-                return Promise.Resolved(13);
-            }, SynchronizationOption.Background);
+                return 13;
+            });
 
             await lazy;
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Threading/AsyncLazyConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Threading/AsyncLazyConcurrencyTests.cs
@@ -21,8 +21,7 @@ namespace ProtoPromiseTests.Threading
 
         [Test]
         public void AsyncLazy_AccessedConcurrently_DelegateIsInvokedOnlyOnce(
-            [Values] bool waitForDeferred,
-            [Values] SynchronizationType synchronizationType)
+            [Values] bool waitForDeferred)
         {
             int expectedResult = 42;
             int invokedCount = 0;
@@ -44,16 +43,13 @@ namespace ProtoPromiseTests.Threading
                     {
                         deferred = Promise.NewDeferred<int>();
                     }
-                    Func<Promise<int>> del = () =>
+                    lazy = new AsyncLazy<int>(() =>
                     {
                         Assert.AreEqual(1, Interlocked.Increment(ref invokedCount));
                         return waitForDeferred
                             ? deferred.Promise
                             : Promise.Resolved(expectedResult);
-                    };
-                    lazy = synchronizationType == SynchronizationType.Explicit
-                        ? new AsyncLazy<int>(del, TestHelper._foregroundContext)
-                        : new AsyncLazy<int>(del, (SynchronizationOption) synchronizationType);
+                    });
                 },
                 // teardown
                 () =>
@@ -71,8 +67,7 @@ namespace ProtoPromiseTests.Threading
         }
 
         [Test]
-        public void AsyncLazy_AccessedConcurrently_ResultIsExpected(
-            [Values] SynchronizationType synchronizationType)
+        public void AsyncLazy_AccessedConcurrently_ResultIsExpected()
         {
             int expectedResult = 42;
             int invokedCount = 0;
@@ -91,14 +86,11 @@ namespace ProtoPromiseTests.Threading
                 {
                     invokedCount = 0;
                     deferred = Promise.NewDeferred<int>();
-                    Func<Promise<int>> del = () =>
+                    lazy = new AsyncLazy<int>(() =>
                     {
                         Assert.AreEqual(1, Interlocked.Increment(ref invokedCount));
                         return deferred.Promise;
-                    };
-                    lazy = synchronizationType == SynchronizationType.Explicit
-                        ? new AsyncLazy<int>(del, TestHelper._foregroundContext)
-                        : new AsyncLazy<int>(del, (SynchronizationOption) synchronizationType);
+                    });
                 },
                 // teardown
                 () =>


### PR DESCRIPTION
Removed invoke options. Users can use `Promise.Run` or `Promise.SwitchToContext` inside the delegate if they want that behavior.
No longer invoke the delegate inside the lock.