### PR TITLE
Add `Promise.AwaitNoThrow()`

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/CompilerServices/PromiseAwaiters.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/CompilerServices/PromiseAwaiters.cs
@@ -33,12 +33,22 @@ namespace Proto.Promises
             return new PromiseAwaiterVoid(this);
         }
 
+        /// <summary>Gets an awaiter for this <see cref="Promise"/> that suppresses throws and returns a <see cref="ResultContainer"/> instead.</summary>
+        /// <returns>The awaiter.</returns>
+        /// <remarks> Use as `var resultContainer = await promise.AwaitNoThrow();`</remarks>
+        [MethodImpl(Internal.InlineOption), EditorBrowsable(EditorBrowsableState.Never)]
+        public PromiseNoThrowAwaiterVoid AwaitNoThrow()
+        {
+            ValidateOperation(1);
+            return new PromiseNoThrowAwaiterVoid(this);
+        }
+
         /// <summary>
         /// Gets an awaiter for this <see cref="Promise"/> that supports reporting progress to the async <see cref="Promise"/> or <see cref="Promise{T}"/> function.
         /// The progress reported will be lerped from <paramref name="minProgress"/> to <paramref name="maxProgress"/>. Both values must be between 0 and 1 inclusive.
         /// </summary>
-        /// <remarks> Use as `await promise.AwaitWithProgress(minProgress, maxProgress);`</remarks>
         /// <returns>The awaiter.</returns>
+        /// <remarks>Use as `await promise.AwaitWithProgress(minProgress, maxProgress);`</remarks>
         public PromiseProgressAwaiterVoid AwaitWithProgress(float minProgress, float maxProgress)
         {
             ValidateOperation(1);
@@ -51,13 +61,48 @@ namespace Proto.Promises
         /// Gets an awaiter for this <see cref="Promise"/> that supports reporting progress to the async <see cref="Promise"/> or <see cref="Promise{T}"/> function.
         /// The progress reported will be lerped from its current progress to <paramref name="maxProgress"/>. <paramref name="maxProgress"/> must be between 0 and 1 inclusive.
         /// </summary>
-        /// <remarks> Use as `await promise.AwaitWithProgress(minProgress, maxProgress);`</remarks>
         /// <returns>The awaiter.</returns>
+        /// <remarks>
+        /// If the previously awaited promise did not complete successfully, minProgress will be set to the previous <paramref name="maxProgress"/> instead of current.
+        /// <para/>Use as `await promise.AwaitWithProgress(maxProgress);`
+        /// </remarks>
         public PromiseProgressAwaiterVoid AwaitWithProgress(float maxProgress)
         {
             ValidateOperation(1);
             Internal.ValidateProgressValue(maxProgress, "maxProgress", 1);
             return new PromiseProgressAwaiterVoid(this, float.NaN, maxProgress);
+        }
+
+        /// <summary>
+        /// Gets an awaiter for this <see cref="Promise"/> that supports reporting progress to the async <see cref="Promise"/> or <see cref="Promise{T}"/> function,
+        /// and suppresses throws and returns a <see cref="ResultContainer"/> instead.
+        /// The progress reported will be lerped from <paramref name="minProgress"/> to <paramref name="maxProgress"/>. Both values must be between 0 and 1 inclusive.
+        /// </summary>
+        /// <returns>The awaiter.</returns>
+        /// <remarks>Use as `var resultContainer = await promise.AwaitWithProgressNoThrow(minProgress, maxProgress);`</remarks>
+        public PromiseProgressNoThrowAwaiterVoid AwaitWithProgressNoThrow(float minProgress, float maxProgress)
+        {
+            ValidateOperation(1);
+            Internal.ValidateProgressValue(minProgress, "minProgress", 1);
+            Internal.ValidateProgressValue(maxProgress, "maxProgress", 1);
+            return new PromiseProgressNoThrowAwaiterVoid(this, minProgress, maxProgress);
+        }
+
+        /// <summary>
+        /// Gets an awaiter for this <see cref="Promise"/> that supports reporting progress to the async <see cref="Promise"/> or <see cref="Promise{T}"/> function,
+        /// and suppresses throws and returns a <see cref="ResultContainer"/> instead.
+        /// The progress reported will be lerped from its current progress to <paramref name="maxProgress"/>. <paramref name="maxProgress"/> must be between 0 and 1 inclusive.
+        /// </summary>
+        /// <returns>The awaiter.</returns>
+        /// <remarks>
+        /// If the previously awaited promise did not complete successfully, minProgress will be set to the previous <paramref name="maxProgress"/> instead of current.
+        /// <para/>Use as `var resultContainer = await promise.AwaitWithProgressNoThrow(maxProgress);`
+        /// </remarks>
+        public PromiseProgressNoThrowAwaiterVoid AwaitWithProgressNoThrow(float maxProgress)
+        {
+            ValidateOperation(1);
+            Internal.ValidateProgressValue(maxProgress, "maxProgress", 1);
+            return new PromiseProgressNoThrowAwaiterVoid(this, float.NaN, maxProgress);
         }
     }
 
@@ -73,15 +118,22 @@ namespace Proto.Promises
             return new PromiseAwaiter<T>(this);
         }
 
+        /// <summary>Gets an awaiter for this <see cref="Promise{T}"/> that suppresses throws and returns a <see cref="ResultContainer"/> instead.</summary>
+        /// <returns>The awaiter.</returns>
+        /// <remarks>Use as `var resultContainer = await promise.AwaitNoThrow();`</remarks>
+        [MethodImpl(Internal.InlineOption), EditorBrowsable(EditorBrowsableState.Never)]
+        public PromiseNoThrowAwaiter<T> AwaitNoThrow()
+        {
+            ValidateOperation(1);
+            return new PromiseNoThrowAwaiter<T>(this);
+        }
+
         /// <summary>
         /// Gets an awaiter for this <see cref="Promise{T}"/> that supports reporting progress to the async <see cref="Promise"/> or <see cref="Promise{T}"/> function.
         /// The progress reported will be lerped from <paramref name="minProgress"/> to <paramref name="maxProgress"/>. Both values must be between 0 and 1 inclusive.
         /// </summary>
-        /// <remarks>
-        /// If the previously awaited promise did not complete successfully, minProgress will be set to the previous <paramref name="maxProgress"/> instead of current.
-        /// <para/>Use as `await promise.AwaitWithProgress(maxProgress);`
-        /// </remarks>
         /// <returns>The awaiter.</returns>
