### PR TITLE
Don't dispose `AsyncEnumerable.GroupBy` groups immediately

### DIFF
--- a/Package/Core/Linq/CompilerServices/AsyncStreamWriter.cs
+++ b/Package/Core/Linq/CompilerServices/AsyncStreamWriter.cs
@@ -96,6 +96,10 @@ namespace Proto.Promises.Async.CompilerServices
 
         void ICriticalNotifyCompletion.UnsafeOnCompleted(Action continuation)
             => throw new InvalidOperationException("AsyncStreamYielder must only be used in AsyncEnumerable methods.");
+
+        [MethodImpl(Internal.InlineOption)]
+        internal Internal.PromiseRefBase.AsyncStreamAwaiterForLinqExtension<T> ForLinqExtension()
+            => new Internal.PromiseRefBase.AsyncStreamAwaiterForLinqExtension<T>(_target, _enumerableId);
     }
-#endif
+#endif // CSHARP_7_3_OR_NEWER
 }

--- a/Package/Core/Linq/Internal/AsyncEnumerableInternal.cs
+++ b/Package/Core/Linq/Internal/AsyncEnumerableInternal.cs
@@ -18,7 +18,6 @@ namespace Proto.Promises
         internal interface IAsyncIterator<T>
         {
             AsyncEnumerableMethod Start(AsyncStreamWriter<T> streamWriter, CancelationToken cancelationToken);
-            bool IsNull { get; }
         }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
@@ -327,14 +326,14 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal void AwaitOnCompletedForAsyncStreamYielder(PromiseRefBase asyncPromiseRef, int enumerableId)
+                internal void AwaitOnCompletedForAsyncStreamYielder(PromiseRefBase asyncPromiseRef, int enumerableId, bool hasValue = true)
                 {
                     if (_enumerableId != enumerableId || Interlocked.CompareExchange(ref _iteratorPromiseRef, asyncPromiseRef, null) != null)
                     {
                         throw new InvalidOperationException("AsyncStreamYielder: invalid await. Only one await is allowed.", GetFormattedStacktrace(2));
                     }
                     // Complete the MoveNextAsync promise.
-                    _result = true;
+                    _result = hasValue;
                     HandleNextInternal(null, Promise.State.Resolved);
                 }
 

--- a/Package/Core/Linq/Internal/AsyncStreamAwaiterForLinqExtensionInternal.cs
+++ b/Package/Core/Linq/Internal/AsyncStreamAwaiterForLinqExtensionInternal.cs
@@ -1,0 +1,76 @@
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Proto.Promises
+{
+#if CSHARP_7_3_OR_NEWER
+    partial class Internal
+    {
+        partial class PromiseRefBase
+        {
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            internal readonly partial struct AsyncStreamAwaiterForLinqExtension<T> : ICriticalNotifyCompletion, IPromiseAwaiter
+            {
+                private readonly AsyncEnumerableWithIterator<T> _target;
+                private readonly int _enumerableId;
+
+                [MethodImpl(InlineOption)]
+                internal AsyncStreamAwaiterForLinqExtension(AsyncEnumerableWithIterator<T> target, int enumerableId)
+                {
+                    _target = target;
+                    _enumerableId = enumerableId;
+                    CreateOverride();
+                }
+
+                static partial void CreateOverride();
+
+#if !NETCOREAPP
+                // Fix for IL2CPP not invoking the static constructor.
+#if ENABLE_IL2CPP
+                [MethodImpl(InlineOption)]
+                static partial void CreateOverride()
+#else
+                static AsyncStreamAwaiterForLinqExtension()
+#endif
+                {
+                    AwaitOverriderImpl<AsyncStreamAwaiterForLinqExtension<T>>.Create();
+                }
+#endif
+
+                [MethodImpl(InlineOption)]
+                public AsyncStreamAwaiterForLinqExtension<T> GetAwaiter() => this;
+
+                public bool IsCompleted
+                {
+                    [MethodImpl(InlineOption)]
+                    get { return false; }
+                }
+
+                [MethodImpl(InlineOption)]
+                public void GetResult()
+                {
+                    // Reset in case the async iterator function completes synchronously from Start.
+                    _target.ResetWithoutStacktrace();
+                    // Don't throw for dispose.
+                }
+
+                [MethodImpl(InlineOption)]
+                void IPromiseAwaiter.AwaitOnCompletedInternal(PromiseRefBase asyncPromiseRef, ref AsyncPromiseFields asyncFields)
+                    => _target.AwaitOnCompletedForAsyncStreamYielder(asyncPromiseRef, _enumerableId, hasValue: false);
+
+                void INotifyCompletion.OnCompleted(Action continuation) => throw new System.InvalidOperationException("Must only be used in async Linq extension methods.");
+                void ICriticalNotifyCompletion.UnsafeOnCompleted(Action continuation) => throw new System.InvalidOperationException("Must only be used in async Linq extension methods.");
+            }
+        }
+    }
+#endif // CSHARP_7_3_OR_NEWER
+}

