### PR TITLE
Fix circular await detection with `Promise.ParallelFor(Each)`

### DIFF
--- a/Package/Core/Promises/Internal/MergeInternal.cs
+++ b/Package/Core/Promises/Internal/MergeInternal.cs
@@ -32,6 +32,9 @@ namespace Proto.Promises
 #endif
             internal abstract partial class MultiHandleablePromiseBase<TResult> : PromiseSingleAwait<TResult>
             {
+                partial void AddPending(PromiseRefBase pendingPromise);
+                partial void ClearPending();
+
                 internal override void Handle(PromiseRefBase handler, object rejectContainer, Promise.State state) { throw new System.InvalidOperationException(); }
 
                 // When each promise is completed, we decrement the wait count until it reaches zero before we handle the next waiter.
@@ -70,12 +73,7 @@ namespace Proto.Promises
                     _passThroughs = promisePassThroughs;
                     foreach (var passThrough in promisePassThroughs)
                     {
-#if PROMISE_DEBUG
-                        lock (_previousPromises)
-                        {
-                            _previousPromises.Push(passThrough.Owner);
-                        }
-#endif
+                        AddPending(passThrough.Owner);
                         passThrough.SetTargetAndAddToOwner(this);
                     }
                 }
@@ -87,12 +85,7 @@ namespace Proto.Promises
                     {
                         _passThroughs.Pop().Dispose();
                     }
-#if PROMISE_DEBUG
-                    lock (_previousPromises)
-                    {
-                        _previousPromises.Clear();
-                    }
-#endif
+                    ClearPending();
                 }
             }
 

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -434,11 +434,6 @@ namespace Proto.Promises
                 // We store the passthroughs for lazy progress subscribe.
                 // The passthroughs will be released when this has fully released if a progress listener did not do it already.
                 protected ValueLinkedStack<PromisePassThrough> _passThroughs;
-
-#if PROMISE_DEBUG
-                // This is used for circular promise chain detection.
-                protected Stack<PromiseRefBase> _previousPromises = new Stack<PromiseRefBase>();
-#endif
             }
 
             partial class MergePromise<TResult> : MultiHandleablePromiseBase<TResult>


### PR DESCRIPTION
#241 had only a half-fix. This fixes it from both directions.