### PR TITLE
Rename `Try` methods

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/CompilerServices/PromiseAwaiters.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/CompilerServices/PromiseAwaiters.cs
@@ -14,7 +14,6 @@
 #endif
 
 using System;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Proto.Promises.Async.CompilerServices;
@@ -24,9 +23,9 @@ namespace Proto.Promises
     partial struct Promise
     {
         /// <summary>Gets an awaiter for this <see cref="Promise"/>.</summary>
-        /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
+        /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
         /// <returns>The awaiter.</returns>
-        [MethodImpl(Internal.InlineOption), EditorBrowsable(EditorBrowsableState.Never)]
+        [MethodImpl(Internal.InlineOption)]
         public PromiseAwaiterVoid GetAwaiter()
         {
             ValidateOperation(1);
@@ -64,9 +63,9 @@ namespace Proto.Promises
     partial struct Promise<T>
     {
         /// <summary>Gets an awaiter for this <see cref="Promise{T}"/>.</summary>
-        /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
+        /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
         /// <returns>The awaiter.</returns>
-        [MethodImpl(Internal.InlineOption), EditorBrowsable(EditorBrowsableState.Never)]
+        [MethodImpl(Internal.InlineOption)]
         public PromiseAwaiter<T> GetAwaiter()
         {
             ValidateOperation(1);
@@ -182,7 +181,7 @@ namespace Proto.Promises
         /// <summary>
         /// Provides an awaiter for awaiting a <see cref="Promise"/>.
         /// </summary>
-        /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
+        /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
@@ -211,7 +210,7 @@ namespace Proto.Promises
             static partial void CreateOverride();
 
             /// <summary>Gets whether the <see cref="Promise"/> being awaited is completed.</summary>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             public bool IsCompleted
             {
@@ -224,7 +223,7 @@ namespace Proto.Promises
             }
 
             /// <summary>Ends the await on the completed <see cref="Promise"/>.</summary>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten, or it has not yet completed.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void GetResult()
@@ -245,7 +244,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseAwaiterVoid"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void OnCompleted(Action continuation)
@@ -262,7 +261,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseAwaiterVoid"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void UnsafeOnCompleted(Action continuation)
@@ -288,7 +287,7 @@ namespace Proto.Promises
         /// <summary>
         /// Provides an awaiter for awaiting a <see cref="Promise{T}"/>.
         /// </summary>
-        /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
+        /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
@@ -317,7 +316,7 @@ namespace Proto.Promises
             static partial void CreateOverride();
 
             /// <summary>Gets whether the <see cref="Promise{T}"/> being awaited is completed.</summary>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             public bool IsCompleted
             {
@@ -331,7 +330,7 @@ namespace Proto.Promises
 
             /// <summary>Ends the await on the completed <see cref="Promise{T}"/>.</summary>
             /// <returns>The result of the completed <see cref="Promise{T}"/></returns>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten, or it has not yet completed.</exception>
             [MethodImpl(Internal.InlineOption)]
             public T GetResult()
@@ -352,7 +351,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseAwaiter{T}"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void OnCompleted(Action continuation)
@@ -369,7 +368,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseAwaiter{T}"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void UnsafeOnCompleted(Action continuation)
@@ -395,7 +394,7 @@ namespace Proto.Promises
         /// <summary>
         /// Provides an awaiter for awaiting a <see cref="Promise"/> and reporting its progress to the associated async <see cref="Promise"/> or <see cref="Promise{T}"/>.
         /// </summary>
-        /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
+        /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
@@ -428,7 +427,7 @@ namespace Proto.Promises
             static partial void CreateOverride();
 
             /// <summary>Gets the awaiter for this.</summary>
-            /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
             /// <returns>this</returns>
             [MethodImpl(Internal.InlineOption)]
             public PromiseProgressAwaiterVoid GetAwaiter()
@@ -437,7 +436,7 @@ namespace Proto.Promises
             }
 
             /// <summary>Gets whether the <see cref="Promise"/> being awaited is completed.</summary>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             public bool IsCompleted
             {
@@ -450,7 +449,7 @@ namespace Proto.Promises
             }
 
             /// <summary>Ends the await on the completed <see cref="Promise"/>.</summary>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten, or it has not yet completed.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void GetResult()
@@ -471,7 +470,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseProgressAwaiterVoid"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void OnCompleted(Action continuation)
@@ -488,7 +487,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseProgressAwaiterVoid"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void UnsafeOnCompleted(Action continuation)
@@ -514,7 +513,7 @@ namespace Proto.Promises
         /// <summary>
         /// Provides an awaiter for awaiting a <see cref="Promise{T}"/> and reporting its progress to the associated async <see cref="Promise"/> or <see cref="Promise{T}"/>.
         /// </summary>
-        /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
+        /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
@@ -547,7 +546,7 @@ namespace Proto.Promises
             static partial void CreateOverride();
 
             /// <summary>Gets the awaiter for this.</summary>
-            /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
             /// <returns>this</returns>
             [MethodImpl(Internal.InlineOption)]
             public PromiseProgressAwaiter<T> GetAwaiter()
@@ -556,7 +555,7 @@ namespace Proto.Promises
             }
 
             /// <summary>Gets whether the <see cref="Promise{T}"/> being awaited is completed.</summary>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             public bool IsCompleted
             {
@@ -570,7 +569,7 @@ namespace Proto.Promises
 
             /// <summary>Ends the await on the completed <see cref="Promise{T}"/>.</summary>
             /// <returns>The result of the completed <see cref="Promise{T}"/></returns>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten, or it has not yet completed.</exception>
             [MethodImpl(Internal.InlineOption)]
             public T GetResult()
@@ -591,7 +590,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseProgressAwaiter{T}"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void OnCompleted(Action continuation)
@@ -608,7 +607,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseProgressAwaiter{T}"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void UnsafeOnCompleted(Action continuation)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/CompilerServices/PromiseAwaiters.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/CompilerServices/PromiseAwaiters.cs
@@ -14,6 +14,7 @@
 #endif
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Proto.Promises.Async.CompilerServices;
@@ -23,9 +24,9 @@ namespace Proto.Promises
     partial struct Promise
     {
         /// <summary>Gets an awaiter for this <see cref="Promise"/>.</summary>
-        /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
+        /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
         /// <returns>The awaiter.</returns>
-        [MethodImpl(Internal.InlineOption)]
+        [MethodImpl(Internal.InlineOption), EditorBrowsable(EditorBrowsableState.Never)]
         public PromiseAwaiterVoid GetAwaiter()
         {
             ValidateOperation(1);
@@ -63,9 +64,9 @@ namespace Proto.Promises
     partial struct Promise<T>
     {
         /// <summary>Gets an awaiter for this <see cref="Promise{T}"/>.</summary>
-        /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
+        /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
         /// <returns>The awaiter.</returns>
-        [MethodImpl(Internal.InlineOption)]
+        [MethodImpl(Internal.InlineOption), EditorBrowsable(EditorBrowsableState.Never)]
         public PromiseAwaiter<T> GetAwaiter()
         {
             ValidateOperation(1);
@@ -181,7 +182,7 @@ namespace Proto.Promises
         /// <summary>
         /// Provides an awaiter for awaiting a <see cref="Promise"/>.
         /// </summary>
-        /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
+        /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
@@ -210,7 +211,7 @@ namespace Proto.Promises
             static partial void CreateOverride();
 
             /// <summary>Gets whether the <see cref="Promise"/> being awaited is completed.</summary>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             public bool IsCompleted
             {
@@ -223,7 +224,7 @@ namespace Proto.Promises
             }
 
             /// <summary>Ends the await on the completed <see cref="Promise"/>.</summary>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten, or it has not yet completed.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void GetResult()
@@ -244,7 +245,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseAwaiterVoid"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void OnCompleted(Action continuation)
@@ -261,7 +262,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseAwaiterVoid"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void UnsafeOnCompleted(Action continuation)
@@ -287,7 +288,7 @@ namespace Proto.Promises
         /// <summary>
         /// Provides an awaiter for awaiting a <see cref="Promise{T}"/>.
         /// </summary>
-        /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
+        /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
@@ -316,7 +317,7 @@ namespace Proto.Promises
             static partial void CreateOverride();
 
             /// <summary>Gets whether the <see cref="Promise{T}"/> being awaited is completed.</summary>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             public bool IsCompleted
             {
@@ -330,7 +331,7 @@ namespace Proto.Promises
 
             /// <summary>Ends the await on the completed <see cref="Promise{T}"/>.</summary>
             /// <returns>The result of the completed <see cref="Promise{T}"/></returns>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten, or it has not yet completed.</exception>
             [MethodImpl(Internal.InlineOption)]
             public T GetResult()
@@ -351,7 +352,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseAwaiter{T}"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void OnCompleted(Action continuation)
@@ -368,7 +369,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseAwaiter{T}"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void UnsafeOnCompleted(Action continuation)
@@ -394,7 +395,7 @@ namespace Proto.Promises
         /// <summary>
         /// Provides an awaiter for awaiting a <see cref="Promise"/> and reporting its progress to the associated async <see cref="Promise"/> or <see cref="Promise{T}"/>.
         /// </summary>
-        /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
+        /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
@@ -427,7 +428,7 @@ namespace Proto.Promises
             static partial void CreateOverride();
 
             /// <summary>Gets the awaiter for this.</summary>
-            /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
             /// <returns>this</returns>
             [MethodImpl(Internal.InlineOption)]
             public PromiseProgressAwaiterVoid GetAwaiter()
@@ -436,7 +437,7 @@ namespace Proto.Promises
             }
 
             /// <summary>Gets whether the <see cref="Promise"/> being awaited is completed.</summary>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             public bool IsCompleted
             {
@@ -449,7 +450,7 @@ namespace Proto.Promises
             }
 
             /// <summary>Ends the await on the completed <see cref="Promise"/>.</summary>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten, or it has not yet completed.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void GetResult()
@@ -470,7 +471,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseProgressAwaiterVoid"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void OnCompleted(Action continuation)
@@ -487,7 +488,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseProgressAwaiterVoid"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void UnsafeOnCompleted(Action continuation)
@@ -513,7 +514,7 @@ namespace Proto.Promises
         /// <summary>
         /// Provides an awaiter for awaiting a <see cref="Promise{T}"/> and reporting its progress to the associated async <see cref="Promise"/> or <see cref="Promise{T}"/>.
         /// </summary>
-        /// <remarks>This type is intended for compiler user rather than use directly in code.</remarks>
+        /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
@@ -546,7 +547,7 @@ namespace Proto.Promises
             static partial void CreateOverride();
 
             /// <summary>Gets the awaiter for this.</summary>
-            /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
             /// <returns>this</returns>
             [MethodImpl(Internal.InlineOption)]
             public PromiseProgressAwaiter<T> GetAwaiter()
@@ -555,7 +556,7 @@ namespace Proto.Promises
             }
 
             /// <summary>Gets whether the <see cref="Promise{T}"/> being awaited is completed.</summary>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             public bool IsCompleted
             {
@@ -569,7 +570,7 @@ namespace Proto.Promises
 
             /// <summary>Ends the await on the completed <see cref="Promise{T}"/>.</summary>
             /// <returns>The result of the completed <see cref="Promise{T}"/></returns>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten, or it has not yet completed.</exception>
             [MethodImpl(Internal.InlineOption)]
             public T GetResult()
@@ -590,7 +591,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseProgressAwaiter{T}"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void OnCompleted(Action continuation)
@@ -607,7 +608,7 @@ namespace Proto.Promises
 
             /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseProgressAwaiter{T}"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
-            /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
             /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void UnsafeOnCompleted(Action continuation)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Promise.cs
@@ -138,14 +138,29 @@ namespace Proto.Promises
 
         /// <summary>
         /// Mark this as awaited and wait for the operation to complete with a specified timeout.
-        /// <para/>This will return true if the operation completed successfully before the timeout expired, false otherwise.
+        /// <para/>This will return <see langword="true"/> if the operation completed successfully before the timeout expired, <see langword="false"/> otherwise.
         /// If the operation was rejected or canceled, the appropriate exception will be thrown.
         /// </summary>
         /// <remarks>
         /// If a <see cref="TimeSpan"/> representing -1 millisecond is specified for the timeout parameter, this method blocks indefinitely until the operation is complete.
         /// <para/>Warning: this may cause a deadlock if you are not careful. Make sure you know what you are doing!
         /// </remarks>
+        [Obsolete("Use TryWait instead.", false), EditorBrowsable(EditorBrowsableState.Never)]
         public bool Wait(TimeSpan timeout)
+        {
+            return TryWait(timeout);
+        }
+
+        /// <summary>
+        /// Mark this as awaited and wait for the operation to complete with a specified timeout.
+        /// <para/>This will return <see langword="true"/> if the operation completed successfully before the timeout expired, <see langword="false"/> otherwise.
+        /// If the operation was rejected or canceled, the appropriate exception will be thrown.
+        /// </summary>
+        /// <remarks>
+        /// If a <see cref="TimeSpan"/> representing -1 millisecond is specified for the timeout parameter, this method blocks indefinitely until the operation is complete.
+        /// <para/>Warning: this may cause a deadlock if you are not careful. Make sure you know what you are doing!
+        /// </remarks>
+        public bool TryWait(TimeSpan timeout)
         {
             ValidateOperation(1);
             var r = _ref;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseT.cs
@@ -181,14 +181,29 @@ namespace Proto.Promises
 
         /// <summary>
         /// Mark this as awaited and wait for the operation to complete with a specified timeout.
-        /// <para/>If the operation completed successfully before the timeout expired, this will return true and <paramref name="result"/> will be assigned from the result of the operation. Otherwise, this will return false.
+        /// <para/>If the operation completed successfully before the timeout expired, this will return <see langword="true"/> and <paramref name="result"/> will be assigned from the result of the operation. Otherwise, this will return <see langword="false"/>.
         /// If the operation was rejected or canceled, the appropriate exception will be thrown.
         /// </summary>
         /// <remarks>
         /// If a <see cref="TimeSpan"/> representing -1 millisecond is specified for the timeout parameter, this method blocks indefinitely until the operation is complete.
         /// <para/>Warning: this may cause a deadlock if you are not careful. Make sure you know what you are doing!
         /// </remarks>
+        [Obsolete("Use TryWaitForResult instead.", false), EditorBrowsable(EditorBrowsableState.Never)]
         public bool WaitForResult(TimeSpan timeout, out T result)
+        {
+            return TryWaitForResult(timeout, out result);
+        }
+
+        /// <summary>
+        /// Mark this as awaited and wait for the operation to complete with a specified timeout.
+        /// <para/>If the operation completed successfully before the timeout expired, this will return <see langword="true"/> and <paramref name="result"/> will be assigned from the result of the operation. Otherwise, this will return <see langword="false"/>.
+        /// If the operation was rejected or canceled, the appropriate exception will be thrown.
+        /// </summary>
+        /// <remarks>
+        /// If a <see cref="TimeSpan"/> representing -1 millisecond is specified for the timeout parameter, this method blocks indefinitely until the operation is complete.
+        /// <para/>Warning: this may cause a deadlock if you are not careful. Make sure you know what you are doing!
+        /// </remarks>
+        public bool TryWaitForResult(TimeSpan timeout, out T result)
         {
             ValidateOperation(1);
             var r = _ref;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncAutoResetEvent.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncAutoResetEvent.cs
@@ -2,6 +2,7 @@
 #define NET_LEGACY
 #endif
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -61,9 +62,9 @@ namespace Proto.Promises.Threading
         /// If this is already set, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<bool> WaitAsync(CancelationToken cancelationToken)
+        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
         {
-            return _impl.WaitAsync(cancelationToken);
+            return _impl.TryWaitAsync(cancelationToken);
         }
 
         /// <summary>
@@ -72,7 +73,7 @@ namespace Proto.Promises.Threading
         [MethodImpl(Internal.InlineOption)]
         public void Wait()
         {
-            _impl.WaitSync();
+            _impl.Wait();
         }
 
         /// <summary>
@@ -84,9 +85,9 @@ namespace Proto.Promises.Threading
         /// If this is already set, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
-        public bool Wait(CancelationToken cancelationToken)
+        public bool TryWait(CancelationToken cancelationToken)
         {
-            return _impl.WaitSync(cancelationToken);
+            return _impl.TryWait(cancelationToken);
         }
 
         /// <summary>
@@ -117,7 +118,7 @@ namespace Proto.Promises.Threading
         /// <summary>
         /// Asynchronous infrastructure support. This method permits instances of <see cref="AsyncAutoResetEvent"/> to be awaited.
         /// </summary>
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public Async.CompilerServices.PromiseAwaiterVoid GetAwaiter()
         {
             return WaitAsync().GetAwaiter();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncLock.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncLock.cs
@@ -55,50 +55,24 @@ namespace Proto.Promises.Threading
         public AsyncLock() { }
 
         /// <summary>
-        /// Asynchronously acquire the lock.
-        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
-        /// The result of the promise is the key that will release the lock when it is disposed.
-        /// </summary>
-        [MethodImpl(Internal.InlineOption)]
-        public Promise<Key> LockAsync()
-        {
-            return _impl.LockAsync();
-        }
-
-        /// <summary>
-        /// Asynchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
-        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired,
-        /// or canceled if the <paramref name="cancelationToken"/> is canceled before the lock is acquired..
+        /// Asynchronously acquire the lock. Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<Key> LockAsync(CancelationToken cancelationToken)
+        public Promise<Key> LockAsync(CancelationToken cancelationToken = default)
         {
-            return _impl.LockAsync(cancelationToken);
+            return _impl.LockAsync(false, cancelationToken);
         }
 
         /// <summary>
-        /// Synchronously acquire the lock.
-        /// Returns the key that will release the lock when it is disposed.
-        /// This method will not return until the lock has been acquired.
-        /// </summary>
-        [MethodImpl(Internal.InlineOption)]
-        public Key Lock()
-        {
-            return _impl.LockSync();
-        }
-
-        /// <summary>
-        /// Synchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
-        /// Returns the key that will release the lock when it is disposed.
-        /// This method will not return until the lock has been acquired, or the <paramref name="cancelationToken"/> has been canceled.
+        /// Synchronously acquire the lock. Returns the key that will release the lock when it is disposed.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, a <see cref="CanceledException"/> will be thrown.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Key Lock(CancelationToken cancelationToken)
+        public Key Lock(CancelationToken cancelationToken = default)
         {
-            return _impl.LockSync(cancelationToken);
+            return _impl.LockAsync(true, cancelationToken).WaitForResult();
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncLock.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncLock.cs
@@ -55,24 +55,50 @@ namespace Proto.Promises.Threading
         public AsyncLock() { }
 
         /// <summary>
-        /// Asynchronously acquire the lock. Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// Asynchronously acquire the lock.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise<Key> LockAsync()
+        {
+            return _impl.LockAsync();
+        }
+
+        /// <summary>
+        /// Asynchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired,
+        /// or canceled if the <paramref name="cancelationToken"/> is canceled before the lock is acquired..
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<Key> LockAsync(CancelationToken cancelationToken = default)
+        public Promise<Key> LockAsync(CancelationToken cancelationToken)
         {
-            return _locker.LockAsync(false, cancelationToken);
+            return _impl.LockAsync(cancelationToken);
         }
 
         /// <summary>
-        /// Synchronously acquire the lock. Returns the key that will release the lock when it is disposed.
+        /// Synchronously acquire the lock.
+        /// Returns the key that will release the lock when it is disposed.
+        /// This method will not return until the lock has been acquired.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public Key Lock()
+        {
+            return _impl.LockSync();
+        }
+
+        /// <summary>
+        /// Synchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
+        /// Returns the key that will release the lock when it is disposed.
+        /// This method will not return until the lock has been acquired, or the <paramref name="cancelationToken"/> has been canceled.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, a <see cref="CanceledException"/> will be thrown.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Key Lock(CancelationToken cancelationToken = default)
+        public Key Lock(CancelationToken cancelationToken)
         {
-            return _locker.LockAsync(true, cancelationToken).WaitForResult();
+            return _impl.LockSync(cancelationToken);
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncManualResetEvent.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncManualResetEvent.cs
@@ -2,6 +2,7 @@
 #define NET_LEGACY
 #endif
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -61,9 +62,9 @@ namespace Proto.Promises.Threading
         /// If this is already set, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<bool> WaitAsync(CancelationToken cancelationToken)
+        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
         {
-            return _impl.WaitAsync(cancelationToken);
+            return _impl.TryWaitAsync(cancelationToken);
         }
 
         /// <summary>
@@ -72,7 +73,7 @@ namespace Proto.Promises.Threading
         [MethodImpl(Internal.InlineOption)]
         public void Wait()
         {
-            _impl.WaitSync();
+            _impl.Wait();
         }
 
         /// <summary>
@@ -84,9 +85,9 @@ namespace Proto.Promises.Threading
         /// If this is already set, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
-        public bool Wait(CancelationToken cancelationToken)
+        public bool TryWait(CancelationToken cancelationToken)
         {
-            return _impl.WaitSync(cancelationToken);
+            return _impl.TryWait(cancelationToken);
         }
 
         /// <summary>
@@ -116,7 +117,7 @@ namespace Proto.Promises.Threading
         /// <summary>
         /// Asynchronous infrastructure support. This method permits instances of <see cref="AsyncManualResetEvent"/> to be awaited.
         /// </summary>
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public Async.CompilerServices.PromiseAwaiterVoid GetAwaiter()
         {
             return WaitAsync().GetAwaiter();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncMonitor.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncMonitor.cs
@@ -2,6 +2,8 @@
 #define NET_LEGACY
 #endif
 
+using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -48,7 +50,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="asyncLock">The async lock instance that is being entered.</param>
         /// <param name="key">If successful, the key that will release the lock when it is disposed.</param>
-        /// <returns>True if the lock was acquired, false otherwise.</returns>
+        /// <returns><see langword="true"/> if the lock was acquired, <see langword="false"/> otherwise.</returns>
         [MethodImpl(Internal.InlineOption)]
         public static bool TryEnter(AsyncLock asyncLock, out AsyncLock.Key key)
         {
@@ -72,13 +74,45 @@ namespace Proto.Promises.Threading
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
         /// <returns>
         /// A <see cref="Promise{T}"/> that will be resolved when the lock is re-acquired.
-        /// Its result will be true if the lock was re-acquired before the <paramref name="cancelationToken"/> was canceled,
-        /// false if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
+        /// Its result will be <see langword="true"/> if the lock was re-acquired before the <paramref name="cancelationToken"/> was canceled,
+        /// <see langword="false"/> if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
         /// </returns>
         [MethodImpl(Internal.InlineOption)]
-        public static Promise<bool> WaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken = default)
+        [Obsolete("Use TryWaitAsync instead.", false), EditorBrowsable(EditorBrowsableState.Never)]
+        public static Promise<bool> WaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken)
         {
-            return asyncLockKey.WaitAsync(cancelationToken);
+            return TryWaitAsync(asyncLockKey, cancelationToken);
+        }
+
+        /// <summary>
+        /// Release the lock and asynchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.
+        /// The lock will be re-acquired before the returned <see cref="Promise{T}"/> is resolved.
+        /// </summary>
+        /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
+        /// <returns>
+        /// A <see cref="Promise"/> that will be resolved when the lock is re-acquired.
+        /// </returns>
+        [MethodImpl(Internal.InlineOption)]
+        public static Promise WaitAsync(AsyncLock.Key asyncLockKey)
+        {
+            return asyncLockKey.WaitAsync();
+        }
+
+        /// <summary>
+        /// Release the lock and asynchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>, while observing a <see cref="CancelationToken"/>.
+        /// The lock will be re-acquired before the returned <see cref="Promise{T}"/> is resolved.
+        /// </summary>
+        /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> that will be resolved when the lock is re-acquired.
+        /// Its result will be <see langword="true"/> if the lock was re-acquired before the <paramref name="cancelationToken"/> was canceled,
+        /// <see langword="false"/> if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
+        /// </returns>
+        [MethodImpl(Internal.InlineOption)]
+        public static Promise<bool> TryWaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken)
+        {
+            return asyncLockKey.TryWaitAsync(cancelationToken);
         }
 
         /// <summary>
@@ -88,13 +122,41 @@ namespace Proto.Promises.Threading
         /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
         /// <returns>
-        /// true if the lock was re-acquired before the <paramref name="cancelationToken"/> was canceled,
-        /// false if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
+        /// <see langword="true"/> if the lock was re-acquired before the <paramref name="cancelationToken"/> was canceled,
+        /// <see langword="false"/> if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
         /// </returns>
         [MethodImpl(Internal.InlineOption)]
-        public static bool Wait(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken = default)
+        [Obsolete("Use TryWait instead.", false), EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool Wait(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken)
         {
-            return asyncLockKey.Wait(cancelationToken);
+            return TryWait(asyncLockKey, cancelationToken);
+        }
+
+        /// <summary>
+        /// Release the lock and synchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.
+        /// The lock will be re-acquired before this method returns.
+        /// </summary>
+        /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
+        [MethodImpl(Internal.InlineOption)]
+        public static void Wait(AsyncLock.Key asyncLockKey)
+        {
+            asyncLockKey.Wait();
+        }
+
+        /// <summary>
+        /// Release the lock and synchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>, while observing a <see cref="CancelationToken"/>.
+        /// The lock will be re-acquired before this method returns.
+        /// </summary>
+        /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
+        /// <returns>
+        /// <see langword="true"/> if the lock was re-acquired before the <paramref name="cancelationToken"/> was canceled,
+        /// <see langword="false"/> if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
+        /// </returns>
+        [MethodImpl(Internal.InlineOption)]
+        public static bool TryWait(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken)
+        {
+            return asyncLockKey.TryWait(cancelationToken);
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncAutoResetEventInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncAutoResetEventInternal.cs
@@ -146,7 +146,7 @@ namespace Proto.Promises
                 return new Promise(promise, promise.Id, 0);
             }
 
-            internal Promise<bool> WaitAsync(CancelationToken cancelationToken)
+            internal Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
             {
                 AsyncResetEventPromise promise;
                 lock (this)
@@ -165,7 +165,7 @@ namespace Proto.Promises
                 return new Promise<bool>(promise, promise.Id, 0);
             }
 
-            internal void WaitSync()
+            internal void Wait()
             {
                 AsyncResetEventPromise promise;
                 lock (this)
@@ -181,7 +181,7 @@ namespace Proto.Promises
                 new Promise(promise, promise.Id, 0).Wait();
             }
 
-            internal bool WaitSync(CancelationToken cancelationToken)
+            internal bool TryWait(CancelationToken cancelationToken)
             {
                 AsyncResetEventPromise promise;
                 lock (this)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncManualResetEventInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncManualResetEventInternal.cs
@@ -151,7 +151,7 @@ namespace Proto.Promises
                 return new Promise(promise, promise.Id, 0);
             }
 
-            internal Promise<bool> WaitAsync(CancelationToken cancelationToken)
+            internal Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
                 bool isSet = _isSet;
@@ -175,7 +175,7 @@ namespace Proto.Promises
                 return new Promise<bool>(promise, promise.Id, 0);
             }
 
-            internal void WaitSync()
+            internal void Wait()
             {
                 // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
                 var spinner = new SpinWait();
@@ -209,7 +209,7 @@ namespace Proto.Promises
                 new Promise(promise, promise.Id, 0).Wait();
             }
 
-            internal bool WaitSync(CancelationToken cancelationToken)
+            internal bool TryWait(CancelationToken cancelationToken)
             {
                 // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
                 var spinner = new SpinWait();

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/CancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/CancelationTests.cs
@@ -1529,7 +1529,7 @@ namespace ProtoPromiseTests.APIs
             public void CancelationRegistrationAwaitUsingUnregistersCallback()
             {
                 bool completedAsync = false;
-                RunAsync().Wait(TimeSpan.FromSeconds(1));
+                RunAsync().TryWait(TimeSpan.FromSeconds(1));
                 Assert.IsTrue(completedAsync);
 
                 async Promise RunAsync()
@@ -1562,7 +1562,7 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsFalse(completedAsync);
                 isCallbackComplete = true;
 
-                if (!promise.Wait(TimeSpan.FromSeconds(1)) | !cancelPromise.Wait(TimeSpan.FromSeconds(1)))
+                if (!promise.TryWait(TimeSpan.FromSeconds(1)) | !cancelPromise.TryWait(TimeSpan.FromSeconds(1)))
                 {
                     throw new TimeoutException();
                 }
@@ -1603,7 +1603,7 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsFalse(completedAsync);
                 isCallbackComplete = true;
 
-                if (!promise.Wait(TimeSpan.FromSeconds(1)) | !cancelPromise.Wait(TimeSpan.FromSeconds(1)))
+                if (!promise.TryWait(TimeSpan.FromSeconds(1)) | !cancelPromise.TryWait(TimeSpan.FromSeconds(1)))
                 {
                     throw new TimeoutException();
                 }
@@ -1697,7 +1697,7 @@ namespace ProtoPromiseTests.APIs
                     asyncComplete = true;
                 }
 
-                RunAsync().Wait(TimeSpan.FromSeconds(5));
+                RunAsync().TryWait(TimeSpan.FromSeconds(5));
                 Assert.IsTrue(asyncComplete);
                 cancelationSource.Dispose();
             }
@@ -1727,7 +1727,7 @@ namespace ProtoPromiseTests.APIs
                     asyncComplete = true;
                 }
 
-                RunAsync().Wait(TimeSpan.FromSeconds(5));
+                RunAsync().TryWait(TimeSpan.FromSeconds(5));
                 Assert.IsTrue(asyncComplete);
                 cancelationSource.Dispose();
             }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/MiscellaneousTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/MiscellaneousTests.cs
@@ -955,7 +955,7 @@ namespace ProtoPromiseTests.APIs
         {
             if (withTimeout)
             {
-                return promise.Wait(System.TimeSpan.Zero);
+                return promise.TryWait(System.TimeSpan.Zero);
             }
             promise.Wait();
             return true;
@@ -965,7 +965,7 @@ namespace ProtoPromiseTests.APIs
         {
             if (withTimeout)
             {
-                return promise.WaitForResult(System.TimeSpan.Zero, out result);
+                return promise.TryWaitForResult(System.TimeSpan.Zero, out result);
             }
             result = promise.WaitForResult();
             return true;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/Threading/AsyncAutoResetEventTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/Threading/AsyncAutoResetEventTests.cs
@@ -53,16 +53,16 @@ namespace ProtoPromiseTests.APIs.Threading
         {
             var e = new AsyncAutoResetEvent(true);
             e.Reset();
-            Assert.False(e.Wait(CancelationToken.Canceled()));
-            Assert.False(e.Wait(CancelationToken.Canceled()));
+            Assert.False(e.TryWait(CancelationToken.Canceled()));
+            Assert.False(e.TryWait(CancelationToken.Canceled()));
             e.Reset();
-            Assert.False(e.Wait(CancelationToken.Canceled()));
+            Assert.False(e.TryWait(CancelationToken.Canceled()));
             e.Set();
-            Assert.True(e.Wait(CancelationToken.Canceled()));
-            Assert.False(e.Wait(CancelationToken.Canceled()));
+            Assert.True(e.TryWait(CancelationToken.Canceled()));
+            Assert.False(e.TryWait(CancelationToken.Canceled()));
             e.Set();
             e.Set();
-            Assert.True(e.Wait(CancelationToken.Canceled()));
+            Assert.True(e.TryWait(CancelationToken.Canceled()));
         }
 
 #if !UNITY_WEBGL
@@ -108,7 +108,7 @@ namespace ProtoPromiseTests.APIs.Threading
                 .Forget();
 
             isAboutToWait = true;
-            Assert.False(are.Wait(cs.Token));
+            Assert.False(are.TryWait(cs.Token));
 
             cs.Dispose();
         }
@@ -121,7 +121,7 @@ namespace ProtoPromiseTests.APIs.Threading
             CancelationSource cs = CancelationSource.New();
             cs.Cancel();
 
-            Assert.False(are.Wait(cs.Token));
+            Assert.False(are.TryWait(cs.Token));
 
             cs.Dispose();
         }
@@ -134,7 +134,7 @@ namespace ProtoPromiseTests.APIs.Threading
             CancelationSource cs = CancelationSource.New();
             cs.Cancel();
 
-            Assert.True(are.Wait(cs.Token));
+            Assert.True(are.TryWait(cs.Token));
 
             cs.Dispose();
         }
@@ -210,7 +210,7 @@ namespace ProtoPromiseTests.APIs.Threading
             AsyncAutoResetEvent are = new AsyncAutoResetEvent();
             CancelationSource cs = CancelationSource.New();
 
-            var promise = are.WaitAsync(cs.Token);
+            var promise = are.TryWaitAsync(cs.Token);
 
             cs.Cancel();
 
@@ -226,7 +226,7 @@ namespace ProtoPromiseTests.APIs.Threading
             CancelationSource cs = CancelationSource.New();
             cs.Cancel();
 
-            Assert.False(are.WaitAsync(cs.Token).WaitWithTimeout(TimeSpan.FromSeconds(1)));
+            Assert.False(are.TryWaitAsync(cs.Token).WaitWithTimeout(TimeSpan.FromSeconds(1)));
 
             cs.Dispose();
         }
@@ -239,7 +239,7 @@ namespace ProtoPromiseTests.APIs.Threading
             CancelationSource cs = CancelationSource.New();
             cs.Cancel();
 
-            Assert.True(are.WaitAsync(cs.Token).WaitWithTimeout(TimeSpan.FromSeconds(1)));
+            Assert.True(are.TryWaitAsync(cs.Token).WaitWithTimeout(TimeSpan.FromSeconds(1)));
 
             cs.Dispose();
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/Threading/AsyncLockTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/Threading/AsyncLockTests.cs
@@ -36,7 +36,7 @@ namespace ProtoPromiseTests.APIs.Threading
             var lockPromise = mutex.LockAsync();
 
             AsyncLock.Key key;
-            Assert.True(lockPromise.WaitForResult(TimeSpan.FromSeconds(1), out key));
+            Assert.True(lockPromise.TryWaitForResult(TimeSpan.FromSeconds(1), out key));
             key.Dispose();
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/Threading/AsyncManualResetEventTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/Threading/AsyncManualResetEventTests.cs
@@ -112,7 +112,7 @@ namespace ProtoPromiseTests.APIs.Threading
                 .Forget();
 
             isAboutToWait = true;
-            Assert.False(mre.Wait(cs.Token));
+            Assert.False(mre.TryWait(cs.Token));
 
             cs.Dispose();
         }
@@ -125,7 +125,7 @@ namespace ProtoPromiseTests.APIs.Threading
             CancelationSource cs = CancelationSource.New();
             cs.Cancel();
 
-            Assert.False(mre.Wait(cs.Token));
+            Assert.False(mre.TryWait(cs.Token));
 
             cs.Dispose();
         }
@@ -138,7 +138,7 @@ namespace ProtoPromiseTests.APIs.Threading
             CancelationSource cs = CancelationSource.New();
             cs.Cancel();
 
-            Assert.True(are.Wait(cs.Token));
+            Assert.True(are.TryWait(cs.Token));
 
             cs.Dispose();
         }
@@ -214,7 +214,7 @@ namespace ProtoPromiseTests.APIs.Threading
             AsyncManualResetEvent mre = new AsyncManualResetEvent();
             CancelationSource cs = CancelationSource.New();
 
-            var promise = mre.WaitAsync(cs.Token);
+            var promise = mre.TryWaitAsync(cs.Token);
 
             cs.Cancel();
 
@@ -230,7 +230,7 @@ namespace ProtoPromiseTests.APIs.Threading
             CancelationSource cs = CancelationSource.New();
             cs.Cancel();
 
-            Assert.False(mre.WaitAsync(cs.Token).WaitWithTimeout(TimeSpan.FromSeconds(1)));
+            Assert.False(mre.TryWaitAsync(cs.Token).WaitWithTimeout(TimeSpan.FromSeconds(1)));
 
             cs.Dispose();
         }
@@ -243,7 +243,7 @@ namespace ProtoPromiseTests.APIs.Threading
             CancelationSource cs = CancelationSource.New();
             cs.Cancel();
 
-            Assert.True(are.WaitAsync(cs.Token).WaitWithTimeout(TimeSpan.FromSeconds(1)));
+            Assert.True(are.TryWaitAsync(cs.Token).WaitWithTimeout(TimeSpan.FromSeconds(1)));
 
             cs.Dispose();
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/UncaughtRejectionTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/UncaughtRejectionTests.cs
@@ -987,13 +987,13 @@ namespace ProtoPromiseTests.APIs
                 foreach (var promise in TestHelper.GetTestablePromises(preservedPromise))
                 {
                     ++expectedCount;
-                    Assert.IsFalse(promise.Wait(System.TimeSpan.FromMilliseconds(timeout)));
+                    Assert.IsFalse(promise.TryWait(System.TimeSpan.FromMilliseconds(timeout)));
                 }
 
                 // Run it again with a freshly preserved promise, because the initial promise will have had its rejection suppressed by the other promises.
                 var secondPreservedPromise = preservedPromise.Preserve();
                 preservedPromise.Forget();
-                Assert.IsFalse(secondPreservedPromise.Wait(System.TimeSpan.FromMilliseconds(timeout)));
+                Assert.IsFalse(secondPreservedPromise.TryWait(System.TimeSpan.FromMilliseconds(timeout)));
 
                 secondPreservedPromise.Forget();
                 deferred.Reject(expectedRejectionValue);
@@ -1033,13 +1033,13 @@ namespace ProtoPromiseTests.APIs
                 foreach (var promise in TestHelper.GetTestablePromises(preservedPromise))
                 {
                     ++expectedCount;
-                    Assert.IsFalse(promise.WaitForResult(System.TimeSpan.FromMilliseconds(timeout), out outResult));
+                    Assert.IsFalse(promise.TryWaitForResult(System.TimeSpan.FromMilliseconds(timeout), out outResult));
                 }
 
                 // Run it again with a freshly preserved promise, because the initial promise will have had its rejection suppressed by the other promises.
                 var secondPreservedPromise = preservedPromise.Preserve();
                 preservedPromise.Forget();
-                Assert.IsFalse(secondPreservedPromise.WaitForResult(System.TimeSpan.FromMilliseconds(timeout), out outResult));
+                Assert.IsFalse(secondPreservedPromise.TryWaitForResult(System.TimeSpan.FromMilliseconds(timeout), out outResult));
 
                 secondPreservedPromise.Forget();
                 deferred.Reject(expectedRejectionValue);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/AsyncLazyConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/AsyncLazyConcurrencyTests.cs
@@ -1,4 +1,6 @@
-﻿#if !PROTO_PROMISE_PROGRESS_DISABLE
+﻿#if !UNITY_WEBGL
+
+#if !PROTO_PROMISE_PROGRESS_DISABLE
 #define PROMISE_PROGRESS
 #else
 #undef PROMISE_PROGRESS
@@ -204,3 +206,5 @@ namespace ProtoPromiseTests.Concurrency
 #endif
     }
 }
+
+#endif // !UNITY_WEBGL

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/Threading/AsyncAutoResetEventConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/Threading/AsyncAutoResetEventConcurrencyTests.cs
@@ -1,4 +1,6 @@
-﻿#if !PROTO_PROMISE_PROGRESS_DISABLE
+﻿#if !UNITY_WEBGL
+
+#if !PROTO_PROMISE_PROGRESS_DISABLE
 #define PROMISE_PROGRESS
 #else
 #undef PROMISE_PROGRESS
@@ -99,7 +101,7 @@ namespace ProtoPromiseTests.Concurrency.Threading
             CancelationSource cancelationSource = default(CancelationSource);
             Action parallelAction = () =>
             {
-                mre.Wait(cancelationSource.Token);
+                mre.TryWait(cancelationSource.Token);
                 Interlocked.Increment(ref invokedCount);
             };
 
@@ -134,7 +136,7 @@ namespace ProtoPromiseTests.Concurrency.Threading
             CancelationSource cancelationSource = default(CancelationSource);
             Action parallelAction = () =>
             {
-                mre.Wait(cancelationSource.Token);
+                mre.TryWait(cancelationSource.Token);
                 Interlocked.Increment(ref invokedCount);
             };
 
@@ -250,7 +252,7 @@ namespace ProtoPromiseTests.Concurrency.Threading
             CancelationSource cancelationSource = default(CancelationSource);
             Action parallelAction = () =>
             {
-                mre.WaitAsync(cancelationSource.Token)
+                mre.TryWaitAsync(cancelationSource.Token)
                     .Then(() => Interlocked.Increment(ref invokedCount))
                     .Forget();
             };
@@ -286,7 +288,7 @@ namespace ProtoPromiseTests.Concurrency.Threading
             CancelationSource cancelationSource = default(CancelationSource);
             Action parallelAction = () =>
             {
-                mre.WaitAsync(cancelationSource.Token)
+                mre.TryWaitAsync(cancelationSource.Token)
                     .Then(() => Interlocked.Increment(ref invokedCount))
                     .Forget();
             };
@@ -317,3 +319,5 @@ namespace ProtoPromiseTests.Concurrency.Threading
         }
     }
 }