+        /// <remarks>Use as `await promise.AwaitWithProgress(minProgress, maxProgress);`</remarks>
         public PromiseProgressAwaiter<T> AwaitWithProgress(float minProgress, float maxProgress)
         {
             ValidateOperation(1);
@@ -94,16 +146,48 @@ namespace Proto.Promises
         /// Gets an awaiter for this <see cref="Promise{T}"/> that supports reporting progress to the async <see cref="Promise"/> or <see cref="Promise{T}"/> function.
         /// The progress reported will be lerped from its current progress to <paramref name="maxProgress"/>. <paramref name="maxProgress"/> must be between 0 and 1 inclusive.
         /// </summary>
+        /// <returns>The awaiter.</returns>
         /// <remarks>
         /// If the previously awaited promise did not complete successfully, minProgress will be set to the previous <paramref name="maxProgress"/> instead of current.
         /// <para/>Use as `await promise.AwaitWithProgress(maxProgress);`
         /// </remarks>
-        /// <returns>The awaiter.</returns>
         public PromiseProgressAwaiter<T> AwaitWithProgress(float maxProgress)
         {
             ValidateOperation(1);
             Internal.ValidateProgressValue(maxProgress, "maxProgress", 1);
             return new PromiseProgressAwaiter<T>(this, float.NaN, maxProgress);
+        }
+
+        /// <summary>
+        /// Gets an awaiter for this <see cref="Promise{T}"/> that supports reporting progress to the async <see cref="Promise"/> or <see cref="Promise{T}"/> function,
+        /// and suppresses throws and returns a <see cref="ResultContainer"/> instead.
+        /// The progress reported will be lerped from <paramref name="minProgress"/> to <paramref name="maxProgress"/>. Both values must be between 0 and 1 inclusive.
+        /// </summary>
+        /// <returns>The awaiter.</returns>
+        /// <remarks>Use as `var resultContainer = await promise.AwaitWithProgressNoThrow(minProgress, maxProgress);`</remarks>
+        public PromiseProgressNoThrowAwaiter<T> AwaitWithProgressNoThrow(float minProgress, float maxProgress)
+        {
+            ValidateOperation(1);
+            Internal.ValidateProgressValue(minProgress, "minProgress", 1);
+            Internal.ValidateProgressValue(maxProgress, "maxProgress", 1);
+            return new PromiseProgressNoThrowAwaiter<T>(this, minProgress, maxProgress);
+        }
+
+        /// <summary>
+        /// Gets an awaiter for this <see cref="Promise{T}"/> that supports reporting progress to the async <see cref="Promise"/> or <see cref="Promise{T}"/> function,
+        /// and suppresses throws and returns a <see cref="ResultContainer"/> instead.
+        /// The progress reported will be lerped from its current progress to <paramref name="maxProgress"/>. <paramref name="maxProgress"/> must be between 0 and 1 inclusive.
+        /// </summary>
+        /// <returns>The awaiter.</returns>
+        /// <remarks>
+        /// If the previously awaited promise did not complete successfully, minProgress will be set to the previous <paramref name="maxProgress"/> instead of current.
+        /// <para/>Use as `var resultContainer = await promise.AwaitWithProgressNoThrow(maxProgress);`
+        /// </remarks>
+        public PromiseProgressNoThrowAwaiter<T> AwaitWithProgressNoThrow(float maxProgress)
+        {
+            ValidateOperation(1);
+            Internal.ValidateProgressValue(maxProgress, "maxProgress", 1);
+            return new PromiseProgressNoThrowAwaiter<T>(this, float.NaN, maxProgress);
         }
     }
 
@@ -144,6 +228,40 @@ namespace Proto.Promises
 #endif
         }
 
+        partial struct PromiseNoThrowAwaiterVoid
+        {
+            // Fix for IL2CPP not invoking the static constructor.
+#if ENABLE_IL2CPP
+            [MethodImpl(Internal.InlineOption)]
+            static partial void CreateOverride()
+            {
+                Internal.AwaitOverrider<PromiseNoThrowAwaiterVoid>.Create<PromiseNoThrowAwaiterVoid>();
+            }
+#else
+            static PromiseNoThrowAwaiterVoid()
+            {
+                Internal.AwaitOverrider<PromiseNoThrowAwaiterVoid>.Create<PromiseNoThrowAwaiterVoid>();
+            }
+#endif
+        }
+
+        partial struct PromiseNoThrowAwaiter<T>
+        {
+            // Fix for IL2CPP not invoking the static constructor.
+#if ENABLE_IL2CPP
+            [MethodImpl(Internal.InlineOption)]
+            static partial void CreateOverride()
+            {
+                Internal.AwaitOverrider<PromiseNoThrowAwaiter<T>>.Create<PromiseNoThrowAwaiter<T>>();
+            }
+#else
+            static PromiseNoThrowAwaiter()
+            {
+                Internal.AwaitOverrider<PromiseNoThrowAwaiter<T>>.Create<PromiseNoThrowAwaiter<T>>();
+            }
+#endif
+        }
+
         partial struct PromiseProgressAwaiterVoid
         {
             // Fix for IL2CPP not invoking the static constructor.
@@ -174,6 +292,40 @@ namespace Proto.Promises
             static PromiseProgressAwaiter()
             {
                 Internal.AwaitOverrider<PromiseProgressAwaiter<T>>.Create<PromiseProgressAwaiter<T>>();
+            }
+#endif
+        }
+
+        partial struct PromiseProgressNoThrowAwaiterVoid
+        {
+            // Fix for IL2CPP not invoking the static constructor.
+#if ENABLE_IL2CPP
+            [MethodImpl(Internal.InlineOption)]
+            static partial void CreateOverride()
+            {
+                Internal.AwaitOverrider<PromiseProgressNoThrowAwaiterVoid>.Create<PromiseProgressNoThrowAwaiterVoid>();
+            }
+#else
+            static PromiseProgressNoThrowAwaiterVoid()
+            {
+                Internal.AwaitOverrider<PromiseProgressNoThrowAwaiterVoid>.Create<PromiseProgressNoThrowAwaiterVoid>();
+            }
+#endif
+        }
+
+        partial struct PromiseProgressNoThrowAwaiter<T>
+        {
+            // Fix for IL2CPP not invoking the static constructor.
+#if ENABLE_IL2CPP
+            [MethodImpl(Internal.InlineOption)]
+            static partial void CreateOverride()
+            {
+                Internal.AwaitOverrider<PromiseProgressNoThrowAwaiter<T>>.Create<PromiseProgressNoThrowAwaiter<T>>();
+            }
+#else
+            static PromiseProgressNoThrowAwaiter()
+            {
+                Internal.AwaitOverrider<PromiseProgressNoThrowAwaiter<T>>.Create<PromiseProgressNoThrowAwaiter<T>>();
             }
 #endif
         }
@@ -393,6 +545,222 @@ namespace Proto.Promises
         } // struct PromiseAwaiter<T>
 
         /// <summary>
