### PR TITLE
Insert end of stacktrace message in causality trace

### DIFF
--- a/Package/Core/InternalShared/AssemblyAttributes.cs
+++ b/Package/Core/InternalShared/AssemblyAttributes.cs
@@ -1,6 +1,18 @@
 ﻿// File named AssemblyAttributes.cs instead of AssemblyInfo.cs to avoid conflicts with an auto-generated file of the same name.
 
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ProtoPromiseUnityHelpers")]
 [assembly: InternalsVisibleTo("ProtoPromiseTests")]
+
+namespace Proto.Promises
+{
+    partial class Internal
+    {
+        internal static readonly HashSet<string> FriendAssemblies = new HashSet<string>()
+        {
+            "ProtoPromiseUnityHelpers"
+        };
+    }
+}

--- a/Package/Core/InternalShared/AssemblyAttributes.cs
+++ b/Package/Core/InternalShared/AssemblyAttributes.cs
@@ -1,18 +1,6 @@
 ﻿// File named AssemblyAttributes.cs instead of AssemblyInfo.cs to avoid conflicts with an auto-generated file of the same name.
 
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ProtoPromiseUnityHelpers")]
 [assembly: InternalsVisibleTo("ProtoPromiseTests")]
-
-namespace Proto.Promises
-{
-    partial class Internal
-    {
-        internal static readonly HashSet<string> FriendAssemblies = new HashSet<string>()
-        {
-            "ProtoPromiseUnityHelpers"
-        };
-    }
-}

--- a/Package/Core/InternalShared/DebugInternal.cs
+++ b/Package/Core/InternalShared/DebugInternal.cs
@@ -211,10 +211,14 @@ namespace Proto.Promises
                     {
                         // Ignore DebuggerNonUserCode and DebuggerHidden.
                         var methodType = frame?.GetMethod();
+                        var declaringType = methodType?.DeclaringType;
                         return methodType != null
                             && !methodType.IsDefined(typeof(DebuggerNonUserCodeAttribute), false)
-                            && !methodType.DeclaringType.IsDefined(typeof(DebuggerNonUserCodeAttribute), false)
-                            && !methodType.IsDefined(typeof(DebuggerHiddenAttribute), false);
+                            && !declaringType.IsDefined(typeof(DebuggerNonUserCodeAttribute), false)
+                            && !methodType.IsDefined(typeof(DebuggerHiddenAttribute), false)
+                            // Also ignore all types from this assembly and friend assemblies (because of compiler-generated types).
+                            && declaringType.Assembly != typeof(Promise).Assembly
+                            && !FriendAssemblies.Contains(declaringType.Assembly.GetName().Name);
                     })
                     // Create a new StackTrace to get proper formatting.
                     .Select(frame => new StackTrace(frame).ToString())