+
+#endif // !UNITY_WEBGL

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/Threading/AsyncLockConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/Threading/AsyncLockConcurrencyTests.cs
@@ -1,4 +1,7 @@
-﻿using NUnit.Framework;
+﻿#if !UNITY_WEBGL
+
+using NUnit.Framework;
+using Proto.Promises;
 using Proto.Promises.Threading;
 using System;
 using System.Threading;
@@ -21,41 +24,53 @@ namespace ProtoPromiseTests.Concurrency.Threading
         }
 
         [Test]
-        public void AsyncLock_EnteredConcurrenctly_OnlyAllowsSingleLocker()
+        public void AsyncLock_EnteredConcurrenctly_OnlyAllowsSingleLocker([Values] bool delayCancel)
         {
             var mutex = new AsyncLock();
+            var cancelationSource = default(CancelationSource);
             int enteredCount = 0;
             int exitedCount = 0;
             int expectedInvokes = ThreadHelper.GetExpandCount(4) * 4;
-            Action syncLockAction = () =>
+            Action<bool> syncLockAction = observeCancelation =>
             {
-                using (mutex.Lock())
+                try
                 {
-                    Assert.AreEqual(1, Interlocked.Increment(ref enteredCount));
-                    Thread.Sleep(10);
-                    Assert.AreEqual(0, Interlocked.Decrement(ref enteredCount));
+                    using (observeCancelation ? mutex.Lock(cancelationSource.Token) : mutex.Lock())
+                    {
+                        Assert.AreEqual(1, Interlocked.Increment(ref enteredCount));
+                        Thread.Sleep(10);
+                        Assert.AreEqual(0, Interlocked.Decrement(ref enteredCount));
+                    }
                 }
-                Interlocked.Increment(ref exitedCount);
+                catch (CanceledException) { }
+                finally
+                {
+                    Interlocked.Increment(ref exitedCount);
+                }
             };
-            Action asyncLockAction = () =>
+            Action<bool> asyncLockAction = observeCancelation =>
             {
-                mutex.LockAsync()
+                (observeCancelation ? mutex.LockAsync(cancelationSource.Token) : mutex.LockAsync())
                     .Then(key =>
                     {
                         Assert.AreEqual(1, Interlocked.Increment(ref enteredCount));
                         Thread.Sleep(10);
                         Assert.AreEqual(0, Interlocked.Decrement(ref enteredCount));
                         key.Dispose();
+                    })
+                    .Finally(() =>
+                    {
                         Interlocked.Increment(ref exitedCount);
                     })
                     .Forget();
             };
 
-            new ThreadHelper().ExecuteParallelActionsWithOffsets(true, // Repeat the parallel actions for as many available hardware threads.
+            new ThreadHelper().ExecuteParallelActionsWithOffsets(false,
                 // setup
                 () =>
                 {
                     exitedCount = 0;
+                    cancelationSource = CancelationSource.New();
                 },
                 // teardown
                 () =>
@@ -64,13 +79,121 @@ namespace ProtoPromiseTests.Concurrency.Threading
                     {
                         TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
                     }
+                    cancelationSource.Dispose();
                 },
-                // parallel actions, repeated to generate offsets
-                syncLockAction,
-                syncLockAction,
-                asyncLockAction,
-                asyncLockAction);
+                // parallel actions
+                () => syncLockAction(false),
+                () => syncLockAction(true),
+                () => asyncLockAction(false),
+                () => asyncLockAction(true),
+                () =>
+                {
+                    if (delayCancel)
+                    {
+                        Thread.Sleep(10);
+                    }
+                    cancelationSource.Cancel();
+                });
+        }
+
+        [Test]
+        public void AsyncLock_OnlyAllowsSingleLocker_WithWait([Values] bool delayCancel)
+        {
+            var mutex = new AsyncLock();
+            var cancelationSource = default(CancelationSource);
+            int enteredCount = 0;
+            int exitedCount = 0;
+            int expectedInvokes = ThreadHelper.GetExpandCount(4) * 4;
+            Action<bool> syncLockAction = observeCancelation =>
+            {
+                using (var key = mutex.Lock())
+                {
+                    Assert.AreEqual(1, Interlocked.Increment(ref enteredCount));
+                    Thread.Sleep(10);
+                    Assert.AreEqual(0, Interlocked.Decrement(ref enteredCount));
+
+                    if (observeCancelation)
+                    {
+                        AsyncMonitor.TryWait(key, cancelationSource.Token);
+                    }
+                    else
+                    {
+                        AsyncMonitor.Wait(key);
+                    }
+
+                    Assert.AreEqual(1, Interlocked.Increment(ref enteredCount));
+                    Thread.Sleep(10);
+                    Assert.AreEqual(0, Interlocked.Decrement(ref enteredCount));
+                }
+                Interlocked.Increment(ref exitedCount);
+            };
+            Action<bool> asyncLockAction = observeCancelation =>
+            {
+                Promise.Run(async () =>
+                {
+                    using (var key = await mutex.LockAsync())
+                    {
+                        Assert.AreEqual(1, Interlocked.Increment(ref enteredCount));
+                        Thread.Sleep(10);
+                        Assert.AreEqual(0, Interlocked.Decrement(ref enteredCount));
+
+                        if (observeCancelation)
+                        {
+                            await AsyncMonitor.TryWaitAsync(key, cancelationSource.Token);
+                        }
+                        else
+                        {
+                            await AsyncMonitor.WaitAsync(key);
+                        }
+
+                        Assert.AreEqual(1, Interlocked.Increment(ref enteredCount));
+                        Thread.Sleep(10);
+                        Assert.AreEqual(0, Interlocked.Decrement(ref enteredCount));
+                    }
+                    Interlocked.Increment(ref exitedCount);
+                }, SynchronizationOption.Synchronous)
+                    .Forget();
+            };
+
+            new ThreadHelper().ExecuteParallelActionsWithOffsets(false,
+                // setup
+                () =>
+                {
+                    exitedCount = 0;
+                    cancelationSource = CancelationSource.New();
+                },
+                // teardown
+                () =>
+                {
+                    cancelationSource.Dispose();
+                },
+                // parallel actions
+                () => syncLockAction(false),
+                () => syncLockAction(true),
+                () => asyncLockAction(false),
+                () => asyncLockAction(true),
+                () =>
+                {
+                    if (!delayCancel)
+                    {
+                        cancelationSource.Cancel();
+                    }
+                    // We pulse until all actions are complete.
+                    while (exitedCount < expectedInvokes)
+                    {
+                        using (var key = mutex.Lock())
+                        {
+                            AsyncMonitor.Pulse(key);
+                        }
+                        if (delayCancel && exitedCount != 0)
+                        {
+                            cancelationSource.TryCancel();
+                        }
+                    }
+                });
         }
     }
 #endif // UNITY_2021_2_OR_NEWER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP
 }
