### PR TITLE
Preserve causality trace

### DIFF
--- a/Package/Core/InternalShared/DebugInternal.cs
+++ b/Package/Core/InternalShared/DebugInternal.cs
@@ -66,6 +66,34 @@ namespace Proto.Promises
             SetCreatedStacktrace(traceable, skipFrames);
         }
 
+#if PROMISE_DEBUG
+        private sealed class SyncTrace : ITraceable
+        {
+            CausalityTrace ITraceable.Trace { get; set; }
+
+            private SyncTrace() { }
+
+            internal static ITraceable GetCurrent(int skipFrames)
+            {
+                if (Promise.Config.DebugCausalityTracer != Promise.TraceLevel.All)
+                {
+                    return null;
+                }
+
+                var syncTrace = new SyncTrace();
+                SetCreatedStacktrace(syncTrace, skipFrames + 1);
+                return syncTrace;
+            }
+        }
+
+        private static ITraceable SynchronousTraceable
+        {
+            get { return SyncTrace.GetCurrent(2); }
+        }
+#else
+        private const ITraceable SynchronousTraceable = null;
+#endif
+
         static partial void SetCreatedStacktrace(ITraceable traceable, int skipFrames);
         static partial void SetCurrentInvoker(ITraceable current);
         static partial void ClearCurrentInvoker();

--- a/Package/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/Package/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -1541,10 +1541,10 @@ namespace Proto.Promises
                     in
 #endif
                     TProgress progress,
-                    float value,
-                    ITraceable traceable)
+                    float value)
                     where TProgress : IProgress<float>
                 {
+                    var traceable = SynchronousTraceable;
                     SetCurrentInvoker(traceable);
                     try
                     {
@@ -1587,7 +1587,7 @@ namespace Proto.Promises
                                 {
                                     _this._ref.MaybeMarkAwaitedAndDispose(_this._id);
                                 }
-                                InvokeAndCatchProgress(progress, 1, null);
+                                InvokeAndCatchProgress(progress, 1);
                                 return CreateResolved(_this.Depth);
                             }
                             break;
@@ -1623,7 +1623,7 @@ namespace Proto.Promises
                                 }
                                 if (!forceAsync & synchronizationContext == ts_currentContext)
                                 {
-                                    InvokeAndCatchProgress(progress, 1, null);
+                                    InvokeAndCatchProgress(progress, 1);
                                     return CreateResolved(_this.Depth);
                                 }
                                 promise = PromiseProgress<VoidResult, TProgress>.GetOrCreateFromResolved(progress, new VoidResult(), _this.Depth, synchronizationContext, forceAsync, cancelationToken);
@@ -1666,7 +1666,7 @@ namespace Proto.Promises
                             if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
                             {
                                 TResult result = GetResultFromResolved(_this);
-                                InvokeAndCatchProgress(progress, 1, null);
+                                InvokeAndCatchProgress(progress, 1);
                                 return CreateResolved(result, _this.Depth);
                             }
                             break;
@@ -1699,7 +1699,7 @@ namespace Proto.Promises
                                 TResult result = GetResultFromResolved(_this);
                                 if (!forceAsync & synchronizationContext == ts_currentContext)
                                 {
-                                    InvokeAndCatchProgress(progress, 1, null);
+                                    InvokeAndCatchProgress(progress, 1);
                                     return CreateResolved(result, _this.Depth);
                                 }
                                 promise = PromiseProgress<TResult, TProgress>.GetOrCreateFromResolved(progress, result, _this.Depth, synchronizationContext, forceAsync, cancelationToken);


### PR DESCRIPTION
when progress callback is invoked synchronously.

Master:

```
Proto.Promises.Internal+UnhandledExceptionInternal : An exception was not handled. -- This exception's Stacktrace contains the causality trace of all async callbacks that ran.
  ----> System.NullReferenceException : Object reference not set to an instance of an object.
  Stack Trace:
     at ProtoPromiseTests.APIs.ProgressTests.ProgressChainSubscribedWillBeInvokedInOrder_Resolved_void(SynchronizationOption synchronizationOption, Boolean forceAsync) in C:\Users\Tim\Documents\git\ProtoPromise\Package\Tests\CoreTests\APIs\ProgressTests.cs:line 1839

--TearDown

--NullReferenceException
   at ProtoPromiseTests.APIs.ProgressTests.<>c.<ProgressChainSubscribedWillBeInvokedInOrder_Resolved_void>b__75_1(Single v) in C:\Users\Tim\Documents\git\ProtoPromise\Package\Tests\CoreTests\APIs\ProgressTests.cs:line 1830
   at Proto.Promises.Internal.PromiseRefBase.CallbackHelperVoid.InvokeAndCatchProgress[TProgress](TProgress& progress, Single value, ITraceable traceable) in C:\Users\Tim\Documents\git\ProtoPromise\Package\Core\Promises\Internal\CallbackHelperInternal.cs:line 1552
```

PR:

