### PR TITLE
Add `TempCollection<T>` type

### DIFF
--- a/Package/Core/Collections.meta
+++ b/Package/Core/Collections.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 472df69e670d00b46b1d5249132b5112
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Core/Collections/TempCollection.cs
+++ b/Package/Core/Collections/TempCollection.cs
@@ -257,7 +257,7 @@ namespace Proto.Promises.Collections
 
         internal void ValidateAccess()
         {
-            if (_disposedChecker._isDisposed)
+            if (_disposedChecker == null || _disposedChecker._isDisposed)
             {
                 throw new InvalidOperationException("TempCollection is invalid.", Internal.GetFormattedStacktrace(2));
             }

--- a/Package/Core/Collections/TempCollection.cs
+++ b/Package/Core/Collections/TempCollection.cs
@@ -1,0 +1,334 @@
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+#if CSHARP_7_3_OR_NEWER
+
+using System;
+#if (NET47 || NETCOREAPP || NETSTANDARD2_0_OR_GREATER || UNITY_2021_2_OR_NEWER)
+using System.Buffers;
+#endif
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+#pragma warning disable IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0251 // Make member 'readonly'
+
+#endif // CSHARP_7_3_OR_NEWER
+
+namespace Proto.Promises.Collections
+{
+#if CSHARP_7_3_OR_NEWER // This is only used for async Linq, so we don't need to expose it in older runtimes.
+    /// <summary>
+    /// Exposes a readonly collection of items using temporary storage.
+    /// </summary>
+    /// <typeparam name="T">The type of the items in the collection.</typeparam>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+    [DebuggerNonUserCode, StackTraceHidden]
+#endif
+    public readonly partial struct TempCollection<T> : IReadOnlyList<T>
+    {
+        // We use this type to expose items from ArrayPool arrays, so we can return to the pool safely.
+        // This way we don't allocate garbage as a library.
+        private readonly TempCollectionBuilder<T> _target;
+
+        [MethodImpl(Internal.InlineOption)]
+        internal TempCollection(TempCollectionBuilder<T> target)
+            => _target = target;
+
+        /// <summary>
+        /// Gets the element at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to get.</param>
+        /// <returns>The element at the specified index.</returns>
+        /// <exception cref="IndexOutOfRangeException">The index is less than 0 or greater than <see cref="Count"/>.</exception>
+        /// <exception cref="InvalidOperationException">This instance is no longer valid.</exception>
+        public T this[int index]
+        {
+            [MethodImpl(Internal.InlineOption)]
+            get
+            {
+                ValidateIndex(index);
+                return _target._items[index];
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of elements in the collection.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">This instance is no longer valid.</exception>
+        public int Count
+        {
+            [MethodImpl(Internal.InlineOption)]
+            get
+            {
+                ValidateAccess();
+                return _target._count;
+            }
+        }
+
+        /// <summary>
+        /// Gets an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        /// <exception cref="InvalidOperationException">This instance is no longer valid.</exception>
+        public Enumerator GetEnumerator()
+        {
+            ValidateAccess();
+            return new Enumerator(this);
+        }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// Copies the items to an <see cref="Array"/>, starting at a particular <see cref="Array"/> index.
+        /// </summary>
+        /// <param name="array">The one-dimensional <see cref="Array"/> that is the destination of the elements copied from this. The <see cref="Array"/> must have zero-based indexing.</param>
+        /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="array"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="arrayIndex"/> is less than 0.</exception>
+        /// <exception cref="ArgumentException">The <see cref="Count"/> of this is greater than the available space from <paramref name="arrayIndex"/> to the end of the destination <paramref name="array"/>.</exception>
+        /// <exception cref="InvalidOperationException">This instance is no longer valid.</exception>
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            ValidateAccess();
+            _target.CopyTo(array, arrayIndex);
+        }
+
+        /// <summary>
+        /// Copies the elements to a new <see cref="Array"/>.
+        /// </summary>
+        /// <returns>A new <see cref="Array"/> containing the copied elements.</returns>
+        /// <exception cref="InvalidOperationException">This instance is no longer valid.</exception>
+        public T[] ToArray()
+        {
+            ValidateAccess();
+            var arr = new T[_target._count];
+            CopyTo(arr, 0);
+            return arr;
+        }
+
+        /// <summary>
+        /// Copies the elements to a new <see cref="List{T}"/>.
+        /// </summary>
+        /// <returns>A new <see cref="List{T}"/> containing the copied elements.</returns>
+        /// <exception cref="InvalidOperationException">This instance is no longer valid.</exception>
+        public List<T> ToList()
+        {
+            ValidateAccess();
+            int count = _target._count;
+            var list = new List<T>(count);
+            for (int i = 0; i < count; ++i)
+            {
+                list.Add(_target._items[i]);
+            }
+            return list;
+        }
+
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER || UNITY_2021_2_OR_NEWER // We only expose Span where it's supported natively (no nuget package required).
+        /// <summary>
+        /// Gets a readonly view of the elements.
+        /// </summary>
+        public ReadOnlySpan<T> Span
+        {
+            [MethodImpl(Internal.InlineOption)]
+            get
+            {
+                ValidateAccess();
+                return _target.Span;
+            }
+        }
+#endif // NETCOREAPP || NETSTANDARD2_1_OR_GREATER || UNITY_2021_2_OR_NEWER
+
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+        private void ValidateIndex(int index)
+        {
+            ValidateAccess();
+            _target.ValidateIndex(index);
+        }
+
+        private void ValidateAccess()
+        {
+            _target.ValidateAccess();
+        }
+#else
+        partial void ValidateIndex(int index);
+        partial void ValidateAccess();
+#endif
+
+        /// <summary>
+        /// Provides an enumerator for iterating over the items in the <see cref="TempCollection{T}"/>.
+        /// </summary>
+        public struct Enumerator : IEnumerator<T>
+        {
+            private readonly TempCollection<T> _target;
+            private int _current;
+
+            /// <summary>
+            /// Gets the element at the current index.
+            /// </summary>
+            /// <exception cref="InvalidOperationException">The collection is no longer valid.</exception>
+            public T Current
+            {
+                [MethodImpl(Internal.InlineOption)]
+                get { return _target[_current]; }
+            }
+
+            object IEnumerator.Current => Current;
+
+            internal Enumerator(TempCollection<T> target)
+            {
+                _target = target;
+                _current = -1;
+            }
+
+            /// <summary>
+            /// Moves the enumerator to the next index.
+            /// </summary>
+            /// <returns>True if there is an element at the next index, otherwise false.</returns>
+            /// <exception cref="InvalidOperationException">The collection is no longer valid.</exception>
+            public bool MoveNext()
+            {
+                int newIndex = _current + 1;
+                if (newIndex >= _target.Count)
+                {
+                    return false;
+                }
+                _current = newIndex;
+                return true;
+            }
+
+            /// <summary>
+            /// Implementation of <see cref="IDisposable.Dispose"/>. Does nothing.
+            /// </summary>
+            public void Dispose() { }
+
+            void IEnumerator.Reset() => throw new NotImplementedException();
+        }
+    }
+
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+    internal sealed class TempCollectionDisposedChecker : Internal.ITraceable
+    {
+#if PROMISE_DEBUG
+        Internal.CausalityTrace Internal.ITraceable.Trace { get; set; }
+#endif
+
+        internal bool _isDisposed;
+
+        internal TempCollectionDisposedChecker()
+        {
+            Internal.SetCreatedStacktraceInternal(this, 2);
+            Internal.MarkNotInPool(this);
+        }
+
+        ~TempCollectionDisposedChecker()
+        {
+            if (!_isDisposed)
+            {
+                // Promise was not awaited or forgotten.
+                string message = "A TempCollectionDisposedChecker was garbage collected without being disposed.";
+                Internal.ReportRejection(new UnreleasedObjectException(message), this);
+            }
+        }
+    }
+#endif // PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+
+    internal struct TempCollectionBuilder<T> : IDisposable
+    {
+        internal T[] _items;
+        internal int _count;
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+        private readonly TempCollectionDisposedChecker _disposedChecker;
+
+        internal void ValidateIndex(int index)
+        {
+            ValidateAccess();
+            if (index < 0 | index >= _count)
+            {
+                throw new IndexOutOfRangeException();
+            }
+        }
+
+        internal void ValidateAccess()
+        {
+            if (_disposedChecker._isDisposed)
+            {
+                throw new InvalidOperationException("TempCollection is invalid.", Internal.GetFormattedStacktrace(2));
+            }
+        }
+#endif // PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+
+        internal TempCollection<T> View
+        {
+            [MethodImpl(Internal.InlineOption)]
+            get { return new TempCollection<T>(this); }
+        }
+
+        internal TempCollectionBuilder(int capacity)
+        {
+            _items = ArrayPool<T>.Shared.Rent(capacity);
+            _count = 0;
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+            _disposedChecker = new TempCollectionDisposedChecker();
+#endif
+        }
+
+        internal void EnsureCapacity(int capacity)
+        {
+            if (capacity <= _items.Length)
+            {
+                return;
+            }
+            var newStorage = ArrayPool<T>.Shared.Rent(capacity);
+            _items.CopyTo(newStorage, 0);
+            Array.Clear(_items, 0, _count);
+            ArrayPool<T>.Shared.Return(_items, false);
+            _items = newStorage;
+        }
+
+        internal void Add(T item)
+        {
+            var count = _count;
+            EnsureCapacity(count + 1);
+
+            _items[count] = item;
+            _count = count + 1;
+        }
+
+        public void Dispose()
+        {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+            ValidateAccess();
+            _disposedChecker._isDisposed = true;
+            Internal.Discard(_disposedChecker);
+#endif
+            Array.Clear(_items, 0, _count);
+            ArrayPool<T>.Shared.Return(_items, false);
+            _items = null;
+            _count = -1;
+        }
+
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER || UNITY_2021_2_OR_NEWER
+        [MethodImpl(Internal.InlineOption)]
+        internal void CopyTo(T[] array, int arrayIndex)
+            => Span.CopyTo(array.AsSpan(arrayIndex));
+
+        internal ReadOnlySpan<T> Span
+        {
+            [MethodImpl(Internal.InlineOption)]
+            get { return new ReadOnlySpan<T>(_items, 0, _count); }
+        }
+#else
+        [MethodImpl(Internal.InlineOption)]
+        internal void CopyTo(T[] array, int arrayIndex)
+            => Array.Copy(_items, 0, array, arrayIndex, _count);
+#endif // NETCOREAPP || NETSTANDARD2_1_OR_GREATER || UNITY_2021_2_OR_NEWER
+    }
+#endif // CSHARP_7_3_OR_NEWER
+} // namespace Proto.Promises.Collections

--- a/Package/Core/Collections/TempCollection.cs.meta
+++ b/Package/Core/Collections/TempCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa978cf72045e4545a7c413db248441f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Core/ForOldRuntime/ArrayPool.meta
+++ b/Package/Core/ForOldRuntime/ArrayPool.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6f982b140fcdbd249bc84a5a98480da9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Core/ForOldRuntime/ArrayPool/ArrayPool.cs
+++ b/Package/Core/ForOldRuntime/ArrayPool/ArrayPool.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Different namespace to avoid collisions if someone else brings in the ArrayPool package.
+namespace Proto.Promises.Collections
+{
+#if CSHARP_7_3_OR_NEWER && !(NET47 || NETCOREAPP || NETSTANDARD2_0_OR_GREATER || UNITY_2021_2_OR_NEWER)
+
+    /// <summary>
+    /// Provides a resource pool that enables reusing instances of arrays.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Renting and returning buffers with an <see cref="ArrayPool{T}"/> can increase performance
+    /// in situations where arrays are created and destroyed frequently, resulting in significant
+    /// memory pressure on the garbage collector.
+    /// </para>
+    /// <para>
+    /// This class is thread-safe.  All members may be used by multiple threads concurrently.
+    /// </para>
+    /// </remarks>
+    internal abstract class ArrayPool<T>
+    {
+        // Store the shared ArrayPool in a field of its derived sealed type so the Jit can "see" the exact type
+        // when the Shared property is inlined which will allow it to devirtualize calls made on it.
+        private static readonly TlsOverPerCoreLockedStacksArrayPool<T> s_shared = new TlsOverPerCoreLockedStacksArrayPool<T>();
+
+        /// <summary>
+        /// Retrieves a shared <see cref="ArrayPool{T}"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// The shared pool provides a default implementation of <see cref="ArrayPool{T}"/>
+        /// that's intended for general applicability.  It maintains arrays of multiple sizes, and
+        /// may hand back a larger array than was actually requested, but will never hand back a smaller
+        /// array than was requested. Renting a buffer from it with <see cref="Rent"/> will result in an
+        /// existing buffer being taken from the pool if an appropriate buffer is available or in a new
+        /// buffer being allocated if one is not available.
+        /// byte[] and char[] are the most commonly pooled array types. For these we use a special pool type
+        /// optimized for very fast access speeds, at the expense of more memory consumption.
+        /// The shared pool instance is created lazily on first access.
+        /// </remarks>
+        public static ArrayPool<T> Shared => s_shared;
+
+        /// <summary>
+        /// Retrieves a buffer that is at least the requested length.
+        /// </summary>
+        /// <param name="minimumLength">The minimum length of the array needed.</param>
+        /// <returns>
+        /// An array that is at least <paramref name="minimumLength"/> in length.
+        /// </returns>
+        /// <remarks>
+        /// This buffer is loaned to the caller and should be returned to the same pool via
+        /// <see cref="Return"/> so that it may be reused in subsequent usage of <see cref="Rent"/>.
+        /// It is not a fatal error to not return a rented buffer, but failure to do so may lead to
+        /// decreased application performance, as the pool may need to create a new buffer to replace
+        /// the one lost.
+        /// </remarks>
+        public abstract T[] Rent(int minimumLength);
+
+        /// <summary>
+        /// Returns to the pool an array that was previously obtained via <see cref="Rent"/> on the same
+        /// <see cref="ArrayPool{T}"/> instance.
+        /// </summary>
+        /// <param name="array">
+        /// The buffer previously obtained from <see cref="Rent"/> to return to the pool.
+        /// </param>
+        /// <param name="clearArray">
+        /// If <c>true</c> and if the pool will store the buffer to enable subsequent reuse, <see cref="Return"/>
+        /// will clear <paramref name="array"/> of its contents so that a subsequent consumer via <see cref="Rent"/>
+        /// will not see the previous consumer's content.  If <c>false</c> or if the pool will release the buffer,
+        /// the array's contents are left unchanged.
+        /// </param>
+        /// <remarks>
+        /// Once a buffer has been returned to the pool, the caller gives up all ownership of the buffer
+        /// and must not use it. The reference returned from a given call to <see cref="Rent"/> must only be
+        /// returned via <see cref="Return"/> once.  The default <see cref="ArrayPool{T}"/>
+        /// may hold onto the returned buffer in order to rent it again, or it may release the returned buffer
+        /// if it's determined that the pool already has enough buffers stored.
+        /// </remarks>
+        public abstract void Return(T[] array, bool clearArray = false);
+    }
+
+#endif // CSHARP_7_3_OR_NEWER && !(NET47 || NETCOREAPP || NETSTANDARD2_0_OR_GREATER || UNITY_2021_2_OR_NEWER)
+}

--- a/Package/Core/ForOldRuntime/ArrayPool/ArrayPool.cs.meta
+++ b/Package/Core/ForOldRuntime/ArrayPool/ArrayPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b47e204fd6419f9469cf494e69434638
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Core/ForOldRuntime/ArrayPool/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/Package/Core/ForOldRuntime/ArrayPool/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -1,0 +1,283 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Modified to work in Unity/netstandard2.0 without using the nuget package.
+// Hooks up to Promise.Manager.ClearObjectPool() event instead of using Gen2GC callbacks.
+
+#if CSHARP_7_3_OR_NEWER && !(NET47 || NETCOREAPP || NETSTANDARD2_0_OR_GREATER || UNITY_2021_2_OR_NEWER)
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+#endif
+
+namespace Proto.Promises.Collections
+{
+#if CSHARP_7_3_OR_NEWER && !(NET47 || NETCOREAPP || NETSTANDARD2_0_OR_GREATER || UNITY_2021_2_OR_NEWER)
+
+    /// <summary>
+    /// Provides an ArrayPool implementation meant to be used as the singleton returned from ArrayPool.Shared.
+    /// </summary>
+    /// <remarks>
+    /// The implementation uses a tiered caching scheme, with a small per-thread cache for each array size, followed
+    /// by a cache per array size shared by all threads, split into per-core stacks meant to be used by threads
+    /// running on that core.  Locks are used to protect each per-core stack, because a thread can migrate after
+    /// checking its processor number, because multiple threads could interleave on the same core, and because
+    /// a thread is allowed to check other core's buckets if its core's bucket is empty/full.
+    /// </remarks>
+    internal sealed partial class TlsOverPerCoreLockedStacksArrayPool<T> : ArrayPool<T>
+    {
+        // TODO https://github.com/dotnet/coreclr/pull/7747: "Investigate optimizing ArrayPool heuristics"
+        // - Explore caching in TLS more than one array per size per thread, and moving stale buffers to the global queue.
+        // - Explore changing the size of each per-core bucket, potentially dynamically or based on other factors like array size.
+        // - Explore changing number of buckets and what sizes of arrays are cached.
+        // - Investigate whether false sharing is causing any issues, in particular on LockedStack's count and the contents of its array.
+        // ...
+
+        /// <summary>The number of buckets (array sizes) in the pool, one for each array length, starting from length 16.</summary>
+        private const int NumBuckets = 17; // Utilities.SelectBucketIndex(2*1024*1024)
+        /// <summary>Maximum number of per-core stacks to use per array size.</summary>
+        private const int MaxPerCorePerArraySizeStacks = 64; // selected to avoid needing to worry about processor groups
+        /// <summary>The maximum number of buffers to store in a bucket's global queue.</summary>
+        private const int MaxBuffersPerArraySizePerCore = 8;
+
+        /// <summary>The length of arrays stored in the corresponding indices in <see cref="_buckets"/>.</summary>
+        private readonly int[] _bucketArraySizes;
+        /// <summary>
+        /// An array of per-core array stacks. The slots are lazily initialized to avoid creating
+        /// lots of overhead for unused array sizes.
+        /// </summary>
+        private readonly PerCoreLockedStacks[] _buckets = new PerCoreLockedStacks[NumBuckets];
+
+        /// <summary>Initialize the pool.</summary>
+        public TlsOverPerCoreLockedStacksArrayPool()
+        {
+            var sizes = new int[NumBuckets];
+            for (int i = 0; i < sizes.Length; i++)
+            {
+                sizes[i] = Utilities.GetMaxSizeForBucket(i);
+            }
+            _bucketArraySizes = sizes;
+
+            // Hook up to Promise.Manage.ClearObjectPool() event.
+            Internal.AddClearPoolListener(Trim);
+        }
+
+        /// <summary>Allocate a new PerCoreLockedStacks and try to store it into the <see cref="_buckets"/> array.</summary>
+        private PerCoreLockedStacks CreatePerCoreLockedStacks(int bucketIndex)
+        {
+            var inst = new PerCoreLockedStacks();
+            return Interlocked.CompareExchange(ref _buckets[bucketIndex], inst, null) ?? inst;
+        }
+
+        /// <summary>Gets an ID for the pool to use with events.</summary>
+        private int Id => GetHashCode();
+
+        public override T[] Rent(int minimumLength)
+        {
+            // Arrays can't be smaller than zero.  We allow requesting zero-length arrays (even though
+            // pooling such an array isn't valuable) as it's a valid length array, and we want the pool
+            // to be usable in general instead of using `new`, even for computed lengths.
+            if (minimumLength < 0)
+            {
+                throw new ArgumentOutOfRangeException("minimumLength is less than 0", nameof(minimumLength));
+            }
+            else if (minimumLength == 0)
+            {
+                // No need to log the empty array.  Our pool is effectively infinite
+                // and we'll never allocate for rents and never store for returns.
+                return Array.Empty<T>();
+            }
+
+            T[] buffer;
+
+            // Get the bucket number for the array length
+            int bucketIndex = Utilities.SelectBucketIndex(minimumLength);
+
+            // If the array could come from a bucket...
+            if (bucketIndex < _buckets.Length)
+            {
+                PerCoreLockedStacks b = _buckets[bucketIndex];
+                if (b != null)
+                {
+                    buffer = b.TryPop();
+                    if (buffer != null)
+                    {
+                        return buffer;
+                    }
+                }
+
+                // No buffer available.  Allocate a new buffer with a size corresponding to the appropriate bucket.
+                buffer = new T[_bucketArraySizes[bucketIndex]];
+            }
+            else
+            {
+                // The request was for a size too large for the pool.  Allocate an array of exactly the requested length.
+                // When it's returned to the pool, we'll simply throw it away.
+                buffer = new T[minimumLength];
+            }
+
+            return buffer;
+        }
+
+        public override void Return(T[] array, bool clearArray = false)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException("array is null", nameof(array));
+            }
+
+            // Determine with what bucket this array length is associated
+            int bucketIndex = Utilities.SelectBucketIndex(array.Length);
+
+            // If we can tell that the buffer was allocated (or empty), drop it. Otherwise, check if we have space in the pool.
+            if (bucketIndex < _buckets.Length)
+            {
+                // Clear the array if the user requests.
+                if (clearArray)
+                {
+                    Array.Clear(array, 0, array.Length);
+                }
+
+                // Check to see if the buffer is the correct size for this bucket
+                if (array.Length != _bucketArraySizes[bucketIndex])
+                {
+                    throw new ArgumentException("BufferNotFromPool", nameof(array));
+                }
+
+                PerCoreLockedStacks stackBucket = _buckets[bucketIndex] ?? CreatePerCoreLockedStacks(bucketIndex);
+                stackBucket.TryPush(array);
+            }
+        }
+
+        public void Trim()
+        {
+            int milliseconds = Environment.TickCount;
+
+            PerCoreLockedStacks[] perCoreBuckets = _buckets;
+            for (int i = 0; i < perCoreBuckets.Length; i++)
+            {
+                perCoreBuckets[i]?.Trim((uint) milliseconds, Id, _bucketArraySizes[i]);
+            }
+        }
+
+        /// <summary>
+        /// Stores a set of stacks of arrays, with one stack per core.
+        /// </summary>
+        private sealed class PerCoreLockedStacks
+        {
+            /// <summary>The stacks.</summary>
+            private readonly LockedStack[] _perCoreStacks;
+
+            /// <summary>Initializes the stacks.</summary>
+            public PerCoreLockedStacks()
+            {
+                // Create the stacks.  We create as many as there are processors, limited by our max.
+                var stacks = new LockedStack[Math.Min(Environment.ProcessorCount, MaxPerCorePerArraySizeStacks)];
+                for (int i = 0; i < stacks.Length; i++)
+                {
+                    stacks[i] = new LockedStack();
+                }
+                _perCoreStacks = stacks;
+            }
+
+            /// <summary>Try to push the array into the stacks. If each is full when it's tested, the array will be dropped.</summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void TryPush(T[] array)
+            {
+                // Try to push on to the associated stack first.  If that fails,
+                // round-robin through the other stacks.
+                LockedStack[] stacks = _perCoreStacks;
+                // Thread.GetCurrentProcessorId is not available in netstandard2.0, so use ManagedThreadId instead.
+                int index = Thread.CurrentThread.ManagedThreadId % stacks.Length;
+                for (int i = 0; i < stacks.Length; i++)
+                {
+                    if (stacks[index].TryPush(array)) return;
+                    if (++index == stacks.Length) index = 0;
+                }
+            }
+
+            /// <summary>Try to get an array from the stacks.  If each is empty when it's tested, null will be returned.</summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public T[] TryPop()
+            {
+                // Try to pop from the associated stack first.  If that fails,
+                // round-robin through the other stacks.
+                T[] arr;
+                LockedStack[] stacks = _perCoreStacks;
+                // Thread.GetCurrentProcessorId is not available in netstandard2.0, so use ManagedThreadId instead.
+                int index = Thread.CurrentThread.ManagedThreadId % stacks.Length;
+                for (int i = 0; i < stacks.Length; i++)
+                {
+                    if ((arr = stacks[index].TryPop()) != null) return arr;
+                    if (++index == stacks.Length) index = 0;
+                }
+                return null;
+            }
+
+            public void Trim(uint tickCount, int id, int bucketSize)
+            {
+                LockedStack[] stacks = _perCoreStacks;
+                for (int i = 0; i < stacks.Length; i++)
+                {
+                    stacks[i].Trim(tickCount, id, bucketSize);
+                }
+            }
+        }
+
+        /// <summary>Provides a simple stack of arrays, protected by a lock.</summary>
+        private sealed class LockedStack
+        {
+            private readonly T[][] _arrays = new T[MaxBuffersPerArraySizePerCore][];
+            private int _count;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool TryPush(T[] array)
+            {
+                bool enqueued = false;
+                lock (this)
+                {
+                    if (_count < MaxBuffersPerArraySizePerCore)
+                    {
+                        _arrays[_count++] = array;
+                        enqueued = true;
+                    }
+                }
+                return enqueued;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public T[] TryPop()
+            {
+                T[] arr = null;
+                lock (this)
+                {
+                    if (_count > 0)
+                    {
+                        arr = _arrays[--_count];
+                        _arrays[_count] = null;
+                    }
+                }
+                return arr;
+            }
+
+            public void Trim(uint tickCount, int id, int bucketSize)
+            {
+                if (_count == 0)
+                    return;
+
+                lock (this)
+                {
+                    for (int i = 0; i < _count; ++i)
+                    {
+                        _arrays[i] = null;
+                    }
+                    _count = 0;
+                }
+            }
+        }
+    }
+
+#endif // CSHARP_7_3_OR_NEWER && !(NET47 || NETCOREAPP || NETSTANDARD2_0_OR_GREATER || UNITY_2021_2_OR_NEWER)
+}

--- a/Package/Core/ForOldRuntime/ArrayPool/TlsOverPerCoreLockedStacksArrayPool.cs.meta
+++ b/Package/Core/ForOldRuntime/ArrayPool/TlsOverPerCoreLockedStacksArrayPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e097d516478b50647a38d9cddbcfa41d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Core/ForOldRuntime/ArrayPool/Utilities.cs
+++ b/Package/Core/ForOldRuntime/ArrayPool/Utilities.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if CSHARP_7_3_OR_NEWER && !(NET47 || NETCOREAPP || NETSTANDARD2_0_OR_GREATER || UNITY_2021_2_OR_NEWER)
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+#endif
+
+using System;
+
+namespace Proto.Promises.Collections
+{
+#if CSHARP_7_3_OR_NEWER && !(NET47 || NETCOREAPP || NETSTANDARD2_0_OR_GREATER || UNITY_2021_2_OR_NEWER)
+
+    internal static class Utilities
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int SelectBucketIndex(int bufferSize)
+        {
+            Debug.Assert(bufferSize >= 0);
+            uint bits = ((uint) bufferSize - 1) >> 4;
+            return 32 - LeadingZeroCount(bits);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int GetMaxSizeForBucket(int binIndex)
+        {
+            int maxSize = 16 << binIndex;
+            Debug.Assert(maxSize >= 0);
+            return maxSize;
+        }
+
+        private static int LeadingZeroCount(uint value)
+        {
+            // Unguarded fallback contract is 0->31
+            if (value == 0)
+            {
+                return 32;
+            }
+
+            return 31 - Log2SoftwareFallback(value);
+        }
+
+        private static int Log2SoftwareFallback(uint value)
+        {
+            // Just implemented with Math.Log since netstandard2.0 doesn't have Unsafe.AddByteOffset.
+            return (int) Math.Log(value, 2);
+        }
+    }
+
+#endif // CSHARP_7_3_OR_NEWER && !(NET47 || NETCOREAPP || NETSTANDARD2_0_OR_GREATER || UNITY_2021_2_OR_NEWER)
+}

--- a/Package/Core/ForOldRuntime/ArrayPool/Utilities.cs.meta
+++ b/Package/Core/ForOldRuntime/ArrayPool/Utilities.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2442f224991d0c4c85c34aaceb94e4e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Tests/CoreTests/APIs/Collections.meta
+++ b/Package/Tests/CoreTests/APIs/Collections.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60b1bd770f733aa47a6deee58e876c31
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Tests/CoreTests/APIs/Collections/TempCollectionTests.cs
+++ b/Package/Tests/CoreTests/APIs/Collections/TempCollectionTests.cs
@@ -1,0 +1,130 @@
+﻿#if CSHARP_7_3_OR_NEWER
+
+using System.Linq;
+using Proto.Promises;
+using NUnit.Framework;
+using Proto.Promises.Collections;
+
+namespace ProtoPromiseTests.APIs.Collections
+{
+    public class TempCollectionTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            TestHelper.Setup();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void TempCollectionBuilder()
+        {
+            var builder = new TempCollectionBuilder<int>(0);
+
+            Assert.AreEqual(0, builder.View.Count);
+            builder.Add(1);
+            Assert.AreEqual(1, builder.View.Count);
+            Assert.AreEqual(1, builder.View[0]);
+            builder.Dispose();
+            builder = new TempCollectionBuilder<int>(0);
+            Assert.AreEqual(0, builder.View.Count);
+            for (int i = 0; i < 100; i++)
+            {
+                builder.Add(i);
+            }
+            Assert.AreEqual(100, builder.View.Count);
+            for (int i = 0; i < 100; i++)
+            {
+                Assert.AreEqual(i, builder.View[i]);
+            }
+            builder.Dispose();
+
+            Promise.Manager.ClearObjectPool();
+        }
+
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER || UNITY_2021_2_OR_NEWER
+        [Test]
+        public void TempCollection_Span()
+        {
+            var builder = new TempCollectionBuilder<int>(0);
+
+            Assert.AreEqual(0, builder.View.Span.Length);
+            builder.Add(1);
+            Assert.AreEqual(1, builder.View.Span.Length);
+            Assert.AreEqual(1, builder.View.Span[0]);
+            builder.Dispose();
+            builder = new TempCollectionBuilder<int>(0);
+            Assert.AreEqual(0, builder.View.Span.Length);
+            for (int i = 0; i < 100; i++)
+            {
+                builder.Add(i);
+            }
+            Assert.AreEqual(100, builder.View.Span.Length);
+            for (int i = 0; i < 100; i++)
+            {
+                Assert.AreEqual(i, builder.View.Span[i]);
+            }
+            builder.Dispose();
+        }
+#endif // NETCOREAPP || NETSTANDARD2_1_OR_GREATER || UNITY_2021_2_OR_NEWER
+
+        [Test]
+        public void TempCollection_Enumerator(
+            [Values(0, 1, 2, 10)] int count)
+        {
+            var builder = new TempCollectionBuilder<int>(0);
+
+            for (int i = 0; i < count; i++)
+            {
+                builder.Add(i);
+            }
+
+            int iteratedCount = 0;
+            foreach (var item in builder.View)
+            {
+                Assert.AreEqual(iteratedCount, item);
+                ++iteratedCount;
+            }
+
+            Assert.AreEqual(count, iteratedCount);
+            builder.Dispose();
+        }
+
+        [Test]
+        public void TempCollection_ToArray(
+            [Values(0, 1, 2, 10)] int count)
+        {
+            var builder = new TempCollectionBuilder<int>(0);
+
+            for (int i = 0; i < count; i++)
+            {
+                builder.Add(i);
+            }
+
+            CollectionAssert.AreEqual(Enumerable.Range(0, count), builder.View.ToArray());
+            builder.Dispose();
+        }
+
+        [Test]
+        public void TempCollection_ToList(
+            [Values(0, 1, 2, 10)] int count)
+        {
+            var builder = new TempCollectionBuilder<int>(0);
+
+            for (int i = 0; i < count; i++)
+            {
+                builder.Add(i);
+            }
+
+            CollectionAssert.AreEqual(Enumerable.Range(0, count), builder.View.ToList());
+            builder.Dispose();
+        }
+    }
+}
+
+#endif // CSHARP_7_3_OR_NEWER