+        /// Provides an awaiter for awaiting a <see cref="Promise"/>, without throwing.
+        /// </summary>
+        /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        public
+#if CSHARP_7_3_OR_NEWER
+            readonly
+#endif
+            partial struct PromiseNoThrowAwaiterVoid : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+        {
+            private readonly Promise _promise;
+
+            /// <summary>
+            /// Internal use.
+            /// </summary>
+            [MethodImpl(Internal.InlineOption)]
+            internal PromiseNoThrowAwaiterVoid(
+#if CSHARP_7_3_OR_NEWER
+                in
+#endif
+                Promise promise)
+            {
+                _promise = promise;
+                CreateOverride();
+            }
+
+            static partial void CreateOverride();
+
+            /// <summary>Gets the awaiter for this.</summary>
+            /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
+            /// <returns>this</returns>
+            [MethodImpl(Internal.InlineOption)]
+            public PromiseNoThrowAwaiterVoid GetAwaiter()
+            {
+                return this;
+            }
+
+            /// <summary>Gets whether the <see cref="Promise"/> being awaited is completed.</summary>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
+            public bool IsCompleted
+            {
+                [MethodImpl(Internal.InlineOption)]
+                get
+                {
+                    var _ref = _promise._ref;
+                    return _ref == null || _ref.GetIsCompleted(_promise._id);
+                }
+            }
+
+            /// <summary>Ends the await on the completed <see cref="Promise"/>.</summary>
+            /// <returns>A <see cref="Promise.ResultContainer"/> that wraps the completion state and reason of the <see cref="Promise"/>.</returns>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten, or it has not yet completed.</exception>
+            [MethodImpl(Internal.InlineOption)]
+            public Promise.ResultContainer GetResult()
+            {
+                var _ref = _promise._ref;
+                return _ref == null
+                    ? new Promise.ResultContainer(null, Promise.State.Resolved)
+                    : _ref.GetResultContainerAndMaybeDispose(_promise._id);
+            }
+
+            /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseAwaiterVoid"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
+            [MethodImpl(Internal.InlineOption)]
+            public void OnCompleted(Action continuation)
+            {
+                ValidateArgument(continuation, "continuation", 1);
+                var _ref = _promise._ref;
+                if (_ref == null)
+                {
+                    continuation();
+                    return;
+                }
+                _ref.OnCompleted(continuation, _promise._id);
+            }
+
+            /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseAwaiterVoid"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
+            [MethodImpl(Internal.InlineOption)]
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                OnCompleted(continuation);
+            }
+
+            [MethodImpl(Internal.InlineOption)]
+            void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref Internal.PromiseRefBase.AsyncPromiseFields asyncFields)
+            {
+                asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
+            }
+
+            static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
+#if PROMISE_DEBUG
+            static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames)
+            {
+                Internal.ValidateArgument(arg, argName, skipFrames + 1);
+            }
+#endif
+        } // struct PromiseNoThrowAwaiterVoid
+
+        /// <summary>
+        /// Provides an awaiter for awaiting a <see cref="Promise{T}"/>, without throwing.
+        /// </summary>
+        /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        public
+#if CSHARP_7_3_OR_NEWER
+            readonly
+#endif
+            partial struct PromiseNoThrowAwaiter<T> : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+        {
+            private readonly Promise<T> _promise;
+
+            /// <summary>
+            /// Internal use.
+            /// </summary>
+            [MethodImpl(Internal.InlineOption)]
+            internal PromiseNoThrowAwaiter(
+#if CSHARP_7_3_OR_NEWER
+                in
+#endif
+                Promise<T> promise)
+            {
+                _promise = promise;
+                CreateOverride();
+            }
+
+            static partial void CreateOverride();
+
+            /// <summary>Gets the awaiter for this.</summary>
+            /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
+            /// <returns>this</returns>
+            [MethodImpl(Internal.InlineOption)]
+            public PromiseNoThrowAwaiter<T> GetAwaiter()
+            {
+                return this;
+            }
+
+            /// <summary>Gets whether the <see cref="Promise{T}"/> being awaited is completed.</summary>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
+            public bool IsCompleted
+            {
+                [MethodImpl(Internal.InlineOption)]
+                get
+                {
+                    var _ref = _promise._ref;
+                    return _ref == null || _ref.GetIsCompleted(_promise._id);
+                }
+            }
+
+            /// <summary>Ends the await on the completed <see cref="Promise{T}"/>.</summary>
+            /// <returns>A <see cref="Promise{T}.ResultContainer"/> that wraps the completion state and result or reason of the <see cref="Promise{T}"/>.</returns>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten, or it has not yet completed.</exception>
+            [MethodImpl(Internal.InlineOption)]
+            public Promise<T>.ResultContainer GetResult()
+            {
+                var _ref = _promise._ref;
+                return _ref == null
+                    ? new Promise<T>.ResultContainer(_promise._result, null, Promise.State.Resolved)
+                    : _ref.GetResultContainerAndMaybeDispose(_promise._id);
+            }
+
+            /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseAwaiter{T}"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
+            [MethodImpl(Internal.InlineOption)]
+            public void OnCompleted(Action continuation)
+            {
+                ValidateArgument(continuation, "continuation", 1);
+                var _ref = _promise._ref;
+                if (_ref == null)
+                {
+                    continuation();
+                    return;
+                }
+                _ref.OnCompleted(continuation, _promise._id);
+            }
+
+            /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseAwaiter{T}"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
+            [MethodImpl(Internal.InlineOption)]
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                OnCompleted(continuation);
+            }
+
+            [MethodImpl(Internal.InlineOption)]
+            void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref Internal.PromiseRefBase.AsyncPromiseFields asyncFields)
+            {
+                asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
+            }
+
+            static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
+#if PROMISE_DEBUG
+            static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames)
+            {
+                Internal.ValidateArgument(arg, argName, skipFrames + 1);
+            }
+#endif
+        } // struct PromiseNoThrowAwaiter<T>
+
+        /// <summary>
         /// Provides an awaiter for awaiting a <see cref="Promise"/> and reporting its progress to the associated async <see cref="Promise"/> or <see cref="Promise{T}"/>.
         /// </summary>
         /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
@@ -509,7 +877,7 @@ namespace Proto.Promises
                 Internal.ValidateArgument(arg, argName, skipFrames + 1);
             }
 #endif
-        } // struct PromiseAwaiterVoid
+        } // struct PromiseProgressAwaiterVoid
 
         /// <summary>
         /// Provides an awaiter for awaiting a <see cref="Promise{T}"/> and reporting its progress to the associated async <see cref="Promise"/> or <see cref="Promise{T}"/>.
@@ -629,6 +997,230 @@ namespace Proto.Promises
                 Internal.ValidateArgument(arg, argName, skipFrames + 1);
             }
 #endif
