### PR TITLE
Optimize `Promise.ParallelFor(Each)`

### DIFF
--- a/Package/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/Package/Core/Cancelations/Internal/CancelationInternal.cs
@@ -463,7 +463,6 @@ namespace Proto.Promises
                 return _this != null && _this.TryDispose(sourceId);
             }
 
-            [MethodImpl(InlineOption)]
             internal bool TryDispose(int sourceId)
             {
                 _smallFields._locker.Enter();

--- a/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
@@ -77,7 +77,12 @@ namespace Proto.Promises
 
                 private void HandleFromContext()
                 {
+                    var currentContext = ts_currentContext;
+                    ts_currentContext = _callerContext;
+
                     HandleNextInternal(_tempRejectContainer, _tempState);
+
+                    ts_currentContext = currentContext;
                 }
 
                 internal void MaybeHookupCancelation(CancelationToken cancelationToken)


### PR DESCRIPTION
Also fixed circular await detection not including the parallel promise.