### PR TITLE
Fix error log after clear pool

### DIFF
--- a/Package/Core/Linq/Generators/Range.cs
+++ b/Package/Core/Linq/Generators/Range.cs
@@ -88,6 +88,8 @@ namespace Proto.Promises
                     // Subtract 1 so that we can implement MoveNextAsync branchlessly.
                     enumerable._current = start - 1;
                 }
+                // We don't actually use this type as a backing reference for Promises, so we need to suppress the UnobservedPromiseException from the base finalizer.
+                enumerable.WasAwaitedOrForgotten = true;
                 return enumerable;
             }
 

--- a/Package/Core/Linq/Generators/Repeat.cs
+++ b/Package/Core/Linq/Generators/Repeat.cs
@@ -91,6 +91,8 @@ namespace Proto.Promises
                 enumerable.Reset();
                 enumerable._count = count;
                 enumerable._current = element;
+                // We don't actually use this type as a backing reference for Promises, so we need to suppress the UnobservedPromiseException from the base finalizer.
+                enumerable.WasAwaitedOrForgotten = true;
                 return enumerable;
             }
 

--- a/Package/Core/Linq/Generators/Return.cs
+++ b/Package/Core/Linq/Generators/Return.cs
@@ -68,6 +68,8 @@ namespace Proto.Promises
                 var enumerable = GetOrCreate();
                 enumerable.Reset();
                 enumerable._current = value;
+                // We don't actually use this type as a backing reference for Promises, so we need to suppress the UnobservedPromiseException from the base finalizer.
+                enumerable.WasAwaitedOrForgotten = true;
                 return enumerable;
             }
 

--- a/Package/Core/Linq/Internal/AsyncEnumerableInternal.cs
+++ b/Package/Core/Linq/Internal/AsyncEnumerableInternal.cs
@@ -254,6 +254,8 @@ namespace Proto.Promises
                         // DisposeAsync was called before MoveNextAsync, the async iterator function never started.
                         // Dispose this and return a resolved promise.
                         State = Promise.State.Resolved;
+                        // This is never used as a backing reference for Promises, so we need to suppress the UnobservedPromiseException from the base finalizer.
+                        WasAwaitedOrForgotten = true;
                         DisposeAndReturnToPool();
                         return Promise.Resolved();
                     }

--- a/Package/Core/Promises/Internal/Progress/ProgressMultiAwaitInternal.cs
+++ b/Package/Core/Promises/Internal/Progress/ProgressMultiAwaitInternal.cs
@@ -38,6 +38,12 @@ namespace Proto.Promises
                 // This is necessary because the _rejectContainerOrPreviousOrLink field is used to hook up the registered promises chain,
                 // and it would not be possible to do that for multiple progress listeners with a single promise object. So we have to create dummy objects to register multiple.
 
+                private IndividualPromisePassThrough()
+                {
+                    // Don't let the base finalizer report an error.
+                    WasAwaitedOrForgotten = true;
+                }
+
                 [MethodImpl(InlineOption)]
                 private static IndividualPromisePassThrough<TResult> GetOrCreate()
                 {

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -376,7 +376,7 @@ namespace Proto.Promises
                     if (!WasAwaitedOrForgotten)
                     {
                         // Promise was not awaited or forgotten.
-                        string message = "A Promise's resources were garbage collected without it being awaited. You must await, return, or forget each promise.";
+                        string message = "A Promise's resources were garbage collected without it being awaited. You must await, return, or forget each promise. " + this;
                         ReportRejection(new UnobservedPromiseException(message), this);
                     }
                     if (_rejectContainerOrPreviousOrLink is IRejectContainer & State == Promise.State.Rejected & !SuppressRejection)

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -359,7 +359,7 @@ namespace Proto.Promises
                 set { _suppressRejection = value; }
             }
 
-            private bool WasAwaitedOrForgotten
+            protected bool WasAwaitedOrForgotten
             {
                 [MethodImpl(InlineOption)]
                 get { return _wasAwaitedorForgotten; }

--- a/Package/Tests/CoreTests/APIs/MiscellaneousTests.cs
+++ b/Package/Tests/CoreTests/APIs/MiscellaneousTests.cs
@@ -1445,5 +1445,24 @@ namespace ProtoPromiseTests.APIs
             }
         }
 #endif // !UNITY_WEBGL
+
+        [Test]
+        public void ClearObjectPool_NoErrors()
+        {
+            var deferred = Promise.NewDeferred();
+            var promise = deferred.Promise.Preserve();
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            promise
+                .Progress(v => { }, SynchronizationOption.Synchronous)
+                .Then(() => { })
+                .Forget();
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            deferred.Resolve();
+            promise.Forget();
+
+            Promise.Manager.ClearObjectPool();
+        }
     }
 }


### PR DESCRIPTION
Error log required a combination of `Promise.Preserve`, `Promise.Progress`, and `Promise.Manager.ClearObjectPool`. Only shows up in RELEASE mode (because the pool is not used in DEBUG mode).