### PR TITLE
`AsyncLock` fix and perf

### DIFF
--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncConditionVariable.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncConditionVariable.cs
@@ -78,7 +78,7 @@ namespace Proto.Promises.Threading
                 rejectContainer.ReportUnhandled();
             }
         }
-#else
+#else // PROMISE_DEBUG
         public AsyncConditionVariable() { }
 #endif
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncLock.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncLock.cs
@@ -55,24 +55,46 @@ namespace Proto.Promises.Threading
         public AsyncLock() { }
 
         /// <summary>
-        /// Asynchronously acquire the lock. Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// Asynchronously acquire the lock.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise<Key> LockAsync()
+        {
+            return _impl.LockAsync();
+        }
+
+        /// <summary>
+        /// Asynchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<Key> LockAsync(CancelationToken cancelationToken = default)
+        public Promise<Key> LockAsync(CancelationToken cancelationToken)
         {
-            return _impl.LockAsync(false, cancelationToken);
+            return _impl.LockAsync(cancelationToken);
         }
 
         /// <summary>
         /// Synchronously acquire the lock. Returns the key that will release the lock when it is disposed.
         /// </summary>
+        [MethodImpl(Internal.InlineOption)]
+        public Key Lock()
+        {
+            return _impl.Lock();
+        }
+
+        /// <summary>
+        /// Synchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
+        /// Returns the key that will release the lock when it is disposed.
+        /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, a <see cref="CanceledException"/> will be thrown.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Key Lock(CancelationToken cancelationToken = default)
+        public Key Lock(CancelationToken cancelationToken)
         {
-            return _impl.LockAsync(true, cancelationToken).WaitForResult();
+            return _impl.Lock(cancelationToken);
         }
 
         /// <summary>

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncMonitor.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/AsyncMonitor.cs
@@ -25,24 +25,49 @@ namespace Proto.Promises.Threading
         private static ConditionalWeakTable<Internal.AsyncLockInternal, AsyncConditionVariable> s_condVarTable = new ConditionalWeakTable<Internal.AsyncLockInternal, AsyncConditionVariable>();
 
         /// <summary>
-        /// Asynchronously acquire the lock on the specified <see cref="AsyncLock"/>. Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// Asynchronously acquire the lock on the specified <see cref="AsyncLock"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="asyncLock">The async lock instance that is being entered.</param>
+        [MethodImpl(Internal.InlineOption)]
+        public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock)
+        {
+            return asyncLock.LockAsync();
+        }
+
+        /// <summary>
+        /// Asynchronously acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         /// <param name="asyncLock">The async lock instance that is being entered.</param>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         [MethodImpl(Internal.InlineOption)]
-        public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken = default)
+        public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken)
         {
             return asyncLock.LockAsync(cancelationToken);
         }
 
         /// <summary>
-        /// Synchronously acquire the lock on the specified <see cref="AsyncLock"/>. Returns the key that will release the lock when it is disposed.
+        /// Synchronously acquire the lock on the specified <see cref="AsyncLock"/>.
+        /// Returns the key that will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="asyncLock">The async lock instance that is being entered.</param>
+        [MethodImpl(Internal.InlineOption)]
+        public static AsyncLock.Key Enter(AsyncLock asyncLock)
+        {
+            return asyncLock.Lock();
+        }
+
+        /// <summary>
+        /// Synchronously acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
+        /// Returns the key that will release the lock when it is disposed.
         /// </summary>
         /// <param name="asyncLock">The async lock instance that is being entered.</param>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, a <see cref="CanceledException"/> will be thrown.</param>
         [MethodImpl(Internal.InlineOption)]
-        public static AsyncLock.Key Enter(AsyncLock asyncLock, CancelationToken cancelationToken = default)
+        public static AsyncLock.Key Enter(AsyncLock asyncLock, CancelationToken cancelationToken)
         {
             return asyncLock.Lock(cancelationToken);
         }

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncAutoResetEventInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncAutoResetEventInternal.cs
@@ -28,7 +28,6 @@ namespace Proto.Promises
 #endif
         internal sealed class AsyncAutoResetEventPromise : AsyncEventPromise<AsyncAutoResetEventInternal>
         {
-
             [MethodImpl(InlineOption)]
             private static AsyncAutoResetEventPromise GetOrCreate()
             {
@@ -42,8 +41,7 @@ namespace Proto.Promises
             internal static AsyncAutoResetEventPromise GetOrCreate(AsyncAutoResetEventInternal owner, SynchronizationContext callerContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset();
-                promise._callerContext = callerContext;
+                promise.Reset(callerContext);
                 promise._owner = owner;
                 return promise;
             }
@@ -70,7 +68,7 @@ namespace Proto.Promises
                     return;
                 }
                 _result = false;
-                Continue(Promise.State.Resolved);
+                Continue();
             }
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncCountdownEventInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncCountdownEventInternal.cs
@@ -42,8 +42,7 @@ namespace Proto.Promises
             internal static AsyncCountdownEventPromise GetOrCreate(AsyncCountdownEventInternal owner, SynchronizationContext callerContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset();
-                promise._callerContext = callerContext;
+                promise.Reset(callerContext);
                 promise._owner = owner;
                 return promise;
             }
