### PR TITLE
Deprecate `Promise.NewDeferred(CancelationToken)`

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Deferred.cs
@@ -395,14 +395,23 @@ namespace Proto.Promises
 
             /// <summary>
             /// Returns a new <see cref="Deferred"/> instance that is linked to and controls the state of a new <see cref="Promises.Promise"/>.
+            /// </summary>
+            [MethodImpl(Internal.InlineOption)]
+            public static Deferred New()
+            {
+                var promise = Internal.PromiseRefBase.DeferredPromise<Internal.VoidResult>.GetOrCreate();
+                return new Deferred(promise, promise.Id, promise.DeferredId);
+            }
+
+            /// <summary>
+            /// Returns a new <see cref="Deferred"/> instance that is linked to and controls the state of a new <see cref="Promises.Promise"/>.
             /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Deferred"/> is pending, it and the <see cref="Promises.Promise"/> will be canceled.
             /// </summary>
             [MethodImpl(Internal.InlineOption)]
-            public static Deferred New(CancelationToken cancelationToken = default(CancelationToken))
+            [Obsolete("You should instead register a callback on the CancelationToken to cancel the deferred directly.", false), EditorBrowsable(EditorBrowsableState.Never)]
+            public static Deferred New(CancelationToken cancelationToken)
             {
-                Internal.PromiseRefBase.DeferredPromise<Internal.VoidResult> promise = cancelationToken.CanBeCanceled
-                    ? Internal.PromiseRefBase.DeferredPromiseCancel<Internal.VoidResult>.GetOrCreate(cancelationToken)
-                    : Internal.PromiseRefBase.DeferredPromise<Internal.VoidResult>.GetOrCreate();
+                var promise = Internal.PromiseRefBase.DeferredPromiseCancel<Internal.VoidResult>.GetOrCreate(cancelationToken);
                 return new Deferred(promise, promise.Id, promise.DeferredId);
             }
 
@@ -706,13 +715,23 @@ namespace Proto.Promises
 
             /// <summary>
             /// Returns a new <see cref="Deferred"/> instance that is linked to and controls the state of a new <see cref="Promises.Promise"/>.
+            /// </summary>
+            [MethodImpl(Internal.InlineOption)]
+            public static Deferred New()
+            {
+                var promise = Internal.PromiseRefBase.DeferredPromise<T>.GetOrCreate();
+                return new Deferred(promise, promise.Id, promise.DeferredId);
+            }
+
+            /// <summary>
+            /// Returns a new <see cref="Deferred"/> instance that is linked to and controls the state of a new <see cref="Promises.Promise"/>.
             /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Deferred"/> is pending, it and the <see cref="Promises.Promise"/> will be canceled.
             /// </summary>
-            public static Deferred New(CancelationToken cancelationToken = default(CancelationToken))
+            [MethodImpl(Internal.InlineOption)]
+            [Obsolete("You should instead register a callback on the CancelationToken to cancel the deferred directly.", false), EditorBrowsable(EditorBrowsableState.Never)]
+            public static Deferred New(CancelationToken cancelationToken)
             {
-                Internal.PromiseRefBase.DeferredPromise<T> promise = cancelationToken.CanBeCanceled
-                    ? Internal.PromiseRefBase.DeferredPromiseCancel<T>.GetOrCreate(cancelationToken)
-                    : Internal.PromiseRefBase.DeferredPromise<T>.GetOrCreate();
+                var promise = Internal.PromiseRefBase.DeferredPromiseCancel<T>.GetOrCreate(cancelationToken);
                 return new Deferred(promise, promise.Id, promise.DeferredId);
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
@@ -605,7 +605,7 @@ namespace Proto.Promises
             return Internal.CreateCanceled();
         }
 
-        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Cancelation reasons are no longer supported. Use Canceled() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise Canceled<TCancel>(TCancel reason)
         {
             throw new InvalidOperationException("Cancelation reasons are no longer supported. Use Canceled() instead.", Internal.GetFormattedStacktrace(1));
@@ -619,7 +619,7 @@ namespace Proto.Promises
             return Promise<T>.Canceled();
         }
 
