### PR TITLE
Add `AsyncMonitor.TryEnter(Async)` accepting `CancelationToken` parameter

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/DebugInternal.cs
@@ -24,9 +24,6 @@ namespace Proto.Promises
 {
     partial class Internal
     {
-        // Just a random number that's not zero.
-        internal const short ValidIdFromApi = 31265;
-
         internal static string CausalityTraceMessage
         {
             get
@@ -81,24 +78,6 @@ namespace Proto.Promises
             traceable.Trace = new CausalityTrace(stackTrace, ts_currentTrace);
         }
 
-        static partial void IncrementInvokeId();
-#if !CSHARP_7_3_OR_NEWER
-        // This is only needed in older language versions that don't support ref structs.
-        [ThreadStatic]
-        private static long ts_invokeId;
-        internal static long InvokeId { get { return ts_invokeId; } }
-
-        static partial void IncrementInvokeId()
-        {
-            unchecked
-            {
-                ++ts_invokeId;
-            }
-        }
-#else
-        internal static long InvokeId { get { return ValidIdFromApi; } }
-#endif // !CSHARP_7_3_OR_NEWER
-
         [ThreadStatic]
         private static CausalityTrace ts_currentTrace;
         [ThreadStatic]
@@ -120,7 +99,6 @@ namespace Proto.Promises
         static partial void ClearCurrentInvoker()
         {
             ts_currentTrace = ts_traces.Pop();
-            IncrementInvokeId();
         }
 
         private static StackTrace GetStackTrace(int skipFrames)
@@ -350,12 +328,6 @@ namespace Proto.Promises
             }
         }
 #else // PROMISE_DEBUG
-        internal static long InvokeId
-        {
-            [MethodImpl(InlineOption)]
-            get { return ValidIdFromApi; }
-        }
-
         internal static string GetFormattedStacktrace(int skipFrames)
         {
             return null;

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ExceptionsInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/InternalShared/ExceptionsInternal.cs
@@ -100,26 +100,5 @@ namespace Proto.Promises
                 ReportRejection(_value, traceable);
             }
         }
-
-#if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode, StackTraceHidden]
-#endif
-        internal sealed class ForcedRethrowException : RethrowException
-        {
-#if !PROMISE_DEBUG
-            private static readonly ForcedRethrowException s_instance = new ForcedRethrowException();
-#endif
-
-            private ForcedRethrowException() { }
-
-            new internal static ForcedRethrowException GetOrCreate()
-            {
-#if PROMISE_DEBUG
-                return new ForcedRethrowException(); // Don't re-use instance in DEBUG mode so that we can read its stacktrace on any thread.
-#else
-                return s_instance;
-#endif
-            }
-        }
     }
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/EnumsAndDelegates.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/EnumsAndDelegates.cs
@@ -44,7 +44,8 @@
             Canceled
         }
 
