### PR TITLE
Fix progress perf degradation

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/Progress/ProgressMultiAwaitInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/Progress/ProgressMultiAwaitInternal.cs
@@ -95,8 +95,9 @@ namespace Proto.Promises
 
                 internal override bool TryRestoreWaiter(HandleablePromiseBase waiter, HandleablePromiseBase expected)
                 {
-                    if (_owner.TryRestoreWaiter(waiter, expected))
+                    if (_owner.TryRestoreWaiter(waiter, this))
                     {
+                        State = Promise.State.Resolved;
                         MaybeDispose();
                         return true;
                     }
@@ -465,15 +466,11 @@ namespace Proto.Promises
                             if (_nextBranches[i] == expected)
                             {
                                 _nextBranches[i] = waiter;
-                                goto DisposePassthrough;
+                                return true;
                             }
                         }
                     }
                     return false;
-
-                DisposePassthrough:
-                    expected.UnsafeAs<IndividualPromisePassThrough<TResult>>().MaybeDispose();
-                    return true;
                 }
             } // PromiseMultiAwait
         } // PromiseRefBase

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/ProgressTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/ProgressTests.cs
@@ -617,6 +617,58 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
+        public void OnProgressWillNoLongerBeInvokedWhenTokenIsCanceled_ChainIsBrokenAfterPreserved_void(
+            [Values] ProgressType progressType,
+            [Values] SynchronizationType synchronizationType)
+        {
+            var deferred = Promise.NewDeferred();
+            var cancelationSource = CancelationSource.New();
+            var progressHelper = new ProgressHelper(progressType, synchronizationType);
+
+            var promise = deferred.Promise.Preserve();
+
+            promise
+                .ThenDuplicate()
+                .WaitAsync(cancelationSource.Token)
+                .ThenDuplicate()
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
+            progressHelper.CancelAndAssertResult(cancelationSource, 0.5f, false);
+            progressHelper.ResolveAndAssertResult(deferred, 0.5f, false);
+
+            promise.Forget();
+            cancelationSource.Dispose();
+        }
+
+        [Test]
+        public void OnProgressWillNoLongerBeInvokedWhenTokenIsCanceled_ChainIsBrokenAfterPreserved_T(
+            [Values] ProgressType progressType,
+            [Values] SynchronizationType synchronizationType)
+        {
+            var deferred = Promise.NewDeferred<int>();
+            var cancelationSource = CancelationSource.New();
+            var progressHelper = new ProgressHelper(progressType, synchronizationType);
+
+            var promise = deferred.Promise.Preserve();
+
+            promise
+                .ThenDuplicate()
+                .WaitAsync(cancelationSource.Token)
+                .ThenDuplicate()
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred, 0.5f, 0.5f);
+            progressHelper.CancelAndAssertResult(cancelationSource, 0.5f, false);
+            progressHelper.ResolveAndAssertResult(deferred, 1, 0.5f, false);
+
+            promise.Forget();
+            cancelationSource.Dispose();
+        }
+
+        [Test]
         public void OnProgressWillNoLongerBeInvokedWhenTokenIsCanceled_void(
             [Values] ProgressType progressType,
             [Values] SynchronizationType synchronizationType)


### PR DESCRIPTION
Fixes the case where an uncommon race condition permanently makes progress slightly slower.
Optimized the common case by moving the race condition check after it.
Fixed `PromiseMultiAwait<TResult>.TryRestoreWaiter` always returning false.