--- a/Package/Core/Linq/Internal/AsyncStreamAwaiterForLinqExtensionInternal.cs.meta
+++ b/Package/Core/Linq/Internal/AsyncStreamAwaiterForLinqExtensionInternal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c250785d687bcb4ab3f9196a863c66b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Core/Linq/Internal/GroupByInternal.cs
+++ b/Package/Core/Linq/Internal/GroupByInternal.cs
@@ -1,0 +1,672 @@
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+using Proto.Promises.Async.CompilerServices;
+using Proto.Promises.Linq;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Proto.Promises
+{
+#if CSHARP_7_3_OR_NEWER
+    partial class Internal
+    {
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        internal static class GroupByHelper<TKey, TElement>
+        {
+            private readonly struct GroupByKeyElementSyncIterator<TSource, TKeySelector, TElementSelector> : IAsyncIterator<Linq.Grouping<TKey, TElement>>
+                where TKeySelector : IFunc<TSource, TKey>
+                where TElementSelector : IFunc<TSource, TElement>
+            {
+                private readonly AsyncEnumerator<TSource> _asyncEnumerator;
+                private readonly TKeySelector _keySelector;
+                private readonly TElementSelector _elementSelector;
+                private readonly IEqualityComparer<TKey> _comparer;
+
+                internal GroupByKeyElementSyncIterator(AsyncEnumerator<TSource> asyncEnumerator, TKeySelector keySelector, TElementSelector elementSelector, IEqualityComparer<TKey> comparer)
+                {
+                    _asyncEnumerator = asyncEnumerator;
+                    _keySelector = keySelector;
+                    _elementSelector = elementSelector;
+                    _comparer = comparer;
+                }
+
+                [MethodImpl(InlineOption)]
+                public Promise DisposeAsyncFromNeverStarted()
+                {
+                    return _asyncEnumerator.DisposeAsync();
+                }
+
+                public async AsyncEnumerableMethod Start(AsyncStreamWriter<Linq.Grouping<TKey, TElement>> writer, CancelationToken cancelationToken)
+                {
+                    // The enumerator was retrieved without a cancelation token when the original function was called.
+                    // We need to propagate the token that was passed in, so we assign it before starting iteration.
+                    _asyncEnumerator._target._cancelationToken = cancelationToken;
+
+                    // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
+                    LookupImpl<TKey, TElement> lookup = default;
+                    try
+                    {
+                        if (!await _asyncEnumerator.MoveNextAsync())
+                        {
+                            // No need to create the lookup if the enumerable is empty.
+                            return;
+                        }
+
+                        lookup = new LookupImpl<TKey, TElement>(_comparer, true);
+                        do
+                        {
+                            var item = _asyncEnumerator.Current;
+                            var key = _keySelector.Invoke(item);
+                            var group = lookup.GetOrCreateGrouping(key, true);
+
+                            var element = _elementSelector.Invoke(item);
+                            group.Add(element);
+                        } while (await _asyncEnumerator.MoveNextAsync());
+                        // We don't dispose the source enumerator until the owner is disposed.
+                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+
+                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                        var g = lookup._lastGrouping;
+                        do
+                        {
+                            g = g._nextGrouping;
+                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                        } while (g != lookup._lastGrouping);
+
+                        // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
+                        await writer.YieldAsync(default).ForLinqExtension();
+                    }
+                    finally
+                    {
+                        lookup.Dispose();
+                        await _asyncEnumerator.DisposeAsync();
+                    }
+                }
+            }
+
+            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupBy<TSource, TKeySelector, TElementSelector>(
+                AsyncEnumerator<TSource> asyncEnumerator,
+                TKeySelector keySelector,
+                TElementSelector elementSelector,
+                IEqualityComparer<TKey> comparer)
+                where TKeySelector : IFunc<TSource, TKey>
+                where TElementSelector : IFunc<TSource, TElement>
+            {
+                var enumerable = AsyncEnumerableCreate<Linq.Grouping<TKey, TElement>, GroupByKeyElementSyncIterator<TSource, TKeySelector, TElementSelector>>.GetOrCreate(
+                    new GroupByKeyElementSyncIterator<TSource, TKeySelector, TElementSelector>(asyncEnumerator, keySelector, elementSelector, comparer));
+                return new AsyncEnumerable<Linq.Grouping<TKey, TElement>>(enumerable);
+            }
+
+            private readonly struct GroupByKeySyncIterator<TKeySelector> : IAsyncIterator<Linq.Grouping<TKey, TElement>>
+                where TKeySelector : IFunc<TElement, TKey>
+            {
+                private readonly AsyncEnumerator<TElement> _asyncEnumerator;
+                private readonly TKeySelector _keySelector;
+                private readonly IEqualityComparer<TKey> _comparer;
+
+                internal GroupByKeySyncIterator(AsyncEnumerator<TElement> asyncEnumerator, TKeySelector keySelector, IEqualityComparer<TKey> comparer)
+                {
+                    _asyncEnumerator = asyncEnumerator;
+                    _keySelector = keySelector;
+                    _comparer = comparer;
+                }
+
+                [MethodImpl(InlineOption)]
+                public Promise DisposeAsyncFromNeverStarted()
+                {
+                    return _asyncEnumerator.DisposeAsync();
+                }
+
+                public async AsyncEnumerableMethod Start(AsyncStreamWriter<Linq.Grouping<TKey, TElement>> writer, CancelationToken cancelationToken)
+                {
+                    // The enumerator was retrieved without a cancelation token when the original function was called.
+                    // We need to propagate the token that was passed in, so we assign it before starting iteration.
+                    _asyncEnumerator._target._cancelationToken = cancelationToken;
+
+                    // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
+                    LookupImpl<TKey, TElement> lookup = default;
+                    try
+                    {
+                        if (!await _asyncEnumerator.MoveNextAsync())
+                        {
+                            // No need to create the lookup if the enumerable is empty.
+                            return;
+                        }
+
+                        lookup = new LookupImpl<TKey, TElement>(_comparer, true);
+                        do
+                        {
+                            var item = _asyncEnumerator.Current;
+                            var key = _keySelector.Invoke(item);
+                            lookup.GetOrCreateGrouping(key, true).Add(item);
+                        } while (await _asyncEnumerator.MoveNextAsync());
+                        // We don't dispose the source enumerator until the owner is disposed.
+                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+
+                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                        var g = lookup._lastGrouping;
+                        do
+                        {
+                            g = g._nextGrouping;
+                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                        } while (g != lookup._lastGrouping);
+
+                        // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
+                        await writer.YieldAsync(default).ForLinqExtension();
+                    }
+                    finally
+                    {
+                        lookup.Dispose();
+                        await _asyncEnumerator.DisposeAsync();
+                    }
+                }
+            }
+
+            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupBy<TKeySelector>(
+                AsyncEnumerator<TElement> asyncEnumerator,
+                TKeySelector keySelector,
+                IEqualityComparer<TKey> comparer)
+                where TKeySelector : IFunc<TElement, TKey>
+            {
+                var enumerable = AsyncEnumerableCreate<Linq.Grouping<TKey, TElement>, GroupByKeySyncIterator<TKeySelector>>.GetOrCreate(
+                    new GroupByKeySyncIterator<TKeySelector>(asyncEnumerator, keySelector, comparer));
+                return new AsyncEnumerable<Linq.Grouping<TKey, TElement>>(enumerable);
+            }
+
+            private readonly struct GroupByKeyElementAsyncIterator<TSource, TKeySelector, TElementSelector> : IAsyncIterator<Linq.Grouping<TKey, TElement>>
+                where TKeySelector : IFunc<TSource, Promise<TKey>>
+                where TElementSelector : IFunc<TSource, Promise<TElement>>
+            {
+                private readonly AsyncEnumerator<TSource> _asyncEnumerator;
+                private readonly TKeySelector _keySelector;
+                private readonly TElementSelector _elementSelector;
+                private readonly IEqualityComparer<TKey> _comparer;
+
+                internal GroupByKeyElementAsyncIterator(AsyncEnumerator<TSource> asyncEnumerator, TKeySelector keySelector, TElementSelector elementSelector, IEqualityComparer<TKey> comparer)
+                {
+                    _asyncEnumerator = asyncEnumerator;
+                    _keySelector = keySelector;
+                    _elementSelector = elementSelector;
+                    _comparer = comparer;
+                }
+
+                [MethodImpl(InlineOption)]
+                public Promise DisposeAsyncFromNeverStarted()
+                {
+                    return _asyncEnumerator.DisposeAsync();
+                }
+
+                public async AsyncEnumerableMethod Start(AsyncStreamWriter<Linq.Grouping<TKey, TElement>> writer, CancelationToken cancelationToken)
+                {
+                    // The enumerator was retrieved without a cancelation token when the original function was called.
+                    // We need to propagate the token that was passed in, so we assign it before starting iteration.
+                    _asyncEnumerator._target._cancelationToken = cancelationToken;
+
+                    // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
+                    LookupImpl<TKey, TElement> lookup = default;
+                    try
+                    {
+                        if (!await _asyncEnumerator.MoveNextAsync())
+                        {
+                            // No need to create the lookup if the enumerable is empty.
+                            return;
+                        }
+
+                        lookup = new LookupImpl<TKey, TElement>(_comparer, true);
+                        do
+                        {
+                            var item = _asyncEnumerator.Current;
+                            var key = await _keySelector.Invoke(item);
+                            var group = lookup.GetOrCreateGrouping(key, true);
+
+                            var element = await _elementSelector.Invoke(item);
+                            group.Add(element);
+                        } while (await _asyncEnumerator.MoveNextAsync());
+                        // We don't dispose the source enumerator until the owner is disposed.
+                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+
+                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                        var g = lookup._lastGrouping;
+                        do
+                        {
+                            g = g._nextGrouping;
+                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                        } while (g != lookup._lastGrouping);
+
+                        // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
+                        await writer.YieldAsync(default).ForLinqExtension();
+                    }
+                    finally
+                    {
+                        lookup.Dispose();
+                        await _asyncEnumerator.DisposeAsync();
+                    }
+                }
+            }
+
+            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupByAwait<TSource, TKeySelector, TElementSelector>(
+                AsyncEnumerator<TSource> asyncEnumerator,
+                TKeySelector keySelector,
+                TElementSelector elementSelector,
+                IEqualityComparer<TKey> comparer)
+                where TKeySelector : IFunc<TSource, Promise<TKey>>
+                where TElementSelector : IFunc<TSource, Promise<TElement>>
+            {
+                var enumerable = AsyncEnumerableCreate<Linq.Grouping<TKey, TElement>, GroupByKeyElementAsyncIterator<TSource, TKeySelector, TElementSelector>>.GetOrCreate(
+                    new GroupByKeyElementAsyncIterator<TSource, TKeySelector, TElementSelector>(asyncEnumerator, keySelector, elementSelector, comparer));
+                return new AsyncEnumerable<Linq.Grouping<TKey, TElement>>(enumerable);
+            }
+
+            private readonly struct GroupByKeyAsyncIterator<TKeySelector> : IAsyncIterator<Linq.Grouping<TKey, TElement>>
+                where TKeySelector : IFunc<TElement, Promise<TKey>>
+            {
+                private readonly AsyncEnumerator<TElement> _asyncEnumerator;
+                private readonly TKeySelector _keySelector;
+                private readonly IEqualityComparer<TKey> _comparer;
+
+                internal GroupByKeyAsyncIterator(AsyncEnumerator<TElement> asyncEnumerator, TKeySelector keySelector, IEqualityComparer<TKey> comparer)
+                {
+                    _asyncEnumerator = asyncEnumerator;
+                    _keySelector = keySelector;
+                    _comparer = comparer;
+                }
+
+                [MethodImpl(InlineOption)]
+                public Promise DisposeAsyncFromNeverStarted()
+                {
+                    return _asyncEnumerator.DisposeAsync();
+                }
+
+                public async AsyncEnumerableMethod Start(AsyncStreamWriter<Linq.Grouping<TKey, TElement>> writer, CancelationToken cancelationToken)
+                {
+                    // The enumerator was retrieved without a cancelation token when the original function was called.
+                    // We need to propagate the token that was passed in, so we assign it before starting iteration.
+                    _asyncEnumerator._target._cancelationToken = cancelationToken;
+
+                    // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
+                    LookupImpl<TKey, TElement> lookup = default;
+                    try
+                    {
+                        if (!await _asyncEnumerator.MoveNextAsync())
+                        {
+                            // No need to create the lookup if the enumerable is empty.
+                            return;
+                        }
+
+                        lookup = new LookupImpl<TKey, TElement>(_comparer, true);
+                        do
+                        {
+                            var item = _asyncEnumerator.Current;
+                            var key = await _keySelector.Invoke(item);
+                            lookup.GetOrCreateGrouping(key, true).Add(item);
+                        } while (await _asyncEnumerator.MoveNextAsync());
+                        // We don't dispose the source enumerator until the owner is disposed.
+                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+
+                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                        var g = lookup._lastGrouping;
+                        do
+                        {
+                            g = g._nextGrouping;
+                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                        } while (g != lookup._lastGrouping);
+
+                        // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
+                        await writer.YieldAsync(default).ForLinqExtension();
+                    }
+                    finally
+                    {
+                        lookup.Dispose();
+                        await _asyncEnumerator.DisposeAsync();
+                    }
+                }
+            }
+
+            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupByAwait<TKeySelector>(
+                AsyncEnumerator<TElement> asyncEnumerator,
+                TKeySelector keySelector,
+                IEqualityComparer<TKey> comparer)
+                where TKeySelector : IFunc<TElement, Promise<TKey>>
+            {
+                var enumerable = AsyncEnumerableCreate<Linq.Grouping<TKey, TElement>, GroupByKeyAsyncIterator<TKeySelector>>.GetOrCreate(
+                    new GroupByKeyAsyncIterator<TKeySelector>(asyncEnumerator, keySelector, comparer));
+                return new AsyncEnumerable<Linq.Grouping<TKey, TElement>>(enumerable);
+            }
+
+            private readonly struct ConfiguredGroupByKeyElementSyncIterator<TSource, TKeySelector, TElementSelector> : IAsyncIterator<Linq.Grouping<TKey, TElement>>
+                where TKeySelector : IFunc<TSource, TKey>
+                where TElementSelector : IFunc<TSource, TElement>
+            {
+                private readonly ConfiguredAsyncEnumerable<TSource>.Enumerator _configuredAsyncEnumerator;
+                private readonly TKeySelector _keySelector;
+                private readonly TElementSelector _elementSelector;
+                private readonly IEqualityComparer<TKey> _comparer;
+
+                internal ConfiguredGroupByKeyElementSyncIterator(ConfiguredAsyncEnumerable<TSource>.Enumerator configuredAsyncEnumerator, TKeySelector keySelector, TElementSelector elementSelector, IEqualityComparer<TKey> comparer)
+                {
+                    _configuredAsyncEnumerator = configuredAsyncEnumerator;
+                    _keySelector = keySelector;
+                    _elementSelector = elementSelector;
+                    _comparer = comparer;
+                }
+
+                [MethodImpl(InlineOption)]
+                public Promise DisposeAsyncFromNeverStarted()
+                {
+                    return _configuredAsyncEnumerator.DisposeAsync();
+                }
+
+                public async AsyncEnumerableMethod Start(AsyncStreamWriter<Linq.Grouping<TKey, TElement>> writer, CancelationToken cancelationToken)
+                {
+                    // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
+                    var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
+                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+
+                    // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
+                    LookupImpl<TKey, TElement> lookup = default;
+                    try
+                    {
+                        if (!await _configuredAsyncEnumerator.MoveNextAsync())
+                        {
+                            // No need to create the lookup if the enumerable is empty.
+                            return;
+                        }
+
+                        lookup = new LookupImpl<TKey, TElement>(_comparer, true);
+                        do
+                        {
+                            var item = _configuredAsyncEnumerator.Current;
+                            var key = _keySelector.Invoke(item);
+                            var group = lookup.GetOrCreateGrouping(key, true);
+
+                            var element = _elementSelector.Invoke(item);
+                            group.Add(element);
+                        } while (await _configuredAsyncEnumerator.MoveNextAsync());
+                        // We don't dispose the source enumerator until the owner is disposed.
+                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+
+                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                        var g = lookup._lastGrouping;
+                        do
+                        {
+                            g = g._nextGrouping;
+                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                        } while (g != lookup._lastGrouping);
+
+                        // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
+                        await writer.YieldAsync(default).ForLinqExtension();
+                    }
+                    finally
+                    {
+                        joinedCancelationSource.TryDispose();
+                        lookup.Dispose();
+                        await _configuredAsyncEnumerator.DisposeAsync();
+                    }
+                }
+            }
+
+            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupBy<TSource, TKeySelector, TElementSelector>(
+                ConfiguredAsyncEnumerable<TSource>.Enumerator configuredAsyncEnumerator,
+                TKeySelector keySelector,
+                TElementSelector elementSelector,
+                IEqualityComparer<TKey> comparer)
+                where TKeySelector : IFunc<TSource, TKey>
+                where TElementSelector : IFunc<TSource, TElement>
+            {
+                var enumerable = AsyncEnumerableCreate<Linq.Grouping<TKey, TElement>, ConfiguredGroupByKeyElementSyncIterator<TSource, TKeySelector, TElementSelector>>.GetOrCreate(
+                    new ConfiguredGroupByKeyElementSyncIterator<TSource, TKeySelector, TElementSelector>(configuredAsyncEnumerator, keySelector, elementSelector, comparer));
+                return new AsyncEnumerable<Linq.Grouping<TKey, TElement>>(enumerable);
+            }
+
+            private readonly struct ConfiguredGroupByKeySyncIterator<TKeySelector> : IAsyncIterator<Linq.Grouping<TKey, TElement>>
+                where TKeySelector : IFunc<TElement, TKey>
+            {
+                private readonly ConfiguredAsyncEnumerable<TElement>.Enumerator _configuredAsyncEnumerator;
+                private readonly TKeySelector _keySelector;
+                private readonly IEqualityComparer<TKey> _comparer;
+
+                internal ConfiguredGroupByKeySyncIterator(ConfiguredAsyncEnumerable<TElement>.Enumerator configuredAsyncEnumerator, TKeySelector keySelector, IEqualityComparer<TKey> comparer)
+                {
+                    _configuredAsyncEnumerator = configuredAsyncEnumerator;
+                    _keySelector = keySelector;
+                    _comparer = comparer;
+                }
+
+                [MethodImpl(InlineOption)]
+                public Promise DisposeAsyncFromNeverStarted()
+                {
+                    return _configuredAsyncEnumerator.DisposeAsync();
+                }
+
+                public async AsyncEnumerableMethod Start(AsyncStreamWriter<Linq.Grouping<TKey, TElement>> writer, CancelationToken cancelationToken)
+                {
+                    // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
+                    var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
+                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+
+                    // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
+                    LookupImpl<TKey, TElement> lookup = default;
+                    try
+                    {
+                        if (!await _configuredAsyncEnumerator.MoveNextAsync())
+                        {
+                            // No need to create the lookup if the enumerable is empty.
+                            return;
+                        }
+
+                        lookup = new LookupImpl<TKey, TElement>(_comparer, true);
+                        do
+                        {
+                            var item = _configuredAsyncEnumerator.Current;
+                            var key = _keySelector.Invoke(item);
+                            lookup.GetOrCreateGrouping(key, true).Add(item);
+                        } while (await _configuredAsyncEnumerator.MoveNextAsync());
+                        // We don't dispose the source enumerator until the owner is disposed.
+                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+
+                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                        var g = lookup._lastGrouping;
+                        do
+                        {
+                            g = g._nextGrouping;
+                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                        } while (g != lookup._lastGrouping);
+
+                        // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
+                        await writer.YieldAsync(default).ForLinqExtension();
+                    }
+                    finally
+                    {
+                        joinedCancelationSource.TryDispose();
+                        lookup.Dispose();
+                        await _configuredAsyncEnumerator.DisposeAsync();
+                    }
+                }
+            }
+
+            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupBy<TKeySelector>(
+                ConfiguredAsyncEnumerable<TElement>.Enumerator configuredAsyncEnumerator,
+                TKeySelector keySelector,
+                IEqualityComparer<TKey> comparer)
+                where TKeySelector : IFunc<TElement, TKey>
+            {
+                var enumerable = AsyncEnumerableCreate<Linq.Grouping<TKey, TElement>, ConfiguredGroupByKeySyncIterator<TKeySelector>>.GetOrCreate(
+                    new ConfiguredGroupByKeySyncIterator<TKeySelector>(configuredAsyncEnumerator, keySelector, comparer));
+                return new AsyncEnumerable<Linq.Grouping<TKey, TElement>>(enumerable);
+            }
+
+            private readonly struct ConfiguredGroupByKeyElementAsyncIterator<TSource, TKeySelector, TElementSelector> : IAsyncIterator<Linq.Grouping<TKey, TElement>>
+                where TKeySelector : IFunc<TSource, Promise<TKey>>
+                where TElementSelector : IFunc<TSource, Promise<TElement>>
+            {
+                private readonly ConfiguredAsyncEnumerable<TSource>.Enumerator _configuredAsyncEnumerator;
+                private readonly TKeySelector _keySelector;
+                private readonly TElementSelector _elementSelector;
+                private readonly IEqualityComparer<TKey> _comparer;
+
+                internal ConfiguredGroupByKeyElementAsyncIterator(ConfiguredAsyncEnumerable<TSource>.Enumerator configuredAsyncEnumerator, TKeySelector keySelector, TElementSelector elementSelector, IEqualityComparer<TKey> comparer)
+                {
+                    _configuredAsyncEnumerator = configuredAsyncEnumerator;
+                    _keySelector = keySelector;
+                    _elementSelector = elementSelector;
+                    _comparer = comparer;
+                }
+
+                [MethodImpl(InlineOption)]
+                public Promise DisposeAsyncFromNeverStarted()
+                {
+                    return _configuredAsyncEnumerator.DisposeAsync();
+                }
+
+                public async AsyncEnumerableMethod Start(AsyncStreamWriter<Linq.Grouping<TKey, TElement>> writer, CancelationToken cancelationToken)
+                {
+                    // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
+                    var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
+                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+
+                    // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
+                    LookupImpl<TKey, TElement> lookup = default;
+                    try
+                    {
+                        if (!await _configuredAsyncEnumerator.MoveNextAsync())
+                        {
+                            // No need to create the lookup if the enumerable is empty.
+                            return;
+                        }
+
+                        lookup = new LookupImpl<TKey, TElement>(_comparer, true);
+                        do
+                        {
+                            var item = _configuredAsyncEnumerator.Current;
+                            var key = await _keySelector.Invoke(item);
+                            var group = lookup.GetOrCreateGrouping(key, true);
+
+                            // The keySelector could have switched contexts.
+                            // We switch back to the configured context before invoking the elementSelector.
+                            await _configuredAsyncEnumerator.SwitchToContext();
+                            var element = await _elementSelector.Invoke(item);
+                            group.Add(element);
+                        } while (await _configuredAsyncEnumerator.MoveNextAsync());
+                        // We don't dispose the source enumerator until the owner is disposed.
+                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+
+                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                        var g = lookup._lastGrouping;
+                        do
+                        {
+                            g = g._nextGrouping;
+                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                        } while (g != lookup._lastGrouping);
+
+                        // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
+                        await writer.YieldAsync(default).ForLinqExtension();
+                    }
+                    finally
+                    {
+                        joinedCancelationSource.TryDispose();
+                        lookup.Dispose();
+                        await _configuredAsyncEnumerator.DisposeAsync();
+                    }
+                }
+            }
+
+            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupByAwait<TSource, TKeySelector, TElementSelector>(
+                ConfiguredAsyncEnumerable<TSource>.Enumerator configuredAsyncEnumerator,
+                TKeySelector keySelector,
+                TElementSelector elementSelector,
+                IEqualityComparer<TKey> comparer)
+                where TKeySelector : IFunc<TSource, Promise<TKey>>
+                where TElementSelector : IFunc<TSource, Promise<TElement>>
+            {
+                var enumerable = AsyncEnumerableCreate<Linq.Grouping<TKey, TElement>, ConfiguredGroupByKeyElementAsyncIterator<TSource, TKeySelector, TElementSelector>>.GetOrCreate(
+                    new ConfiguredGroupByKeyElementAsyncIterator<TSource, TKeySelector, TElementSelector>(configuredAsyncEnumerator, keySelector, elementSelector, comparer));
+                return new AsyncEnumerable<Linq.Grouping<TKey, TElement>>(enumerable);
+            }
+
+            private readonly struct ConfiguredGroupByKeyAsyncIterator<TKeySelector> : IAsyncIterator<Linq.Grouping<TKey, TElement>>
+                where TKeySelector : IFunc<TElement, Promise<TKey>>
+            {
+                private readonly ConfiguredAsyncEnumerable<TElement>.Enumerator _configuredAsyncEnumerator;
+                private readonly TKeySelector _keySelector;
+                private readonly IEqualityComparer<TKey> _comparer;
+
+                internal ConfiguredGroupByKeyAsyncIterator(ConfiguredAsyncEnumerable<TElement>.Enumerator configuredAsyncEnumerator, TKeySelector keySelector, IEqualityComparer<TKey> comparer)
+                {
+                    _configuredAsyncEnumerator = configuredAsyncEnumerator;
+                    _keySelector = keySelector;
+                    _comparer = comparer;
+                }
+
+                [MethodImpl(InlineOption)]
+                public Promise DisposeAsyncFromNeverStarted()
+                {
+                    return _configuredAsyncEnumerator.DisposeAsync();
+                }
+
+                public async AsyncEnumerableMethod Start(AsyncStreamWriter<Linq.Grouping<TKey, TElement>> writer, CancelationToken cancelationToken)
+                {
+                    // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
+                    var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
+                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+
+                    // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
+                    LookupImpl<TKey, TElement> lookup = default;
+                    try
+                    {
+                        if (!await _configuredAsyncEnumerator.MoveNextAsync())
+                        {
+                            // No need to create the lookup if the enumerable is empty.
+                            return;
+                        }
+
+                        lookup = new LookupImpl<TKey, TElement>(_comparer, true);
+                        do
+                        {
+                            var item = _configuredAsyncEnumerator.Current;
+                            var key = await _keySelector.Invoke(item);
+                            lookup.GetOrCreateGrouping(key, true).Add(item);
+                        } while (await _configuredAsyncEnumerator.MoveNextAsync());
+                        // We don't dispose the source enumerator until the owner is disposed.
+                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+
+                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                        var g = lookup._lastGrouping;
+                        do
+                        {
+                            g = g._nextGrouping;
+                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                        } while (g != lookup._lastGrouping);
+
+                        // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
+                        await writer.YieldAsync(default).ForLinqExtension();
+                    }
+                    finally
+                    {
+                        joinedCancelationSource.TryDispose();
+                        lookup.Dispose();
+                        await _configuredAsyncEnumerator.DisposeAsync();
+                    }
+                }
+            }
+
+            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupByAwait<TKeySelector>(
+                ConfiguredAsyncEnumerable<TElement>.Enumerator configuredAsyncEnumerator,
+                TKeySelector keySelector,
+                IEqualityComparer<TKey> comparer)
+                where TKeySelector : IFunc<TElement, Promise<TKey>>
+            {
+                var enumerable = AsyncEnumerableCreate<Linq.Grouping<TKey, TElement>, ConfiguredGroupByKeyAsyncIterator<TKeySelector>>.GetOrCreate(
+                    new ConfiguredGroupByKeyAsyncIterator<TKeySelector>(configuredAsyncEnumerator, keySelector, comparer));
+                return new AsyncEnumerable<Linq.Grouping<TKey, TElement>>(enumerable);
+            }
+        } // class Lookup<TKey, TElement>
+    } // class Internal
+#endif
+} // namespace Proto.Promises