-        [Obsolete("Cancelation reasons are no longer supported. Use Cancel() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Cancelation reasons are no longer supported. Use Canceled() instead.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<T> Canceled<T, TCancel>(TCancel reason)
         {
             return Promise<T>.Canceled(reason);
@@ -627,20 +627,42 @@ namespace Proto.Promises
 
         /// <summary>
         /// Returns a new <see cref="Deferred"/> instance that is linked to and controls the state of a new <see cref="Promise"/>.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public static Deferred NewDeferred()
+        {
+            return Deferred.New();
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="Deferred"/> instance that is linked to and controls the state of a new <see cref="Promise"/>.
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Deferred"/> is pending, it and the <see cref="Promise"/> will be canceled.
         /// </summary>
-        public static Deferred NewDeferred(CancelationToken cancelationToken = default(CancelationToken))
+        [MethodImpl(Internal.InlineOption)]
+        [Obsolete("You should instead register a callback on the CancelationToken to cancel the deferred directly.", false), EditorBrowsable(EditorBrowsableState.Never)]
+        public static Deferred NewDeferred(CancelationToken cancelationToken)
         {
             return Deferred.New(cancelationToken);
         }
 
         /// <summary>
         /// Returns a <see cref="Promise{T}.Deferred"/> object that is linked to and controls the state of a new <see cref="Promise{T}"/>.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public static Promise<T>.Deferred NewDeferred<T>()
+        {
+            return Promise<T>.Deferred.New();
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Promise{T}.Deferred"/> object that is linked to and controls the state of a new <see cref="Promise{T}"/>.
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Promise{T}.Deferred"/> is pending, it and the <see cref="Promise{T}"/> will be canceled.
         /// </summary>
-        public static Promise<T>.Deferred NewDeferred<T>(CancelationToken cancelationToken = default(CancelationToken))
+        [MethodImpl(Internal.InlineOption)]
+        [Obsolete("You should instead register a callback on the CancelationToken to cancel the deferred directly.", false), EditorBrowsable(EditorBrowsableState.Never)]
+        public static Promise<T>.Deferred NewDeferred<T>(CancelationToken cancelationToken)
         {
-            return Promise<T>.NewDeferred(cancelationToken);
+            return Promise<T>.Deferred.New(cancelationToken);
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseTStatic.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Proto.Promises
@@ -957,9 +958,20 @@ namespace Proto.Promises
 
         /// <summary>
         /// Returns a <see cref="Promise{T}.Deferred"/> object that is linked to and controls the state of a new <see cref="Promise{T}"/>.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public static Deferred NewDeferred()
+        {
+            return Deferred.New();
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Promise{T}.Deferred"/> object that is linked to and controls the state of a new <see cref="Promise{T}"/>.
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while the <see cref="Promise{T}.Deferred"/> is pending, it and the <see cref="Promise{T}"/> will be canceled with its reason.
         /// </summary>
-        public static Deferred NewDeferred(CancelationToken cancelationToken = default(CancelationToken))
+        [MethodImpl(Internal.InlineOption)]
+        [Obsolete("You should instead register a callback on the CancelationToken to cancel the deferred directly.", false), EditorBrowsable(EditorBrowsableState.Never)]
+        public static Deferred NewDeferred(CancelationToken cancelationToken)
         {
             return Deferred.New(cancelationToken);
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/AllTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/AllTests.cs
@@ -368,7 +368,8 @@ namespace ProtoPromiseTests.APIs
         {
             CancelationSource cancelationSource = CancelationSource.New();
 
-            var deferred1 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred();
 
             bool canceled = false;
@@ -394,7 +395,8 @@ namespace ProtoPromiseTests.APIs
         {
             CancelationSource cancelationSource = CancelationSource.New();
 
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred<int>();
 
             bool canceled = false;
@@ -420,7 +422,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred2);
 
             bool canceled = false;
 
@@ -445,7 +448,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred<int>();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred2);
 
             bool canceled = false;
 
@@ -471,8 +475,10 @@ namespace ProtoPromiseTests.APIs
             CancelationSource cancelationSource1 = CancelationSource.New();
             CancelationSource cancelationSource2 = CancelationSource.New();
 
-            var deferred1 = Promise.NewDeferred(cancelationSource1.Token);
-            var deferred2 = Promise.NewDeferred(cancelationSource2.Token);
+            var deferred1 = Promise.NewDeferred();
+            cancelationSource1.Token.Register(deferred1);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource2.Token.Register(deferred2);
 
             bool canceled = false;
 
@@ -499,8 +505,10 @@ namespace ProtoPromiseTests.APIs
             CancelationSource cancelationSource1 = CancelationSource.New();
             CancelationSource cancelationSource2 = CancelationSource.New();
 
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource1.Token);
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource2.Token);
+            var deferred1 = Promise.NewDeferred<int>();
+            cancelationSource1.Token.Register(deferred1);
+            var deferred2 = Promise.NewDeferred<int>();
+            cancelationSource2.Token.Register(deferred2);
 
             bool canceled = false;
 
@@ -897,7 +905,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred();
             var cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred2);
             var deferred3 = Promise.NewDeferred();
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);
@@ -924,7 +933,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred<int>();
             var cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred2);
             var deferred3 = Promise.NewDeferred<int>();
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/AsyncFunctionTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/AsyncFunctionTests.cs
@@ -278,7 +278,8 @@ namespace ProtoPromiseTests.APIs
         public void AsyncPromiseIsCanceledFromPromise1()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             //System.Diagnostics.Debugger.Launch();
             bool canceled = false;
@@ -306,7 +307,8 @@ namespace ProtoPromiseTests.APIs
         public void AsyncPromiseIsCanceledFromPromise2()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
 
             bool canceled = false;
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/AwaitTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/AwaitTests.cs
@@ -218,7 +218,8 @@ namespace ProtoPromiseTests.APIs
         public void CancelAwaitedPromiseThrowsOperationCanceled_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             bool continued = false;
 
@@ -247,7 +248,8 @@ namespace ProtoPromiseTests.APIs
         public void CancelAwaitedPromiseThrowsOperationCanceled_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
 
             bool continued = false;
 
@@ -536,7 +538,8 @@ namespace ProtoPromiseTests.APIs
         public void CancelDoubleAwaitedPromiseThrowsOperationCanceled_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
             var promise = deferred.Promise.Preserve();
 
             int continuedCount = 0;
@@ -568,7 +571,8 @@ namespace ProtoPromiseTests.APIs
         public void CancelDoubleAwaitedPromiseThrowsOperationCanceled_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
             var promise = deferred.Promise.Preserve();
 
             int continuedCount = 0;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/CaptureTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/CaptureTests.cs
@@ -646,7 +646,8 @@ namespace ProtoPromiseTests.APIs
             bool invoked = false;
 
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             deferred.Promise
                 .CatchCancelation(expected, cv =>
@@ -670,7 +671,8 @@ namespace ProtoPromiseTests.APIs
             bool invoked = false;
 
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
 
             deferred.Promise
                 .CatchCancelation(expected, cv =>
@@ -780,7 +782,8 @@ namespace ProtoPromiseTests.APIs
         {
             string expected = "expected";
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             bool invoked = false;
 
@@ -803,7 +806,8 @@ namespace ProtoPromiseTests.APIs
         {
             string expected = "expected";
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
 
             bool invoked = false;
 
@@ -940,7 +944,8 @@ namespace ProtoPromiseTests.APIs
         {
             Exception expected = new Exception();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             bool invoked = false;
 
@@ -964,7 +969,8 @@ namespace ProtoPromiseTests.APIs
         {
             Exception expected = new Exception();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
 
             bool invoked = false;
 
@@ -1088,7 +1094,8 @@ namespace ProtoPromiseTests.APIs
         {
             string expected = "expected";
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
             var promise = deferred.Promise.Preserve();
 
             bool invoked = false;
@@ -1113,7 +1120,8 @@ namespace ProtoPromiseTests.APIs
         public void OnContinueWillBeInvokedWithCapturedValue_canceled_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
             var promise = deferred.Promise.Preserve();
 
             string expected = "expected";

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/ContinuewithTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/ContinuewithTests.cs
@@ -283,7 +283,8 @@ namespace ProtoPromiseTests.APIs
         public void OnContinueIsInvokedWhenPromiseIsCanceled_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
             var promise = deferred.Promise.Preserve();
 
             int finallyCount = 0;
@@ -303,7 +304,8 @@ namespace ProtoPromiseTests.APIs
         public void OnContinueIsInvokedWhenPromiseIsCanceled_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
             var promise = deferred.Promise.Preserve();
 
             int finallyCount = 0;
@@ -323,7 +325,8 @@ namespace ProtoPromiseTests.APIs
         public void OnContinueCancelStateWhenPromiseIsCanceled_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
             var promise = deferred.Promise.Preserve();
 
             TestHelper.AddContinueCallbacks<int, string>(promise,
@@ -343,7 +346,8 @@ namespace ProtoPromiseTests.APIs
         public void OnContinueCancelStateWhenPromiseIsCanceled_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
             var promise = deferred.Promise.Preserve();
 
             TestHelper.AddContinueCallbacks<int, int, string>(promise,
@@ -363,7 +367,8 @@ namespace ProtoPromiseTests.APIs
         public void OnContinueRethrowCancelWhenPromiseIsCanceled_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
             var promise = deferred.Promise.Preserve();
 
             int cancelCount = 0;
@@ -388,7 +393,8 @@ namespace ProtoPromiseTests.APIs
         public void OnContinueRethrowCancelReasonWhenPromiseIsCanceled_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
             var promise = deferred.Promise.Preserve();
 
             int cancelCount = 0;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/FinallyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/FinallyTests.cs
@@ -130,7 +130,8 @@ namespace ProtoPromiseTests.APIs
         public void OnFinallyIsInvokedWhenPromiseIsCanceled_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             bool invoked = false;
 
@@ -148,7 +149,8 @@ namespace ProtoPromiseTests.APIs
         public void OnFinallyIsInvokedWhenPromiseIsCanceled_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
 
             bool invoked = false;
 
@@ -281,7 +283,8 @@ namespace ProtoPromiseTests.APIs
         {
             Exception expected = new Exception();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             bool invoked = false;
 
@@ -305,7 +308,8 @@ namespace ProtoPromiseTests.APIs
         {
             Exception expected = new Exception();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
 
             bool invoked = false;
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/FirstTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/FirstTests.cs
@@ -275,7 +275,8 @@ namespace ProtoPromiseTests.APIs
         public void FirstIsResolvedWhenFirstPromiseIsCanceledThenSecondPromiseIsResolved_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred();
 
             bool resolved = false;
@@ -302,7 +303,8 @@ namespace ProtoPromiseTests.APIs
         public void FirstIsResolvedWhenFirstPromiseIsCanceledThenSecondPromiseIsResolved_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred<int>();
 
             bool resolved = false;
@@ -331,7 +333,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred2);
 
             bool resolved = false;
 
@@ -358,7 +361,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred<int>();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred2);
 
             bool resolved = false;
 
@@ -385,9 +389,11 @@ namespace ProtoPromiseTests.APIs
         public void FirstIsCanceledWhenAllPromisesAreCanceled_void()
         {
             CancelationSource cancelationSource1 = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred(cancelationSource1.Token);
+            var deferred1 = Promise.NewDeferred();
+            cancelationSource1.Token.Register(deferred1);
             CancelationSource cancelationSource2 = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource2.Token);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource2.Token.Register(deferred2);
 
             bool canceled = false;
 
@@ -412,9 +418,11 @@ namespace ProtoPromiseTests.APIs
         public void FirstIsCanceledWhenAllPromisesAreCanceled_T()
         {
             CancelationSource cancelationSource1 = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource1.Token);
+            var deferred1 = Promise.NewDeferred<int>();
+            cancelationSource1.Token.Register(deferred1);
             CancelationSource cancelationSource2 = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource2.Token);
+            var deferred2 = Promise.NewDeferred<int>();
+            cancelationSource2.Token.Register(deferred2);
 
             bool canceled = false;
 
@@ -439,7 +447,8 @@ namespace ProtoPromiseTests.APIs
         public void FirstIsRejectededWhenFirstPromiseIsCanceledThenSecondPromiseIsRejected_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred();
 
             bool rejected = false;
@@ -468,7 +477,8 @@ namespace ProtoPromiseTests.APIs
         public void FirstIsRejectededWhenFirstPromiseIsCanceledThenSecondPromiseIsRejected_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred<int>();
 
             bool rejected = false;
@@ -498,7 +508,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred2);
 
             bool rejected = false;
             string expected = "Error";
@@ -527,7 +538,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred<int>();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred2);
 
             bool rejected = false;
             string expected = "Error";
@@ -556,7 +568,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred2);
 
             bool canceled = false;
 
@@ -583,7 +596,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred<int>();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred2);
 
             bool canceled = false;
 
@@ -609,7 +623,8 @@ namespace ProtoPromiseTests.APIs
         public void FirstIsCancelededWhenSecondPromiseIsRejectedThenFirstPromiseIsCanceled_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred();
 
             bool canceled = false;
@@ -636,7 +651,8 @@ namespace ProtoPromiseTests.APIs
         public void FirstIsCancelededWhenSecondPromiseIsRejectedThenFirstPromiseIsCanceled_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred<int>();
 
             bool canceled = false;
@@ -1265,8 +1281,10 @@ namespace ProtoPromiseTests.APIs
         {
             var cancelationSource1 = CancelationSource.New();
             var cancelationSource2 = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred(cancelationSource1.Token);
-            var deferred2 = Promise.NewDeferred(cancelationSource2.Token);
+            var deferred1 = Promise.NewDeferred();
+            cancelationSource1.Token.Register(deferred1);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource2.Token.Register(deferred2);
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);
             Promise.First(deferred1.Promise, deferred2.Promise)
@@ -1290,8 +1308,10 @@ namespace ProtoPromiseTests.APIs
         {
             var cancelationSource1 = CancelationSource.New();
             var cancelationSource2 = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource1.Token);
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource2.Token);
+            var deferred1 = Promise.NewDeferred<int>();
+            cancelationSource1.Token.Register(deferred1);
+            var deferred2 = Promise.NewDeferred<int>();
+            cancelationSource2.Token.Register(deferred2);
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);
             Promise<int>.First(deferred1.Promise, deferred2.Promise)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/MergeTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/MergeTests.cs
@@ -171,7 +171,8 @@ namespace ProtoPromiseTests.APIs
         public void MergePromiseIsCanceledWhenFirstPromiseIsCanceled()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred<string>();
 
             bool canceled = false;
@@ -196,7 +197,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred<int>();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<string>(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred<string>();
+            cancelationSource.Token.Register(deferred2);
 
             bool canceled = false;
 
@@ -219,9 +221,11 @@ namespace ProtoPromiseTests.APIs
         public void MergePromiseIsCanceledWhenBothPromisesAreCanceled()
         {
             CancelationSource cancelationSource1 = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource1.Token);
+            var deferred1 = Promise.NewDeferred<int>();
+            cancelationSource1.Token.Register(deferred1);
             CancelationSource cancelationSource2 = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<string>(cancelationSource2.Token);
+            var deferred2 = Promise.NewDeferred<string>();
+            cancelationSource2.Token.Register(deferred2);
 
             bool canceled = false;
 
@@ -449,7 +453,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred<int>();
             var cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<float>(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred<float>();
+            cancelationSource.Token.Register(deferred2);
             var deferred3 = Promise.NewDeferred<bool>();
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/ProgressTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/ProgressTests.cs
@@ -58,7 +58,8 @@ namespace ProtoPromiseTests.APIs
             [Values] ProgressType progressType)
         {
             var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, SynchronizationType.Foreground, forceAsync: true);
             deferred.Promise
@@ -100,7 +101,8 @@ namespace ProtoPromiseTests.APIs
             [Values] ProgressType progressType)
         {
             var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, SynchronizationType.Foreground, forceAsync: true);
             deferred.Promise
@@ -379,7 +381,8 @@ namespace ProtoPromiseTests.APIs
             [Values] SynchronizationType synchronizationType)
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);
             deferred.Promise
@@ -432,7 +435,8 @@ namespace ProtoPromiseTests.APIs
             [Values] SynchronizationType synchronizationType)
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);
             deferred.Promise
@@ -571,7 +575,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred = Promise.NewDeferred();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred2);
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);
             deferred.Promise