```
Proto.Promises.Internal+UnhandledExceptionInternal : An exception was not handled. -- This exception's Stacktrace contains the causality trace of all async callbacks that ran.
  ----> System.NullReferenceException : Object reference not set to an instance of an object.
  Stack Trace:
     at ProtoPromiseTests.APIs.ProgressTests.ProgressChainSubscribedWillBeInvokedInOrder_Resolved_void(SynchronizationOption synchronizationOption, Boolean forceAsync) in C:\Users\Tim\Documents\git\ProtoPromise\Package\Tests\CoreTests\APIs\ProgressTests.cs:line 1840

--TearDown
   at ProtoPromiseTests.APIs.ProgressTests.<>c__DisplayClass75_0.<ProgressChainSubscribedWillBeInvokedInOrder_Resolved_void>b__0() in C:\Users\Tim\Documents\git\ProtoPromise\Package\Tests\CoreTests\APIs\ProgressTests.cs:line 1828

   at ProtoPromiseTests.APIs.ProgressTests.ProgressChainSubscribedWillBeInvokedInOrder_Resolved_void(SynchronizationOption synchronizationOption, Boolean forceAsync) in C:\Users\Tim\Documents\git\ProtoPromise\Package\Tests\CoreTests\APIs\ProgressTests.cs:line 1824

   at NUnit.Framework.Internal.Reflect.InvokeMethod(MethodInfo method, Object fixture, Object[] args)

   at NUnit.Framework.Internal.MethodWrapper.Invoke(Object fixture, Object[] args)

   at NUnit.Framework.Internal.Commands.TestMethodCommand.InvokeTestMethod(TestExecutionContext context)

   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)

   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)

   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()

   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)

   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.Execute(TestExecutionContext context)

   at NUnit.Framework.Internal.Execution.SimpleWorkItem.<>c__DisplayClass4_0.<PerformWork>b__0()

   at NUnit.Framework.Internal.ContextUtils.<>c__DisplayClass1_0`1.<DoIsolated>b__0(Object _)

   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)

   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)

   at NUnit.Framework.Internal.ContextUtils.DoIsolated(ContextCallback callback, Object state)

   at NUnit.Framework.Internal.ContextUtils.DoIsolated[T](Func`1 func)

   at NUnit.Framework.Internal.Execution.SimpleWorkItem.PerformWork()

   at NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()

   at NUnit.Framework.Internal.Execution.WorkItem.Execute()

   at NUnit.Framework.Internal.Execution.ParallelWorkItemDispatcher.Dispatch(WorkItem work, ParallelExecutionStrategy strategy)

   at NUnit.Framework.Internal.Execution.ParallelWorkItemDispatcher.Dispatch(WorkItem work)

   at NUnit.Framework.Internal.Execution.CompositeWorkItem.RunChildren()

   at NUnit.Framework.Internal.Execution.CompositeWorkItem.PerformWork()

   at NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()

   at NUnit.Framework.Internal.Execution.WorkItem.Execute()

   at NUnit.Framework.Internal.Execution.ParallelWorkItemDispatcher.Dispatch(WorkItem work, ParallelExecutionStrategy strategy)

   at NUnit.Framework.Internal.Execution.ParallelWorkItemDispatcher.Dispatch(WorkItem work)

   at NUnit.Framework.Internal.Execution.CompositeWorkItem.RunChildren()

   at NUnit.Framework.Internal.Execution.CompositeWorkItem.PerformWork()

   at NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()

   at NUnit.Framework.Internal.Execution.WorkItem.Execute()

   at NUnit.Framework.Internal.Execution.TestWorker.TestWorkerThreadProc()

   at System.Threading.Thread.StartHelper.Callback(Object state)

   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)

   at System.Threading.Thread.StartCallback()

   at ProtoPromiseTests.APIs.ProgressTests.ProgressChainSubscribedWillBeInvokedInOrder_Resolved_void(SynchronizationOption synchronizationOption, Boolean forceAsync) in C:\Users\Tim\Documents\git\ProtoPromise\Package\Tests\CoreTests\APIs\ProgressTests.cs:line 1824

   at NUnit.Framework.Internal.Reflect.InvokeMethod(MethodInfo method, Object fixture, Object[] args)

   at NUnit.Framework.Internal.MethodWrapper.Invoke(Object fixture, Object[] args)

   at NUnit.Framework.Internal.Commands.TestMethodCommand.InvokeTestMethod(TestExecutionContext context)

   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)

   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)

   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()

   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)

   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.Execute(TestExecutionContext context)

   at NUnit.Framework.Internal.Execution.SimpleWorkItem.<>c__DisplayClass4_0.<PerformWork>b__0()

   at NUnit.Framework.Internal.ContextUtils.<>c__DisplayClass1_0`1.<DoIsolated>b__0(Object _)

   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)

   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)

   at NUnit.Framework.Internal.ContextUtils.DoIsolated(ContextCallback callback, Object state)

   at NUnit.Framework.Internal.ContextUtils.DoIsolated[T](Func`1 func)

   at NUnit.Framework.Internal.Execution.SimpleWorkItem.PerformWork()

   at NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()

   at NUnit.Framework.Internal.Execution.WorkItem.Execute()

   at NUnit.Framework.Internal.Execution.ParallelWorkItemDispatcher.Dispatch(WorkItem work, ParallelExecutionStrategy strategy)

   at NUnit.Framework.Internal.Execution.ParallelWorkItemDispatcher.Dispatch(WorkItem work)

   at NUnit.Framework.Internal.Execution.CompositeWorkItem.RunChildren()

   at NUnit.Framework.Internal.Execution.CompositeWorkItem.PerformWork()

   at NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()

   at NUnit.Framework.Internal.Execution.WorkItem.Execute()

   at NUnit.Framework.Internal.Execution.ParallelWorkItemDispatcher.Dispatch(WorkItem work, ParallelExecutionStrategy strategy)

   at NUnit.Framework.Internal.Execution.ParallelWorkItemDispatcher.Dispatch(WorkItem work)

   at NUnit.Framework.Internal.Execution.CompositeWorkItem.RunChildren()

   at NUnit.Framework.Internal.Execution.CompositeWorkItem.PerformWork()

   at NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()

   at NUnit.Framework.Internal.Execution.WorkItem.Execute()

   at NUnit.Framework.Internal.Execution.TestWorker.TestWorkerThreadProc()

   at System.Threading.Thread.StartHelper.Callback(Object state)

   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)

   at System.Threading.Thread.StartCallback()

--NullReferenceException
   at ProtoPromiseTests.APIs.ProgressTests.<>c.<ProgressChainSubscribedWillBeInvokedInOrder_Resolved_void>b__75_1(Single v) in C:\Users\Tim\Documents\git\ProtoPromise\Package\Tests\CoreTests\APIs\ProgressTests.cs:line 1830
   at Proto.Promises.Internal.PromiseRefBase.CallbackHelperVoid.InvokeAndCatchProgress[TProgress](TProgress& progress, Single value) in C:\Users\Tim\Documents\git\ProtoPromise\Package\Core\Promises\Internal\CallbackHelperInternal.cs:line 1549
```