--- a/Package/Core/Linq/Internal/GroupByInternal.cs.meta
+++ b/Package/Core/Linq/Internal/GroupByInternal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50d12694810604947bac82012e2f1a33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Core/Linq/Internal/LookupInternal.cs
+++ b/Package/Core/Linq/Internal/LookupInternal.cs
@@ -23,143 +23,136 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
-        internal sealed class Lookup<TKey, TElement> : ILookup<TKey, TElement>
+        // Implemented in a struct so that GroupBy doesn't need to allocate the Lookup class.
+        internal struct LookupImpl<TKey, TElement> : IDisposable
         {
-#if !PROTO_PROMISE_DEVELOPER_MODE
-            [DebuggerNonUserCode, StackTraceHidden]
-#endif
-            // Implemented in a struct so that GroupBy doesn't need to allocate the Lookup class.
-            private struct Impl
+            private readonly IEqualityComparer<TKey> _comparer;
+            internal Grouping<TKey, TElement> _lastGrouping;
+            // We use a TempCollectionBuilder to handle renting from ArrayPool.
+            internal TempCollectionBuilder<Grouping<TKey, TElement>> _groupings;
+            internal int _count;
+
+            internal LookupImpl(IEqualityComparer<TKey> comparer, bool willBeDisposed)
             {
-                private readonly IEqualityComparer<TKey> _comparer;
-                internal Grouping<TKey, TElement> _lastGrouping;
-                // We use a TempCollectionBuilder to handle renting from ArrayPool.
-                internal TempCollectionBuilder<Grouping<TKey, TElement>> _groupings;
-                internal int _count;
-
-                internal Impl(IEqualityComparer<TKey> comparer, bool willBeDisposed)
-                {
-                    _comparer = comparer ?? EqualityComparer<TKey>.Default;
-                    _lastGrouping = null;
-                    // The smallest array returned from ArrayPool by default is 16, so we use 15 count to start instead of 7 that System.Linq uses.
-                    // The actual array length could be larger than the requested size, so we make sure the count is what we expect.
-                    _groupings = new TempCollectionBuilder<Grouping<TKey, TElement>>(15, 15);
+                _comparer = comparer ?? EqualityComparer<TKey>.Default;
+                _lastGrouping = null;
+                // The smallest array returned from ArrayPool by default is 16, so we use 15 count to start instead of 7 that System.Linq uses.
+                // The actual array length could be larger than the requested size, so we make sure the count is what we expect.
+                _groupings = new TempCollectionBuilder<Grouping<TKey, TElement>>(15, 15);
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    // ToLookupAsync does not dispose. GroupByAsync does.
-                    if (!willBeDisposed)
-                    {
-                        Discard(_groupings._disposedChecker);
-                    }
+                // ToLookupAsync does not dispose. GroupBy does.
+                if (!willBeDisposed)
+                {
+                    Discard(_groupings._disposedChecker);
+                }
 #endif
-                    _count = 0;
-                }
-
-                internal Grouping<TKey, TElement> GetGrouping(TKey key)
-                {
-                    var hashCode = InternalGetHashCode(key);
-
-                    return GetGrouping(key, hashCode);
-                }
-
-                private Grouping<TKey, TElement> GetGrouping(TKey key, int hashCode)
-                {
-                    for (var g = _groupings._items[hashCode % _groupings._count]; g != null; g = g._hashNext)
-                    {
-                        if (g._hashCode == hashCode && _comparer.Equals(g._key, key))
-                        {
-                            return g;
-                        }
-                    }
-
-                    return null;
-                }
-
-                internal Grouping<TKey, TElement> GetOrCreateGrouping(TKey key, bool willBeDisposed)
-                {
-                    var hashCode = InternalGetHashCode(key);
-
-                    var grouping = GetGrouping(key, hashCode);
-                    if (grouping != null)
-                    {
-                        return grouping;
-                    }
-
-                    if (_count == _groupings._count)
-                    {
-                        Resize();
-                    }
-
-                    var index = hashCode % _groupings._count;
-                    var g = Grouping<TKey, TElement>.GetOrCreate(key, hashCode, _groupings._items[index], willBeDisposed);
-                    _groupings._items[index] = g;
-                    if (_lastGrouping == null)
-                    {
-                        g._nextGrouping = g;
-                    }
-                    else
-                    {
-                        g._nextGrouping = _lastGrouping._nextGrouping;
-                        _lastGrouping._nextGrouping = g;
-                    }
-
-                    _lastGrouping = g;
-                    _count++;
-                    return g;
-                }
-
-                private int InternalGetHashCode(TKey key)
-                {
-                    // Handle comparer implementations that throw when passed null
-                    return (key == null) ? 0 : _comparer.GetHashCode(key) & 0x7FFFFFFF;
-                }
-
-                private void Resize()
-                {
-                    var newSize = checked((_count * 2) + 1);
-                    _groupings.SetCapacityNoCopy(newSize);
-                    _groupings._count = newSize;
-                    var g = _lastGrouping;
-                    do
-                    {
-                        g = g._nextGrouping;
-                        var index = g._hashCode % newSize;
-                        g._hashNext = _groupings._items[index];
-                        _groupings._items[index] = g;
-                    } while (g != _lastGrouping);
-                }
-
-                public void Dispose(Grouping<TKey, TElement> currentGroup)
-                {
-                    // Dispose each grouping that wasn't disposed in the iterator.
-                    while (true)
-                    {
-                        var temp = currentGroup;
-                        currentGroup = currentGroup._nextGrouping;
-                        temp.Dispose();
-                        if (temp == _lastGrouping)
-                        {
-                            break;
-                        }
-                    }
-                    _groupings.Dispose();
-                }
-
-                internal void MaybeDispose()
-                {
-                    if (_lastGrouping != null)
-                    {
-                        Dispose(_lastGrouping._nextGrouping);
-                    }
-                    else if (_comparer != null)
-                    {
-                        _groupings.Dispose();
-                    }
-                }
+                _count = 0;
             }
 
-            private readonly Impl _impl;
+            internal Grouping<TKey, TElement> GetGrouping(TKey key)
+            {
+                var hashCode = InternalGetHashCode(key);
 
-            private Lookup(Impl impl)
+                return GetGrouping(key, hashCode);
+            }
+
+            private Grouping<TKey, TElement> GetGrouping(TKey key, int hashCode)
+            {
+                for (var g = _groupings._items[hashCode % _groupings._count]; g != null; g = g._hashNext)
+                {
+                    if (g._hashCode == hashCode && _comparer.Equals(g._key, key))
+                    {
+                        return g;
+                    }
+                }
+
+                return null;
+            }
+
+            internal Grouping<TKey, TElement> GetOrCreateGrouping(TKey key, bool willBeDisposed)
+            {
+                var hashCode = InternalGetHashCode(key);
+
+                var grouping = GetGrouping(key, hashCode);
+                if (grouping != null)
+                {
+                    return grouping;
+                }
+
+                if (_count == _groupings._count)
+                {
+                    Resize();
+                }
+
+                var index = hashCode % _groupings._count;
+                var g = Grouping<TKey, TElement>.GetOrCreate(key, hashCode, _groupings._items[index], willBeDisposed);
+                _groupings._items[index] = g;
+                if (_lastGrouping == null)
+                {
+                    g._nextGrouping = g;
+                }
+                else
+                {
+                    g._nextGrouping = _lastGrouping._nextGrouping;
+                    _lastGrouping._nextGrouping = g;
+                }
+
+                _lastGrouping = g;
+                _count++;
+                return g;
+            }
+
+            private int InternalGetHashCode(TKey key)
+            {
+                // Handle comparer implementations that throw when passed null
+                return (key == null) ? 0 : _comparer.GetHashCode(key) & 0x7FFFFFFF;
+            }
+
+            private void Resize()
+            {
+                var newSize = checked((_count * 2) + 1);
+                _groupings.SetCapacityNoCopy(newSize);
+                _groupings._count = newSize;
+                var g = _lastGrouping;
+                do
+                {
+                    g = g._nextGrouping;
+                    var index = g._hashCode % newSize;
+                    g._hashNext = _groupings._items[index];
+                    _groupings._items[index] = g;
+                } while (g != _lastGrouping);
+            }
+
+            public void Dispose()
+            {
+                if (_groupings._items == null)
+                {
+                    return;
+                }
+                // Dispose each grouping.
+                if (_lastGrouping != null)
+                {
+                    var current = _lastGrouping._nextGrouping;
+                    while (current != _lastGrouping)
+                    {
+                        var temp = current;
+                        current = current._nextGrouping;
+                        temp.Dispose();
+                    }
+                    _lastGrouping.Dispose();
+                }
+                _groupings.Dispose();
+            }
+        }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        internal sealed class Lookup<TKey, TElement> : ILookup<TKey, TElement>
+        {
+            private readonly LookupImpl<TKey, TElement> _impl;
+
+            private Lookup(LookupImpl<TKey, TElement> impl)
             {
                 _impl = impl;
             }
@@ -196,7 +189,6 @@ namespace Proto.Promises
                 }
             }
 