@@ -597,7 +602,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred = Promise.NewDeferred();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred2);
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);
             deferred.Promise

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/PromiseCancelationTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/PromiseCancelationTests.cs
@@ -73,7 +73,8 @@ namespace ProtoPromiseTests.APIs
 
                 state = null;
                 CancelationSource cancelationSource = CancelationSource.New();
-                deferred = Promise.NewDeferred(cancelationSource.Token);
+                deferred = Promise.NewDeferred();
+                cancelationSource.Token.Register(deferred);
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
@@ -90,7 +91,8 @@ namespace ProtoPromiseTests.APIs
 
                 state = null;
                 cancelationSource = CancelationSource.New();
-                deferred = Promise.NewDeferred(cancelationSource.Token);
+                deferred = Promise.NewDeferred();
+                cancelationSource.Token.Register(deferred);
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
@@ -141,7 +143,8 @@ namespace ProtoPromiseTests.APIs
 
                 state = null;
                 CancelationSource cancelationSource = CancelationSource.New();
-                deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                deferred = Promise.NewDeferred<int>();
+                cancelationSource.Token.Register(deferred);
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
@@ -158,7 +161,8 @@ namespace ProtoPromiseTests.APIs
 
                 state = null;
                 cancelationSource = CancelationSource.New();
-                deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                deferred = Promise.NewDeferred<int>();
+                cancelationSource.Token.Register(deferred);
                 Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
