### PR TITLE
Add more efficient `Promise.SwitchToContextAwait` functions

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/CompilerServices/PromiseSwitchContextAwaiter.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/CompilerServices/PromiseSwitchContextAwaiter.cs
@@ -1,0 +1,112 @@
+#if UNITY_5_5 || NET_2_0 || NET_2_0_SUBSET
+#define NET_LEGACY
+#endif
+
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+#if !PROTO_PROMISE_PROGRESS_DISABLE
+#define PROMISE_PROGRESS
+#else
+#undef PROMISE_PROGRESS
+#endif
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Proto.Promises.Async.CompilerServices
+{
+    /// <summary>
+    /// Provides an awaiter for switching to a context.
+    /// </summary>
+    /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+    [DebuggerNonUserCode, StackTraceHidden]
+#endif
+    public
+#if CSHARP_7_3_OR_NEWER
+        readonly
+#endif
+        partial struct PromiseSwitchToContextAwaiter : ICriticalNotifyCompletion
+    {
+        private readonly SynchronizationContext _context;
+        private readonly bool _forceAsync;
+
+        /// <summary>
+        /// Internal use.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        internal PromiseSwitchToContextAwaiter(SynchronizationContext context, bool forceAsync)
+        {
+            _context = context;
+            _forceAsync = forceAsync;
+        }
+
+        /// <summary>Gets the awaiter for this.</summary>
+        /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
+        /// <returns>this</returns>
+        [MethodImpl(Internal.InlineOption)]
+        public PromiseSwitchToContextAwaiter GetAwaiter()
+        {
+            return this;
+        }
+
+        /// <summary>Gets whether the <see cref="Promise"/> being awaited is completed.</summary>
+        /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+        public bool IsCompleted
+        {
+            [MethodImpl(Internal.InlineOption)]
+            get
+            {
+                return !_forceAsync & _context == Internal.ts_currentContext;
+            }
+        }
+
+        /// <summary>Ends the await on the context.</summary>
+        /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public void GetResult()
+        {
+            // Do nothing.
+        }
+
+        /// <summary>Schedules the continuation onto the context.</summary>
+        /// <param name="continuation">The action to invoke when the await operation completes.</param>
+        /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public void OnCompleted(Action continuation)
+        {
+            ValidateArgument(continuation, "continuation", 1);
+            var context = _context;
+            if (context == null)
+            {
+                ThreadPool.QueueUserWorkItem(state => state.UnsafeAs<Action>().Invoke(), continuation);
+            }
+            else
+            {
+                context.Post(state => state.UnsafeAs<Action>().Invoke(), continuation);
+            }
+        }
+
+        /// <summary>Schedules the continuation onto the context.</summary>
+        /// <param name="continuation">The action to invoke when the await operation completes.</param>
+        /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public void UnsafeOnCompleted(Action continuation)
+        {
+            OnCompleted(continuation);
+        }
+
+        static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
+#if PROMISE_DEBUG
+        static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames)
+        {
+            Internal.ValidateArgument(arg, argName, skipFrames + 1);
+        }
+#endif
+    } // struct PromiseSwitchToContextAwaiter
+} // namespace Proto.Promises.Async.CompilerServices

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/CompilerServices/PromiseSwitchContextAwaiter.cs.meta
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/CompilerServices/PromiseSwitchContextAwaiter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd91c53e6a862fd4196de5b486d090e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/PromiseStatic.cs
@@ -5,8 +5,10 @@
 #endif
 
 #pragma warning disable IDE0034 // Simplify 'default' expression
+#pragma warning disable IDE0270 // Use coalesce expression
 #pragma warning disable 1591 // Missing XML comment for publicly visible type or member
 