-            #region ToLookupAsync
             internal static async Promise<ILookup<TKey, TElement>> GetOrCreateAsync<TSource, TKeySelector, TElementSelector>(
                 AsyncEnumerator<TSource> asyncEnumerator,
                 TKeySelector keySelector,
@@ -205,7 +197,7 @@ namespace Proto.Promises
                 where TKeySelector : IFunc<TSource, TKey>
                 where TElementSelector : IFunc<TSource, TElement>
             {
-                var lookup = new Impl(comparer, false);
+                var lookup = new LookupImpl<TKey, TElement>(comparer, false);
 
                 try
                 {
@@ -233,7 +225,7 @@ namespace Proto.Promises
                 IEqualityComparer<TKey> comparer)
                 where TKeySelector : IFunc<TElement, TKey>
             {
-                var lookup = new Impl(comparer, false);
+                var lookup = new LookupImpl<TKey, TElement>(comparer, false);
 
                 try
                 {
@@ -260,7 +252,7 @@ namespace Proto.Promises
                 where TKeySelector : IFunc<TSource, Promise<TKey>>
                 where TElementSelector : IFunc<TSource, Promise<TElement>>
             {
-                var lookup = new Impl(comparer, false);
+                var lookup = new LookupImpl<TKey, TElement>(comparer, false);
 
                 try
                 {
@@ -288,7 +280,7 @@ namespace Proto.Promises
                 IEqualityComparer<TKey> comparer)
                 where TKeySelector : IFunc<TElement, Promise<TKey>>
             {
-                var lookup = new Impl(comparer, false);
+                var lookup = new LookupImpl<TKey, TElement>(comparer, false);
 
                 try
                 {
@@ -315,7 +307,7 @@ namespace Proto.Promises
                 where TKeySelector : IFunc<TSource, TKey>
                 where TElementSelector : IFunc<TSource, TElement>
             {
-                var lookup = new Impl(comparer, false);
+                var lookup = new LookupImpl<TKey, TElement>(comparer, false);
 
                 try
                 {
@@ -343,7 +335,7 @@ namespace Proto.Promises
                 IEqualityComparer<TKey> comparer)
                 where TKeySelector : IFunc<TElement, TKey>
             {
-                var lookup = new Impl(comparer, false);
+                var lookup = new LookupImpl<TKey, TElement>(comparer, false);
 
                 try
                 {
@@ -370,7 +362,7 @@ namespace Proto.Promises
                 where TKeySelector : IFunc<TSource, Promise<TKey>>
                 where TElementSelector : IFunc<TSource, Promise<TElement>>
             {
-                var lookup = new Impl(comparer, false);
+                var lookup = new LookupImpl<TKey, TElement>(comparer, false);
 
                 try
                 {
@@ -401,7 +393,7 @@ namespace Proto.Promises
                 IEqualityComparer<TKey> comparer)
                 where TKeySelector : IFunc<TElement, Promise<TKey>>
             {
-                var lookup = new Impl(comparer, false);
+                var lookup = new LookupImpl<TKey, TElement>(comparer, false);
 
                 try
                 {
@@ -418,589 +410,6 @@ namespace Proto.Promises
                 }
 
                 return new Lookup<TKey, TElement>(lookup);
-            }
-            #endregion ToLookupAsync
-
-            #region GroupBy
-            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupBy<TSource, TKeySelector, TElementSelector>(
-                AsyncEnumerator<TSource> asyncEnumerator,
-                TKeySelector keySelector,
-                TElementSelector elementSelector,
-                IEqualityComparer<TKey> comparer)
-                where TKeySelector : IFunc<TSource, TKey>
-                where TElementSelector : IFunc<TSource, TElement>
-            {
-                return AsyncEnumerable<Linq.Grouping<TKey, TElement>>.Create((asyncEnumerator, keySelector, elementSelector, comparer), async (cv, writer, cancelationToken) =>
-                {
-                    // The enumerator was retrieved without a cancelation token when the original function was called.
-                    // We need to propagate the token that was passed in, so we assign it before starting iteration.
-                    cv.asyncEnumerator._target._cancelationToken = cancelationToken;
-
-                    // We could just do await GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
-                    Impl lookup = default;
-                    try
-                    {
-                        if (!await cv.asyncEnumerator.MoveNextAsync())
-                        {
-                            // No need to create the lookup if the enumerable is empty.
-                            return;
-                        }
-
-                        lookup = new Impl(cv.comparer, true);
-                        do
-                        {
-                            var item = cv.asyncEnumerator.Current;
-                            var key = cv.keySelector.Invoke(item);
-                            var group = lookup.GetOrCreateGrouping(key, true);
-
-                            var element = cv.elementSelector.Invoke(item);
-                            group.Add(element);
-                        } while (await cv.asyncEnumerator.MoveNextAsync());
-                    }
-                    catch
-                    {
-                        lookup.MaybeDispose();
-                        throw;
-                    }
-                    finally
-                    {
-                        await cv.asyncEnumerator.DisposeAsync();
-                    }
-
-                    // We don't need to check if _lastGrouping is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                    var currentGroup = lookup._lastGrouping._nextGrouping;
-                    try
-                    {
-                        while (true)
-                        {
-                            // We dispose each grouping after the enumerator is moved forward or disposed.
-                            // This makes the TempCollection only valid during the single iteration step.
-                            // If the YieldAsync throws (because of an early AsyncEnumerator.DisposeAsync),
-                            // or it's the final group, it will be disposed in the finally block.
-                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(currentGroup));
-                            if (currentGroup == lookup._lastGrouping)
-                            {
-                                break;
-                            }
-                            var temp = currentGroup;
-                            currentGroup = currentGroup._nextGrouping;
-                            temp.Dispose();
-                        }
-                    }
-                    finally
-                    {
-                        lookup.Dispose(currentGroup);
-                    }
-                });
-            }
-
-            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupBy<TKeySelector>(
-                AsyncEnumerator<TElement> asyncEnumerator,
-                TKeySelector keySelector,
-                IEqualityComparer<TKey> comparer)
-                where TKeySelector : IFunc<TElement, TKey>
-            {
-                return AsyncEnumerable<Linq.Grouping<TKey, TElement>>.Create((asyncEnumerator, keySelector, comparer), async (cv, writer, cancelationToken) =>
-                {
-                    // The enumerator was retrieved without a cancelation token when the original function was called.
-                    // We need to propagate the token that was passed in, so we assign it before starting iteration.
-                    cv.asyncEnumerator._target._cancelationToken = cancelationToken;
-
-                    Impl lookup = default;
-                    try
-                    {
-                        if (!await cv.asyncEnumerator.MoveNextAsync())
-                        {
-                            // No need to create the lookup if the enumerable is empty.
-                            return;
-                        }
-
-                        lookup = new Impl(cv.comparer, true);
-                        do
-                        {
-                            var item = cv.asyncEnumerator.Current;
-                            var key = cv.keySelector.Invoke(item);
-                            lookup.GetOrCreateGrouping(key, true).Add(item);
-                        } while (await cv.asyncEnumerator.MoveNextAsync());
-                    }
-                    catch
-                    {
-                        lookup.MaybeDispose();
-                        throw;
-                    }
-                    finally
-                    {
-                        await cv.asyncEnumerator.DisposeAsync();
-                    }
-
-                    // We don't need to check if _lastGrouping is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                    var currentGroup = lookup._lastGrouping._nextGrouping;
-                    try
-                    {
-                        while (true)
-                        {
-                            // We dispose each grouping after the enumerator is moved forward or disposed.
-                            // This makes the TempCollection only valid during the single iteration step.
-                            // If the YieldAsync throws (because of an early AsyncEnumerator.DisposeAsync),
-                            // or it's the final group, it will be disposed in the finally block.
-                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(currentGroup));
-                            if (currentGroup == lookup._lastGrouping)
-                            {
-                                break;
-                            }
-                            var temp = currentGroup;
-                            currentGroup = currentGroup._nextGrouping;
-                            temp.Dispose();
-                        }
-                    }
-                    finally
-                    {
-                        lookup.Dispose(currentGroup);
-                    }
-                });
-            }
-
-            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupByAwait<TSource, TKeySelector, TElementSelector>(
-                AsyncEnumerator<TSource> asyncEnumerator,
-                TKeySelector keySelector,
-                TElementSelector elementSelector,
-                IEqualityComparer<TKey> comparer)
-                where TKeySelector : IFunc<TSource, Promise<TKey>>
-                where TElementSelector : IFunc<TSource, Promise<TElement>>
-            {
-                return AsyncEnumerable<Linq.Grouping<TKey, TElement>>.Create((asyncEnumerator, keySelector, elementSelector, comparer), async (cv, writer, cancelationToken) =>
-                {
-                    // The enumerator was retrieved without a cancelation token when the original function was called.
-                    // We need to propagate the token that was passed in, so we assign it before starting iteration.
-                    cv.asyncEnumerator._target._cancelationToken = cancelationToken;
-
-                    Impl lookup = default;
-                    try
-                    {
-                        if (!await cv.asyncEnumerator.MoveNextAsync())
-                        {
-                            // No need to create the lookup if the enumerable is empty.
-                            return;
-                        }
-
-                        lookup = new Impl(cv.comparer, true);
-                        do
-                        {
-                            var item = cv.asyncEnumerator.Current;
-                            var key = await cv.keySelector.Invoke(item);
-                            var group = lookup.GetOrCreateGrouping(key, true);
-
-                            var element = await cv.elementSelector.Invoke(item);
-                            group.Add(element);
-                        } while (await cv.asyncEnumerator.MoveNextAsync());
-                    }
-                    catch
-                    {
-                        lookup.MaybeDispose();
-                        throw;
-                    }
-                    finally
-                    {
-                        await cv.asyncEnumerator.DisposeAsync();
-                    }
-
-                    // We don't need to check if _lastGrouping is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                    var currentGroup = lookup._lastGrouping._nextGrouping;
-                    try
-                    {
-                        while (true)
-                        {
-                            // We dispose each grouping after the enumerator is moved forward or disposed.
-                            // This makes the TempCollection only valid during the single iteration step.
-                            // If the YieldAsync throws (because of an early AsyncEnumerator.DisposeAsync),
-                            // or it's the final group, it will be disposed in the finally block.
-                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(currentGroup));
-                            if (currentGroup == lookup._lastGrouping)
-                            {
-                                break;
-                            }
-                            var temp = currentGroup;
-                            currentGroup = currentGroup._nextGrouping;
-                            temp.Dispose();
-                        }
-                    }
-                    finally
-                    {
-                        lookup.Dispose(currentGroup);
-                    }
-                });
-            }
-
-            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupByAwait<TKeySelector>(
-                AsyncEnumerator<TElement> asyncEnumerator,
-                TKeySelector keySelector,
-                IEqualityComparer<TKey> comparer)
-                where TKeySelector : IFunc<TElement, Promise<TKey>>
-            {
-                return AsyncEnumerable<Linq.Grouping<TKey, TElement>>.Create((asyncEnumerator, keySelector, comparer), async (cv, writer, cancelationToken) =>
-                {
-                    // The enumerator was retrieved without a cancelation token when the original function was called.
-                    // We need to propagate the token that was passed in, so we assign it before starting iteration.
-                    cv.asyncEnumerator._target._cancelationToken = cancelationToken;
-
-                    Impl lookup = default;
-                    try
-                    {
-                        if (!await cv.asyncEnumerator.MoveNextAsync())
-                        {
-                            // No need to create the lookup if the enumerable is empty.
-                            return;
-                        }
-
-                        lookup = new Impl(cv.comparer, true);
-                        do
-                        {
-                            var item = cv.asyncEnumerator.Current;
-                            var key = await cv.keySelector.Invoke(item);
-                            lookup.GetOrCreateGrouping(key, true).Add(item);
-                        } while (await cv.asyncEnumerator.MoveNextAsync());
-                    }
-                    catch
-                    {
-                        lookup.MaybeDispose();
-                        throw;
-                    }
-                    finally
-                    {
-                        await cv.asyncEnumerator.DisposeAsync();
-                    }
-
-                    // We don't need to check if _lastGrouping is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                    var currentGroup = lookup._lastGrouping._nextGrouping;
-                    try
-                    {
-                        while (true)
-                        {
-                            // We dispose each grouping after the enumerator is moved forward or disposed.
-                            // This makes the TempCollection only valid during the single iteration step.
-                            // If the YieldAsync throws (because of an early AsyncEnumerator.DisposeAsync),
-                            // or it's the final group, it will be disposed in the finally block.
-                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(currentGroup));
-                            if (currentGroup == lookup._lastGrouping)
-                            {
-                                break;
-                            }
-                            var temp = currentGroup;
-                            currentGroup = currentGroup._nextGrouping;
-                            temp.Dispose();
-                        }
-                    }
-                    finally
-                    {
-                        lookup.Dispose(currentGroup);
-                    }
-                });
-            }
-
-            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupBy<TSource, TKeySelector, TElementSelector>(
-                ConfiguredAsyncEnumerable<TSource>.Enumerator configuredAsyncEnumerator,
-                TKeySelector keySelector,
-                TElementSelector elementSelector,
-                IEqualityComparer<TKey> comparer)
-                where TKeySelector : IFunc<TSource, TKey>
-                where TElementSelector : IFunc<TSource, TElement>
-            {
-                return AsyncEnumerable<Linq.Grouping<TKey, TElement>>.Create((configuredAsyncEnumerator, keySelector, elementSelector, comparer), async (cv, writer, cancelationToken) =>
-                {
-                    // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
-                    var enumerableRef = cv.configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
-
-                    try
-                    {
-                        Impl lookup = default;
-                        try
-                        {
-                            if (!await cv.configuredAsyncEnumerator.MoveNextAsync())
-                            {
-                                // No need to create the lookup if the enumerable is empty.
-                                return;
-                            }
-
-                            lookup = new Impl(cv.comparer, true);
-                            do
-                            {
-                                var item = cv.configuredAsyncEnumerator.Current;
-                                var key = cv.keySelector.Invoke(item);
-                                var group = lookup.GetOrCreateGrouping(key, true);
-
-                                var element = cv.elementSelector.Invoke(item);
-                                group.Add(element);
-                            } while (await cv.configuredAsyncEnumerator.MoveNextAsync());
-                        }
-                        catch
-                        {
-                            lookup.MaybeDispose();
-                            throw;
-                        }
-                        finally
-                        {
-                            await cv.configuredAsyncEnumerator.DisposeAsync();
-                        }
-
-                        // We don't need to check if _lastGrouping is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var currentGroup = lookup._lastGrouping._nextGrouping;
-                        try
-                        {
-                            while (true)
-                            {
-                                // We dispose each grouping after the enumerator is moved forward or disposed.
-                                // This makes the TempCollection only valid during the single iteration step.
-                                // If the YieldAsync throws (because of an early AsyncEnumerator.DisposeAsync),
-                                // or it's the final group, it will be disposed in the finally block.
-                                await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(currentGroup));
-                                if (currentGroup == lookup._lastGrouping)
-                                {
-                                    break;
-                                }
-                                var temp = currentGroup;
-                                currentGroup = currentGroup._nextGrouping;
-                                temp.Dispose();
-                            }
-                        }
-                        finally
-                        {
-                            lookup.Dispose(currentGroup);
-                        }
-                    }
-                    finally
-                    {
-                        joinedCancelationSource.TryDispose();
-                    }
-                });
-            }
-
-            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupBy<TKeySelector>(
-                ConfiguredAsyncEnumerable<TElement>.Enumerator configuredAsyncEnumerator,
-                TKeySelector keySelector,
-                IEqualityComparer<TKey> comparer)
-                where TKeySelector : IFunc<TElement, TKey>
-            {
-                return AsyncEnumerable<Linq.Grouping<TKey, TElement>>.Create((configuredAsyncEnumerator, keySelector, comparer), async (cv, writer, cancelationToken) =>
-                {
-                    // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
-                    var enumerableRef = cv.configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
-
-                    try
-                    {
-                        Impl lookup = default;
-                        try
-                        {
-                            if (!await cv.configuredAsyncEnumerator.MoveNextAsync())
-                            {
-                                // No need to create the lookup if the enumerable is empty.
-                                return;
-                            }
-
-                            lookup = new Impl(cv.comparer, true);
-                            do
-                            {
-                                var item = cv.configuredAsyncEnumerator.Current;
-                                var key = cv.keySelector.Invoke(item);
-                                lookup.GetOrCreateGrouping(key, true).Add(item);
-                            } while (await cv.configuredAsyncEnumerator.MoveNextAsync());
-                        }
-                        catch
-                        {
-                            lookup.MaybeDispose();
-                            throw;
-                        }
-                        finally
-                        {
-                            await cv.configuredAsyncEnumerator.DisposeAsync();
-                        }
-
-                        // We don't need to check if _lastGrouping is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var currentGroup = lookup._lastGrouping._nextGrouping;
-                        try
-                        {
-                            while (true)
-                            {
-                                // We dispose each grouping after the enumerator is moved forward or disposed.
-                                // This makes the TempCollection only valid during the single iteration step.
-                                // If the YieldAsync throws (because of an early AsyncEnumerator.DisposeAsync),
-                                // or it's the final group, it will be disposed in the finally block.
-                                await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(currentGroup));
-                                if (currentGroup == lookup._lastGrouping)
-                                {
-                                    break;
-                                }
-                                var temp = currentGroup;
-                                currentGroup = currentGroup._nextGrouping;
-                                temp.Dispose();
-                            }
-                        }
-                        finally
-                        {
-                            lookup.Dispose(currentGroup);
-                        }
-                    }
-                    finally
-                    {
-                        joinedCancelationSource.TryDispose();
-                    }
-                });
-            }
-
-            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupByAwait<TSource, TKeySelector, TElementSelector>(
-                ConfiguredAsyncEnumerable<TSource>.Enumerator configuredAsyncEnumerator,
-                TKeySelector keySelector,
-                TElementSelector elementSelector,
-                IEqualityComparer<TKey> comparer)
-                where TKeySelector : IFunc<TSource, Promise<TKey>>
-                where TElementSelector : IFunc<TSource, Promise<TElement>>
-            {
-                return AsyncEnumerable<Linq.Grouping<TKey, TElement>>.Create((configuredAsyncEnumerator, keySelector, elementSelector, comparer), async (cv, writer, cancelationToken) =>
-                {
-                    // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
-                    var enumerableRef = cv.configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
-
-                    try
-                    {
-                        Impl lookup = default;
-                        try
-                        {
-                            if (!await cv.configuredAsyncEnumerator.MoveNextAsync())
-                            {
-                                // No need to create the lookup if the enumerable is empty.
-                                return;
-                            }
-
-                            lookup = new Impl(cv.comparer, true);
-                            do
-                            {
-                                var item = cv.configuredAsyncEnumerator.Current;
-                                var key = await cv.keySelector.Invoke(item);
-                                var group = lookup.GetOrCreateGrouping(key, true);
-
-                                // The keySelector could have switched contexts.
-                                // We switch back to the configured context before invoking the elementSelector.
-                                await cv.configuredAsyncEnumerator.SwitchToContext();
-                                var element = await cv.elementSelector.Invoke(item);
-                                group.Add(element);
-                            } while (await cv.configuredAsyncEnumerator.MoveNextAsync());
-                        }
-                        catch
-                        {
-                            lookup.MaybeDispose();
-                            throw;
-                        }
-                        finally
-                        {
-                            await cv.configuredAsyncEnumerator.DisposeAsync();
-                        }
-
-                        // We don't need to check if _lastGrouping is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var currentGroup = lookup._lastGrouping._nextGrouping;
-                        try
-                        {
-                            while (true)
-                            {
-                                // We dispose each grouping after the enumerator is moved forward or disposed.
-                                // This makes the TempCollection only valid during the single iteration step.
-                                // If the YieldAsync throws (because of an early AsyncEnumerator.DisposeAsync),
-                                // or it's the final group, it will be disposed in the finally block.
-                                await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(currentGroup));
-                                if (currentGroup == lookup._lastGrouping)
-                                {
-                                    break;
-                                }
-                                var temp = currentGroup;
-                                currentGroup = currentGroup._nextGrouping;
-                                temp.Dispose();
-                            }
-                        }
-                        finally
-                        {
-                            lookup.Dispose(currentGroup);
-                        }
-                    }
-                    finally
-                    {
-                        joinedCancelationSource.TryDispose();
-                    }
-                });
-            }
-
-            internal static AsyncEnumerable<Linq.Grouping<TKey, TElement>> GroupByAwait<TKeySelector>(
-                ConfiguredAsyncEnumerable<TElement>.Enumerator configuredAsyncEnumerator,
-                TKeySelector keySelector,
-                IEqualityComparer<TKey> comparer)
-                where TKeySelector : IFunc<TElement, Promise<TKey>>
-            {
-                return AsyncEnumerable<Linq.Grouping<TKey, TElement>>.Create((configuredAsyncEnumerator, keySelector, comparer), async (cv, writer, cancelationToken) =>
-                {
-                    // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
-                    var enumerableRef = cv.configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
-
-                    try
-                    {
-                        Impl lookup = default;
-                        try
-                        {
-                            if (!await cv.configuredAsyncEnumerator.MoveNextAsync())
-                            {
-                                // No need to create the lookup if the enumerable is empty.
-                                return;
-                            }
-
-                            lookup = new Impl(cv.comparer, true);
-                            do
-                            {
-                                var item = cv.configuredAsyncEnumerator.Current;
-                                var key = await cv.keySelector.Invoke(item);
-                                lookup.GetOrCreateGrouping(key, true).Add(item);
-                            } while (await cv.configuredAsyncEnumerator.MoveNextAsync());
-                        }
-                        catch
-                        {
-                            lookup.MaybeDispose();
-                            throw;
-                        }
-                        finally
-                        {
-                            await cv.configuredAsyncEnumerator.DisposeAsync();
-                        }
-
-                        // We don't need to check if _lastGrouping is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var currentGroup = lookup._lastGrouping._nextGrouping;
-                        try
-                        {
-                            while (true)
-                            {
-                                // We dispose each grouping after the enumerator is moved forward or disposed.
-                                // This makes the TempCollection only valid during the single iteration step.
-                                // If the YieldAsync throws (because of an early AsyncEnumerator.DisposeAsync),
-                                // or it's the final group, it will be disposed in the finally block.
-                                await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(currentGroup));
-                                if (currentGroup == lookup._lastGrouping)
-                                {
-                                    break;
-                                }
-                                var temp = currentGroup;
-                                currentGroup = currentGroup._nextGrouping;
-                                temp.Dispose();
-                            }
-                        }
-                        finally
-                        {
-                            lookup.Dispose(currentGroup);
-                        }
-                    }
-                    finally
-                    {
-                        joinedCancelationSource.TryDispose();
-                    }
-                });
-                #endregion GroupBy
             }
         } // class Lookup<TKey, TElement>
     } // class Internal

--- a/Package/Core/Linq/Operators/GroupBy.cs
+++ b/Package/Core/Linq/Operators/GroupBy.cs
@@ -22,7 +22,7 @@ namespace Proto.Promises.Linq
     /// <typeparam name="TElement">The type of the elements.</typeparam>
     /// <remarks>
     /// The temporary collection will no longer be valid when the <see cref="AsyncEnumerator{T}"/>
-    /// that produced the <see cref="Grouping{TKey, TElement}"/> is moved forward or disposed.
+    /// that produced the <see cref="Grouping{TKey, TElement}"/> is disposed or completed unsuccessfully.
     /// Copy the elements to a new collection or call <see cref="TempCollection{T}.ToArray"/>
     /// or <see cref="TempCollection{T}.ToList"/> if you need the elements to persist.
     /// </remarks>
@@ -56,7 +56,7 @@ namespace Proto.Promises.Linq
         /// </summary>
         /// <remarks>
         /// The temporary collection will no longer be valid when the <see cref="AsyncEnumerator{T}"/>
-        /// that produced this <see cref="Grouping{TKey, TElement}"/> is moved forward or disposed.
+        /// that produced this <see cref="Grouping{TKey, TElement}"/> is disposed or completed unsuccessfully.
         /// Copy the elements to a new collection or call <see cref="TempCollection{T}.ToArray"/>
         /// or <see cref="TempCollection{T}.ToList"/> if you need the elements to persist.
         /// </remarks>
@@ -132,7 +132,7 @@ namespace Proto.Promises.Linq
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
 
-            return Internal.Lookup<TKey, TSource>.GroupBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
+            return Internal.GroupByHelper<TKey, TSource>.GroupBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Proto.Promises.Linq
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
 
-            return Internal.Lookup<TKey, TSource>.GroupBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
+            return Internal.GroupByHelper<TKey, TSource>.GroupBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
 
         /// <summary>
@@ -206,7 +206,7 @@ namespace Proto.Promises.Linq
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
 
-            return Internal.Lookup<TKey, TSource>.GroupByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
+            return Internal.GroupByHelper<TKey, TSource>.GroupByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
 
         /// <summary>
@@ -229,7 +229,7 @@ namespace Proto.Promises.Linq
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
 
-            return Internal.Lookup<TKey, TSource>.GroupByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
+            return Internal.GroupByHelper<TKey, TSource>.GroupByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
 
         /// <summary>
@@ -333,7 +333,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupBy(source.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupBy(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementSelector),
                 comparer);
@@ -363,7 +363,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupBy(source.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupBy(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementSelector),
                 comparer);
@@ -393,7 +393,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupBy(source.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupBy(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementCaptureValue, elementSelector),
                 comparer);
@@ -426,7 +426,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupBy(source.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupBy(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementCaptureValue, elementSelector),
                 comparer);
@@ -533,7 +533,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupByAwait(source.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementSelector),
                 comparer);