@@ -192,8 +196,7 @@ namespace ProtoPromiseTests.APIs
             [Test]
             public void MustNotTransitionToAnyOtherState_void()
             {
-                CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred(cancelationSource.Token);
+                var deferred = Promise.NewDeferred();
 
                 bool resolved = false;
 
@@ -209,19 +212,16 @@ namespace ProtoPromiseTests.APIs
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve());
                 Assert.IsFalse(deferred.TryReject("Fail value"));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
-
-                cancelationSource.Cancel();
+                Assert.IsFalse(deferred.TryCancel());
+                Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Cancel());
 
                 Assert.IsTrue(resolved);
-
-                cancelationSource.Dispose();
             }
 
             [Test]
             public void MustNotTransitionToAnyOtherState_T()
             {
-                CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                var deferred = Promise.NewDeferred<int>();
 
                 bool resolved = false;
 
@@ -237,12 +237,10 @@ namespace ProtoPromiseTests.APIs
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve(1));
                 Assert.IsFalse(deferred.TryReject("Fail value"));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
-
-                cancelationSource.Cancel();
+                Assert.IsFalse(deferred.TryCancel());
+                Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Cancel());
 
                 Assert.IsTrue(resolved);
-
-                cancelationSource.Dispose();
             }
         }
 
@@ -263,8 +261,7 @@ namespace ProtoPromiseTests.APIs
             [Test]
             public void MustNotTransitionToAnyOtherState_void()
             {
-                CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred(cancelationSource.Token);
+                var deferred = Promise.NewDeferred();
 
                 bool rejected = false;
 
@@ -280,19 +277,16 @@ namespace ProtoPromiseTests.APIs
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve());
                 Assert.IsFalse(deferred.TryReject("Fail value"));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
-
-                cancelationSource.Cancel();
+                Assert.IsFalse(deferred.TryCancel());
+                Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Cancel());
 
                 Assert.IsTrue(rejected);
-
-                cancelationSource.Dispose();
             }
 
             [Test]
             public void MustNotTransitionToAnyOtherState_T()
             {
-                CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                var deferred = Promise.NewDeferred<int>();
 
                 bool rejected = false;
 
@@ -308,12 +302,10 @@ namespace ProtoPromiseTests.APIs
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve(1));
                 Assert.IsFalse(deferred.TryReject("Fail value"));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
-
-                cancelationSource.Cancel();
+                Assert.IsFalse(deferred.TryCancel());
+                Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Cancel());
 
                 Assert.IsTrue(rejected);
-
-                cancelationSource.Dispose();
             }
         }
 
@@ -335,7 +327,8 @@ namespace ProtoPromiseTests.APIs
             public void MustNotTransitionToAnyOtherState_void()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred(cancelationSource.Token);
+                var deferred = Promise.NewDeferred();
+                cancelationSource.Token.Register(deferred);
 
                 bool canceled = false;
 
@@ -362,7 +355,8 @@ namespace ProtoPromiseTests.APIs
             public void MustNotTransitionToAnyOtherState_T()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                var deferred = Promise.NewDeferred<int>();
+                cancelationSource.Token.Register(deferred);
 
                 bool canceled = false;
 