+using Proto.Promises.Async.CompilerServices;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -129,6 +131,50 @@ namespace Proto.Promises
         {
             return Internal.CreateResolved(0)
                 .WaitAsync(synchronizationContext, forceAsync);
+        }
+
+        /// <summary>
+        /// Switch to the foreground context in an async method.
+        /// </summary>
+        /// <param name="forceAsync">If true, forces the context switch to happen asynchronously.</param>
+        /// <remarks>
+        /// This method is equivalent to <see cref="SwitchToForeground(bool)"/>, but is more efficient when used directly with the <see langword="await"/> keyword.
+        /// </remarks>
+        public static PromiseSwitchToContextAwaiter SwitchToForegroundAwait(bool forceAsync = false)
+        {
+            var context = Config.ForegroundContext;
+            if (context == null)
+            {
+                throw new InvalidOperationException("Promise.Config.ForegroundContext is null. You should set Promise.Config.ForegroundContext at the start of your application" +
+                    " (which may be as simple as 'Promise.Config.ForegroundContext = SynchronizationContext.Current;'). Alternatively, you may pass the context directly via SwitchToContextAwait(context).",
+                    Internal.GetFormattedStacktrace(1));
+            }
+            return new PromiseSwitchToContextAwaiter(context, forceAsync);
+        }
+
+        /// <summary>
+        /// Switch to the background context in an async method.
+        /// </summary>
+        /// <param name="forceAsync">If true, forces the context switch to happen asynchronously.</param>
+        /// <remarks>
+        /// This method is equivalent to <see cref="SwitchToBackground(bool)"/>, butbut is more efficient when used directly with the <see langword="await"/> keyword.
+        /// </remarks>
+        public static PromiseSwitchToContextAwaiter SwitchToBackgroundAwait(bool forceAsync = false)
+        {
+            return new PromiseSwitchToContextAwaiter(Config.BackgroundContext, forceAsync);
+        }
+
+        /// <summary>
+        /// Switch to the provided context in an async method.
+        /// </summary>
+        /// <param name="synchronizationContext">The context to switch to. If null, <see cref="ThreadPool.QueueUserWorkItem(WaitCallback, object)"/> will be used.</param>
+        /// <param name="forceAsync">If true, forces the context switch to happen asynchronously.</param>
+        /// <remarks>
+        /// This method is equivalent to <see cref="SwitchToContext(SynchronizationContext, bool)"/>, but is more efficient when used directly with the <see langword="await"/> keyword.
+        /// </remarks>
+        public static PromiseSwitchToContextAwaiter SwitchToContextAwait(SynchronizationContext synchronizationContext, bool forceAsync = false)
+        {
+            return new PromiseSwitchToContextAwaiter(synchronizationContext, forceAsync);
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/MiscellaneousTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/MiscellaneousTests.cs
@@ -870,7 +870,8 @@ namespace ProtoPromiseTests.APIs
 #if !UNITY_WEBGL
                 , SynchronizationType.Background
 #endif
-                )] SynchronizationType invokeContext)
+                )] SynchronizationType invokeContext,
+            [Values] bool forceAsync)
         {
             Thread foregroundThread = Thread.CurrentThread;
             bool invoked = false;
@@ -878,10 +879,10 @@ namespace ProtoPromiseTests.APIs
             new ThreadHelper().ExecuteSynchronousOrOnThread(() =>
             {
                 Promise promise = synchronizationType == SynchronizationType.Foreground
-                    ? Promise.SwitchToForeground()
+                    ? Promise.SwitchToForeground(forceAsync)
                     : synchronizationType == TestHelper.backgroundType
-                    ? Promise.SwitchToBackground()
-                    : Promise.SwitchToContext(TestHelper._foregroundContext);
+                    ? Promise.SwitchToBackground(forceAsync)
+                    : Promise.SwitchToContext(TestHelper._foregroundContext, forceAsync);
 
                 promise
                     .Then(() =>
@@ -908,7 +909,8 @@ namespace ProtoPromiseTests.APIs
 #if !UNITY_WEBGL
                 , SynchronizationType.Background
 #endif
-                )] SynchronizationType invokeContext)
+                )] SynchronizationType invokeContext,
+            [Values] bool forceAsync)
         {
             Thread foregroundThread = Thread.CurrentThread;
             bool invoked = false;
@@ -919,13 +921,13 @@ namespace ProtoPromiseTests.APIs
 
                 async Promise Await()
                 {
-                    Promise promise = synchronizationType == SynchronizationType.Foreground
-                        ? Promise.SwitchToForeground()
+                    var contextSwitcher = synchronizationType == SynchronizationType.Foreground
+                        ? Promise.SwitchToForegroundAwait(forceAsync)
                         : synchronizationType == TestHelper.backgroundType
-                        ? Promise.SwitchToBackground()
-                        : Promise.SwitchToContext(TestHelper._foregroundContext);
+                        ? Promise.SwitchToBackgroundAwait(forceAsync)
+                        : Promise.SwitchToContextAwait(TestHelper._foregroundContext, forceAsync);
                     
-                    await promise;
+                    await contextSwitcher;
 
                     TestHelper.AssertCallbackContext(synchronizationType, invokeContext, foregroundThread);
                     invoked = true;


### PR DESCRIPTION
Added `SwitchToForegroundAwait`, `SwitchToBackgroundAwait`, and `SwitchToContextAwait`.
These avoid the overhead of `Promise`, and just post the continuations directly to the context.