-        } // struct PromiseAwaiter<T>
+        } // struct PromiseProgressAwaiter<T>
+
+        /// <summary>
+        /// Provides an awaiter for awaiting a <see cref="Promise"/> and reporting its progress to the associated async <see cref="Promise"/> or <see cref="Promise{T}"/>, without throwing.
+        /// </summary>
+        /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        public
+#if CSHARP_7_3_OR_NEWER
+            readonly
+#endif
+            partial struct PromiseProgressNoThrowAwaiterVoid : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+        {
+            private readonly Promise _promise;
+            private readonly float _minProgress;
+            private readonly float _maxProgress;
+
+            /// <summary>
+            /// Internal use.
+            /// </summary>
+            [MethodImpl(Internal.InlineOption)]
+            internal PromiseProgressNoThrowAwaiterVoid(
+#if CSHARP_7_3_OR_NEWER
+                in
+#endif
+                Promise promise, float minProgress, float maxProgress)
+            {
+                _promise = promise;
+                _minProgress = minProgress;
+                _maxProgress = maxProgress;
+                CreateOverride();
+            }
+
+            static partial void CreateOverride();
+
+            /// <summary>Gets the awaiter for this.</summary>
+            /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
+            /// <returns>this</returns>
+            [MethodImpl(Internal.InlineOption)]
+            public PromiseProgressNoThrowAwaiterVoid GetAwaiter()
+            {
+                return this;
+            }
+
+            /// <summary>Gets whether the <see cref="Promise"/> being awaited is completed.</summary>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
+            public bool IsCompleted
+            {
+                [MethodImpl(Internal.InlineOption)]
+                get
+                {
+                    var _ref = _promise._ref;
+                    return _ref == null || _ref.GetIsCompleted(_promise._id);
+                }
+            }
+
+            /// <summary>Ends the await on the completed <see cref="Promise"/>.</summary>
+            /// <returns>A <see cref="Promise.ResultContainer"/> that wraps the completion state and reason of the <see cref="Promise"/>.</returns>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten, or it has not yet completed.</exception>
+            [MethodImpl(Internal.InlineOption)]
+            public Promise.ResultContainer GetResult()
+            {
+                var _ref = _promise._ref;
+                return _ref == null
+                    ? new Promise.ResultContainer(null, Promise.State.Resolved)
+                    : _ref.GetResultContainerAndMaybeDispose(_promise._id);
+            }
+
+            /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseAwaiterVoid"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
+            [MethodImpl(Internal.InlineOption)]
+            public void OnCompleted(Action continuation)
+            {
+                ValidateArgument(continuation, "continuation", 1);
+                var _ref = _promise._ref;
+                if (_ref == null)
+                {
+                    continuation();
+                    return;
+                }
+                _ref.OnCompleted(continuation, _promise._id);
+            }
+
+            /// <summary>Schedules the continuation onto the <see cref="Promise"/> associated with this <see cref="PromiseAwaiterVoid"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise"/> has already been awaited or forgotten.</exception>
+            [MethodImpl(Internal.InlineOption)]
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                OnCompleted(continuation);
+            }
+
+            [MethodImpl(Internal.InlineOption)]
+            void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref Internal.PromiseRefBase.AsyncPromiseFields asyncFields)
+            {
+                asyncPromiseRef.HookupAwaiterWithProgress(_promise._ref, _promise._id, _promise.Depth, _minProgress, _maxProgress, ref asyncFields);
+            }
+
+            static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
+#if PROMISE_DEBUG
+            static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames)
+            {
+                Internal.ValidateArgument(arg, argName, skipFrames + 1);
+            }
+#endif
+        } // struct PromiseProgressNoThrowAwaiterVoid
+
+        /// <summary>
+        /// Provides an awaiter for awaiting a <see cref="Promise{T}"/> and reporting its progress to the associated async <see cref="Promise"/> or <see cref="Promise{T}"/>, without throwing.
+        /// </summary>
+        /// <remarks>This type is intended for compiler use rather than use directly in code.</remarks>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        public
+#if CSHARP_7_3_OR_NEWER
+            readonly
+#endif
+            partial struct PromiseProgressNoThrowAwaiter<T> : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+        {
+            private readonly Promise<T> _promise;
+            private readonly float _minProgress;
+            private readonly float _maxProgress;
+
+            /// <summary>
+            /// Internal use.
+            /// </summary>
+            [MethodImpl(Internal.InlineOption)]
+            internal PromiseProgressNoThrowAwaiter(
+#if CSHARP_7_3_OR_NEWER
+                in
+#endif
+                Promise<T> promise, float minProgress, float maxProgress)
+            {
+                _promise = promise;
+                _minProgress = minProgress;
+                _maxProgress = maxProgress;
+                CreateOverride();
+            }
+
+            static partial void CreateOverride();
+
+            /// <summary>Gets the awaiter for this.</summary>
+            /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
+            /// <returns>this</returns>
+            [MethodImpl(Internal.InlineOption)]
+            public PromiseProgressNoThrowAwaiter<T> GetAwaiter()
+            {
+                return this;
+            }
+
+            /// <summary>Gets whether the <see cref="Promise{T}"/> being awaited is completed.</summary>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
+            public bool IsCompleted
+            {
+                [MethodImpl(Internal.InlineOption)]
+                get
+                {
+                    var _ref = _promise._ref;
+                    return _ref == null || _ref.GetIsCompleted(_promise._id);
+                }
+            }
+
+            /// <summary>Ends the await on the completed <see cref="Promise{T}"/>.</summary>
+            /// <returns>A <see cref="Promise{T}.ResultContainer"/> that wraps the completion state and result or reason of the <see cref="Promise{T}"/>.</returns>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten, or it has not yet completed.</exception>
+            [MethodImpl(Internal.InlineOption)]
+            public Promise<T>.ResultContainer GetResult()
+            {
+                var _ref = _promise._ref;
+                return _ref == null
+                    ? new Promise<T>.ResultContainer(_promise._result, null, Promise.State.Resolved)
+                    : _ref.GetResultContainerAndMaybeDispose(_promise._id);
+            }
+
+            /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseAwaiter{T}"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
+            [MethodImpl(Internal.InlineOption)]
+            public void OnCompleted(Action continuation)
+            {
+                ValidateArgument(continuation, "continuation", 1);
+                var _ref = _promise._ref;
+                if (_ref == null)
+                {
+                    continuation();
+                    return;
+                }
+                _ref.OnCompleted(continuation, _promise._id);
+            }
+
+            /// <summary>Schedules the continuation onto the <see cref="Promise{T}"/> associated with this <see cref="PromiseAwaiter{T}"/>.</summary>
+            /// <param name="continuation">The action to invoke when the await operation completes.</param>
+            /// <remarks>This property is intended for compiler use rather than use directly in code.</remarks>
+            /// <exception cref="InvalidOperationException">The <see cref="Promise{T}"/> has already been awaited or forgotten.</exception>
+            [MethodImpl(Internal.InlineOption)]
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                OnCompleted(continuation);
+            }
+
+            [MethodImpl(Internal.InlineOption)]
+            void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref Internal.PromiseRefBase.AsyncPromiseFields asyncFields)
+            {
+                asyncPromiseRef.HookupAwaiterWithProgress(_promise._ref, _promise._id, _promise.Depth, _minProgress, _maxProgress, ref asyncFields);
+            }
+
+            static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
+#if PROMISE_DEBUG
+            static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames)
+            {
+                Internal.ValidateArgument(arg, argName, skipFrames + 1);
+            }
+#endif
+        } // struct PromiseProgressNoThrowAwaiter<T>
     } // namespace Async.CompilerServices
 }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Promises/Internal/PromiseInternal.cs