--- a/Package/Core/InternalShared/DebugInternal.cs
+++ b/Package/Core/InternalShared/DebugInternal.cs
@@ -163,10 +163,6 @@ namespace Proto.Promises
             var sb = new System.Text.StringBuilder();
             foreach (StackTrace st in stackTraces)
             {
-                if (st == null)
-                {
-                    continue;
-                }
                 string stackTrace = st.ToString();
                 if (string.IsNullOrEmpty(stackTrace))
                 {
@@ -176,14 +172,14 @@ namespace Proto.Promises
                 {
                     if (!trace.Contains("Proto.Promises"))
                     {
-                        sb.Append(trace)
-                            .Replace(":line ", ":")
-                            .Replace("(", " (")
-                            .Replace(") in", ") [0x00000] in"); // Not sure what "[0x00000]" is, but it's necessary for Unity's parsing.
-                        _stackTraces.Add(sb.ToString());
-                        sb.Length = 0;
+                        sb.AppendLine(trace);
                     }
                 }
+                sb.Replace(":line ", ":")
+                    .Replace("(", " (")
+                    .Replace(") in", ") [0x00000] in"); // Not sure what "[0x00000]" is, but it's necessary for Unity's parsing.
+                _stackTraces.Add(sb.ToString());
+                sb.Length = 0;
             }
             if (_stackTraces.Count == 0)
             {


### PR DESCRIPTION
Matches the message that `ExceptionDispatchInfo` inserts in stack traces.
Also ignore all stack frames from `[DebuggerNonUserCode]` methods and DeclaringTypes (recursive).

Master:

```
Exception: Exception of type 'System.Exception' was thrown.
PromiseTest+<>c.<Func2>b__2_0 () (at Assets/PromiseTest.cs:26)
Proto.Promises.Internal+PromiseRefBase+DelegatePromiseVoidVoid.Invoke () (at Assets/Package/Core/Promises/Internal/DelegateWrappersInternal.cs:777)
Proto.Promises.Internal+PromiseRefBase+DelegatePromiseVoidVoid.Proto.Promises.Internal.PromiseRefBase.IDelegateResolveOrCancelPromise.InvokeResolver (Proto.Promises.Internal+PromiseRefBase handler, Proto.Promises.Promise+State state, Proto.Promises.Internal+PromiseRefBase owner) (at Assets/Package/Core/Promises/Internal/DelegateWrappersInternal.cs:784)
Proto.Promises.Internal+PromiseRefBase+PromiseResolvePromise`2[TResult,TResolver].Execute (Proto.Promises.Internal+PromiseRefBase handler, System.Object rejectContainer, Proto.Promises.Promise+State state, System.Boolean& invokingRejected) (at Assets/Package/Core/Promises/Internal/PromiseInternal.cs:1604)
Proto.Promises.Internal+PromiseRefBase+PromiseSingleAwait`1[TResult].Handle (Proto.Promises.Internal+PromiseRefBase handler, System.Object rejectContainer, Proto.Promises.Promise+State state) (at Assets/Package/Core/Promises/Internal/PromiseInternal.cs:706)
Rethrow as UnhandledExceptionInternal: An exception was not handled. -- This exception's Stacktrace contains the causality trace of all async callbacks that ran.
PromiseTest.Func2 () (at Assets/PromiseTest.cs:23)
Proto.Promises.Internal+PromiseRefBase+PromiseConfigured`1+<>c[TResult].<ScheduleContinuationOnContext>b__15_0 (System.Object obj) (at Assets/Package/Core/Promises/Internal/PromiseInternal.cs:1136)
Proto.Promises.Internal+<>c__DisplayClass33_0.<ScheduleContextCallback>b__1 (System.Object _) (at Assets/Package/Core/InternalShared/HelperFunctionsInternal.cs:71)
PromiseTest.Func1 () (at Assets/PromiseTest.cs:17)
PromiseTest.Start () (at Assets/PromiseTest.cs:12)
```

PR:

```
Exception: Exception of type 'System.Exception' was thrown.
PromiseTest+<>c.<Func2>b__2_0 () (at Assets/PromiseTest.cs:26)
Proto.Promises.Internal+PromiseRefBase+DelegatePromiseVoidVoid.Invoke () (at Assets/Package/Core/Promises/Internal/DelegateWrappersInternal.cs:777)
Proto.Promises.Internal+PromiseRefBase+DelegatePromiseVoidVoid.Proto.Promises.Internal.PromiseRefBase.IDelegateResolveOrCancelPromise.InvokeResolver (Proto.Promises.Internal+PromiseRefBase handler, Proto.Promises.Promise+State state, Proto.Promises.Internal+PromiseRefBase owner) (at Assets/Package/Core/Promises/Internal/DelegateWrappersInternal.cs:784)
Proto.Promises.Internal+PromiseRefBase+PromiseResolvePromise`2[TResult,TResolver].Execute (Proto.Promises.Internal+PromiseRefBase handler, System.Object rejectContainer, Proto.Promises.Promise+State state, System.Boolean& invokingRejected) (at Assets/Package/Core/Promises/Internal/PromiseInternal.cs:1604)
Proto.Promises.Internal+PromiseRefBase+PromiseSingleAwait`1[TResult].Handle (Proto.Promises.Internal+PromiseRefBase handler, System.Object rejectContainer, Proto.Promises.Promise+State state) (at Assets/Package/Core/Promises/Internal/PromiseInternal.cs:706)
Rethrow as UnhandledExceptionInternal: An exception was not handled. -- This exception's Stacktrace contains the causality trace of all async callbacks that ran.
PromiseTest.Func2 () (at Assets/PromiseTest.cs:23)
--- End of stack trace from the previous location where the exception was thrown ---
PromiseTest.Func1 () (at Assets/PromiseTest.cs:17)
PromiseTest.Start () (at Assets/PromiseTest.cs:12)
```