--- a/Package/Tests/CoreTests/APIs/Collections/TempCollectionTests.cs
+++ b/Package/Tests/CoreTests/APIs/Collections/TempCollectionTests.cs
@@ -1,9 +1,17 @@
-﻿#if CSHARP_7_3_OR_NEWER
+﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+#if CSHARP_7_3_OR_NEWER
 
 using System.Linq;
 using Proto.Promises;
 using NUnit.Framework;
 using Proto.Promises.Collections;
+using Proto.Promises.Linq;
+using System;
 
 namespace ProtoPromiseTests.APIs.Collections
 {
@@ -123,6 +131,104 @@ namespace ProtoPromiseTests.APIs.Collections
 
             CollectionAssert.AreEqual(Enumerable.Range(0, count), builder.View.ToList());
             builder.Dispose();
+        }
+
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+        [Test]
+        public void TempCollectionIsInvalidAfterDisposed(
+            [Values(0, 1, 2, 10)] int count)
+        {
+            var builder = new TempCollectionBuilder<int>(0);
+
+            for (int i = 0; i < count; i++)
+            {
+                builder.Add(i);
+            }
+
+            var tempCollection = builder.View;
+
+            CollectionAssert.AreEqual(Enumerable.Range(0, count), tempCollection.ToList());
+            builder.Dispose();
+
+            AssertIsInvalid(tempCollection);
+        }
+#endif // PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+
+        private static void AssertIsInvalid<T>(TempCollection<T> tempCollection)
+        {
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+            Assert.Catch<System.InvalidOperationException>(() => { var _ = tempCollection.Count; });
+            Assert.Catch<System.InvalidOperationException>(() => { var _ = tempCollection[0]; });
+            Assert.Catch<System.InvalidOperationException>(() => { var _ = tempCollection.GetEnumerator(); });
+            Assert.Catch<System.InvalidOperationException>(() => { var _ = tempCollection.ToArray(); });
+            Assert.Catch<System.InvalidOperationException>(() => { var _ = tempCollection.ToList(); });
+            Assert.Catch<System.InvalidOperationException>(() =>
+            {
+                T[] array = new T[1];
+                tempCollection.CopyTo(array, 0);
+            });
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER || UNITY_2021_2_OR_NEWER
+            Assert.Catch<System.InvalidOperationException>(() => { var _ = tempCollection.Span; });
+#endif
+#endif // PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+        }
+
+        // We test that a TempCollection is valid when percolated through multiple AsyncEnumerables,
+        // and is invalidated when the AsyncEnumerator has MoveNextAsync or DisposeAsync called.
+        [Test]
+        public void TempCollection_IsValidUntilDisposedAsync(
+            [Values(0, 1, 2, 10)] int tempCollectionSize,
+            [Values(0, 1, 2, 10)] int tempCollectionCount)
+        {
+            var tempCollectionEnumerable = AsyncEnumerable.Create<TempCollection<int>>(async (writer, cancelationToken) =>
+            {
+                for (int i = 0; i < tempCollectionCount; ++i)
+                {
+                    using (var builder = new TempCollectionBuilder<int>(0))
+                    {
+                        for (int j = 0; j < tempCollectionCount; j++)
+                        {
+                            builder.Add(j);
+                        }
+
+                        await writer.YieldAsync(builder.View);
+                    }
+                }
+            });
+
+            var cachedCollection = default(TempCollection<int>);
+            int counter = 0;
+
+            AsyncEnumerable.Create<TempCollection<int>>(async (writer, cancelationToken) =>
+            {
+                var asyncEnumerator = tempCollectionEnumerable.GetAsyncEnumerator();
+                try
+                {
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        await writer.YieldAsync(asyncEnumerator.Current);
+                    }
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            })
+                .ForEachAsync(tempCollection =>
+                {
+                    AssertIsInvalid(cachedCollection);
+                    cachedCollection = tempCollection;
+                    CollectionAssert.AreEqual(Enumerable.Range(0, tempCollectionCount), tempCollection.ToList());
+                    if (++counter == 5)
+                    {
+                        throw Promise.CancelException();
+                    }
+                })
+                .CatchCancelation(() => { })
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+
+            AssertIsInvalid(cachedCollection);
+            Assert.AreEqual(Math.Min(tempCollectionCount, 5), counter);
         }
     }
 }

--- a/Package/Tests/CoreTests/APIs/Collections/TempCollectionTests.cs.meta
+++ b/Package/Tests/CoreTests/APIs/Collections/TempCollectionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65db4358528742a4d9baafb035576b61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProtoPromise/ProtoPromise.csproj
+++ b/ProtoPromise/ProtoPromise.csproj
@@ -112,6 +112,12 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47' OR '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Buffers">
+      <Version>4.5.1</Version>
+    </PackageReference>
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net47' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
       <Version>5.0.0</Version>

--- a/ProtoPromise/nuget/ProtoPromise.nuspec
+++ b/ProtoPromise/nuget/ProtoPromise.nuspec
@@ -24,10 +24,12 @@
       </group>
       <group targetFramework="net47">
         <dependency id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
         <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
         <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="netstandard2.1" />


### PR DESCRIPTION
This should help with implementing `AsyncEnumerable` Linq extensions like `Chunk` and `GroupBy`, without allocating garbage (using `ArrayPool`).