### PR TITLE
Add `AsyncManualResetEvent` type.

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -1359,6 +1359,11 @@ namespace Proto.Promises
                                 {
                                     _this._ref.MaybeMarkAwaitedAndDispose(_this._id);
                                 }
+                                if (!forceAsync & synchronizationContext == ts_currentContext)
+                                {
+                                    InvokeAndCatchProgress(progress, 1, null);
+                                    return CreateResolved(_this.Depth);
+                                }
                                 promise = PromiseProgress<VoidResult, TProgress>.GetOrCreateFromResolved(progress, new VoidResult(), _this.Depth, synchronizationContext, forceAsync, cancelationToken);
                                 ScheduleForHandle(promise, synchronizationContext);
                                 return new Promise(promise, promise.Id, _this.Depth);
@@ -1430,6 +1435,11 @@ namespace Proto.Promises
                             if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
                             {
                                 TResult result = GetResultFromResolved(_this);
+                                if (!forceAsync & synchronizationContext == ts_currentContext)
+                                {
+                                    InvokeAndCatchProgress(progress, 1, null);
+                                    return CreateResolved(result, _this.Depth);
+                                }
                                 promise = PromiseProgress<TResult, TProgress>.GetOrCreateFromResolved(progress, result, _this.Depth, synchronizationContext, forceAsync, cancelationToken);
                                 ScheduleForHandle(promise, synchronizationContext);
                                 return new Promise<TResult>(promise, promise.Id, _this.Depth);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncManualResetEvent.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncManualResetEvent.cs
@@ -1,0 +1,125 @@
+#if UNITY_5_5 || NET_2_0 || NET_2_0_SUBSET
+#define NET_LEGACY
+#endif
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Proto.Promises.Threading
+{
+    /// <summary>
+    /// An async-compatible manual-reset event.
+    /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+    [DebuggerNonUserCode, StackTraceHidden]
+#endif
+    public sealed class AsyncManualResetEvent
+    {
+        // We wrap the impl with another class so that we can lock on it safely.
+        private readonly Internal.AsyncManualResetEventInternal _impl;
+
+        /// <summary>
+        /// Creates an async-compatible manual-reset event.
+        /// </summary>
+        /// <param name="set">Whether the manual-reset event is initially set or unset.</param>
+        public AsyncManualResetEvent(bool set)
+        {
+            _impl = new Internal.AsyncManualResetEventInternal(set);
+        }
+
+        /// <summary>
+        /// Creates an async-compatible manual-reset event that is initially unset.
+        /// </summary>
+        public AsyncManualResetEvent() : this(false)
+        {
+        }
+
+        /// <summary>
+        /// Whether this event is currently set.
+        /// </summary>
+        public bool IsSet
+        {
+            [MethodImpl(Internal.InlineOption)]
+            get { return _impl._isSet; }
+        }
+
+        /// <summary>
+        /// Asynchronously wait for this event to be set.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise WaitAsync()
+        {
+            return _impl.WaitAsync();
+        }
+
+        /// <summary>
+        /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
+        /// </summary>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
+        /// <remarks>
+        /// The result of the returned <see cref="Promise{T}"/> will be <see langword="true"/> if this is set before the <paramref name="cancelationToken"/> was canceled, otherwise it will be <see langword="false"/>.
+        /// If this is already set, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise<bool> WaitAsync(CancelationToken cancelationToken)
+        {
+            return _impl.WaitAsync(cancelationToken);
+        }
+
+        /// <summary>
+        /// Synchronously wait for this event to be set.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public void Wait()
+        {
+            _impl.WaitSync();
+        }
+
+        /// <summary>
+        /// Synchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
+        /// </summary>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
+        /// <remarks>
+        /// The returned value will be <see langword="true"/> if this is set before the <paramref name="cancelationToken"/> was canceled, otherwise it will be <see langword="false"/>.
+        /// If this is already set, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public bool Wait(CancelationToken cancelationToken)
+        {
+            return _impl.WaitSync(cancelationToken);
+        }
+
+        /// <summary>
+        /// Sets this event, completing every wait.
+        /// </summary>
+        /// <remarks>
+        /// If this event is already set, this does nothing.
+        /// </remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public void Set()
+        {
+            _impl.Set();
+        }
+
+        /// <summary>
+        /// Resets this event.
+        /// </summary>
+        /// <remarks>
+        /// If this event is already reset, this does nothing.
+        /// </remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public void Reset()
+        {
+            _impl.Reset();
+        }
+
+        /// <summary>
+        /// Asynchronous infrastructure support. This method permits instances of <see cref="AsyncManualResetEvent"/> to be awaited.
+        /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public Async.CompilerServices.PromiseAwaiterVoid GetAwaiter()
+        {
+            return WaitAsync().GetAwaiter();
+        }
+    }
+}

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncManualResetEvent.cs.meta
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncManualResetEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72f60510ec6e7f043a46a09ab096f3bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncManualResetEventInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncManualResetEventInternal.cs
@@ -1,0 +1,245 @@
+#if UNITY_5_5 || NET_2_0 || NET_2_0_SUBSET
+#define NET_LEGACY
+#endif
+
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+#if !PROTO_PROMISE_PROGRESS_DISABLE
+#define PROMISE_PROGRESS
+#else
+#undef PROMISE_PROGRESS
+#endif
+
+#pragma warning disable IDE0090 // Use 'new(...)'
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Proto.Promises
+{
+    partial class Internal
+    {
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        internal sealed class AsyncResetEventPromise : PromiseRefBase.AsyncSynchronizationPromiseBase<VoidResult>, ICancelable, ILinked<AsyncResetEventPromise>
+        {
+            AsyncResetEventPromise ILinked<AsyncResetEventPromise>.Next { get; set; }
+            private AsyncManualResetEventInternal _owner;
+
+            [MethodImpl(InlineOption)]
+            private static AsyncResetEventPromise GetOrCreate()
+            {
+                var obj = ObjectPool.TryTakeOrInvalid<AsyncResetEventPromise>();
+                return obj == InvalidAwaitSentinel.s_instance
+                    ? new AsyncResetEventPromise()
+                    : obj.UnsafeAs<AsyncResetEventPromise>();
+            }
+
+            [MethodImpl(InlineOption)]
+            internal static AsyncResetEventPromise GetOrCreate(AsyncManualResetEventInternal owner, SynchronizationContext callerContext)
+            {
+                var promise = GetOrCreate();
+                promise.Reset();
+                promise._callerContext = callerContext;
+                promise._owner = owner;
+                return promise;
+            }
+
+            internal override void MaybeDispose()
+            {
+                Dispose();
+                _owner = null;
+                ObjectPool.MaybeRepool(this);
+            }
+
+            internal void Resolve()
+            {
+                ThrowIfInPool(this);
+
+                // We don't need to check if the unregister was successful or not.
+                // The fact that this was called means the cancelation was unable to unregister this from the lock.
+                // We just dispose to wait for the callback to complete before we continue.
+                _cancelationRegistration.Dispose();
+
+                Continue(Promise.State.Resolved);
+            }
+
+            internal void MaybeHookupCancelation(CancelationToken cancelationToken)
+            {
+                ThrowIfInPool(this);
+                cancelationToken.TryRegister(this, out _cancelationRegistration);
+            }
+
+            void ICancelable.Cancel()
+            {
+                ThrowIfInPool(this);
+                if (!_owner.TryRemoveWaiter(this))
+                {
+                    return;
+                }
+                Continue(Promise.State.Canceled);
+            }
+        }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        internal sealed class AsyncManualResetEventInternal
+        {
+            // This must not be readonly.
+            private ValueLinkedQueue<AsyncResetEventPromise> _waiters = new ValueLinkedQueue<AsyncResetEventPromise>();
+            volatile internal bool _isSet;
+
+            internal AsyncManualResetEventInternal(bool set)
+            {
+                _isSet = set;
+            }
+
+            // I'm unsure if there is a legitimate case for dropping a MRE without setting it, causing the waiters to never continue,
+            // so not adding a finalizer for validation.
+
+            internal Promise WaitAsync()
+            {
+                // We don't spinwait here because it's async; we want to return to caller as fast as possible.
+                if (_isSet)
+                {
+                    return Promise.Resolved();
+                }
+
+                AsyncResetEventPromise promise;
+                lock (this)
+                {
+                    promise = AsyncResetEventPromise.GetOrCreate(this, CaptureContext());
+                    _waiters.Enqueue(promise);
+                }
+                return new Promise(promise, promise.Id, 0);
+            }
+
+            internal Promise<bool> WaitAsync(CancelationToken cancelationToken)
+            {
+                // We don't spinwait here because it's async; we want to return to caller as fast as possible.
+                bool isSet = _isSet;
+                if (isSet | cancelationToken.IsCancelationRequested)
+                {
+                    return Promise.Resolved(isSet);
+                }
+
+                AsyncResetEventPromise promise;
+                lock (this)
+                {
+                    promise = AsyncResetEventPromise.GetOrCreate(this, CaptureContext());
+                    _waiters.Enqueue(promise);
+                    promise.MaybeHookupCancelation(cancelationToken);
+                }
+                return new Promise(promise, promise.Id, 0)
+                    .ContinueWith(r =>
+                    {
+                        r.RethrowIfRejected();
+                        return r.State == Promise.State.Resolved;
+                    });
+            }
+
+            internal void WaitSync()
+            {
+                // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
+                var spinner = new SpinWait();
+                bool isSet = _isSet;
+                while (true)
+                {
+                    if (isSet | spinner.NextSpinWillYield)
+                    {
+                        break;
+                    }
+                    spinner.SpinOnce();
+                    isSet = _isSet;
+                }
+
+                if (isSet)
+                {
+                    return;
+                }
+
+                AsyncResetEventPromise promise;
+                lock (this)
+                {
+                    promise = AsyncResetEventPromise.GetOrCreate(this, null);
+                    _waiters.Enqueue(promise);
+                }
+                new Promise(promise, promise.Id, 0).Wait();
+            }
+
+            internal bool WaitSync(CancelationToken cancelationToken)
+            {
+                // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
+                var spinner = new SpinWait();
+                bool isSet = _isSet;
+                bool isCanceled = cancelationToken.IsCancelationRequested;
+                while (true)
+                {
+                    if (isSet | isCanceled | spinner.NextSpinWillYield)
+                    {
+                        break;
+                    }
+                    spinner.SpinOnce();
+                    isSet = _isSet;
+                    isCanceled = cancelationToken.IsCancelationRequested;
+                }
+
+                if (isSet | isCanceled)
+                {
+                    return isSet;
+                }
+
+                AsyncResetEventPromise promise;
+                lock (this)
+                {
+                    promise = AsyncResetEventPromise.GetOrCreate(this, null);
+                    _waiters.Enqueue(promise);
+                    promise.MaybeHookupCancelation(cancelationToken);
+                }
+                return new Promise(promise, promise.Id, 0)
+                    .ContinueWith(r =>
+                    {
+                        r.RethrowIfRejected();
+                        return r.State == Promise.State.Resolved;
+                    })
+                    .WaitForResult();
+            }
+
+            internal void Set()
+            {
+                // Set the field before lock.
+                _isSet = true;
+
+                ValueLinkedStack<AsyncResetEventPromise> waiters;
+                lock (this)
+                {
+                    waiters = _waiters.MoveElementsToStack();
+                }
+                while (waiters.IsNotEmpty)
+                {
+                    waiters.Pop().Resolve();
+                }
+            }
+
+            [MethodImpl(InlineOption)]
+            internal void Reset()
+            {
+                _isSet = false;
+            }
+
+            internal bool TryRemoveWaiter(AsyncResetEventPromise waiter)
+            {
+                lock (this)
+                {
+                    return _waiters.TryRemove(waiter);
+                }
+            }
+        } // class AsyncManualResetEventInternal
+    } // class Internal
+} // namespace Proto.Promises

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncManualResetEventInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncManualResetEventInternal.cs
@@ -114,6 +114,11 @@ namespace Proto.Promises
                 AsyncResetEventPromise promise;
                 lock (this)
                 {
+                    // Check the flag again inside the lock to resolve race condition with Set().
+                    if (_isSet)
+                    {
+                        return Promise.Resolved();
+                    }
                     promise = AsyncResetEventPromise.GetOrCreate(this, CaptureContext());
                     _waiters.Enqueue(promise);
                 }
@@ -132,6 +137,11 @@ namespace Proto.Promises
                 AsyncResetEventPromise promise;
                 lock (this)
                 {
+                    // Check the flag again inside the lock to resolve race condition with Set().
+                    if (_isSet)
+                    {
+                        return Promise.Resolved(true);
+                    }
                     promise = AsyncResetEventPromise.GetOrCreate(this, CaptureContext());
                     _waiters.Enqueue(promise);
                     promise.MaybeHookupCancelation(cancelationToken);
@@ -167,6 +177,11 @@ namespace Proto.Promises
                 AsyncResetEventPromise promise;
                 lock (this)
                 {
+                    // Check the flag again inside the lock to resolve race condition with Set().
+                    if (_isSet)
+                    {
+                        return;
+                    }
                     promise = AsyncResetEventPromise.GetOrCreate(this, null);
                     _waiters.Enqueue(promise);
                 }
@@ -198,6 +213,11 @@ namespace Proto.Promises
                 AsyncResetEventPromise promise;
                 lock (this)
                 {
+                    // Check the flag again inside the lock to resolve race condition with Set().
+                    if (_isSet)
+                    {
+                        return true;
+                    }
                     promise = AsyncResetEventPromise.GetOrCreate(this, null);
                     _waiters.Enqueue(promise);
                     promise.MaybeHookupCancelation(cancelationToken);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncManualResetEventInternal.cs.meta
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncManualResetEventInternal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7f48c9538cad1641b82625700131aa9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncSynchronizationPromiseBaseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncSynchronizationPromiseBaseInternal.cs
@@ -1,0 +1,79 @@
+#if UNITY_5_5 || NET_2_0 || NET_2_0_SUBSET
+#define NET_LEGACY
+#endif
+
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+#if !PROTO_PROMISE_PROGRESS_DISABLE
+#define PROMISE_PROGRESS
+#else
+#undef PROMISE_PROGRESS
+#endif
+
+#pragma warning disable IDE0034 // Simplify 'default' expression
+
+using System.Diagnostics;
+using System.Threading;
+
+namespace Proto.Promises
+{
+    partial class Internal
+    {
+        partial class PromiseRefBase
+        {
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            internal abstract class AsyncSynchronizationPromiseBase<TResult> : PromiseSingleAwait<TResult>
+            {
+                // We post continuations to the caller's context to prevent blocking the thread that released the lock (and to avoid StackOverflowException).
+                protected SynchronizationContext _callerContext;
+                protected CancelationRegistration _cancelationRegistration;
+                // We have to store the state in a separate field until the next awaiter is ready to be invoked on the proper context.
+                private Promise.State _tempState;
+
+                new protected void Dispose()
+                {
+                    base.Dispose();
+                    _callerContext = null;
+                    _cancelationRegistration = default(CancelationRegistration);
+                }
+
+                protected void Continue(Promise.State state)
+                {
+                    if (_callerContext == null)
+                    {
+                        // It was a synchronous lock or wait, handle next continuation synchronously so that the PromiseSynchronousWaiter will be pulsed to wake the waiting thread.
+                        HandleNextInternal(null, state);
+                        return;
+                    }
+                    // Post the continuation to the caller's context. This prevents blocking the current thread and avoids StackOverflowException.
+                    _tempState = state;
+                    ScheduleForHandle(this, _callerContext);
+                }
+
+                internal override sealed void HandleFromContext()
+                {
+                    HandleNextInternal(null, _tempState);
+                }
+
+                internal override sealed void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state) { throw new System.InvalidOperationException(); }
+
+#if PROMISE_DEBUG
+                internal void Reject(IRejectContainer rejectContainer)
+                {
+                    Promise.Run(() =>
+                    {
+                        _cancelationRegistration.Dispose();
+                        HandleNextInternal(rejectContainer, Promise.State.Rejected);
+                    }, _callerContext, forceAsync: true)
+                        .Forget();
+                }
+#endif
+            }
+        }
+    }
+}

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncSynchronizationPromiseBaseInternal.cs.meta
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncSynchronizationPromiseBaseInternal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 425889739c9409e4daa97c66ab78f598
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/ProgressTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/ProgressTests.cs
@@ -39,7 +39,7 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred = Promise.NewDeferred();
 
-            ProgressHelper progressHelper = new ProgressHelper(progressType, SynchronizationType.Foreground);
+            ProgressHelper progressHelper = new ProgressHelper(progressType, SynchronizationType.Foreground, forceAsync: true);
             deferred.Promise
                 .SubscribeProgressAndAssert(progressHelper, 0f)
                 .Forget();
@@ -60,7 +60,7 @@ namespace ProtoPromiseTests.APIs
             var cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred(cancelationSource.Token);
 
-            ProgressHelper progressHelper = new ProgressHelper(progressType, SynchronizationType.Foreground);
+            ProgressHelper progressHelper = new ProgressHelper(progressType, SynchronizationType.Foreground, forceAsync: true);
             deferred.Promise
                 .SubscribeProgressAndAssert(progressHelper, 0f)
                 .Forget();
@@ -81,7 +81,7 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred = Promise.NewDeferred<int>();
 
-            ProgressHelper progressHelper = new ProgressHelper(progressType, SynchronizationType.Foreground);
+            ProgressHelper progressHelper = new ProgressHelper(progressType, SynchronizationType.Foreground, forceAsync: true);
             deferred.Promise
                 .SubscribeProgressAndAssert(progressHelper, 0f)
                 .Forget();
@@ -102,7 +102,7 @@ namespace ProtoPromiseTests.APIs
             var cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
 
-            ProgressHelper progressHelper = new ProgressHelper(progressType, SynchronizationType.Foreground);
+            ProgressHelper progressHelper = new ProgressHelper(progressType, SynchronizationType.Foreground, forceAsync: true);
             deferred.Promise
                 .SubscribeProgressAndAssert(progressHelper, 0f)
                 .Forget();
@@ -1753,7 +1753,8 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void ProgressChainSubscribedWillBeInvokedInOrder_Resolved_void(
             // This test is unverifiable when progress is executed on background threads.
-            [Values(SynchronizationOption.Synchronous, SynchronizationOption.Foreground)] SynchronizationOption synchronizationOption)
+            [Values(SynchronizationOption.Synchronous, SynchronizationOption.Foreground)] SynchronizationOption synchronizationOption,
+            [Values] bool forceAsync)
         {
             Promise promise = Promise.Resolved();
             int[] results = new int[MultiProgressCount];
@@ -1762,7 +1763,7 @@ namespace ProtoPromiseTests.APIs
             for (int i = 0; i < MultiProgressCount; ++i)
             {
                 int num = i;
-                promise = promise.Progress(v => { results[index++] = num; }, synchronizationOption);
+                promise = promise.Progress(v => { results[index++] = num; }, synchronizationOption, forceAsync: forceAsync);
             }
 
             promise.Forget();
@@ -1773,7 +1774,8 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void ProgressChainSubscribedWillBeInvokedInOrder_Resolved_T(
             // This test is unverifiable when progress is executed on background threads.
-            [Values(SynchronizationOption.Synchronous, SynchronizationOption.Foreground)] SynchronizationOption synchronizationOption)
+            [Values(SynchronizationOption.Synchronous, SynchronizationOption.Foreground)] SynchronizationOption synchronizationOption,
+            [Values] bool forceAsync)
         {
             Promise<int> promise = Promise.Resolved(1);
             int[] results = new int[MultiProgressCount];
@@ -1782,7 +1784,7 @@ namespace ProtoPromiseTests.APIs
             for (int i = 0; i < MultiProgressCount; ++i)
             {
                 int num = i;
-                promise = promise.Progress(v => { results[index++] = num; }, synchronizationOption);
+                promise = promise.Progress(v => { results[index++] = num; }, synchronizationOption, forceAsync: forceAsync);
             }
 
             promise.Forget();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/Threading/AsyncManualResetEventTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/Threading/AsyncManualResetEventTests.cs
@@ -1,0 +1,389 @@
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+using NUnit.Framework;
+using Proto.Promises;
+using Proto.Promises.Threading;
+using ProtoPromiseTests.Threading;
+using System;
+using System.Threading;
+
+namespace ProtoPromiseTests.APIs
+{
+    public class AsyncManualResetEventTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            TestHelper.Setup();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_StateTrans([Values] bool init)
+        {
+            AsyncManualResetEvent ev = new AsyncManualResetEvent(init);
+            Assert.AreEqual(init, ev.IsSet);
+
+            if (!init)
+            {
+                ev.Reset();
+                Assert.False(ev.IsSet);
+            }
+
+            for (int i = 0; i < 50; i++)
+            {
+                ev.Set();
+                Assert.True(ev.IsSet);
+
+                ev.Reset();
+                Assert.False(ev.IsSet);
+            }
+        }
+
+#if !UNITY_WEBGL
+        [Test]
+        // Uses 3 events to coordinate between two threads.
+        public void AsyncManualResetEvent_2ThreadCoordination()
+        {
+            AsyncManualResetEvent ev1 = new AsyncManualResetEvent(false);
+            AsyncManualResetEvent ev2 = new AsyncManualResetEvent(false);
+            AsyncManualResetEvent ev3 = new AsyncManualResetEvent(false);
+
+            bool first = false, second = false, third = false;
+
+            Promise.Run(() =>
+            {
+                Assert.False(first);
+                Assert.False(second);
+                Assert.False(third);
+
+                first = true;
+                ev1.Set();
+                // No asserts here, race condition with other thread until we wait.
+                ev2.Wait();
+                Assert.True(first);
+                Assert.True(second);
+                Assert.False(third);
+
+                third = true;
+                ev3.Set();
+                // No asserts here, other thread will assert after wait completes.
+            }, SynchronizationOption.Background)
+                .Forget();
+
+            Assert.False(first);
+            Assert.False(second);
+            Assert.False(third);
+
+            ev1.Wait();
+            Assert.True(first);
+            Assert.False(second);
+            Assert.False(third);
+
+            second = true;
+            ev2.Set();
+            // No asserts here, race condition with other thread until we wait.
+            ev3.Wait();
+            Assert.True(first);
+            Assert.True(second);
+            Assert.True(third);
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_CancelAfterWait()
+        {
+            AsyncManualResetEvent mres = new AsyncManualResetEvent();
+            CancelationSource cs = CancelationSource.New();
+            bool isAboutToWait = false;
+
+            Promise.Run(() =>
+            {
+                SpinWait.SpinUntil(() => isAboutToWait);
+                Thread.Sleep(TimeSpan.FromSeconds(0.5f));
+                cs.Cancel();
+            }, SynchronizationOption.Background)
+                .Forget();
+
+            isAboutToWait = true;
+            Assert.False(mres.Wait(cs.Token));
+
+            cs.Dispose();
+        }
+#endif
+
+        [Test]
+        public void AsyncManualResetEvent_CancelBeforeWait()
+        {
+            AsyncManualResetEvent mres = new AsyncManualResetEvent();
+            CancelationSource cs = CancelationSource.New();
+            cs.Cancel();
+
+            Assert.False(mres.Wait(cs.Token));
+
+            cs.Dispose();
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_AsyncCoordination_Then()
+        {
+            AsyncManualResetEvent ev1 = new AsyncManualResetEvent(false);
+            AsyncManualResetEvent ev2 = new AsyncManualResetEvent(false);
+            AsyncManualResetEvent ev3 = new AsyncManualResetEvent(false);
+
+            bool first = false, second = false, third = false;
+
+            Promise.Run(() =>
+            {
+                Assert.False(first);
+                Assert.False(second);
+                Assert.False(third);
+
+                return ev1.WaitAsync()
+                    .Then(() =>
+                    {
+                        Assert.True(first);
+                        Assert.False(second);
+                        Assert.False(third);
+
+                        second = true;
+                        ev2.Set();
+                        return ev3.WaitAsync();
+                    })
+                    .Then(() =>
+                    {
+                        Assert.True(first);
+                        Assert.True(second);
+                        Assert.True(third);
+                    });
+            }, SynchronizationOption.Synchronous)
+                .Forget();
+
+            Promise.Run(() =>
+            {
+                Assert.False(first);
+                Assert.False(second);
+                Assert.False(third);
+
+                first = true;
+                ev1.Set();
+                return ev2.WaitAsync()
+                    .Then(() =>
+                    {
+                        Assert.True(first);
+                        Assert.True(second);
+                        Assert.False(third);
+
+                        third = true;
+                        ev3.Set();
+                    });
+            }, SynchronizationOption.Synchronous)
+                .Forget();
+
+            // WaitAsync continuations happen on the caller's context, so we need to execute the foreground context.
+            // There were 3 waits and sets, so we execute it 3 times.
+            TestHelper.ExecuteForegroundCallbacks();
+            TestHelper.ExecuteForegroundCallbacks();
+            TestHelper.ExecuteForegroundCallbacks();
+            Assert.True(first);
+            Assert.True(second);
+            Assert.True(third);
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_CancelAfterWaitAsync()
+        {
+            AsyncManualResetEvent mres = new AsyncManualResetEvent();
+            CancelationSource cs = CancelationSource.New();
+
+            var promise = mres.WaitAsync(cs.Token);
+
+            cs.Cancel();
+
+            Assert.False(promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1)));
+
+            cs.Dispose();
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_CancelBeforeWaitAsync()
+        {
+            AsyncManualResetEvent mres = new AsyncManualResetEvent();
+            CancelationSource cs = CancelationSource.New();
+            cs.Cancel();
+
+            Assert.False(mres.WaitAsync(cs.Token).WaitWithTimeout(TimeSpan.FromSeconds(1)));
+
+            cs.Dispose();
+        }
+
+#if CSHARP_7_3_OR_NEWER
+        [Test]
+        public void AsyncManualResetEvent_AsyncCoordination_Async()
+        {
+            AsyncManualResetEvent ev1 = new AsyncManualResetEvent(false);
+            AsyncManualResetEvent ev2 = new AsyncManualResetEvent(false);
+            AsyncManualResetEvent ev3 = new AsyncManualResetEvent(false);
+
+            bool first = false, second = false, third = false;
+
+            Promise.Run(async () =>
+            {
+                Assert.False(first);
+                Assert.False(second);
+                Assert.False(third);
+
+                await ev1.WaitAsync();
+                Assert.True(first);
+                Assert.False(second);
+                Assert.False(third);
+
+                second = true;
+                ev2.Set();
+                await ev3.WaitAsync();
+                Assert.True(first);
+                Assert.True(second);
+                Assert.True(third);
+            }, SynchronizationOption.Synchronous)
+                .Forget();
+
+            Promise.Run(async () =>
+            {
+                Assert.False(first);
+                Assert.False(second);
+                Assert.False(third);
+
+                first = true;
+                ev1.Set();
+                await ev2.WaitAsync();
+                Assert.True(first);
+                Assert.True(second);
+                Assert.False(third);
+
+                third = true;
+                ev3.Set();
+            }, SynchronizationOption.Synchronous)
+                .Forget();
+
+            // WaitAsync continuations happen on the caller's context, so we need to execute the foreground context.
+            // There were 3 waits and sets, so we execute it 3 times.
+            TestHelper.ExecuteForegroundCallbacks();
+            TestHelper.ExecuteForegroundCallbacks();
+            TestHelper.ExecuteForegroundCallbacks();
+            Assert.True(first);
+            Assert.True(second);
+            Assert.True(third);
+        }
+#endif // CSHARP_7_3_OR_NEWER
+
+        [Test]
+        public void AsyncManualResetEvent_WaitAsync_AfterSet_IsCompleted()
+        {
+            var mre = new AsyncManualResetEvent();
+
+            mre.Set();
+
+            bool isComplete = false;
+            mre.WaitAsync()
+                .Then(() => isComplete = true)
+                .Forget();
+
+            Assert.True(isComplete);
+        }
+
+        [Test, Timeout(1000)]
+        public void AsyncManualResetEvent_Wait_AfterSet_IsCompleted()
+        {
+            var mre = new AsyncManualResetEvent();
+
+            mre.Set();
+            mre.Wait();
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_WaitAsync_Set_IsCompleted()
+        {
+            var mre = new AsyncManualResetEvent(true);
+
+            bool isComplete = false;
+            mre.WaitAsync()
+                .Then(() => isComplete = true)
+                .Forget();
+
+            Assert.True(isComplete);
+        }
+
+        [Test, Timeout(1000)]
+        public void AsyncManualResetEvent_Wait_Set_IsCompleted()
+        {
+            var mre = new AsyncManualResetEvent(true);
+
+            mre.Wait();
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_MultipleWaitAsync_AfterSet_IsCompleted()
+        {
+            var mre = new AsyncManualResetEvent();
+
+            mre.Set();
+
+            bool isComplete = false;
+            mre.WaitAsync()
+                .Then(() => isComplete = true)
+                .Forget();
+            Assert.True(isComplete);
+
+            isComplete = false;
+            mre.WaitAsync()
+                .Then(() => isComplete = true)
+                .Forget();
+            Assert.True(isComplete);
+        }
+
+        [Test, Timeout(1000)]
+        public void AsyncManualResetEvent_MultipleWait_AfterSet_IsCompleted()
+        {
+            var mre = new AsyncManualResetEvent();
+
+            mre.Set();
+            mre.Wait();
+            mre.Wait();
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_MultipleWaitAsync_Set_IsCompleted()
+        {
+            var mre = new AsyncManualResetEvent(true);
+
+            bool isComplete = false;
+            mre.WaitAsync()
+                .Then(() => isComplete = true)
+                .Forget();
+            Assert.True(isComplete);
+
+            isComplete = false;
+            mre.WaitAsync()
+                .Then(() => isComplete = true)
+                .Forget();
+            Assert.True(isComplete);
+        }
+
+        [Test, Timeout(1000)]
+        public void AsyncManualResetEvent_MultipleWait_Set_IsCompleted()
+        {
+            var mre = new AsyncManualResetEvent(true);
+
+            mre.Wait();
+            mre.Wait();
+        }
+    }
+}

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/Threading/AsyncManualResetEventTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/Threading/AsyncManualResetEventTests.cs
@@ -80,7 +80,6 @@ namespace ProtoPromiseTests.APIs
             }, SynchronizationOption.Background)
                 .Forget();
 
-            Assert.False(first);
             Assert.False(second);
             Assert.False(third);
 
@@ -143,7 +142,6 @@ namespace ProtoPromiseTests.APIs
 
             Promise.Run(() =>
             {
-                Assert.False(first);
                 Assert.False(second);
                 Assert.False(third);
 
@@ -237,7 +235,6 @@ namespace ProtoPromiseTests.APIs
 
             Promise.Run(async () =>
             {
-                Assert.False(first);
                 Assert.False(second);
                 Assert.False(third);
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/Threading/AsyncManualResetEventTests.cs.meta
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/Threading/AsyncManualResetEventTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f5d73907fa6b854db690b39f7143172
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/AsyncManualResetEventConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/AsyncManualResetEventConcurrencyTests.cs
@@ -1,0 +1,299 @@
+﻿#if !PROTO_PROMISE_PROGRESS_DISABLE
+#define PROMISE_PROGRESS
+#else
+#undef PROMISE_PROGRESS
+#endif
+
+using NUnit.Framework;
+using Proto.Promises;
+using Proto.Promises.Threading;
+using System;
+using System.Threading;
+
+namespace ProtoPromiseTests.Threading
+{
+    public class AsyncManualResetEventConcurrencyTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            TestHelper.Setup();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_WaitCalledConcurrently_AlreadySet()
+        {
+            int invokedCount = 0;
+            var mre = new AsyncManualResetEvent(true);
+            Action parallelAction = () =>
+            {
+                mre.Wait();
+                Interlocked.Increment(ref invokedCount);
+            };
+
+            new ThreadHelper().ExecuteParallelActionsWithOffsets(false,
+                // setup
+                () =>
+                {
+                    invokedCount = 0;
+                },
+                // teardown
+                () =>
+                {
+                    Assert.AreEqual(4, invokedCount);
+                },
+                // parallel actions, repeated to generate offsets
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                parallelAction
+            );
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_WaitAndSetCalledConcurrently()
+        {
+            int invokedCount = 0;
+            var mre = new AsyncManualResetEvent(false);
+            Action parallelAction = () =>
+            {
+                mre.Wait();
+                Interlocked.Increment(ref invokedCount);
+            };
+
+            new ThreadHelper().ExecuteParallelActionsWithOffsets(false,
+                // setup
+                () =>
+                {
+                    invokedCount = 0;
+                    mre.Reset();
+                },
+                // teardown
+                () =>
+                {
+                    Assert.AreEqual(4, invokedCount);
+                },
+                // parallel actions, repeated to generate offsets
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                () => mre.Set()
+            );
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_WaitAndCancelCalledConcurrently_AlreadySet()
+        {
+            int invokedCount = 0;
+            var mre = new AsyncManualResetEvent(true);
+            CancelationSource cancelationSource = default(CancelationSource);
+            Action parallelAction = () =>
+            {
+                mre.Wait(cancelationSource.Token);
+                Interlocked.Increment(ref invokedCount);
+            };
+
+            new ThreadHelper().ExecuteParallelActionsWithOffsets(false,
+                // setup
+                () =>
+                {
+                    invokedCount = 0;
+                    cancelationSource = CancelationSource.New();
+                },
+                // teardown
+                () =>
+                {
+                    Assert.AreEqual(4, invokedCount);
+                    cancelationSource.Dispose();
+                },
+                // parallel actions, repeated to generate offsets
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                () => cancelationSource.Cancel()
+            );
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_WaitAndSetAndCancelCalledConcurrently()
+        {
+            int invokedCount = 0;
+            var mre = new AsyncManualResetEvent(false);
+            CancelationSource cancelationSource = default(CancelationSource);
+            Action parallelAction = () =>
+            {
+                mre.Wait(cancelationSource.Token);
+                Interlocked.Increment(ref invokedCount);
+            };
+
+            new ThreadHelper().ExecuteParallelActionsWithOffsets(false,
+                // setup
+                () =>
+                {
+                    invokedCount = 0;
+                    cancelationSource = CancelationSource.New();
+                    mre.Reset();
+                },
+                // teardown
+                () =>
+                {
+                    Assert.AreEqual(4, invokedCount);
+                    cancelationSource.Dispose();
+                },
+                // parallel actions, repeated to generate offsets
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                () => mre.Set(),
+                () => cancelationSource.Cancel()
+            );
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_WaitAsyncCalledConcurrently_AlreadySet()
+        {
+            int invokedCount = 0;
+            var mre = new AsyncManualResetEvent(true);
+            Action parallelAction = () =>
+            {
+                mre.WaitAsync()
+                    .Then(() => Interlocked.Increment(ref invokedCount))
+                    .Forget();
+            };
+
+            new ThreadHelper().ExecuteParallelActionsWithOffsets(false,
+                // setup
+                () =>
+                {
+                    invokedCount = 0;
+                },
+                // teardown
+                () =>
+                {
+                    Assert.AreEqual(4, invokedCount);
+                },
+                // parallel actions, repeated to generate offsets
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                parallelAction
+            );
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_WaitAsyncAndSetCalledConcurrently()
+        {
+            int invokedCount = 0;
+            var mre = new AsyncManualResetEvent(false);
+            Action parallelAction = () =>
+            {
+                mre.WaitAsync()
+                    .Then(() => Interlocked.Increment(ref invokedCount))
+                    .Forget();
+            };
+
+            new ThreadHelper().ExecuteParallelActionsWithOffsets(false,
+                // setup
+                () =>
+                {
+                    invokedCount = 0;
+                    mre.Reset();
+                },
+                // teardown
+                () =>
+                {
+                    TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                    Assert.AreEqual(4, invokedCount);
+                },
+                // parallel actions, repeated to generate offsets
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                () => mre.Set()
+            );
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_WaitAsyncAndCancelCalledConcurrently_AlreadySet()
+        {
+            int invokedCount = 0;
+            var mre = new AsyncManualResetEvent(true);
+            CancelationSource cancelationSource = default(CancelationSource);
+            Action parallelAction = () =>
+            {
+                mre.WaitAsync(cancelationSource.Token)
+                    .Then(() => Interlocked.Increment(ref invokedCount))
+                    .Forget();
+            };
+
+            new ThreadHelper().ExecuteParallelActionsWithOffsets(false,
+                // setup
+                () =>
+                {
+                    invokedCount = 0;
+                    cancelationSource = CancelationSource.New();
+                },
+                // teardown
+                () =>
+                {
+                    Assert.AreEqual(4, invokedCount);
+                    cancelationSource.Dispose();
+                },
+                // parallel actions, repeated to generate offsets
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                () => cancelationSource.Cancel()
+            );
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_WaitAsyncAndSetAndCancelCalledConcurrently()
+        {
+            int invokedCount = 0;
+            var mre = new AsyncManualResetEvent(false);
+            CancelationSource cancelationSource = default(CancelationSource);
+            Action parallelAction = () =>
+            {
+                mre.WaitAsync(cancelationSource.Token)
+                    .Then(() => Interlocked.Increment(ref invokedCount))
+                    .Forget();
+            };
+
+            new ThreadHelper().ExecuteParallelActionsWithOffsets(false,
+                // setup
+                () =>
+                {
+                    invokedCount = 0;
+                    cancelationSource = CancelationSource.New();
+                    mre.Reset();
+                },
+                // teardown
+                () =>
+                {
+                    TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                    Assert.AreEqual(4, invokedCount);
+                    cancelationSource.Dispose();
+                },
+                // parallel actions, repeated to generate offsets
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                parallelAction,
+                () => mre.Set(),
+                () => cancelationSource.Cancel()
+            );
+        }
+    }
+}

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/ProgressHelper.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/ProgressHelper.cs
@@ -20,16 +20,18 @@ namespace ProtoPromiseTests
         private readonly object _locker = new object();
         private readonly ProgressType _progressType;
         private readonly SynchronizationType _synchronizationType;
+        private readonly bool _forceAsync;
         private readonly Action<float> _onProgress;
         volatile private bool _wasInvoked;
         volatile private float _currentProgress = float.NaN;
 
-        public ProgressHelper(ProgressType progressType, SynchronizationType synchronizationType, Action<float> onProgress = null, float delta = float.NaN)
+        public ProgressHelper(ProgressType progressType, SynchronizationType synchronizationType, Action<float> onProgress = null, float delta = float.NaN, bool forceAsync = false)
         {
             _progressType = progressType;
             _synchronizationType = synchronizationType;
             _onProgress = onProgress;
             _delta = float.IsNaN(delta) ? TestHelper.progressEpsilon : delta;
+            _forceAsync = forceAsync;
         }
 
         public void MaybeEnterLock()
@@ -391,11 +393,11 @@ namespace ProtoPromiseTests
                 switch (_progressType)
                 {
                     case ProgressType.Callback:
-                        return promise.Progress(Report, TestHelper._foregroundContext, cancelationToken);
+                        return promise.Progress(Report, TestHelper._foregroundContext, cancelationToken, _forceAsync);
                     case ProgressType.CallbackWithCapture:
-                        return promise.Progress(this, (helper, v) => helper.Report(v), TestHelper._foregroundContext, cancelationToken);
+                        return promise.Progress(this, (helper, v) => helper.Report(v), TestHelper._foregroundContext, cancelationToken, _forceAsync);
                     default:
-                        return promise.Progress(this, TestHelper._foregroundContext, cancelationToken);
+                        return promise.Progress(this, TestHelper._foregroundContext, cancelationToken, _forceAsync);
                 }
             }
             else
@@ -403,11 +405,11 @@ namespace ProtoPromiseTests
                 switch (_progressType)
                 {
                     case ProgressType.Callback:
-                        return promise.Progress(Report, (SynchronizationOption) _synchronizationType, cancelationToken);
+                        return promise.Progress(Report, (SynchronizationOption) _synchronizationType, cancelationToken, _forceAsync);
                     case ProgressType.CallbackWithCapture:
-                        return promise.Progress(this, (helper, v) => helper.Report(v), (SynchronizationOption) _synchronizationType, cancelationToken);
+                        return promise.Progress(this, (helper, v) => helper.Report(v), (SynchronizationOption) _synchronizationType, cancelationToken, _forceAsync);
                     default:
-                        return promise.Progress(this, (SynchronizationOption) _synchronizationType, cancelationToken);
+                        return promise.Progress(this, (SynchronizationOption) _synchronizationType, cancelationToken, _forceAsync);
                 }
             }
         }
@@ -419,11 +421,11 @@ namespace ProtoPromiseTests
                 switch (_progressType)
                 {
                     case ProgressType.Callback:
-                        return promise.Progress(Report, TestHelper._foregroundContext, cancelationToken);
+                        return promise.Progress(Report, TestHelper._foregroundContext, cancelationToken, _forceAsync);
                     case ProgressType.CallbackWithCapture:
-                        return promise.Progress(this, (helper, v) => helper.Report(v), TestHelper._foregroundContext, cancelationToken);
+                        return promise.Progress(this, (helper, v) => helper.Report(v), TestHelper._foregroundContext, cancelationToken, _forceAsync);
                     default:
-                        return promise.Progress(this, TestHelper._foregroundContext, cancelationToken);
+                        return promise.Progress(this, TestHelper._foregroundContext, cancelationToken, _forceAsync);
                 }
             }
             else
@@ -431,11 +433,11 @@ namespace ProtoPromiseTests
                 switch (_progressType)
                 {
                     case ProgressType.Callback:
-                        return promise.Progress(Report, (SynchronizationOption) _synchronizationType, cancelationToken);
+                        return promise.Progress(Report, (SynchronizationOption) _synchronizationType, cancelationToken, _forceAsync);
                     case ProgressType.CallbackWithCapture:
-                        return promise.Progress(this, (helper, v) => helper.Report(v), (SynchronizationOption) _synchronizationType, cancelationToken);
+                        return promise.Progress(this, (helper, v) => helper.Report(v), (SynchronizationOption) _synchronizationType, cancelationToken, _forceAsync);
                     default:
-                        return promise.Progress(this, (SynchronizationOption) _synchronizationType, cancelationToken);
+                        return promise.Progress(this, (SynchronizationOption) _synchronizationType, cancelationToken, _forceAsync);
                 }
             }
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/TestHelper.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/Helpers/TestHelper.cs
@@ -125,6 +125,7 @@ namespace ProtoPromiseTests
             }
 
             SynchronizationContext.SetSynchronizationContext(_foregroundContext);
+            Promise.Manager.ThreadStaticSynchronizationContext = _foregroundContext;
             TestContext.Progress.WriteLine("Begin time: " + _stopwatch.Elapsed.ToString() + ", test: " + TestContext.CurrentContext.Test.FullName);
         }
 


### PR DESCRIPTION
#163

Also fixes progress callback order in case the promise is already resolved and the provided context matches the current context.