@@ -391,7 +385,8 @@ namespace ProtoPromiseTests.APIs
         public void IfOnCanceledIsNullThrow_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
             {
@@ -407,7 +402,8 @@ namespace ProtoPromiseTests.APIs
         public void IfOnCanceledIsNullThrow_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
 
             Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
             {
@@ -439,7 +435,8 @@ namespace ProtoPromiseTests.APIs
             {
                 var canceled = false;
                 CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                var deferred = Promise.NewDeferred<int>();
+                cancelationSource.Token.Register(deferred);
                 var promise = deferred.Promise.Preserve();
 
                 TestHelper.AddCancelCallbacks<float>(promise,
@@ -467,7 +464,8 @@ namespace ProtoPromiseTests.APIs
             {
                 var canceled = false;
                 CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred(cancelationSource.Token);
+                var deferred = Promise.NewDeferred();
+                cancelationSource.Token.Register(deferred);
 
                 TestHelper.AddCancelCallbacks<float>(deferred.Promise,
                     onCancel: () => canceled = true
@@ -487,7 +485,8 @@ namespace ProtoPromiseTests.APIs
             {
                 var canceled = false;
                 CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                var deferred = Promise.NewDeferred<int>();
+                cancelationSource.Token.Register(deferred);
 
                 TestHelper.AddCancelCallbacks<int, float>(deferred.Promise,
                     onCancel: () => canceled = true
@@ -506,7 +505,8 @@ namespace ProtoPromiseTests.APIs
             public void ItMustNotBeCalledMoreThanOnce_void()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred(cancelationSource.Token);
+                var deferred = Promise.NewDeferred();
+                cancelationSource.Token.Register(deferred);
                 var cancelCount = 0;
 
                 TestHelper.AddCancelCallbacks<float>(deferred.Promise,
@@ -528,7 +528,8 @@ namespace ProtoPromiseTests.APIs
             public void ItMustNotBeCalledMoreThanOnce_T()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                var deferred = Promise.NewDeferred<int>();
+                cancelationSource.Token.Register(deferred);
                 var cancelCount = 0;
 
                 TestHelper.AddCancelCallbacks<int, float>(deferred.Promise,
@@ -551,7 +552,8 @@ namespace ProtoPromiseTests.APIs
         public void OnCanceledMustNotBeCalledUntilTheExecutionContextStackContainsOnlyPlatformCode_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             bool canceled = false;
             TestHelper.AddCancelCallbacks<float>(deferred.Promise,
@@ -572,7 +574,8 @@ namespace ProtoPromiseTests.APIs
         public void OnCanceledMustNotBeCalledUntilTheExecutionContextStackContainsOnlyPlatformCode_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
 
             bool canceled = false;
             TestHelper.AddCancelCallbacks<int, float>(deferred.Promise,
@@ -607,7 +610,8 @@ namespace ProtoPromiseTests.APIs
             public void IfWhenPromiseCancelationIsCanceled_AllRespectiveOnCanceledCallbacksMustExecuteInTheOrderOfTheirOriginatingCallsToCatchCancelation_void()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred(cancelationSource.Token);
+                var deferred = Promise.NewDeferred();
+                cancelationSource.Token.Register(deferred);
                 var promise = deferred.Promise.Preserve();
 
                 int counter = 0;
@@ -632,7 +636,8 @@ namespace ProtoPromiseTests.APIs
             public void IfWhenPromiseCancelationIsCanceled_AllRespectiveOnCanceledCallbacksMustExecuteInTheOrderOfTheirOriginatingCallsToCatchCancelation_T()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                var deferred = Promise.NewDeferred<int>();
+                cancelationSource.Token.Register(deferred);
                 var promise = deferred.Promise.Preserve();
 
                 int counter = 0;
@@ -1449,7 +1454,8 @@ namespace ProtoPromiseTests.APIs
         public void IfPromiseIsCanceled_OnResolveAndOnRejectedMustNotBeInvoked_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             Action rejectAssert = () => Assert.Fail("Promise was rejected when it should have been canceled.");
 
@@ -1467,7 +1473,8 @@ namespace ProtoPromiseTests.APIs
         public void IfPromiseIsCanceled_OnResolveAndOnRejectedMustNotBeInvoked_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
 
             Action rejectAssert = () => Assert.Fail("Promise was rejected when it should have been canceled.");
 
@@ -1506,7 +1513,8 @@ namespace ProtoPromiseTests.APIs
         public void CancelationsPropagateToBranches()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
 
             bool invoked = false;
 
@@ -1612,7 +1620,8 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
 
-                var deferred = Promise.NewDeferred(cancelationSource.Token);
+                var deferred = Promise.NewDeferred();
+                cancelationSource.Token.Register(deferred);
 
                 deferred.Promise
                     .CatchCancelation(() =>
@@ -1633,7 +1642,8 @@ namespace ProtoPromiseTests.APIs
                 CancelationSource cancelationSource = CancelationSource.New();
                 cancelationSource.Cancel();
 
-                var deferred = Promise.NewDeferred(Proto.Promises.CancelationToken.Canceled());
+                var deferred = Promise.NewDeferred();
+                Proto.Promises.CancelationToken.Canceled().Register(deferred);
 
                 deferred.Promise
                     .CatchCancelation(() =>
@@ -1651,7 +1661,8 @@ namespace ProtoPromiseTests.APIs
             public void OnCanceledIsNotInvokedIfTokenIsCanceled_void0()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred(cancelationSource.Token);
+                var deferred = Promise.NewDeferred();
+                cancelationSource.Token.Register(deferred);
 
                 deferred.Promise
                     .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
@@ -1667,7 +1678,8 @@ namespace ProtoPromiseTests.APIs
             public void OnCanceledIsNotInvokedIfTokenIsCanceled_T0()
             {
                 CancelationSource cancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+                var deferred = Promise.NewDeferred<int>();
+                cancelationSource.Token.Register(deferred);
 
                 deferred.Promise
                     .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), cancelationSource.Token)
@@ -1684,7 +1696,8 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource deferredCancelationSource = CancelationSource.New();
                 CancelationSource catchCancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred(deferredCancelationSource.Token);
+                var deferred = Promise.NewDeferred();
+                deferredCancelationSource.Token.Register(deferred);
 
                 deferred.Promise
                     .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), catchCancelationSource.Token)
@@ -1703,7 +1716,8 @@ namespace ProtoPromiseTests.APIs
             {
                 CancelationSource deferredCancelationSource = CancelationSource.New();
                 CancelationSource catchCancelationSource = CancelationSource.New();
-                var deferred = Promise.NewDeferred<int>(deferredCancelationSource.Token);
+                var deferred = Promise.NewDeferred<int>();
+                deferredCancelationSource.Token.Register(deferred);
 
                 deferred.Promise
                     .CatchCancelation(() => Assert.Fail("OnCanceled was invoked."), catchCancelationSource.Token)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/RaceTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/RaceTests.cs
@@ -229,7 +229,8 @@ namespace ProtoPromiseTests.APIs
         public void RaceIsCanceledWhenFirstPromiseIsCanceledFirst_void()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred();
 
             bool invoked = false;
@@ -256,7 +257,8 @@ namespace ProtoPromiseTests.APIs
         public void RaceIsCanceledWhenFirstPromiseIsCanceledFirst_T()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred<int>();
 
             bool invoked = false;
@@ -284,7 +286,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred2);
 
             bool invoked = false;
 
@@ -311,7 +314,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred<int>();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred2);
 
             bool invoked = false;
 
@@ -941,7 +945,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred();
             var cancelationSource1 = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource1.Token);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource1.Token.Register(deferred2);
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);
             Promise.Race(deferred1.Promise, deferred2.Promise)
@@ -966,7 +971,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred<int>();
             var cancelationSource1 = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>(cancelationSource1.Token);
+            var deferred2 = Promise.NewDeferred<int>();
+            cancelationSource1.Token.Register(deferred2);
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);
             Promise<int>.Race(deferred1.Promise, deferred2.Promise)

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/SequenceTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/SequenceTests.cs
@@ -173,7 +173,8 @@ namespace ProtoPromiseTests.APIs
         public void SequencePromiseIsCanceledWhenFirstPromiseIsCanceled()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred();
 
             bool invoked = false;
@@ -201,7 +202,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred();
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred2);
 
             bool invoked = false;
 
@@ -226,7 +228,8 @@ namespace ProtoPromiseTests.APIs
         public void SequenceDelegatesStopGettingInvokedWhenAPromiseIsCanceled()
         {
             CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred1 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred1);
             var deferred2 = Promise.NewDeferred();
 
             int invokes = 0;
@@ -480,7 +483,8 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred1 = Promise.NewDeferred();
             var cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred(cancelationSource.Token);
+            var deferred2 = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred2);
             var deferred3 = Promise.NewDeferred();
             var deferred4 = Promise.NewDeferred();
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/DeferredConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/DeferredConcurrencyTests.cs
@@ -30,10 +30,8 @@ namespace ProtoPromiseTests.Concurrency
         [Test]
         public void DeferredReportProgressMayBeCalledConcurrently_void(
             [Values] ProgressType progressType,
-            [Values] SynchronizationType synchronizationType,
-            [Values] bool withCancelationToken)
+            [Values] SynchronizationType synchronizationType)
         {
-            var cancelationSource = CancelationSource.New();
             var deferred = default(Promise.Deferred);
 
             var progressHelper = default(ProgressHelper);
@@ -43,9 +41,7 @@ namespace ProtoPromiseTests.Concurrency
                 // Setup
                 () =>
                 {
-                    deferred = withCancelationToken
-                        ? Promise.NewDeferred(cancelationSource.Token)
-                        : Promise.NewDeferred();
+                    deferred = Promise.NewDeferred();
                     progressHelper = new ProgressHelper(progressType, synchronizationType);
 
                     deferred.Promise
@@ -72,17 +68,13 @@ namespace ProtoPromiseTests.Concurrency
                 () => deferred.ReportProgress(0.3f),
                 () => deferred.ReportProgress(0.4f)
             );
-
-            cancelationSource.Dispose();
         }
 
         [Test]
         public void DeferredReportProgressMayBeCalledConcurrently_T(
             [Values] ProgressType progressType,
-            [Values] SynchronizationType synchronizationType,
-            [Values] bool withCancelationToken)
+            [Values] SynchronizationType synchronizationType)
         {
-            var cancelationSource = CancelationSource.New();
             var deferred = default(Promise<int>.Deferred);
 
             var progressHelper = default(ProgressHelper);
@@ -92,9 +84,7 @@ namespace ProtoPromiseTests.Concurrency
                 // Setup
                 () =>
                 {
-                    deferred = withCancelationToken
-                        ? Promise.NewDeferred<int>(cancelationSource.Token)
-                        : Promise.NewDeferred<int>();
+                    deferred = Promise.NewDeferred<int>();
                     progressHelper = new ProgressHelper(progressType, synchronizationType);
 
                     deferred.Promise
@@ -121,13 +111,11 @@ namespace ProtoPromiseTests.Concurrency
                 () => deferred.ReportProgress(0.3f),
                 () => deferred.ReportProgress(0.4f)
             );
-         
-            cancelationSource.Dispose();
         }
 #endif
 
         [Test]
-        public void DeferredResolveMayNotBeCalledConcurrently_void0()
+        public void DeferredResolveMayNotBeCalledConcurrently_void()
         {
             int invokedCount = 0;
             var deferred = Promise.NewDeferred();
@@ -150,33 +138,7 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
-        public void DeferredResolveMayNotBeCalledConcurrently_void1()
-        {
-            int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
-            deferred.Promise
-                .Then(() => { Interlocked.Increment(ref invokedCount); })
-                .Forget();
-            int failedTryResolveCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() =>
-            {
-                if (!deferred.TryResolve())
-                {
-                    Interlocked.Increment(ref failedTryResolveCount);
-                }
-            });
-
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
-            Assert.AreEqual(1, invokedCount);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void DeferredResolveMayNotBeCalledConcurrently_T0()
+        public void DeferredResolveMayNotBeCalledConcurrently_T()
         {
             int invokedCount = 0;
             var deferred = Promise.NewDeferred<int>();
@@ -199,33 +161,7 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
-        public void DeferredResolveMayNotBeCalledConcurrently_T1()
-        {
-            int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-            deferred.Promise
-                .Then(v => { Interlocked.Increment(ref invokedCount); })
-                .Forget();
-            int failedTryResolveCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() =>
-            {
-                if (!deferred.TryResolve(1))
-                {
-                    Interlocked.Increment(ref failedTryResolveCount);
-                }
-            });
-
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
-            Assert.AreEqual(1, invokedCount);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void DeferredRejectMayNotBeCalledConcurrently_void0()
+        public void DeferredRejectMayNotBeCalledConcurrently_void()
         {
             int invokedCount = 0;
             var deferred = Promise.NewDeferred();
@@ -248,33 +184,7 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
-        public void DeferredRejectMayNotBeCalledConcurrently_void1()
-        {
-            int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
-            deferred.Promise
-                .Catch(() => { Interlocked.Increment(ref invokedCount); })
-                .Forget();
-            int failedTryResolveCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() =>
-            {
-                if (!deferred.TryReject("Reject"))
-                {
-                    Interlocked.Increment(ref failedTryResolveCount);
-                }
-            });
-
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
-            Assert.AreEqual(1, invokedCount);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void DeferredRejectMayNotBeCalledConcurrently_T0()
+        public void DeferredRejectMayNotBeCalledConcurrently_T()
         {
             int invokedCount = 0;
             var deferred = Promise.NewDeferred<int>();
@@ -297,33 +207,7 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
-        public void DeferredRejectMayNotBeCalledConcurrently_T1()
-        {
-            int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-            deferred.Promise
-                .Catch(() => { Interlocked.Increment(ref invokedCount); })
-                .Forget();
-            int failedTryResolveCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() =>
-            {
-                if (!deferred.TryReject("Reject"))
-                {
-                    Interlocked.Increment(ref failedTryResolveCount);
-                }
-            });
-
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
-            Assert.AreEqual(1, invokedCount);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void DeferredCancelMayNotBeCalledConcurrently_void0()
+        public void DeferredCancelMayNotBeCalledConcurrently_void()
         {
             int invokedCount = 0;
             var deferred = Promise.NewDeferred();
@@ -346,33 +230,7 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
-        public void DeferredCancelMayNotBeCalledConcurrently_void1()
-        {
-            int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
-            deferred.Promise
-                .CatchCancelation(() => { Interlocked.Increment(ref invokedCount); })
-                .Forget();
-            int failedTryResolveCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() =>
-            {
-                if (!deferred.TryCancel())
-                {
-                    Interlocked.Increment(ref failedTryResolveCount);
-                }
-            });
-
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
-            Assert.AreEqual(1, invokedCount);
-
-            cancelationSource.Dispose();
-        }
-
-        [Test]
-        public void DeferredCancelMayNotBeCalledConcurrently_T0()
+        public void DeferredCancelMayNotBeCalledConcurrently_T()
         {
             int invokedCount = 0;
             var deferred = Promise.NewDeferred<int>();
@@ -392,43 +250,15 @@ namespace ProtoPromiseTests.Concurrency
 
             Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
             Assert.AreEqual(1, invokedCount);
-        }
-
-        [Test]
-        public void DeferredCancelMayNotBeCalledConcurrently_T1()
-        {
-            int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-            deferred.Promise
-                .CatchCancelation(() => { Interlocked.Increment(ref invokedCount); })
-                .Forget();
-            int failedTryResolveCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() =>
-            {
-                if (!deferred.TryCancel())
-                {
-                    Interlocked.Increment(ref failedTryResolveCount);
-                }
-            });
-
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
-            Assert.AreEqual(1, invokedCount);
-
-            cancelationSource.Dispose();
         }
 
 #if PROMISE_PROGRESS
         [Test]
         public void DeferredMayReportProgressAndPromiseMaySubscribeProgressConcurrently_void(
             [Values] ProgressType progressType,
-            [Values] SynchronizationType synchronizationType,
-            [Values] bool withCancelationToken)
+            [Values] SynchronizationType synchronizationType)
         {
             float expected = 0.1f;
-            var cancelationSource = CancelationSource.New();
             var deferred = default(Promise.Deferred);
             var promise = default(Promise);
 
@@ -439,9 +269,7 @@ namespace ProtoPromiseTests.Concurrency
                 // Setup
                 () =>
                 {
-                    deferred = withCancelationToken
-                        ? Promise.NewDeferred(cancelationSource.Token)
-                        : Promise.NewDeferred();
+                    deferred = Promise.NewDeferred();
                     promise = deferred.Promise;
                     progressHelper = new ProgressHelper(progressType, synchronizationType);
                     progressHelper.MaybeEnterLock();
@@ -466,18 +294,14 @@ namespace ProtoPromiseTests.Concurrency
                 () => deferred.ReportProgress(expected),
                 () => promise.SubscribeProgress(progressHelper).Forget()
             );
-
-            cancelationSource.Dispose();
         }
 
         [Test]
-        public void DeferredMayReportProgressAndPromiseMaySubscribeProgressConcurrently_T0(
+        public void DeferredMayReportProgressAndPromiseMaySubscribeProgressConcurrently_T(
             [Values] ProgressType progressType,
-            [Values] SynchronizationType synchronizationType,
-            [Values] bool withCancelationToken)
+            [Values] SynchronizationType synchronizationType)
         {
             float expected = 0.1f;
-            var cancelationSource = CancelationSource.New();
             var deferred = default(Promise<int>.Deferred);
             var promise = default(Promise);
 
@@ -488,9 +312,7 @@ namespace ProtoPromiseTests.Concurrency
                 // Setup
                 () =>
                 {
-                    deferred = withCancelationToken
-                        ? Promise.NewDeferred<int>(cancelationSource.Token)
-                        : Promise.NewDeferred<int>();
+                    deferred = Promise.NewDeferred<int>();
                     promise = deferred.Promise;
                     progressHelper = new ProgressHelper(progressType, synchronizationType);
                     progressHelper.MaybeEnterLock();
@@ -515,13 +337,11 @@ namespace ProtoPromiseTests.Concurrency
                 () => deferred.ReportProgress(expected),
                 () => promise.SubscribeProgress(progressHelper).Forget()
             );
-
-            cancelationSource.Dispose();
         }
 #endif
 
         [Test]
-        public void DeferredMayBeResolvedAndPromiseAwaitedConcurrently_void0()
+        public void DeferredMayBeResolvedAndPromiseAwaitedConcurrently_void()
         {
             var deferred = default(Promise.Deferred);
             var promise = default(Promise);
@@ -549,38 +369,7 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
-        public void DeferredMayBeResolvedAndPromiseAwaitedConcurrently_void1()
-        {
-            var cancelationSource = default(CancelationSource);
-            var deferred = default(Promise.Deferred);
-            var promise = default(Promise);
-
-            int invokedCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteParallelActionsWithOffsets(false,
-                // Setup
-                () =>
-                {
-                    invokedCount = 0;
-                    cancelationSource = CancelationSource.New();
-                    deferred = Promise.NewDeferred(cancelationSource.Token);
-                    promise = deferred.Promise;
-                },
-                // Teardown
-                () =>
-                {
-                    cancelationSource.Dispose();
-                    Assert.AreEqual(1, invokedCount);
-                },
-                // Parallel Actions
-                () => deferred.Resolve(),
-                () => promise.Then(() => { Interlocked.Increment(ref invokedCount); }).Forget()
-            );
-        }
-
-        [Test]
-        public void DeferredMayBeResolvedAndPromiseAwaitedConcurrently_T0()
+        public void DeferredMayBeResolvedAndPromiseAwaitedConcurrently_T()
         {
             var deferred = default(Promise<int>.Deferred);
             var promise = default(Promise<int>);
@@ -608,38 +397,7 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
-        public void DeferredMayBeResolvedAndPromiseAwaitedConcurrently_T1()
-        {
-            var cancelationSource = default(CancelationSource);
-            var deferred = default(Promise<int>.Deferred);
-            var promise = default(Promise<int>);
-
-            int invokedCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteParallelActionsWithOffsets(false,
-                // Setup
-                () =>
-                {
-                    invokedCount = 0;
-                    cancelationSource = CancelationSource.New();
-                    deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-                    promise = deferred.Promise;
-                },
-                // Teardown
-                () =>
-                {
-                    cancelationSource.Dispose();
-                    Assert.AreEqual(1, invokedCount);
-                },
-                // Parallel Actions
-                () => deferred.Resolve(1),
-                () => promise.Then(v => { Interlocked.Increment(ref invokedCount); }).Forget()
-            );
-        }
-
-        [Test]
-        public void DeferredMayBeRejectedAndPromiseAwaitedConcurrently_void0()
+        public void DeferredMayBeRejectedAndPromiseAwaitedConcurrently_void()
         {
             var deferred = default(Promise.Deferred);
             var promise = default(Promise);
@@ -667,38 +425,7 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
-        public void DeferredMayBeRejectedAndPromiseAwaitedConcurrently_void1()
-        {
-            var cancelationSource = default(CancelationSource);
-            var deferred = default(Promise.Deferred);
-            var promise = default(Promise);
-
-            int invokedCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteParallelActionsWithOffsets(false,
-                // Setup
-                () =>
-                {
-                    invokedCount = 0;
-                    cancelationSource = CancelationSource.New();
-                    deferred = Promise.NewDeferred(cancelationSource.Token);
-                    promise = deferred.Promise;
-                },
-                // Teardown
-                () =>
-                {
-                    cancelationSource.Dispose();
-                    Assert.AreEqual(1, invokedCount);
-                },
-                // Parallel Actions
-                () => deferred.Reject(1),
-                () => promise.Catch(() => { Interlocked.Increment(ref invokedCount); }).Forget()
-            );
-        }
-
-        [Test]
-        public void DeferredMayBeRejectedAndPromiseAwaitedConcurrently_T0()
+        public void DeferredMayBeRejectedAndPromiseAwaitedConcurrently_T()
         {
             var deferred = default(Promise<int>.Deferred);
             var promise = default(Promise<int>);
@@ -726,69 +453,7 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
-        public void DeferredMayBeRejectedAndPromiseAwaitedConcurrently_T1()
-        {
-            var cancelationSource = default(CancelationSource);
-            var deferred = default(Promise<int>.Deferred);
-            var promise = default(Promise<int>);
-
-            int invokedCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteParallelActionsWithOffsets(false,
-                // Setup
-                () =>
-                {
-                    invokedCount = 0;
-                    cancelationSource = CancelationSource.New();
-                    deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-                    promise = deferred.Promise;
-                },
-                // Teardown
-                () =>
-                {
-                    cancelationSource.Dispose();
-                    Assert.AreEqual(1, invokedCount);
-                },
-                // Parallel Actions
-                () => deferred.Reject(1),
-                () => promise.Catch(() => { Interlocked.Increment(ref invokedCount); }).Forget()
-            );
-        }
-
-        [Test]
-        public void DeferredMayBeCanceledAndPromiseAwaitedConcurrently_void0()
-        {
-            var cancelationSource = default(CancelationSource);
-            var deferred = default(Promise.Deferred);
-            var promise = default(Promise);
-
-            int invokedCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteParallelActionsWithOffsets(false,
-                // Setup
-                () =>
-                {
-                    invokedCount = 0;
-                    cancelationSource = CancelationSource.New();
-                    deferred = Promise.NewDeferred(cancelationSource.Token);
-                    promise = deferred.Promise;
-                },
-                // Teardown
-                () =>
-                {
-                    cancelationSource.Dispose();
-                    Assert.AreEqual(1, invokedCount);
-                },
-                // Parallel Actions
-                () => cancelationSource.Cancel(),
-                () => promise.CatchCancelation(() => { Interlocked.Increment(ref invokedCount); }).Forget()
-            );
-        }
-
-        [Test]
-        public void DeferredMayBeCanceledAndPromiseAwaitedConcurrently_void1()
+        public void DeferredMayBeCanceledAndPromiseAwaitedConcurrently_void()
         {
             var deferred = default(Promise.Deferred);
             var promise = default(Promise);
@@ -816,38 +481,7 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
-        public void DeferredMayBeCanceledAndPromiseAwaitedConcurrently_T0()
-        {
-            var cancelationSource = default(CancelationSource);
-            var deferred = default(Promise<int>.Deferred);
-            var promise = default(Promise<int>);
-
-            int invokedCount = 0;
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteParallelActionsWithOffsets(false,
-                // Setup
-                () =>
-                {
-                    invokedCount = 0;
-                    cancelationSource = CancelationSource.New();
-                    deferred = Promise.NewDeferred<int>(cancelationSource.Token);
-                    promise = deferred.Promise;
-                },
-                // Teardown
-                () =>
-                {
-                    cancelationSource.Dispose();
-                    Assert.AreEqual(1, invokedCount);
-                },
-                // Parallel Actions
-                () => cancelationSource.Cancel(),
-                () => promise.CatchCancelation(() => { Interlocked.Increment(ref invokedCount); }).Forget()
-            );
-        }
-
-        [Test]
-        public void DeferredMayBeCanceledAndPromiseAwaitedConcurrently_T2()
+        public void DeferredMayBeCanceledAndPromiseAwaitedConcurrently_T()
         {
             var deferred = default(Promise<int>.Deferred);
             var promise = default(Promise<int>);

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/DeferredThreadTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/DeferredThreadTests.cs
@@ -29,13 +29,9 @@ namespace ProtoPromiseTests.Concurrency
         [Test]
         public void DeferredMayReportProgressOnSeparateThread_void(
             [Values] ProgressType progressType,
-            [Values] SynchronizationType synchronizationType,
-            [Values] bool withCancelationToken)
+            [Values] SynchronizationType synchronizationType)
         {
-            var cancelationSource = CancelationSource.New();
-            var deferred = withCancelationToken
-                ? Promise.NewDeferred(cancelationSource.Token)
-                : Promise.NewDeferred();
+            var deferred = Promise.NewDeferred();
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);
 
@@ -50,19 +46,14 @@ namespace ProtoPromiseTests.Concurrency
             progressHelper.AssertCurrentProgress(0.1f);
 
             deferred.Resolve();
-            cancelationSource.Dispose();
         }
 
         [Test]
         public void DeferredMayReportProgressOnSeparateThread_T(
             [Values] ProgressType progressType,
-            [Values] SynchronizationType synchronizationType,
-            [Values] bool withCancelationToken)
+            [Values] SynchronizationType synchronizationType)
         {
-            var cancelationSource = CancelationSource.New();
-            var deferred = withCancelationToken
-                ? Promise.NewDeferred<int>(cancelationSource.Token)
-                : Promise.NewDeferred<int>();
+            var deferred = Promise.NewDeferred<int>();
 
             ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationType);
 
@@ -77,7 +68,6 @@ namespace ProtoPromiseTests.Concurrency
             progressHelper.AssertCurrentProgress(0.1f);
 
             deferred.Resolve(1);
-            cancelationSource.Dispose();
         }
 #endif
 
@@ -213,34 +203,30 @@ namespace ProtoPromiseTests.Concurrency
         public void DeferredMayBeCanceledOnSeparateThread_void()
         {
             bool invoked = false;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
             deferred.Promise
                 .CatchCancelation(() => { invoked = true; })
                 .Forget();
 
             var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteSingleAction(() => cancelationSource.Cancel());
+            threadHelper.ExecuteSingleAction(() => deferred.Cancel());
 
             Assert.IsTrue(invoked);
-            cancelationSource.Dispose();
         }
 
         [Test]
         public void DeferredMayBeCanceledOnSeparateThread_T()
         {
             bool invoked = false;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
             deferred.Promise
                 .CatchCancelation(() => { invoked = true; })
                 .Forget();
 
             var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteSingleAction(() => cancelationSource.Cancel());
+            threadHelper.ExecuteSingleAction(() => deferred.Cancel());
 
             Assert.IsTrue(invoked);
-            cancelationSource.Dispose();
         }
     }
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/PromiseConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/PromiseConcurrencyTests.cs
@@ -850,18 +850,15 @@ namespace ProtoPromiseTests.Concurrency
         public void PromiseCatchCancelationnMayBeCalledConcurrently_PendingThenCanceled_void()
         {
             int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
             var promise = deferred.Promise.Preserve();
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(() => Interlocked.Increment(ref invokedCount)).Forget());
             threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
             promise.Forget();
-            cancelationSource.Cancel();
+            deferred.Cancel();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-
-            cancelationSource.Dispose();
         }
 
         [Test]
@@ -881,18 +878,15 @@ namespace ProtoPromiseTests.Concurrency
         public void PromiseCatchCancelationnMayBeCalledConcurrently_PendingThenCanceled_T()
         {
             int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
             var promise = deferred.Promise.Preserve();
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(() => Interlocked.Increment(ref invokedCount)).Forget());
             threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
             promise.Forget();
-            cancelationSource.Cancel();
+            deferred.Cancel();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-
-            cancelationSource.Dispose();
         }
 
         [Test]
@@ -1048,8 +1042,7 @@ namespace ProtoPromiseTests.Concurrency
         public void PreservedPromiseContinueWithMayBeCalledConcurrently_PendingThenCanceled_void()
         {
             int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
             var promise = deferred.Promise.Preserve();
 
             var continueActions = TestHelper.ContinueWithActionsVoid(() => Interlocked.Increment(ref invokedCount));
@@ -1059,10 +1052,8 @@ namespace ProtoPromiseTests.Concurrency
                 threadHelper.ExecuteMultiActionParallel(() => action(promise));
             }
             promise.Forget();
-            cancelationSource.Cancel();
+            deferred.Cancel();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueVoidCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-
-            cancelationSource.Dispose();
         }
 
         [Test]
@@ -1085,8 +1076,7 @@ namespace ProtoPromiseTests.Concurrency
         public void PreservedPromiseContinueWithMayBeCalledConcurrently_PendingThenCanceled_T()
         {
             int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
             var promise = deferred.Promise.Preserve();
 
             var continueActions = TestHelper.ContinueWithActions<int>(() => Interlocked.Increment(ref invokedCount));
@@ -1096,10 +1086,8 @@ namespace ProtoPromiseTests.Concurrency
                 threadHelper.ExecuteMultiActionParallel(() => action(promise));
             }
             promise.Forget();
-            cancelationSource.Cancel();
+            deferred.Cancel();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueTCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-
-            cancelationSource.Dispose();
         }
 
         [Test]
@@ -1234,18 +1222,15 @@ namespace ProtoPromiseTests.Concurrency
         public void PromiseFinallyMayBeCalledConcurrently_PendingThenCanceled_void()
         {
             int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred(cancelationSource.Token);
+            var deferred = Promise.NewDeferred();
             var promise = deferred.Promise.Preserve();
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Forget());
             threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
             promise.Forget();
-            cancelationSource.Cancel();
+            deferred.Cancel();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-
-            cancelationSource.Dispose();
         }
 
         [Test]
@@ -1265,18 +1250,15 @@ namespace ProtoPromiseTests.Concurrency
         public void PromiseFinallyMayBeCalledConcurrently_PendingThenCanceled_T()
         {
             int invokedCount = 0;
-            var cancelationSource = CancelationSource.New();
-            var deferred = Promise.NewDeferred<int>(cancelationSource.Token);
+            var deferred = Promise.NewDeferred<int>();
             var promise = deferred.Promise.Preserve();
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Forget());
             threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
             promise.Forget();
-            cancelationSource.Cancel();
+            deferred.Cancel();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-
-            cancelationSource.Dispose();
         }
 
         [Test]


### PR DESCRIPTION
Added `Promise.NewDeferred()` instead.

This is done because deferreds should be canceled directly instead of relying on the token. A callback can be registered with the token to cancel the deferred directly, then that registration can be unregistered if/when necessary.