### PR TITLE
Optimize `Promise.Run`

### DIFF
--- a/Package/Core/Promises/Internal/DelegateWrappersInternal.cs
+++ b/Package/Core/Promises/Internal/DelegateWrappersInternal.cs
@@ -387,7 +387,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal struct DelegateVoidVoid : IAction, IFunc<Promise>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
+            internal struct DelegateVoidVoid : IAction, IFunc<Promise>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise, IDelegateRun
             {
                 private readonly Action _callback;
 
@@ -444,12 +444,19 @@ namespace Proto.Promises
                     Invoke();
                     owner.HandleNextInternal(null, Promise.State.Resolved);
                 }
+
+                [MethodImpl(InlineOption)]
+                void IDelegateRun.Invoke(PromiseRefBase owner)
+                {
+                    Invoke();
+                    owner.HandleNextInternal(null, Promise.State.Resolved);
+                }
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal struct DelegateVoidResult<TResult> : IFunc<TResult>, IFunc<Promise<TResult>>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
+            internal struct DelegateVoidResult<TResult> : IFunc<TResult>, IFunc<Promise<TResult>>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise, IDelegateRun
             {
                 private readonly Func<TResult> _callback;
 
@@ -505,6 +512,14 @@ namespace Proto.Promises
                 void IDelegateRejectPromise.InvokeRejecter(PromiseRefBase handler, object rejectContainer, PromiseRefBase owner)
                 {
                     handler.MaybeDispose();
+                    TResult result = Invoke();
+                    owner.UnsafeAs<PromiseRef<TResult>>()._result = result;
+                    owner.HandleNextInternal(null, Promise.State.Resolved);
+                }
+
+                [MethodImpl(InlineOption)]
+                void IDelegateRun.Invoke(PromiseRefBase owner)
+                {
                     TResult result = Invoke();
                     owner.UnsafeAs<PromiseRef<TResult>>()._result = result;
                     owner.HandleNextInternal(null, Promise.State.Resolved);
@@ -668,7 +683,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal struct DelegatePromiseVoidVoid : IFunc<Promise>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise
+            internal struct DelegatePromiseVoidVoid : IFunc<Promise>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise, IDelegateRunPromise
             {
                 private readonly Func<Promise> _callback;
 
@@ -704,12 +719,19 @@ namespace Proto.Promises
                     Promise result = Invoke();
                     owner.WaitFor(result, handler);
                 }
+
+                [MethodImpl(InlineOption)]
+                void IDelegateRunPromise.Invoke(PromiseRefBase owner)
+                {
+                    Promise result = Invoke();
+                    owner.WaitFor(result, null);
+                }
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal struct DelegatePromiseVoidResult<TResult> : IFunc<Promise<TResult>>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise
+            internal struct DelegatePromiseVoidResult<TResult> : IFunc<Promise<TResult>>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise, IDelegateRunPromise
             {
                 private readonly Func<Promise<TResult>> _callback;
 
@@ -744,6 +766,13 @@ namespace Proto.Promises
                     handler.MaybeDispose();
                     Promise<TResult> result = Invoke();
                     owner.WaitFor(result, handler);
+                }
+
+                [MethodImpl(InlineOption)]
+                void IDelegateRunPromise.Invoke(PromiseRefBase owner)
+                {
+                    Promise<TResult> result = Invoke();
+                    owner.WaitFor(result, null);
                 }
             }
 
@@ -1227,7 +1256,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal struct DelegateCaptureVoidVoid<TCapture> : IAction, IFunc<Promise>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
+            internal struct DelegateCaptureVoidVoid<TCapture> : IAction, IFunc<Promise>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise, IDelegateRun
             {
                 private readonly Action<TCapture> _callback;
                 private readonly TCapture _capturedValue;
@@ -1290,12 +1319,19 @@ namespace Proto.Promises
                     Invoke();
                     owner.HandleNextInternal(null, Promise.State.Resolved);
                 }
+                
+                [MethodImpl(InlineOption)]
+                void IDelegateRun.Invoke(PromiseRefBase owner)
+                {
+                    Invoke();
+                    owner.HandleNextInternal(null, Promise.State.Resolved);
+                }
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal struct DelegateCaptureVoidResult<TCapture, TResult> : IFunc<TResult>, IFunc<Promise<TResult>>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise
+            internal struct DelegateCaptureVoidResult<TCapture, TResult> : IFunc<TResult>, IFunc<Promise<TResult>>, IDelegateResolveOrCancel, IDelegateResolveOrCancelPromise, IDelegateReject, IDelegateRejectPromise, IDelegateRun
             {
                 private readonly Func<TCapture, TResult> _callback;
                 private readonly TCapture _capturedValue;
@@ -1357,6 +1393,14 @@ namespace Proto.Promises
                 void IDelegateRejectPromise.InvokeRejecter(PromiseRefBase handler, object rejectContainer, PromiseRefBase owner)
                 {
                     handler.MaybeDispose();
+                    TResult result = Invoke();
+                    owner.UnsafeAs<PromiseRef<TResult>>()._result = result;
+                    owner.HandleNextInternal(null, Promise.State.Resolved);
+                }
+
+                [MethodImpl(InlineOption)]
+                void IDelegateRun.Invoke(PromiseRefBase owner)
+                {
                     TResult result = Invoke();
                     owner.UnsafeAs<PromiseRef<TResult>>()._result = result;
                     owner.HandleNextInternal(null, Promise.State.Resolved);
@@ -1532,7 +1576,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal struct DelegateCapturePromiseVoidVoid<TCapture> : IFunc<Promise>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise
+            internal struct DelegateCapturePromiseVoidVoid<TCapture> : IFunc<Promise>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise, IDelegateRunPromise
             {
                 private readonly Func<TCapture, Promise> _callback;
                 private readonly TCapture _capturedValue;
@@ -1574,12 +1618,19 @@ namespace Proto.Promises
                     Promise result = Invoke();
                     owner.WaitFor(result, handler);
                 }
+                
+                [MethodImpl(InlineOption)]
+                void IDelegateRunPromise.Invoke(PromiseRefBase owner)
+                {
+                    Promise result = Invoke();
+                    owner.WaitFor(result, null);
+                }
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal struct DelegateCapturePromiseVoidResult<TCapture, TResult> : IFunc<Promise<TResult>>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise
+            internal struct DelegateCapturePromiseVoidResult<TCapture, TResult> : IFunc<Promise<TResult>>, IDelegateResolveOrCancelPromise, IDelegateRejectPromise, IDelegateRunPromise
             {
                 private readonly Func<TCapture, Promise<TResult>> _callback;
                 private readonly TCapture _capturedValue;
@@ -1620,6 +1671,13 @@ namespace Proto.Promises
                     handler.MaybeDispose();
                     Promise<TResult> result = Invoke();
                     owner.WaitFor(result, handler);
+                }
+                
+                [MethodImpl(InlineOption)]
+                void IDelegateRunPromise.Invoke(PromiseRefBase owner)
+                {
+                    Promise<TResult> result = Invoke();
+                    owner.WaitFor(result, null);
                 }
             }
 

--- a/Package/Core/Promises/Internal/InterfacesInternal.cs
+++ b/Package/Core/Promises/Internal/InterfacesInternal.cs
@@ -95,6 +95,16 @@ namespace Proto.Promises
                 void Invoke(PromiseRefBase handler, object rejectContainer, Promise.State state, PromiseRefBase owner);
                 bool IsNull { get; }
             }
+
+            internal interface IDelegateRun
+            {
+                void Invoke(PromiseRefBase owner);
+            }
+
+            internal interface IDelegateRunPromise
+            {
+                void Invoke(PromiseRefBase owner);
+            }
         }
     }
 }

