### PR TITLE
Use function pointers instead of delegates to clear object pool in C#9.

### DIFF
--- a/Package/UnityHelpers/ProtoPromiseUnityHelpers.asmdef
+++ b/Package/UnityHelpers/ProtoPromiseUnityHelpers.asmdef
@@ -6,7 +6,7 @@
     "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,

--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -63,9 +63,11 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <!--Otherwise, we don't need any newer language features beyond 7.3.-->
-        <LangVersion>7.3</LangVersion>
-        <DefineConstants>$(DefineConstants);CSHARP_7_3_OR_NEWER</DefineConstants>
+        <!--For function pointers.-->
+        <LangVersion>9</LangVersion>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <!--We check UNITY_2021_2_OR_NEWER to see if C#9 is supported, since Unity doesn't have a language define constant for it.-->
+        <DefineConstants>$(DefineConstants);CSHARP_7_3_OR_NEWER;UNITY_2021_2_OR_NEWER</DefineConstants>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/ProtoPromiseUnityHelpers/ProtoPromiseUnityHelpers.csproj
+++ b/ProtoPromiseUnityHelpers/ProtoPromiseUnityHelpers.csproj
@@ -31,7 +31,9 @@
       <PropertyGroup>
         <!-- The language version Unity supports with netstandard2.1. -->
         <LangVersion>9</LangVersion>
-        <DefineConstants>$(DefineConstants);CSHARP_7_3_OR_NEWER</DefineConstants>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <!--We check UNITY_2021_2_OR_NEWER to see if C#9 is supported, since Unity doesn't have a language define constant for it.-->
+        <DefineConstants>$(DefineConstants);CSHARP_7_3_OR_NEWER;UNITY_2021_2_OR_NEWER</DefineConstants>
       </PropertyGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
Resolves #252