@@ -563,7 +563,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupByAwait(source.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementSelector),
                 comparer);
@@ -593,7 +593,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupByAwait(source.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementCaptureValue, elementSelector),
                 comparer);
@@ -626,7 +626,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupByAwait(source.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementCaptureValue, elementSelector),
                 comparer);
@@ -682,7 +682,7 @@ namespace Proto.Promises.Linq
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
 
-            return Internal.Lookup<TKey, TSource>.GroupBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
+            return Internal.GroupByHelper<TKey, TSource>.GroupBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
 
         /// <summary>
@@ -705,7 +705,7 @@ namespace Proto.Promises.Linq
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
 
-            return Internal.Lookup<TKey, TSource>.GroupBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
+            return Internal.GroupByHelper<TKey, TSource>.GroupBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
 
         /// <summary>
@@ -756,7 +756,7 @@ namespace Proto.Promises.Linq
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
 
-            return Internal.Lookup<TKey, TSource>.GroupByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
+            return Internal.GroupByHelper<TKey, TSource>.GroupByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
 
         /// <summary>
@@ -779,7 +779,7 @@ namespace Proto.Promises.Linq
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
 
-            return Internal.Lookup<TKey, TSource>.GroupByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
+            return Internal.GroupByHelper<TKey, TSource>.GroupByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
 
         /// <summary>