--- a/Package/Core/Promises/Internal/Progress/ProgressSingleAwaitInternal.cs
+++ b/Package/Core/Promises/Internal/Progress/ProgressSingleAwaitInternal.cs
@@ -132,6 +132,13 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
+                new protected void Reset()
+                {
+                    base.Reset();
+                    _waitState = WaitState.First;
+                }
+
+                [MethodImpl(InlineOption)]
                 partial void SetSecondPreviousAndMaybeHookupProgress(PromiseRefBase secondPrevious, PromiseRefBase handler)
                 {
                     SetSecondPrevious(secondPrevious, handler);

--- a/Package/Core/Promises/Internal/Progress/ProgressSingleAwaitInternal.cs
+++ b/Package/Core/Promises/Internal/Progress/ProgressSingleAwaitInternal.cs
@@ -143,6 +143,7 @@ namespace Proto.Promises
                 {
                     SetSecondPrevious(secondPrevious, handler);
                     var listenerProgressRange = new ProgressRange(0f, 1f);
+                    Thread.MemoryBarrier(); // Prevent writes from moving after the read.
                     _next.MaybeHookupProgressToAwaited(this, secondPrevious, ref _progressRange, ref listenerProgressRange);
                 }
 

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -230,6 +230,20 @@ namespace Proto.Promises
                 private bool _forceAsync;
             }
 