-        // These are necesary to pass ResultContainer to ContinueWith callbacks (because it is a ref struct, it cannot be used as a generic argument in System.Action<> and System.Func<>).
+        // These were necessary to pass ResultContainer to ContinueWith callbacks (because it was a ref struct, it could not be used as a generic argument in System.Action<> and System.Func<>).
+        // This is no longer necessary since ResultContainer was relaxed to a normal struct, but changing the signature would be a breaking change.
 
         /// <summary>
         /// The delegate type used for <see cref="ContinueWith(ContinueAction, CancelationToken)"/>.

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Extensions.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Extensions.cs
@@ -24,7 +24,7 @@ namespace Proto.Promises
 #endif
     public static partial class Extensions
     {
-#if CSHARP_7_3_OR_NEWER
+#if CSHARP_7_3_OR_NEWER || NET45
         /// <summary>
         /// Convert the <paramref name="promise"/> to a <see cref="Task"/>.
         /// </summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncMonitor.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncMonitor.cs
@@ -38,7 +38,7 @@ namespace Proto.Promises.Threading
         /// Synchronously acquire the lock on the specified <see cref="AsyncLock"/>. Returns the key that will release the lock when it is disposed.
         /// </summary>
         /// <param name="asyncLock">The async lock instance that is being entered.</param>
-        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, <see cref="CanceledException"/> will be thrown.</param>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, a <see cref="CanceledException"/> will be thrown.</param>
         [MethodImpl(Internal.InlineOption)]
         public static AsyncLock.Key Enter(AsyncLock asyncLock, CancelationToken cancelationToken = default)
         {
@@ -47,6 +47,7 @@ namespace Proto.Promises.Threading
 
         /// <summary>
         /// Synchronously try to acquire the lock on the specified <see cref="AsyncLock"/>. If successful, <paramref name="key"/> is the key that will release the lock when it is disposed.
+        /// This function does not wait, and returns immediately.
         /// </summary>
         /// <param name="asyncLock">The async lock instance that is being entered.</param>
         /// <param name="key">If successful, the key that will release the lock when it is disposed.</param>
@@ -55,6 +56,42 @@ namespace Proto.Promises.Threading
         public static bool TryEnter(AsyncLock asyncLock, out AsyncLock.Key key)
         {
             return asyncLock.TryEnter(out key);
+        }
+
+        /// <summary>
+        /// Asynchronously try to acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired, or the <paramref name="cancelationToken"/> has been canceled, with the success state and key.
+        /// If successful, the key will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="asyncLock">The async lock instance that is being entered.</param>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, this will return <see langword="false"/>.</param>
+        /// <remarks>
+        /// This first tries to take the lock before checking the <paramref name="cancelationToken"/>>.
+        /// If the lock was available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public static Promise<(bool didEnter, AsyncLock.Key key)> TryEnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken)
+        {
+            return asyncLock.TryEnterAsync(cancelationToken);
+        }
+
+        /// <summary>
+        /// Synchronously try to acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
+        /// If successful, <paramref name="key"/> is the key that will release the lock when it is disposed.
+        /// This function does not return until the lock has been acquired, or the <paramref name="cancelationToken"/> has been canceled.
+        /// </summary>
+        /// <param name="asyncLock">The async lock instance that is being entered.</param>
+        /// <param name="key">If successful, the key that will release the lock when it is disposed.</param>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, this will return <see langword="false"/>.</param>
+        /// <returns><see langword="true"/> if the lock was acquired before the <paramref name="cancelationToken"/> was canceled, <see langword="false"/> otherwise.</returns>
+        /// <remarks>
+        /// This first tries to take the lock before checking the <paramref name="cancelationToken"/>>.
+        /// If the lock was available, this will return <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public static bool TryEnter(AsyncLock asyncLock, out AsyncLock.Key key, CancelationToken cancelationToken)
+        {
+            return asyncLock.TryEnter(out key, cancelationToken);
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncReaderWriterLockInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncReaderWriterLockInternal.cs
@@ -34,7 +34,7 @@ namespace Proto.Promises
         internal sealed class AsyncReaderLockPromise : PromiseRefBase.AsyncSynchronizationPromiseBase<AsyncReaderWriterLock.ReaderKey>, ICancelable, ILinked<AsyncReaderLockPromise>
         {
             AsyncReaderLockPromise ILinked<AsyncReaderLockPromise>.Next { get; set; }
-            private AsyncReaderWriterLockInternal Owner { get { return _result._impl._owner; } }
+            private AsyncReaderWriterLockInternal Owner => _result._impl._owner;
 
             [MethodImpl(InlineOption)]
             private static AsyncReaderLockPromise GetOrCreate()
@@ -96,7 +96,7 @@ namespace Proto.Promises
         internal sealed class AsyncWriterLockPromise : PromiseRefBase.AsyncSynchronizationPromiseBase<AsyncReaderWriterLock.WriterKey>, ICancelable, ILinked<AsyncWriterLockPromise>
         {
             AsyncWriterLockPromise ILinked<AsyncWriterLockPromise>.Next { get; set; }
-            private AsyncReaderWriterLockInternal Owner { get { return _result._impl._owner; } }
+            private AsyncReaderWriterLockInternal Owner => _result._impl._owner;
 
             [MethodImpl(InlineOption)]
             private static AsyncWriterLockPromise GetOrCreate()
@@ -157,7 +157,7 @@ namespace Proto.Promises
         internal sealed class AsyncUpgradeableReaderLockPromise : PromiseRefBase.AsyncSynchronizationPromiseBase<AsyncReaderWriterLock.UpgradeableReaderKey>, ICancelable, ILinked<AsyncUpgradeableReaderLockPromise>
         {
             AsyncUpgradeableReaderLockPromise ILinked<AsyncUpgradeableReaderLockPromise>.Next { get; set; }
-            private AsyncReaderWriterLockInternal Owner { get { return _result._impl._owner; } }
+            private AsyncReaderWriterLockInternal Owner => _result._impl._owner;
 
             [MethodImpl(InlineOption)]
             private static AsyncUpgradeableReaderLockPromise GetOrCreate()

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/UnityHelpers/PromiseYieldInstruction.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/UnityHelpers/PromiseYieldInstruction.cs
@@ -75,8 +75,7 @@ namespace Proto.Promises
 
         /// <summary>
         /// Get the result. If the Promise resolved successfully, this will return without error.
-        /// If the Promise was rejected, this will throw an <see cref="UnhandledException"/>.
-        /// If the Promise was canceled, this will throw a <see cref="CanceledException"/>.
+        /// If the Promise was rejected or canceled, this will throw the appropriate exception.
         /// </summary>
         public void GetResult()
         {
@@ -99,7 +98,7 @@ namespace Proto.Promises
                 }
                 default:
                 {
-                    throw new InvalidOperationException("Promise is still pending. You must wait for the promse to settle before calling GetResult.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("Promise is still pending. You must wait for the promise to settle before calling GetResult.", Internal.GetFormattedStacktrace(1));
                 }
             }
         }
@@ -109,11 +108,11 @@ namespace Proto.Promises
         /// Don't try to access it after disposing! Results are undefined.
         /// </summary>
         /// <remarks>Call <see cref="Dispose"/> when you are finished using the
-        /// <see cref="T:ProtoPromise.Promise.YieldInstruction"/>. The <see cref="Dispose"/> method leaves the
-        /// <see cref="T:ProtoPromise.Promise.YieldInstruction"/> in an unusable state. After calling
+        /// <see cref="YieldInstruction"/>. The <see cref="Dispose"/> method leaves the
+        /// <see cref="YieldInstruction"/> in an unusable state. After calling
         /// <see cref="Dispose"/>, you must release all references to the
-        /// <see cref="T:ProtoPromise.Promise.YieldInstruction"/> so the garbage collector can reclaim the memory
-        /// that the <see cref="T:ProtoPromise.Promise.YieldInstruction"/> was occupying.</remarks>
+        /// <see cref="YieldInstruction"/> so the garbage collector can reclaim the memory
+        /// that the <see cref="YieldInstruction"/> was occupying.</remarks>
         public virtual void Dispose()
         {
             ValidateOperation();
@@ -143,8 +142,7 @@ namespace Proto.Promises
 
         /// <summary>
         /// Get the result. If the Promise resolved successfully, this will return the result of the operation.
-        /// If the Promise was rejected, this will throw an <see cref="UnhandledException"/>.
-        /// If the Promise was canceled, this will throw a <see cref="CanceledException"/>.
+        /// If the Promise was rejected or canceled, this will throw the appropriate exception.
         /// </summary>
         public new T GetResult()
         {

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/Threading/AsyncSemaphoreConcurrencyTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/Concurrency/Threading/AsyncSemaphoreConcurrencyTests.cs
@@ -32,7 +32,7 @@ namespace ProtoPromiseTests.Concurrency.Threading
             var cancelationSource = default(CancelationSource);
             int enteredCount = 0;
             int exitedCount = 0;
-            int expectedInvokes = ThreadHelper.GetExpandCount(4) * 4;
+            int expectedInvokes = 4;
             Action<bool> syncAction = observeCancelation =>
             {
                 bool didWait;


### PR DESCRIPTION
Added `AsyncMonitor.TryEnter(Async)` accepting `CancelationToken` parameter.
Added `ResultContainer.RethrowIfRejectedOrCanceled`.
Changed `Promise(<T>).ResultContainer`s from `readonly ref struct` to `readonly struct`. (This could be used in the future to have `WaitNoThrow` or `AwaitNoThrow` methods on `Promise(<T>)`.)
`ResultContainer.Rethrow...` now throws the actual exception instead of a `RethrowException`.