@@ -143,8 +143,7 @@ namespace Proto.Promises
                     resultContainer = default(Promise.ResultContainer);
                     return false;
                 }
-                resultContainer = new Promise.ResultContainer(promise._rejectContainerOrPreviousOrLink, promise.State);
-                promise.MaybeDispose();
+                resultContainer = promise.GetResultContainerAndMaybeDispose();
                 return true;
             }
 
@@ -156,8 +155,7 @@ namespace Proto.Promises
                     resultContainer = default(Promise<TResult>.ResultContainer);
                     return false;
                 }
-                resultContainer = new Promise<TResult>.ResultContainer(promise._result, promise._rejectContainerOrPreviousOrLink, promise.State);
-                promise.MaybeDispose();
+                resultContainer = promise.GetResultContainerAndMaybeDispose();
                 return true;
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/AsyncFunctionTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/AsyncFunctionTests.cs
@@ -593,7 +593,7 @@ namespace ProtoPromiseTests.APIs
             async Promise Func()
             {
                 await deferred1.Promise.AwaitWithProgress(0f, 0.3f);
-                await deferred2.Promise.AwaitWithProgress(0.5f, 1f);
+                (await deferred2.Promise.AwaitWithProgressNoThrow(0.5f, 1f)).RethrowIfRejectedOrCanceled();
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
@@ -622,7 +622,7 @@ namespace ProtoPromiseTests.APIs
             async Promise Func()
             {
                 await deferred1.Promise.AwaitWithProgress(0.3f);
-                await deferred2.Promise.AwaitWithProgress(1f);
+                (await deferred2.Promise.AwaitWithProgressNoThrow(1f)).RethrowIfRejectedOrCanceled();
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
@@ -651,7 +651,9 @@ namespace ProtoPromiseTests.APIs
             async Promise<int> Func()
             {
                 await deferred1.Promise.AwaitWithProgress(0f, 0.3f);
-                return await deferred2.Promise.AwaitWithProgress(0.5f, 1f);
+                var resultContainer = await deferred2.Promise.AwaitWithProgressNoThrow(0.5f, 1f);
+                resultContainer.RethrowIfRejectedOrCanceled();
+                return resultContainer.Result;
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
@@ -680,7 +682,9 @@ namespace ProtoPromiseTests.APIs
             async Promise<int> Func()
             {
                 await deferred1.Promise.AwaitWithProgress(0.3f);
-                return await deferred2.Promise.AwaitWithProgress(1f);
+                var resultContainer = await deferred2.Promise.AwaitWithProgressNoThrow(1f);
+                resultContainer.RethrowIfRejectedOrCanceled();
+                return resultContainer.Result;
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
@@ -709,7 +713,7 @@ namespace ProtoPromiseTests.APIs
             async Promise Func()
             {
                 await Func1().AwaitWithProgress(0f, 0.3f);
-                await Func2().AwaitWithProgress(0.5f, 1f);
+                (await Func2().AwaitWithProgressNoThrow(0.5f, 1f)).RethrowIfRejectedOrCanceled();
             }
 
             async Promise Func1()
@@ -719,7 +723,7 @@ namespace ProtoPromiseTests.APIs
 
             async Promise Func2()
             {
-                await deferred2.Promise.AwaitWithProgress(0f, 1f);
+                (await deferred2.Promise.AwaitWithProgressNoThrow(0f, 1f)).RethrowIfRejectedOrCanceled();
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
@@ -748,7 +752,7 @@ namespace ProtoPromiseTests.APIs
             async Promise Func()
             {
                 await Func1().AwaitWithProgress(0.3f);
-                await Func2().AwaitWithProgress(1f);
+                (await Func2().AwaitWithProgressNoThrow(1f)).RethrowIfRejectedOrCanceled();
             }
 
             async Promise Func1()
@@ -758,7 +762,7 @@ namespace ProtoPromiseTests.APIs
 
             async Promise Func2()
             {
-                await deferred2.Promise.AwaitWithProgress(0f, 1f);
+                (await deferred2.Promise.AwaitWithProgressNoThrow(0f, 1f)).RethrowIfRejectedOrCanceled();
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
@@ -787,7 +791,9 @@ namespace ProtoPromiseTests.APIs
             async Promise<int> Func()
             {
                 await Func1().AwaitWithProgress(0f, 0.3f);
-                return await Func2().AwaitWithProgress(0.5f, 1f);
+                var resultContainer = await Func2().AwaitWithProgressNoThrow(0.5f, 1f);
+                resultContainer.RethrowIfRejectedOrCanceled();
+                return resultContainer.Result;
             }
 
             async Promise<int> Func1()
@@ -797,7 +803,9 @@ namespace ProtoPromiseTests.APIs
 
             async Promise<int> Func2()
             {
-                return await deferred2.Promise.AwaitWithProgress(0f, 1f);
+                var resultContainer = await deferred2.Promise.AwaitWithProgressNoThrow(0f, 1f);
+                resultContainer.RethrowIfRejectedOrCanceled();
+                return resultContainer.Result;
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
@@ -826,7 +834,9 @@ namespace ProtoPromiseTests.APIs
             async Promise<int> Func()
             {
                 await Func1().AwaitWithProgress(0.3f);
-                return await Func2().AwaitWithProgress(1f);
+                var resultContainer = await Func2().AwaitWithProgressNoThrow(1f);
+                resultContainer.RethrowIfRejectedOrCanceled();
+                return resultContainer.Result;
             }
 
             async Promise<int> Func1()
@@ -836,7 +846,9 @@ namespace ProtoPromiseTests.APIs
 
             async Promise<int> Func2()
             {
-                return await deferred2.Promise.AwaitWithProgress(0f, 1f);
+                var resultContainer = await deferred2.Promise.AwaitWithProgressNoThrow(0f, 1f);
+                resultContainer.RethrowIfRejectedOrCanceled();
+                return resultContainer.Result;
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
@@ -870,10 +882,10 @@ namespace ProtoPromiseTests.APIs
                     .ThenDuplicate(cancelationSource1.Token)
                     .CatchCancelation(() => { })
                     .AwaitWithProgress(0f, 0.3f);
-                await deferred2.Promise
+                (await deferred2.Promise
                     .ThenDuplicate(cancelationSource2.Token)
                     .CatchCancelation(() => { })
-                    .AwaitWithProgress(0.5f, 1f);
+                    .AwaitWithProgressNoThrow(0.5f, 1f)).RethrowIfRejectedOrCanceled();
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
@@ -916,10 +928,10 @@ namespace ProtoPromiseTests.APIs
                     .ThenDuplicate(cancelationSource1.Token)
                     .CatchCancelation(() => { })
                     .AwaitWithProgress(0.3f);
-                await deferred2.Promise
+                (await deferred2.Promise
                     .ThenDuplicate(cancelationSource2.Token)
                     .CatchCancelation(() => { })
-                    .AwaitWithProgress(1f);
+                    .AwaitWithProgressNoThrow(1f)).RethrowIfRejectedOrCanceled();
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
@@ -964,10 +976,10 @@ namespace ProtoPromiseTests.APIs
                     .ThenDuplicate(cancelationSource1.Token)
                     .CatchCancelation(() => deferred3.Promise)
                     .AwaitWithProgress(0f, 0.3f);
-                await deferred2.Promise
+                (await deferred2.Promise
                     .ThenDuplicate(cancelationSource2.Token)
                     .CatchCancelation(() => deferred4.Promise)
-                    .AwaitWithProgress(0.5f, 1f);
+                    .AwaitWithProgressNoThrow(0.5f, 1f)).RethrowIfRejectedOrCanceled();
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous, delta: TestHelper.progressEpsilon * 2); // Increase delta to accommodate for internal scaling operations with loss of precision.
@@ -1026,10 +1038,10 @@ namespace ProtoPromiseTests.APIs
                     .ThenDuplicate(cancelationSource1.Token)
                     .CatchCancelation(() => deferred3.Promise)
                     .AwaitWithProgress(0.3f);
-                await deferred2.Promise
+                (await deferred2.Promise
                     .ThenDuplicate(cancelationSource2.Token)
                     .CatchCancelation(() => deferred4.Promise)
-                    .AwaitWithProgress(1f);
+                    .AwaitWithProgressNoThrow(1f)).RethrowIfRejectedOrCanceled();
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous, delta: TestHelper.progressEpsilon * 2); // Increase delta to accommodate for internal scaling operations with loss of precision.
@@ -1086,10 +1098,12 @@ namespace ProtoPromiseTests.APIs
                     .ThenDuplicate(cancelationSource1.Token)
                     .CatchCancelation(() => 2)
                     .AwaitWithProgress(0f, 0.3f);
-                return await deferred2.Promise
+                var resultContainer = await deferred2.Promise
                     .ThenDuplicate(cancelationSource2.Token)
                     .CatchCancelation(() => 2)
-                    .AwaitWithProgress(0.5f, 1f);
+                    .AwaitWithProgressNoThrow(0.5f, 1f);
+                resultContainer.RethrowIfRejectedOrCanceled();
+                return resultContainer.Result;
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
@@ -1132,10 +1146,12 @@ namespace ProtoPromiseTests.APIs
                     .ThenDuplicate(cancelationSource1.Token)
                     .CatchCancelation(() => 2)
                     .AwaitWithProgress(0.3f);
-                return await deferred2.Promise
+                var resultContainer = await deferred2.Promise
                     .ThenDuplicate(cancelationSource2.Token)
                     .CatchCancelation(() => 2)
-                    .AwaitWithProgress(1f);
+                    .AwaitWithProgressNoThrow(1f);
+                resultContainer.RethrowIfRejectedOrCanceled();
+                return resultContainer.Result;
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
@@ -1180,10 +1196,12 @@ namespace ProtoPromiseTests.APIs
                     .ThenDuplicate(cancelationSource1.Token)
                     .CatchCancelation(() => deferred3.Promise)
                     .AwaitWithProgress(0f, 0.3f);
-                return await deferred2.Promise
+                var resultContainer = await deferred2.Promise
                     .ThenDuplicate(cancelationSource2.Token)
                     .CatchCancelation(() => deferred4.Promise)
-                    .AwaitWithProgress(0.5f, 1f);
+                    .AwaitWithProgressNoThrow(0.5f, 1f);
+                resultContainer.RethrowIfRejectedOrCanceled();
+                return resultContainer.Result;
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous, delta: TestHelper.progressEpsilon * 2); // Increase delta to accommodate for internal scaling operations with loss of precision.
@@ -1242,10 +1260,12 @@ namespace ProtoPromiseTests.APIs
                     .ThenDuplicate(cancelationSource1.Token)
                     .CatchCancelation(() => deferred3.Promise)
                     .AwaitWithProgress(0.3f);
-                return await deferred2.Promise
+                var resultContainer = await deferred2.Promise
                     .ThenDuplicate(cancelationSource2.Token)
                     .CatchCancelation(() => deferred4.Promise)
-                    .AwaitWithProgress(1f);
+                    .AwaitWithProgressNoThrow(1f);
+                resultContainer.RethrowIfRejectedOrCanceled();
+                return resultContainer.Result;
             }
 
             var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous, delta: TestHelper.progressEpsilon * 2); // Increase delta to accommodate for internal scaling operations with loss of precision.
@@ -1317,6 +1337,34 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
+        public void AsyncPromiseWillReportProgress_WhenAnotherAwaitableIsAwaitedWithoutProgress_MinMax_NoThrow_void()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+
+            async Promise Func()
+            {
+                (await deferred1.Promise.AwaitWithProgressNoThrow(0f, 0.5f)).RethrowIfRejectedOrCanceled();
+                await deferred2.Promise;
+            }
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+            bool complete = false;
+
+            Func()
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Then(() => complete = true)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f));
+            // Implementation detail - progress is not reported after awaited promise is resolved, until another promise is awaited with progress.
+            progressHelper.ResolveAndAssertResult(deferred1, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ResolveAndAssertResult(deferred2, 1f, true);
+            Assert.IsTrue(complete);
+        }
+
+        [Test]
         public void AsyncPromiseWillReportProgress_WhenAnotherAwaitableIsAwaitedWithoutProgress_Max_void()
         {
             var deferred1 = Promise.NewDeferred();
@@ -1325,6 +1373,34 @@ namespace ProtoPromiseTests.APIs
             async Promise Func()
             {
                 await deferred1.Promise.AwaitWithProgress(0.5f);
+                await deferred2.Promise;
+            }
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+            bool complete = false;
+
+            Func()
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Then(() => complete = true)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f));
+            // Implementation detail - progress is not reported after awaited promise is resolved, until another promise is awaited with progress.
+            progressHelper.ResolveAndAssertResult(deferred1, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ResolveAndAssertResult(deferred2, 1f, true);
+            Assert.IsTrue(complete);
+        }
+
+        [Test]
+        public void AsyncPromiseWillReportProgress_WhenAnotherAwaitableIsAwaitedWithoutProgress_Max_NoThrow_void()
+        {
+            var deferred1 = Promise.NewDeferred();
+            var deferred2 = Promise.NewDeferred();
+
+            async Promise Func()
+            {
+                (await deferred1.Promise.AwaitWithProgressNoThrow(0.5f)).RethrowIfRejectedOrCanceled();
                 await deferred2.Promise;
             }
 
@@ -1373,6 +1449,34 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
+        public void AsyncPromiseWillReportProgress_WhenAnotherAwaitableIsAwaitedWithoutProgress_MinMax_NoThrow_T()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            async Promise<int> Func()
+            {
+                (await deferred1.Promise.AwaitWithProgressNoThrow(0f, 0.5f)).RethrowIfRejectedOrCanceled();
+                return await deferred2.Promise;
+            }
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+            bool complete = false;
+
+            Func()
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Then(() => complete = true)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f));
+            // Implementation detail - progress is not reported after awaited promise is resolved, until another promise is awaited with progress.
+            progressHelper.ResolveAndAssertResult(deferred1, 1, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ResolveAndAssertResult(deferred2, 2, 1f, true);
+            Assert.IsTrue(complete);
+        }
+
+        [Test]
         public void AsyncPromiseWillReportProgress_WhenAnotherAwaitableIsAwaitedWithoutProgress_Max_T()
         {
             var deferred1 = Promise.NewDeferred<int>();
@@ -1381,6 +1485,34 @@ namespace ProtoPromiseTests.APIs
             async Promise<int> Func()
             {
                 await deferred1.Promise.AwaitWithProgress(0.5f);
+                return await deferred2.Promise;
+            }
+
+            var progressHelper = new ProgressHelper(ProgressType.Interface, SynchronizationType.Synchronous);
+            bool complete = false;
+
+            Func()
+                .SubscribeProgressAndAssert(progressHelper, 0f)
+                .Then(() => complete = true)
+                .Forget();
+
+            progressHelper.ReportProgressAndAssertResult(deferred1, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f));
+            // Implementation detail - progress is not reported after awaited promise is resolved, until another promise is awaited with progress.
+            progressHelper.ResolveAndAssertResult(deferred1, 1, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ReportProgressAndAssertResult(deferred2, 0.5f, TestHelper.Lerp(0f, 0.5f, 0.5f), false);
+            progressHelper.ResolveAndAssertResult(deferred2, 2, 1f, true);
+            Assert.IsTrue(complete);
+        }
+
+        [Test]
+        public void AsyncPromiseWillReportProgress_WhenAnotherAwaitableIsAwaitedWithoutProgress_Max_NoThrow_T()
+        {
+            var deferred1 = Promise.NewDeferred<int>();
+            var deferred2 = Promise.NewDeferred<int>();
+
+            async Promise<int> Func()
+            {
+                (await deferred1.Promise.AwaitWithProgressNoThrow(0.5f)).RethrowIfRejectedOrCanceled();
                 return await deferred2.Promise;
             }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/AwaitTests.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromiseTests/CoreTests/APIs/AwaitTests.cs
@@ -47,6 +47,26 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
+        public void ResolveAwaitedPromiseContinuesExecution_NoThrow()
+        {
+            var deferred = Promise.NewDeferred();
+
+            bool continued = false;
+
+            async void Func()
+            {
+                (await deferred.Promise.AwaitNoThrow()).RethrowIfRejectedOrCanceled();
+                continued = true;
+            }
+
+            Func();
+            Assert.IsFalse(continued);
+
+            deferred.Resolve();
+            Assert.IsTrue(continued);
+        }
+
+        [Test]
         public void ResolveAwaitedPromiseReturnsValueAndContinuesExecution()
         {
             var deferred = Promise.NewDeferred<int>();
@@ -69,6 +89,29 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
+        public void ResolveAwaitedPromiseReturnsValueAndContinuesExecution_NoThrow()
+        {
+            var deferred = Promise.NewDeferred<int>();
+
+            int expected = 50;
+            bool continued = false;
+
+            async void Func()
+            {
+                var resultContainer = await deferred.Promise.AwaitNoThrow();
+                resultContainer.RethrowIfRejectedOrCanceled();
+                Assert.AreEqual(expected, resultContainer.Result);
+                continued = true;
+            }
+
+            Func();
+            Assert.IsFalse(continued);
+
+            deferred.Resolve(expected);
+            Assert.IsTrue(continued);
+        }
+
+        [Test]
         public void AwaitAlreadyResolvedPromiseContinuesExecution()
         {
             bool continued = false;
@@ -76,6 +119,24 @@ namespace ProtoPromiseTests.APIs
             async void Func()
             {
                 await Promise.Resolved();
+                continued = true;
+            }
+
+            Assert.IsFalse(continued);
+            Func();
+            Assert.IsTrue(continued);
+
+            Assert.IsTrue(continued);
+        }
+
+        [Test]
+        public void AwaitAlreadyResolvedPromiseContinuesExecution_NoThrow()
+        {
+            bool continued = false;
+
+            async void Func()
+            {
+                (await Promise.Resolved().AwaitNoThrow()).RethrowIfRejectedOrCanceled();
                 continued = true;
             }
 
@@ -107,7 +168,28 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RejectAwaitedPromiseThrows1()
+        public void AwaitAlreadyResolvedPromiseReturnsValueAndContinuesExecution_NoThrow()
+        {
+            int expected = 50;
+            bool continued = false;
+
+            async void Func()
+            {
+                var resultContainer = await Promise.Resolved(expected).AwaitNoThrow();
+                resultContainer.RethrowIfRejectedOrCanceled();
+                Assert.AreEqual(expected, resultContainer.Result);
+                continued = true;
+            }
+
+            Assert.IsFalse(continued);
+            Func();
+            Assert.IsTrue(continued);
+
+            Assert.IsTrue(continued);
+        }
+
+        [Test]
+        public void RejectAwaitedPromiseThrows_void()
         {
             var deferred = Promise.NewDeferred();
 
@@ -135,7 +217,30 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RejectAwaitedPromiseThrows2()
+        public void RejectAwaitedPromiseNoThrow_IsRejectedWithReason_void()
+        {
+            var deferred = Promise.NewDeferred();
+
+            bool continued = false;
+            string rejectValue = "Reject";
+
+            async void Func()
+            {
+                var resultContainer = await deferred.Promise.AwaitNoThrow();
+                Assert.AreEqual(Promise.State.Rejected, resultContainer.State);
+                Assert.AreEqual(rejectValue, resultContainer.RejectReason);
+                continued = true;
+            }
+
+            Func();
+            Assert.IsFalse(continued);
+
+            deferred.Reject(rejectValue);
+            Assert.IsTrue(continued);
+        }
+
+        [Test]
+        public void RejectAwaitedPromiseThrows_T()
         {
             var deferred = Promise.NewDeferred<int>();
 
@@ -163,7 +268,30 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void AwaitAlreadyRejectedPromiseThrows1()
+        public void RejectAwaitedPromiseNoThrow_IsRejectedWithReason_T()
+        {
+            var deferred = Promise.NewDeferred<int>();
+
+            bool continued = false;
+            string rejectValue = "Reject";
+
+            async void Func()
+            {
+                var resultContainer = await deferred.Promise.AwaitNoThrow();
+                Assert.AreEqual(Promise.State.Rejected, resultContainer.State);
+                Assert.AreEqual(rejectValue, resultContainer.RejectReason);
+                continued = true;
+            }
+
+            Func();
+            Assert.IsFalse(continued);
+
+            deferred.Reject(rejectValue);
+            Assert.IsTrue(continued);
+        }
+
+        [Test]
+        public void AwaitAlreadyRejectedPromiseThrows_void()
         {
             bool continued = false;
             string rejectValue = "Reject";
@@ -184,12 +312,29 @@ namespace ProtoPromiseTests.APIs
             Assert.IsFalse(continued);
             Func();
             Assert.IsTrue(continued);
+        }
 
+        [Test]
+        public void AwaitNoThrowAlreadyRejectedPromise_IsRejectedWithReason_void()
+        {
+            bool continued = false;
+            string rejectValue = "Reject";
+
+            async void Func()
+            {
+                var resultContainer = await Promise.Rejected(rejectValue).AwaitNoThrow();
+                Assert.AreEqual(Promise.State.Rejected, resultContainer.State);
+                Assert.AreEqual(rejectValue, resultContainer.RejectReason);
+                continued = true;
+            }
+
+            Assert.IsFalse(continued);
+            Func();
             Assert.IsTrue(continued);
         }
 
         [Test]
-        public void AwaitAlreadyRejectedPromiseThrows2()
+        public void AwaitAlreadyRejectedPromiseThrows_T()
         {
             bool continued = false;
             string rejectValue = "Reject";
@@ -210,7 +355,24 @@ namespace ProtoPromiseTests.APIs
             Assert.IsFalse(continued);
             Func();
             Assert.IsTrue(continued);
+        }
 
+        [Test]
+        public void AwaitNoThrowAlreadyRejectedPromise_IsRejectedWithReason_T()
+        {
+            bool continued = false;
+            string rejectValue = "Reject";
+
+            async void Func()
+            {
+                var resultContainer = await Promise<int>.Rejected(rejectValue).AwaitNoThrow();
+                Assert.AreEqual(Promise.State.Rejected, resultContainer.State);
+                Assert.AreEqual(rejectValue, resultContainer.RejectReason);
+                continued = true;
+            }
+
+            Assert.IsFalse(continued);
+            Func();
             Assert.IsTrue(continued);
         }
 
@@ -233,6 +395,31 @@ namespace ProtoPromiseTests.APIs
                 {
                     continued = true;
                 }
+            }
+
+            Func();
+            Assert.IsFalse(continued);
+
+            cancelationSource.Cancel();
+            Assert.IsTrue(continued);
+
+            cancelationSource.Dispose();
+        }
+
+        [Test]
+        public void CancelAwaitedPromiseNoThrow_IsCanceled_void()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred();
+            cancelationSource.Token.Register(deferred);
+
+            bool continued = false;
+
+            async void Func()
+            {
+                var resultContainer = await deferred.Promise.AwaitNoThrow();
+                Assert.AreEqual(Promise.State.Canceled, resultContainer.State);
+                continued = true;
             }
 
             Func();
@@ -275,6 +462,31 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
+        public void CancelAwaitedPromiseNoThrow_IsCanceled_T()
+        {
+            CancelationSource cancelationSource = CancelationSource.New();
+            var deferred = Promise.NewDeferred<int>();
+            cancelationSource.Token.Register(deferred);
+
+            bool continued = false;
+
+            async void Func()
+            {
+                var resultContainer = await deferred.Promise.AwaitNoThrow();
+                Assert.AreEqual(Promise.State.Canceled, resultContainer.State);
+                continued = true;
+            }
+
+            Func();
+            Assert.IsFalse(continued);
+
+            cancelationSource.Cancel();
+            Assert.IsTrue(continued);
+
+            cancelationSource.Dispose();
+        }
+
+        [Test]
         public void AwaitAlreadyCanceledPromiseThrowsOperationCanceled_void()
         {
             bool continued = false;
@@ -299,6 +511,23 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
+        public void AwaitNoThrowAlreadyCanceledPromise_IsCanceled_void()
+        {
+            bool continued = false;
+
+            async void Func()
+            {
+                var resultContainer = await Promise.Canceled().AwaitNoThrow();
+                Assert.AreEqual(Promise.State.Canceled, resultContainer.State);
+                continued = true;
+            }
+
+            Assert.IsFalse(continued);
+            Func();
+            Assert.IsTrue(continued);
+        }
+
+        [Test]
         public void AwaitAlreadyCanceledPromiseThrowsOperationCanceled_T()
         {
             bool continued = false;
@@ -318,7 +547,22 @@ namespace ProtoPromiseTests.APIs
             Assert.IsFalse(continued);
             Func();
             Assert.IsTrue(continued);
+        }
 
+        [Test]
+        public void AwaitNoThrowAlreadyCanceledPromise_IsCanceled_T()
+        {
+            bool continued = false;
+
+            async void Func()
+            {
+                var resultContainer = await Promise<int>.Canceled().AwaitNoThrow();
+                Assert.AreEqual(Promise.State.Canceled, resultContainer.State);
+                continued = true;
+            }
+
+            Assert.IsFalse(continued);
+            Func();
             Assert.IsTrue(continued);
         }
 


### PR DESCRIPTION
Added `Promise(<T>).AwaitNoThrow()` and `Promise(<T>).AwaitWithProgressNoThrow()`.
Fixed `Promise.Wait(NoThrow)` not suppressing the rejection.