@@ -70,7 +69,7 @@ namespace Proto.Promises
                     return;
                 }
                 _result = false;
-                Continue(Promise.State.Resolved);
+                Continue();
             }
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncManualResetEventInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncManualResetEventInternal.cs
@@ -41,8 +41,7 @@ namespace Proto.Promises
             internal static AsyncManualResetEventPromise GetOrCreate(AsyncManualResetEventInternal owner, SynchronizationContext callerContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset();
-                promise._callerContext = callerContext;
+                promise.Reset(callerContext);
                 promise._owner = owner;
                 return promise;
             }
@@ -69,7 +68,7 @@ namespace Proto.Promises
                     return;
                 }
                 _result = false;
-                Continue(Promise.State.Resolved);
+                Continue();
             }
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncReaderWriterLockInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncReaderWriterLockInternal.cs
@@ -48,9 +48,8 @@ namespace Proto.Promises
             internal static AsyncReaderLockPromise GetOrCreate(AsyncReaderWriterLockInternal owner, SynchronizationContext callerContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset();
+                promise.Reset(callerContext);
                 promise._result = new AsyncReaderWriterLock.ReaderKey(owner); ; // This will be overwritten when this is resolved, we just store the key with the owner here for cancelation.
-                promise._callerContext = callerContext;
                 return promise;
             }
 
@@ -70,7 +69,7 @@ namespace Proto.Promises
                 _cancelationRegistration.Dispose();
 
                 _result = new AsyncReaderWriterLock.ReaderKey(Owner, currentKey, this);
-                Continue(Promise.State.Resolved);
+                Continue();
             }
 
             public override void Cancel()
@@ -80,7 +79,8 @@ namespace Proto.Promises
                 {
                     return;
                 }
-                Continue(Promise.State.Canceled);
+                _tempState = Promise.State.Canceled;
+                Continue();
             }
         }
 
@@ -104,8 +104,7 @@ namespace Proto.Promises
             internal static AsyncWriterLockPromise GetOrCreate(AsyncReaderWriterLockInternal owner, SynchronizationContext callerContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset();
-                promise._callerContext = callerContext;
+                promise.Reset(callerContext);
                 promise._result = new AsyncReaderWriterLock.WriterKey(owner); // This will be overwritten when this is resolved, we just store the key with the owner here for cancelation.
                 return promise;
             }
@@ -126,16 +125,18 @@ namespace Proto.Promises
                 _cancelationRegistration.Dispose();
 
                 _result = new AsyncReaderWriterLock.WriterKey(Owner, writerKey, this);
-                Continue(Promise.State.Resolved);
+                Continue();
             }
 
             public override void Cancel()
             {
                 ThrowIfInPool(this);
-                if (Owner.TryUnregister(this))
+                if (!Owner.TryUnregister(this))
                 {
-                    Continue(Promise.State.Canceled);
+                    return;
                 }
+                _tempState = Promise.State.Canceled;
+                Continue();
             }
         }
 
@@ -159,9 +160,8 @@ namespace Proto.Promises
             internal static AsyncUpgradeableReaderLockPromise GetOrCreate(AsyncReaderWriterLockInternal owner, SynchronizationContext callerContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset();
+                promise.Reset(callerContext);
                 promise._result = new AsyncReaderWriterLock.UpgradeableReaderKey(owner); // This will be overwritten when this is resolved, we just store the key with the owner here for cancelation.
-                promise._callerContext = callerContext;
                 return promise;
             }
 
@@ -181,7 +181,7 @@ namespace Proto.Promises
                 _cancelationRegistration.Dispose();
 
                 _result = new AsyncReaderWriterLock.UpgradeableReaderKey(Owner, currentKey, this);
-                Continue(Promise.State.Resolved);
+                Continue();
             }
 
             public override void Cancel()
@@ -191,7 +191,8 @@ namespace Proto.Promises
                 {
                     return;
                 }
-                Continue(Promise.State.Canceled);
+                _tempState = Promise.State.Canceled;
+                Continue();
             }
         }
 

--- a/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncSemaphoreInternal.cs
+++ b/ProtoPromise_Unity/Assets/Plugins/ProtoPromise/Core/Threading/Internal/AsyncSemaphoreInternal.cs
@@ -42,8 +42,7 @@ namespace Proto.Promises
             internal static AsyncSemaphorePromise GetOrCreate(AsyncSemaphoreInternal owner, SynchronizationContext callerContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset();
-                promise._callerContext = callerContext;
+                promise.Reset(callerContext);
                 promise._owner = owner;
                 return promise;
             }
@@ -70,7 +69,7 @@ namespace Proto.Promises
                     return;
                 }
                 _result = false;
-                Continue(Promise.State.Resolved);
+                Continue();
             }
         }
 


### PR DESCRIPTION
Fixed abandoned `AsyncConditionVariable` not allowing exiting the `AsyncLock`.
Separated `AsyncLock.LockAsync(CancelationToken)` methods.