+            partial class RunPromise<TResult, TDelegate> : PromiseSingleAwait<TResult>
+                where TDelegate : IDelegateRun
+            {
+                private SynchronizationContext _synchronizationContext;
+                private TDelegate _runner;
+            }
+
+            partial class RunWaitPromise<TResult, TDelegate> : PromiseWaitPromise<TResult>
+                where TDelegate : IDelegateRunPromise
+            {
+                private SynchronizationContext _synchronizationContext;
+                private TDelegate _runner;
+            }
+
             partial class PromiseMultiAwait<TResult> : PromiseRef<TResult>
             {
                 internal ValueList<HandleablePromiseBase> _nextBranches = new ValueList<HandleablePromiseBase>(8);

--- a/Package/Core/Promises/Internal/SentinelsInternal.cs
+++ b/Package/Core/Promises/Internal/SentinelsInternal.cs
@@ -159,10 +159,13 @@ namespace Proto.Promises
 
                 internal override PromiseRefBase AddWaiter(short promiseId, HandleablePromiseBase waiter, out HandleablePromiseBase previousWaiter)
                 {
-                    // Set the previous waiter to pending await sentinel so the caller will do nothing.
-                    previousWaiter = PendingAwaitSentinel.s_instance;
-                    // Immediately handle the waiter.
-                    waiter.Handle(this, null, Promise.State.Canceled);
+                    // The id is unlikely to not match, but check just in case the Promise struct was torn.
+                    if (promiseId != Id)
+                    {
+                        previousWaiter = InvalidAwaitSentinel.s_instance;
+                        return InvalidAwaitSentinel.s_instance;
+                    }
+                    previousWaiter = PromiseCompletionSentinel.s_instance;
                     return null;
                 }
 

--- a/Package/Core/Promises/PromiseStatic.cs
+++ b/Package/Core/Promises/PromiseStatic.cs
@@ -348,8 +348,7 @@ namespace Proto.Promises
         {
             ValidateArgument(action, "action", 1);
 
-            return SwitchToContext(synchronizationOption, forceAsync)
-                .Finally(action);
+            return Internal.PromiseRefBase.CallbackHelperVoid.Run(Internal.PromiseRefBase.DelegateWrapper.Create(action), (Internal.SynchronizationOption) synchronizationOption, null, forceAsync);
         }
 
         /// <summary>
@@ -364,8 +363,7 @@ namespace Proto.Promises
         {
             ValidateArgument(action, "action", 1);
 
-            return SwitchToContext(synchronizationOption, forceAsync)
-                .Finally(captureValue, action);
+            return Internal.PromiseRefBase.CallbackHelperVoid.Run(Internal.PromiseRefBase.DelegateWrapper.Create(captureValue, action), (Internal.SynchronizationOption) synchronizationOption, null, forceAsync);
         }
 
         /// <summary>
@@ -379,8 +377,7 @@ namespace Proto.Promises
         {
             ValidateArgument(action, "action", 1);
 
-            return SwitchToContext(synchronizationContext, forceAsync)
-                .Finally(action);
+            return Internal.PromiseRefBase.CallbackHelperVoid.Run(Internal.PromiseRefBase.DelegateWrapper.Create(action), Internal.SynchronizationOption.Explicit, synchronizationContext, forceAsync);
         }
 
         /// <summary>
@@ -395,8 +392,7 @@ namespace Proto.Promises
         {
             ValidateArgument(action, "action", 1);
 
-            return SwitchToContext(synchronizationContext, forceAsync)
-                .Finally(captureValue, action);
+            return Internal.PromiseRefBase.CallbackHelperVoid.Run(Internal.PromiseRefBase.DelegateWrapper.Create(captureValue, action), Internal.SynchronizationOption.Explicit, synchronizationContext, forceAsync);
         }
 
         /// <summary>
@@ -410,8 +406,7 @@ namespace Proto.Promises
         {
             ValidateArgument(function, "function", 1);
 
-            return SwitchToContext(synchronizationOption, forceAsync)
-                .Then(function);
+            return Internal.PromiseRefBase.CallbackHelperResult<T>.Run(Internal.PromiseRefBase.DelegateWrapper.Create(function), (Internal.SynchronizationOption) synchronizationOption, null, forceAsync);
         }
 
         /// <summary>
@@ -426,8 +421,7 @@ namespace Proto.Promises
         {
             ValidateArgument(function, "function", 1);
 
-            return SwitchToContext(synchronizationOption, forceAsync)
-                .Then(captureValue, function);
+            return Internal.PromiseRefBase.CallbackHelperResult<T>.Run(Internal.PromiseRefBase.DelegateWrapper.Create(captureValue, function), (Internal.SynchronizationOption) synchronizationOption, null, forceAsync);
         }
 
         /// <summary>
@@ -441,8 +435,7 @@ namespace Proto.Promises
         {
             ValidateArgument(function, "function", 1);
 
-            return SwitchToContext(synchronizationContext, forceAsync)
-                .Then(function);
+            return Internal.PromiseRefBase.CallbackHelperResult<T>.Run(Internal.PromiseRefBase.DelegateWrapper.Create(function), Internal.SynchronizationOption.Explicit, synchronizationContext, forceAsync);
         }
 
         /// <summary>
@@ -457,8 +450,7 @@ namespace Proto.Promises
         {
             ValidateArgument(function, "function", 1);
 
-            return SwitchToContext(synchronizationContext, forceAsync)
-                .Then(captureValue, function);
+            return Internal.PromiseRefBase.CallbackHelperResult<T>.Run(Internal.PromiseRefBase.DelegateWrapper.Create(captureValue, function), Internal.SynchronizationOption.Explicit, synchronizationContext, forceAsync);
         }
 
         /// <summary>
@@ -472,10 +464,7 @@ namespace Proto.Promises
         {
             ValidateArgument(function, "function", 1);
 
-            Promise promise = SwitchToContext(synchronizationOption, forceAsync);
-            // Depth -1 to properly normalize the progress from the returned promise.
-            return new Promise(promise._ref, promise._id, Internal.NegativeOneDepth)
-                .Then(function);
+            return Internal.PromiseRefBase.CallbackHelperVoid.RunWait(Internal.PromiseRefBase.DelegateWrapper.Create(function), (Internal.SynchronizationOption) synchronizationOption, null, forceAsync);
         }
 
         /// <summary>
@@ -490,10 +479,7 @@ namespace Proto.Promises
         {
             ValidateArgument(function, "function", 1);
 
-            Promise promise = SwitchToContext(synchronizationOption, forceAsync);
-            // Depth -1 to properly normalize the progress from the returned promise.
-            return new Promise(promise._ref, promise._id, Internal.NegativeOneDepth)
-                .Then(captureValue, function);
+            return Internal.PromiseRefBase.CallbackHelperVoid.RunWait(Internal.PromiseRefBase.DelegateWrapper.Create(captureValue, function), (Internal.SynchronizationOption) synchronizationOption, null, forceAsync);
         }
 
         /// <summary>
@@ -507,10 +493,7 @@ namespace Proto.Promises
         {
             ValidateArgument(function, "function", 1);
 
-            Promise promise = SwitchToContext(synchronizationContext, forceAsync);
-            // Depth -1 to properly normalize the progress from the returned promise.
-            return new Promise(promise._ref, promise._id, Internal.NegativeOneDepth)
-                .Then(function);
+            return Internal.PromiseRefBase.CallbackHelperVoid.RunWait(Internal.PromiseRefBase.DelegateWrapper.Create(function), Internal.SynchronizationOption.Explicit, synchronizationContext, forceAsync);
         }
 
         /// <summary>
@@ -525,10 +508,7 @@ namespace Proto.Promises
         {
             ValidateArgument(function, "function", 1);
 
-            Promise promise = SwitchToContext(synchronizationContext, forceAsync);
-            // Depth -1 to properly normalize the progress from the returned promise.
-            return new Promise(promise._ref, promise._id, Internal.NegativeOneDepth)
-                .Then(captureValue, function);
+            return Internal.PromiseRefBase.CallbackHelperVoid.RunWait(Internal.PromiseRefBase.DelegateWrapper.Create(captureValue, function), Internal.SynchronizationOption.Explicit, synchronizationContext, forceAsync);
         }
 
         /// <summary>
@@ -542,10 +522,7 @@ namespace Proto.Promises
         {
             ValidateArgument(function, "function", 1);
 
-            Promise promise = SwitchToContext(synchronizationOption, forceAsync);
-            // Depth -1 to properly normalize the progress from the returned promise.
-            return new Promise(promise._ref, promise._id, Internal.NegativeOneDepth)
-                .Then(function);
+            return Internal.PromiseRefBase.CallbackHelperResult<T>.RunWait(Internal.PromiseRefBase.DelegateWrapper.Create(function), (Internal.SynchronizationOption) synchronizationOption, null, forceAsync);
         }
 
         /// <summary>
@@ -560,10 +537,7 @@ namespace Proto.Promises
         {
             ValidateArgument(function, "function", 1);
 
-            Promise promise = SwitchToContext(synchronizationOption, forceAsync);
-            // Depth -1 to properly normalize the progress from the returned promise.
-            return new Promise(promise._ref, promise._id, Internal.NegativeOneDepth)
-                .Then(captureValue, function);
+            return Internal.PromiseRefBase.CallbackHelperResult<T>.RunWait(Internal.PromiseRefBase.DelegateWrapper.Create(captureValue, function), (Internal.SynchronizationOption) synchronizationOption, null, forceAsync);
         }
 
         /// <summary>
@@ -577,10 +551,7 @@ namespace Proto.Promises
         {
             ValidateArgument(function, "function", 1);
 
-            Promise promise = SwitchToContext(synchronizationContext, forceAsync);
-            // Depth -1 to properly normalize the progress from the returned promise.
-            return new Promise(promise._ref, promise._id, Internal.NegativeOneDepth)
-                .Then(function);
+            return Internal.PromiseRefBase.CallbackHelperResult<T>.RunWait(Internal.PromiseRefBase.DelegateWrapper.Create(function), Internal.SynchronizationOption.Explicit, synchronizationContext, forceAsync);
         }
 
         /// <summary>
@@ -595,10 +566,7 @@ namespace Proto.Promises
         {
             ValidateArgument(function, "function", 1);
 
-            Promise promise = SwitchToContext(synchronizationContext, forceAsync);
-            // Depth -1 to properly normalize the progress from the returned promise.
-            return new Promise(promise._ref, promise._id, Internal.NegativeOneDepth)
-                .Then(captureValue, function);
+            return Internal.PromiseRefBase.CallbackHelperResult<T>.RunWait(Internal.PromiseRefBase.DelegateWrapper.Create(captureValue, function), Internal.SynchronizationOption.Explicit, synchronizationContext, forceAsync);
         }
 
         /// <summary>


### PR DESCRIPTION
Also fixed a bug where `Promise.Canceled()` causes fields of the parent promise to be mutated after it is repooled.