+
+#endif // !UNITY_WEBGL

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/Threading/AsyncManualResetEventConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/Threading/AsyncManualResetEventConcurrencyTests.cs
@@ -1,4 +1,6 @@
-﻿#if !PROTO_PROMISE_PROGRESS_DISABLE
+﻿#if !UNITY_WEBGL
+
+#if !PROTO_PROMISE_PROGRESS_DISABLE
 #define PROMISE_PROGRESS
 #else
 #undef PROMISE_PROGRESS
@@ -96,7 +98,7 @@ namespace ProtoPromiseTests.Concurrency.Threading
             CancelationSource cancelationSource = default(CancelationSource);
             Action parallelAction = () =>
             {
-                mre.Wait(cancelationSource.Token);
+                mre.TryWait(cancelationSource.Token);
                 Interlocked.Increment(ref invokedCount);
             };
 
@@ -130,7 +132,7 @@ namespace ProtoPromiseTests.Concurrency.Threading
             CancelationSource cancelationSource = default(CancelationSource);
             Action parallelAction = () =>
             {
-                mre.Wait(cancelationSource.Token);
+                mre.TryWait(cancelationSource.Token);
                 Interlocked.Increment(ref invokedCount);
             };
 
@@ -231,7 +233,7 @@ namespace ProtoPromiseTests.Concurrency.Threading
             CancelationSource cancelationSource = default(CancelationSource);
             Action parallelAction = () =>
             {
-                mre.WaitAsync(cancelationSource.Token)
+                mre.TryWaitAsync(cancelationSource.Token)
                     .Then(() => Interlocked.Increment(ref invokedCount))
                     .Forget();
             };
@@ -266,7 +268,7 @@ namespace ProtoPromiseTests.Concurrency.Threading
             CancelationSource cancelationSource = default(CancelationSource);
             Action parallelAction = () =>
             {
-                mre.WaitAsync(cancelationSource.Token)
+                mre.TryWaitAsync(cancelationSource.Token)
                     .Then(() => Interlocked.Increment(ref invokedCount))
                     .Forget();
             };
@@ -297,3 +299,5 @@ namespace ProtoPromiseTests.Concurrency.Threading
         }
     }
 }
+
+#endif // !UNITY_WEBGL

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/Threading/AsyncReaderWriterLockConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/Threading/AsyncReaderWriterLockConcurrencyTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿#if !UNITY_WEBGL
+
+using NUnit.Framework;
 using Proto.Promises;
 using Proto.Promises.Threading;
 using System;
@@ -283,3 +285,5 @@ namespace ProtoPromiseTests.Concurrency.Threading
     }
 #endif // UNITY_2021_2_OR_NEWER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP
 }
+
+#endif // !UNITY_WEBGL


### PR DESCRIPTION
Fixes #211.

Added `Try`-prefixed methods, deprecated non-try versions.
Added more `AsyncLock` concurrency tests.