@@ -883,7 +883,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupBy(configuredSource.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupBy(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementSelector),
                 comparer);
@@ -913,7 +913,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupBy(configuredSource.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupBy(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementSelector),
                 comparer);
@@ -943,7 +943,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupBy(configuredSource.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupBy(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementCaptureValue, elementSelector),
                 comparer);
@@ -976,7 +976,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupBy(configuredSource.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupBy(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementCaptureValue, elementSelector),
                 comparer);
@@ -1083,7 +1083,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupByAwait(configuredSource.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementSelector),
                 comparer);
@@ -1113,7 +1113,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupByAwait(configuredSource.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementSelector),
                 comparer);
@@ -1143,7 +1143,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupByAwait(configuredSource.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementCaptureValue, elementSelector),
                 comparer);
@@ -1176,7 +1176,7 @@ namespace Proto.Promises.Linq
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
 
-            return Internal.Lookup<TKey, TElement>.GroupByAwait(configuredSource.GetAsyncEnumerator(),
+            return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
                 Internal.PromiseRefBase.DelegateWrapper.Create(elementCaptureValue, elementSelector),
                 comparer);


### PR DESCRIPTION
This makes the `TempCollection`s persist until the `GroupBy` enumerator is disposed or completed unsuccessfully (exception or canceled). This will help when chaining extensions (like `.GroupBy(...).OrderBy(group => group.Elements.Count)`) so they won't be surprisingly invalid during iteration.

Also optimized the extensions to use a direct struct instead of using `AsyncEnumerable.Create`.