### PR TITLE
Accept generic comparers in `AsyncEnumerable` Linq extensions.

### DIFF
--- a/Package/Core/Linq/Internal/OrderByInternal.cs
+++ b/Package/Core/Linq/Internal/OrderByInternal.cs
@@ -1032,11 +1032,12 @@ namespace Proto.Promises
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
         // We use a reverse comparer and generics so that we don't need an extra branch on every comparison.
-        internal readonly struct ReverseComparer<TKey> : IComparer<TKey>
+        internal readonly struct ReverseComparer<TKey, TComparer> : IComparer<TKey>
+            where TComparer : IComparer<TKey>
         {
-            private readonly IComparer<TKey> _comparer;
+            private readonly TComparer _comparer;
 
-            internal ReverseComparer(IComparer<TKey> comparer)
+            internal ReverseComparer(TComparer comparer)
                 => _comparer = comparer;
 
             [MethodImpl(InlineOption)]

--- a/Package/Core/Linq/Operators/GroupBy.cs
+++ b/Package/Core/Linq/Operators/GroupBy.cs
@@ -96,7 +96,7 @@ namespace Proto.Promises.Linq
         public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector)
-            => GroupBy(source, keySelector, comparer: null);
+            => GroupBy(source, keySelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of an async-enumerable sequence according to a specified key selector function.
@@ -113,24 +113,27 @@ namespace Proto.Promises.Linq
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector)
-            => GroupBy(source, keyCaptureValue, keySelector, comparer: null);
+            => GroupBy(source, keyCaptureValue, keySelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of an async-enumerable sequence according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence whose elements to group.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey, TEqualityComparer>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TSource>.GroupBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
@@ -141,19 +144,22 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence whose elements to group.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TCaptureKey, TKey, TEqualityComparer>(
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TSource>.GroupBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
@@ -170,7 +176,7 @@ namespace Proto.Promises.Linq
         public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector)
-            => GroupBy<TSource, TKey>(source, keySelector, comparer: null);
+            => GroupBy<TSource, TKey, IEqualityComparer<TKey>>(source, keySelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of an async-enumerable sequence by invoking a key-selector function on each element and awaiting the result.
@@ -187,24 +193,27 @@ namespace Proto.Promises.Linq
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector)
-            => GroupBy<TSource, TCaptureKey, TKey>(source, keyCaptureValue, keySelector, comparer: null);
+            => GroupBy<TSource, TCaptureKey, TKey, IEqualityComparer<TKey>>(source, keyCaptureValue, keySelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of an async-enumerable sequence by invoking a key-selector function on each element and awaiting the result.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence whose elements to group.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey, TEqualityComparer>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TSource>.GroupByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
@@ -215,19 +224,22 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence whose elements to group.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TCaptureKey, TKey, TEqualityComparer>(
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TSource>.GroupByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
@@ -247,7 +259,7 @@ namespace Proto.Promises.Linq
             this AsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             Func<TSource, TElement> elementSelector)
-            => GroupBy(source, keySelector, elementSelector, comparer: null);
+            => GroupBy(source, keySelector, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of an async-enumerable sequence according to a specified key selector function, and an element selector function.
@@ -267,7 +279,7 @@ namespace Proto.Promises.Linq
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
             Func<TSource, TElement> elementSelector)
-            => GroupBy(source, keyCaptureValue, keySelector, elementSelector, comparer: null);
+            => GroupBy(source, keyCaptureValue, keySelector, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of an async-enumerable sequence according to a specified key selector function, and an element selector function.
@@ -287,7 +299,7 @@ namespace Proto.Promises.Linq
             Func<TSource, TKey> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, TElement> elementSelector)
-            => GroupBy(source, keySelector, elementCaptureValue, elementSelector, comparer: null);
+            => GroupBy(source, keySelector, elementCaptureValue, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of an async-enumerable sequence according to a specified key selector function, and an element selector function.
@@ -310,7 +322,7 @@ namespace Proto.Promises.Linq
             Func<TCaptureKey, TSource, TKey> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, TElement> elementSelector)
-            => GroupBy(source, keyCaptureValue, keySelector, elementCaptureValue, elementSelector, comparer: null);
+            => GroupBy(source, keyCaptureValue, keySelector, elementCaptureValue, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of an async-enumerable sequence according to a specified key selector function, a comparer, and an element selector function.
@@ -318,20 +330,23 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence whose elements to group.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TElement, TEqualityComparer>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             Func<TSource, TElement> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupBy(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
@@ -346,22 +361,25 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence whose elements to group.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TElement, TEqualityComparer>(
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
             Func<TSource, TElement> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupBy(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
@@ -376,22 +394,25 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TCaptureElement">The type of the captured value that will be passed to the element selector.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence whose elements to group.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementCaptureValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TCaptureElement, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TCaptureElement, TElement, TEqualityComparer>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, TElement> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupBy(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
@@ -407,6 +428,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TCaptureElement">The type of the captured value that will be passed to the element selector.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence whose elements to group.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
@@ -414,17 +436,19 @@ namespace Proto.Promises.Linq
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TCaptureElement, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TCaptureElement, TElement, TEqualityComparer>(
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, TElement> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupBy(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
@@ -447,7 +471,7 @@ namespace Proto.Promises.Linq
             this AsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector,
             Func<TSource, Promise<TElement>> elementSelector)
-            => GroupBy<TSource, TKey, TElement>(source, keySelector, elementSelector, comparer: null);
+            => GroupBy<TSource, TKey, TElement, IEqualityComparer<TKey>>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of an async-enumerable sequence by invoking key and element selector functions on each source element and awaiting the results.
@@ -467,7 +491,7 @@ namespace Proto.Promises.Linq
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
             Func<TSource, Promise<TElement>> elementSelector)
-            => GroupBy<TSource, TCaptureKey, TKey, TElement>(source, keyCaptureValue, keySelector, elementSelector, comparer: null);
+            => GroupBy<TSource, TCaptureKey, TKey, TElement, IEqualityComparer<TKey>>(source, keyCaptureValue, keySelector, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of an async-enumerable sequence by invoking key and element selector functions on each source element and awaiting the results.
@@ -487,7 +511,7 @@ namespace Proto.Promises.Linq
             Func<TSource, Promise<TKey>> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, Promise<TElement>> elementSelector)
-            => GroupBy<TSource, TKey, TCaptureElement, TElement>(source, keySelector, elementCaptureValue, elementSelector, comparer: null);
+            => GroupBy<TSource, TKey, TCaptureElement, TElement, IEqualityComparer<TKey>>(source, keySelector, elementCaptureValue, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of an async-enumerable sequence by invoking key and element selector functions on each source element and awaiting the results.
@@ -510,7 +534,7 @@ namespace Proto.Promises.Linq
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, Promise<TElement>> elementSelector)
-            => GroupBy<TSource, TCaptureKey, TKey, TCaptureElement, TElement>(source, keyCaptureValue, keySelector, elementCaptureValue, elementSelector, comparer: null);
+            => GroupBy<TSource, TCaptureKey, TKey, TCaptureElement, TElement, IEqualityComparer<TKey>>(source, keyCaptureValue, keySelector, elementCaptureValue, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of an async-enumerable sequence by invoking key and element selector functions on each source element and awaiting the results.
@@ -518,20 +542,23 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence whose elements to group.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from each element.</param>
         /// <param name="elementSelector">An asynchronous transform function to produce a result element value from each source element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TElement, TEqualityComparer>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector,
             Func<TSource, Promise<TElement>> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
@@ -546,22 +573,25 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence whose elements to group.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from each element.</param>
         /// <param name="elementSelector">An asynchronous transform function to produce a result element value from each source element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TElement, TEqualityComparer>(
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
             Func<TSource, Promise<TElement>> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
@@ -576,22 +606,25 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TCaptureElement">The type of the captured value that will be passed to the element selector.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence whose elements to group.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from each element.</param>
         /// <param name="elementCaptureValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
         /// <param name="elementSelector">An asynchronous transform function to produce a result element value from each source element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TCaptureElement, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TCaptureElement, TElement, TEqualityComparer>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, Promise<TElement>> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
@@ -607,6 +640,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TCaptureElement">The type of the captured value that will be passed to the element selector.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence whose elements to group.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from each element.</param>
@@ -614,17 +648,19 @@ namespace Proto.Promises.Linq
         /// <param name="elementSelector">An asynchronous transform function to produce a result element value from each source element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TCaptureElement, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TCaptureElement, TElement, TEqualityComparer>(
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, Promise<TElement>> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(source.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
@@ -646,7 +682,7 @@ namespace Proto.Promises.Linq
         public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, TKey> keySelector)
-            => GroupBy(configuredSource, keySelector, comparer: null);
+            => GroupBy(configuredSource, keySelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of a configured async-enumerable sequence according to a specified key selector function.
@@ -663,24 +699,27 @@ namespace Proto.Promises.Linq
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector)
-            => GroupBy(configuredSource, keyCaptureValue, keySelector, comparer: null);
+            => GroupBy(configuredSource, keyCaptureValue, keySelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of a configured async-enumerable sequence according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence whose elements to group.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey, TEqualityComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, TKey> keySelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TSource>.GroupBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
@@ -691,19 +730,22 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence whose elements to group.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TCaptureKey, TKey, TEqualityComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TSource>.GroupBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
@@ -720,7 +762,7 @@ namespace Proto.Promises.Linq
         public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, Promise<TKey>> keySelector)
-            => GroupBy<TSource, TKey>(configuredSource, keySelector, comparer: null);
+            => GroupBy<TSource, TKey, IEqualityComparer<TKey>>(configuredSource, keySelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of a configured async-enumerable sequence by invoking a key-selector function on each element and awaiting the result.
@@ -737,24 +779,27 @@ namespace Proto.Promises.Linq
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector)
-            => GroupBy<TSource, TCaptureKey, TKey>(configuredSource, keyCaptureValue, keySelector, comparer: null);
+            => GroupBy<TSource, TCaptureKey, TKey, IEqualityComparer<TKey>>(configuredSource, keyCaptureValue, keySelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of a configured async-enumerable sequence by invoking a key-selector function on each element and awaiting the result.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence whose elements to group.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey, TEqualityComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, Promise<TKey>> keySelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TSource>.GroupByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
@@ -765,19 +810,22 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence whose elements to group.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TCaptureKey, TKey, TEqualityComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TSource>.GroupByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
@@ -797,7 +845,7 @@ namespace Proto.Promises.Linq
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, TKey> keySelector,
             Func<TSource, TElement> elementSelector)
-            => GroupBy(configuredSource, keySelector, elementSelector, comparer: null);
+            => GroupBy(configuredSource, keySelector, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of a configured async-enumerable sequence according to a specified key selector function, and an element selector function.
@@ -817,7 +865,7 @@ namespace Proto.Promises.Linq
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
             Func<TSource, TElement> elementSelector)
-            => GroupBy(configuredSource, keyCaptureValue, keySelector, elementSelector, comparer: null);
+            => GroupBy(configuredSource, keyCaptureValue, keySelector, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of a configured async-enumerable sequence according to a specified key selector function, and an element selector function.
@@ -837,7 +885,7 @@ namespace Proto.Promises.Linq
             Func<TSource, TKey> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, TElement> elementSelector)
-            => GroupBy(configuredSource, keySelector, elementCaptureValue, elementSelector, comparer: null);
+            => GroupBy(configuredSource, keySelector, elementCaptureValue, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of a configured async-enumerable sequence according to a specified key selector function, and an element selector function.
@@ -860,7 +908,7 @@ namespace Proto.Promises.Linq
             Func<TCaptureKey, TSource, TKey> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, TElement> elementSelector)
-            => GroupBy(configuredSource, keyCaptureValue, keySelector, elementCaptureValue, elementSelector, comparer: null);
+            => GroupBy(configuredSource, keyCaptureValue, keySelector, elementCaptureValue, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of a configured async-enumerable sequence according to a specified key selector function, a comparer, and an element selector function.
@@ -868,20 +916,23 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence whose elements to group.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TElement, TEqualityComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, TKey> keySelector,
             Func<TSource, TElement> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupBy(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
@@ -896,22 +947,25 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence whose elements to group.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TElement, TEqualityComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
             Func<TSource, TElement> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupBy(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
@@ -926,22 +980,25 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TCaptureElement">The type of the captured value that will be passed to the element selector.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence whose elements to group.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementCaptureValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TCaptureElement, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TCaptureElement, TElement, TEqualityComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, TKey> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, TElement> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupBy(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
@@ -957,6 +1014,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TCaptureElement">The type of the captured value that will be passed to the element selector.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence whose elements to group.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
@@ -964,17 +1022,19 @@ namespace Proto.Promises.Linq
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TCaptureElement, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TCaptureElement, TElement, TEqualityComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, TElement> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupBy(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
@@ -997,7 +1057,7 @@ namespace Proto.Promises.Linq
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, Promise<TKey>> keySelector,
             Func<TSource, Promise<TElement>> elementSelector)
-            => GroupBy<TSource, TKey, TElement>(configuredSource, keySelector, elementSelector, comparer: null);
+            => GroupBy<TSource, TKey, TElement, IEqualityComparer<TKey>>(configuredSource, keySelector, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of a configured async-enumerable sequence by invoking key and element selector functions on each source element and awaiting the results.
@@ -1017,7 +1077,7 @@ namespace Proto.Promises.Linq
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
             Func<TSource, Promise<TElement>> elementSelector)
-            => GroupBy<TSource, TCaptureKey, TKey, TElement>(configuredSource, keyCaptureValue, keySelector, elementSelector, comparer: null);
+            => GroupBy<TSource, TCaptureKey, TKey, TElement, IEqualityComparer<TKey>>(configuredSource, keyCaptureValue, keySelector, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of a configured async-enumerable sequence by invoking key and element selector functions on each source element and awaiting the results.
@@ -1037,7 +1097,7 @@ namespace Proto.Promises.Linq
             Func<TSource, Promise<TKey>> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, Promise<TElement>> elementSelector)
-            => GroupBy<TSource, TKey, TCaptureElement, TElement>(configuredSource, keySelector, elementCaptureValue, elementSelector, comparer: null);
+            => GroupBy<TSource, TKey, TCaptureElement, TElement, IEqualityComparer<TKey>>(configuredSource, keySelector, elementCaptureValue, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of a configured async-enumerable sequence by invoking key and element selector functions on each source element and awaiting the results.
@@ -1060,7 +1120,7 @@ namespace Proto.Promises.Linq
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, Promise<TElement>> elementSelector)
-            => GroupBy<TSource, TCaptureKey, TKey, TCaptureElement, TElement>(configuredSource, keyCaptureValue, keySelector, elementCaptureValue, elementSelector, comparer: null);
+            => GroupBy<TSource, TCaptureKey, TKey, TCaptureElement, TElement, IEqualityComparer<TKey>>(configuredSource, keyCaptureValue, keySelector, elementCaptureValue, elementSelector, EqualityComparer<TKey>.Default);
 
         /// <summary>
         /// Groups the elements of a configured async-enumerable sequence by invoking key and element selector functions on each source element and awaiting the results.
@@ -1068,20 +1128,23 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence whose elements to group.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from each element.</param>
         /// <param name="elementSelector">An asynchronous transform function to produce a result element value from each source element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TElement, TEqualityComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, Promise<TKey>> keySelector,
             Func<TSource, Promise<TElement>> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
@@ -1096,22 +1159,25 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence whose elements to group.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from each element.</param>
         /// <param name="elementSelector">An asynchronous transform function to produce a result element value from each source element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TElement, TEqualityComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
             Func<TSource, Promise<TElement>> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),
@@ -1126,22 +1192,25 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TCaptureElement">The type of the captured value that will be passed to the element selector.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence whose elements to group.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from each element.</param>
         /// <param name="elementCaptureValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
         /// <param name="elementSelector">An asynchronous transform function to produce a result element value from each source element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TCaptureElement, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TKey, TCaptureElement, TElement, TEqualityComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, Promise<TKey>> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, Promise<TElement>> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keySelector),
@@ -1157,6 +1226,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TCaptureElement">The type of the captured value that will be passed to the element selector.</typeparam>
         /// <typeparam name="TElement">The type of the lookup value computed for each element in the source sequence.</typeparam>
+        /// <typeparam name="TEqualityComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence whose elements to group.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from each element.</param>
@@ -1164,17 +1234,19 @@ namespace Proto.Promises.Linq
         /// <param name="elementSelector">An asynchronous transform function to produce a result element value from each source element.</param>
         /// <param name="comparer">An equality comparer to compare keys. If null, the default equality comparer will be used.</param>
         /// <returns>An async-enumerable sequence of groups, each of which corresponds to a unique key value, containing all elements that share that same key value.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> is null.</exception>
-        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TCaptureElement, TElement>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="elementSelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static AsyncEnumerable<Grouping<TKey, TElement>> GroupBy<TSource, TCaptureKey, TKey, TCaptureElement, TElement, TEqualityComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
             TCaptureElement elementCaptureValue,
             Func<TCaptureElement, TSource, Promise<TElement>> elementSelector,
-            IEqualityComparer<TKey> comparer)
+            TEqualityComparer comparer)
+            where TEqualityComparer : IEqualityComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
             ValidateArgument(elementSelector, nameof(elementSelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
             return Internal.GroupByHelper<TKey, TElement>.GroupByAwait(configuredSource.GetAsyncEnumerator(),
                 Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector),

--- a/Package/Core/Linq/Operators/OrderBy.cs
+++ b/Package/Core/Linq/Operators/OrderBy.cs
@@ -21,17 +21,24 @@ namespace Proto.Promises.Linq
         /// <param name="source">An async-enumerable sequence to sort.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
         public static OrderedAsyncEnumerable<TSource> Order<TSource>(this AsyncEnumerable<TSource> source)
-            => Order(source, comparer: null);
+            => Order(source, Comparer<TSource>.Default);
 
         /// <summary>
         /// Sorts the elements of an async-enumerable sequence in ascending order according to a specified comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence to sort.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        public static OrderedAsyncEnumerable<TSource> Order<TSource>(this AsyncEnumerable<TSource> source, IComparer<TSource> comparer)
-            => Internal.OrderHelper<TSource>.Order(source.GetAsyncEnumerator(), comparer ?? Comparer<TSource>.Default);
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> Order<TSource, TComparer>(this AsyncEnumerable<TSource> source, TComparer comparer)
+            where TComparer : IComparer<TSource>
+        {
+            ValidateArgument(comparer, nameof(comparer), 1);
+
+            return Internal.OrderHelper<TSource>.Order(source.GetAsyncEnumerator(), comparer);
+        }
 
         /// <summary>
         /// Sorts the elements of a configured async-enumerable sequence in ascending order.
@@ -40,17 +47,24 @@ namespace Proto.Promises.Linq
         /// <param name="configuredSource">A configured async-enumerable sequence to sort.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
         public static OrderedAsyncEnumerable<TSource> Order<TSource>(this ConfiguredAsyncEnumerable<TSource> configuredSource)
-            => Order(configuredSource, comparer: null);
+            => Order(configuredSource, Comparer<TSource>.Default);
 
         /// <summary>
         /// Sorts the elements of a configured async-enumerable sequence in ascending order according to a specified comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence to sort.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        public static OrderedAsyncEnumerable<TSource> Order<TSource>(this ConfiguredAsyncEnumerable<TSource> configuredSource, IComparer<TSource> comparer)
-            => Internal.OrderHelper<TSource>.Order(configuredSource.GetAsyncEnumerator(), comparer ?? Comparer<TSource>.Default);
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> Order<TSource, TComparer>(this ConfiguredAsyncEnumerable<TSource> configuredSource, TComparer comparer)
+            where TComparer : IComparer<TSource>
+        {
+            ValidateArgument(comparer, nameof(comparer), 1);
+
+            return Internal.OrderHelper<TSource>.Order(configuredSource.GetAsyncEnumerator(), comparer);
+        }
 
         /// <summary>
         /// Sorts the elements of an async-enumerable sequence in descending order.
@@ -59,17 +73,24 @@ namespace Proto.Promises.Linq
         /// <param name="source">An async-enumerable sequence to sort.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
         public static OrderedAsyncEnumerable<TSource> OrderDescending<TSource>(this AsyncEnumerable<TSource> source)
-            => OrderDescending(source, comparer: null);
+            => OrderDescending(source, Comparer<TSource>.Default);
 
         /// <summary>
         /// Sorts the elements of an async-enumerable sequence in descending order according to a specified comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence to sort.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        public static OrderedAsyncEnumerable<TSource> OrderDescending<TSource>(this AsyncEnumerable<TSource> source, IComparer<TSource> comparer)
-            => Internal.OrderHelper<TSource>.Order(source.GetAsyncEnumerator(), new Internal.ReverseComparer<TSource>(comparer ?? Comparer<TSource>.Default));
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderDescending<TSource, TComparer>(this AsyncEnumerable<TSource> source, TComparer comparer)
+            where TComparer : IComparer<TSource>
+        {
+            ValidateArgument(comparer, nameof(comparer), 1);
+
+            return Internal.OrderHelper<TSource>.Order(source.GetAsyncEnumerator(), new Internal.ReverseComparer<TSource, TComparer>(comparer));
+        }
 
         /// <summary>
         /// Sorts the elements of a configured async-enumerable sequence in descending order.
@@ -78,17 +99,24 @@ namespace Proto.Promises.Linq
         /// <param name="configuredSource">A configured async-enumerable sequence to sort.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
         public static OrderedAsyncEnumerable<TSource> OrderDescending<TSource>(this ConfiguredAsyncEnumerable<TSource> configuredSource)
-            => OrderDescending(configuredSource, comparer: null);
+            => OrderDescending(configuredSource, Comparer<TSource>.Default);
 
         /// <summary>
         /// Sorts the elements of a configured async-enumerable sequence in descending order according to a specified comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence to sort.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        public static OrderedAsyncEnumerable<TSource> OrderDescending<TSource>(this ConfiguredAsyncEnumerable<TSource> configuredSource, IComparer<TSource> comparer)
-            => Internal.OrderHelper<TSource>.Order(configuredSource.GetAsyncEnumerator(), new Internal.ReverseComparer<TSource>(comparer ?? Comparer<TSource>.Default));
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderDescending<TSource, TComparer>(this ConfiguredAsyncEnumerable<TSource> configuredSource, TComparer comparer)
+            where TComparer : IComparer<TSource>
+        {
+            ValidateArgument(comparer, nameof(comparer), 1);
+
+            return Internal.OrderHelper<TSource>.Order(configuredSource.GetAsyncEnumerator(), new Internal.ReverseComparer<TSource, TComparer>(comparer));
+        }
         #endregion Order
 
         #region OrderBy
@@ -104,7 +132,7 @@ namespace Proto.Promises.Linq
         public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector)
-            => OrderBy(source, keySelector, comparer: null);
+            => OrderBy(source, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of an async-enumerable sequence in ascending order according to a specified key selector function.
@@ -121,26 +149,29 @@ namespace Proto.Promises.Linq
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector)
-            => OrderBy(source, keyCaptureValue, keySelector, comparer: null);
+            => OrderBy(source, keyCaptureValue, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of an async-enumerable sequence in ascending order according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence to sort.</param>
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey, TComparer>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer ?? Comparer<TKey>.Default);
+            return Internal.OrderHelper<TSource, TKey>.OrderBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
 
         /// <summary>
@@ -149,21 +180,24 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence to sort.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TCaptureKey, TKey, TComparer>(
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer ?? Comparer<TKey>.Default);
+            return Internal.OrderHelper<TSource, TKey>.OrderBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
 
         /// <summary>
@@ -178,7 +212,7 @@ namespace Proto.Promises.Linq
         public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector)
-            => OrderBy<TSource, TKey>(source, keySelector, comparer: null);
+            => OrderBy<TSource, TKey, IComparer<TKey>>(source, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of an async-enumerable sequence in ascending order according to a specified key selector function.
@@ -195,26 +229,29 @@ namespace Proto.Promises.Linq
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector)
-            => OrderBy<TSource, TCaptureKey, TKey>(source, keyCaptureValue, keySelector, comparer: null);
+            => OrderBy<TSource, TCaptureKey, TKey, IComparer<TKey>>(source, keyCaptureValue, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of an async-enumerable sequence in ascending order according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence to sort.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey, TComparer>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer ?? Comparer<TKey>.Default);
+            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
 
         /// <summary>
@@ -223,21 +260,24 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence to sort.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TCaptureKey, TKey, TComparer>(
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer ?? Comparer<TKey>.Default);
+            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
 
         /// <summary>
@@ -252,7 +292,7 @@ namespace Proto.Promises.Linq
         public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, TKey> keySelector)
-            => OrderBy(configuredSource, keySelector, comparer: null);
+            => OrderBy(configuredSource, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of a configured async-enumerable sequence in ascending order according to a specified key selector function.
@@ -269,26 +309,29 @@ namespace Proto.Promises.Linq
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector)
-            => OrderBy(configuredSource, keyCaptureValue, keySelector, comparer: null);
+            => OrderBy(configuredSource, keyCaptureValue, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of a configured async-enumerable sequence in ascending order according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence to sort.</param>
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey, TComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, TKey> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer ?? Comparer<TKey>.Default);
+            return Internal.OrderHelper<TSource, TKey>.OrderBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
 
         /// <summary>
@@ -297,21 +340,24 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence to sort.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TCaptureKey, TKey, TComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer ?? Comparer<TKey>.Default);
+            return Internal.OrderHelper<TSource, TKey>.OrderBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
 
         /// <summary>
@@ -326,7 +372,7 @@ namespace Proto.Promises.Linq
         public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, Promise<TKey>> keySelector)
-            => OrderBy<TSource, TKey>(configuredSource, keySelector, comparer: null);
+            => OrderBy<TSource, TKey, IComparer<TKey>>(configuredSource, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of a configured async-enumerable sequence in ascending order according to a specified key selector function.
@@ -343,26 +389,29 @@ namespace Proto.Promises.Linq
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector)
-            => OrderBy<TSource, TCaptureKey, TKey>(configuredSource, keyCaptureValue, keySelector, comparer: null);
+            => OrderBy<TSource, TCaptureKey, TKey, IComparer<TKey>>(configuredSource, keyCaptureValue, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of a configured async-enumerable sequence in ascending order according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence to sort.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TKey, TComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, Promise<TKey>> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer ?? Comparer<TKey>.Default);
+            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
 
         /// <summary>
@@ -371,21 +420,24 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence to sort.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderBy<TSource, TCaptureKey, TKey, TComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer ?? Comparer<TKey>.Default);
+            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
 
         /// <summary>
@@ -400,7 +452,7 @@ namespace Proto.Promises.Linq
         public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector)
-            => OrderByDescending(source, keySelector, comparer: null);
+            => OrderByDescending(source, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of an async-enumerable sequence in descending order according to a specified key selector function.
@@ -417,26 +469,29 @@ namespace Proto.Promises.Linq
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector)
-            => OrderByDescending(source, keyCaptureValue, keySelector, comparer: null);
+            => OrderByDescending(source, keyCaptureValue, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of an async-enumerable sequence in descending order according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence to sort.</param>
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey, TComparer>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), new Internal.ReverseComparer<TKey>(comparer ?? Comparer<TKey>.Default));
+            return Internal.OrderHelper<TSource, TKey>.OrderBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), new Internal.ReverseComparer<TKey, TComparer>(comparer));
         }
 
         /// <summary>
@@ -445,21 +500,24 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence to sort.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TCaptureKey, TKey, TComparer>(
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), new Internal.ReverseComparer<TKey>(comparer ?? Comparer<TKey>.Default));
+            return Internal.OrderHelper<TSource, TKey>.OrderBy(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), new Internal.ReverseComparer<TKey, TComparer>(comparer));
         }
 
         /// <summary>
@@ -474,7 +532,7 @@ namespace Proto.Promises.Linq
         public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector)
-            => OrderByDescending<TSource, TKey>(source, keySelector, comparer: null);
+            => OrderByDescending<TSource, TKey, IComparer<TKey>>(source, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of an async-enumerable sequence in descending order according to a specified key selector function.
@@ -491,26 +549,29 @@ namespace Proto.Promises.Linq
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector)
-            => OrderByDescending<TSource, TCaptureKey, TKey>(source, keyCaptureValue, keySelector, comparer: null);
+            => OrderByDescending<TSource, TCaptureKey, TKey, IComparer<TKey>>(source, keyCaptureValue, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of an async-enumerable sequence in descending order according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence to sort.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey, TComparer>(
             this AsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), new Internal.ReverseComparer<TKey>(comparer ?? Comparer<TKey>.Default));
+            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), new Internal.ReverseComparer<TKey, TComparer>(comparer));
         }
 
         /// <summary>
@@ -519,21 +580,24 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An async-enumerable sequence to sort.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TCaptureKey, TKey, TComparer>(
             this AsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), new Internal.ReverseComparer<TKey>(comparer ?? Comparer<TKey>.Default));
+            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(source.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), new Internal.ReverseComparer<TKey, TComparer>(comparer));
         }
 
         /// <summary>
@@ -548,7 +612,7 @@ namespace Proto.Promises.Linq
         public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, TKey> keySelector)
-            => OrderByDescending(configuredSource, keySelector, comparer: null);
+            => OrderByDescending(configuredSource, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of a configured async-enumerable sequence in descending order according to a specified key selector function.
@@ -565,26 +629,29 @@ namespace Proto.Promises.Linq
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector)
-            => OrderByDescending(configuredSource, keyCaptureValue, keySelector, comparer: null);
+            => OrderByDescending(configuredSource, keyCaptureValue, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of a configured async-enumerable sequence in descending order according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence to sort.</param>
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey, TComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, TKey> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), new Internal.ReverseComparer<TKey>(comparer ?? Comparer<TKey>.Default));
+            return Internal.OrderHelper<TSource, TKey>.OrderBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), new Internal.ReverseComparer<TKey, TComparer>(comparer));
         }
 
         /// <summary>
@@ -593,21 +660,24 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence to sort.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TCaptureKey, TKey, TComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), new Internal.ReverseComparer<TKey>(comparer ?? Comparer<TKey>.Default));
+            return Internal.OrderHelper<TSource, TKey>.OrderBy(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), new Internal.ReverseComparer<TKey, TComparer>(comparer));
         }
 
         /// <summary>
@@ -622,7 +692,7 @@ namespace Proto.Promises.Linq
         public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, Promise<TKey>> keySelector)
-            => OrderByDescending<TSource, TKey>(configuredSource, keySelector, comparer: null);
+            => OrderByDescending<TSource, TKey, IComparer<TKey>>(configuredSource, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of a configured async-enumerable sequence in descending order according to a specified key selector function.
@@ -639,26 +709,29 @@ namespace Proto.Promises.Linq
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector)
-            => OrderByDescending<TSource, TCaptureKey, TKey>(configuredSource, keyCaptureValue, keySelector, comparer: null);
+            => OrderByDescending<TSource, TCaptureKey, TKey, IComparer<TKey>>(configuredSource, keyCaptureValue, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Sorts the elements of a configured async-enumerable sequence in descending order according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence to sort.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TKey, TComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             Func<TSource, Promise<TKey>> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), new Internal.ReverseComparer<TKey>(comparer ?? Comparer<TKey>.Default));
+            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), new Internal.ReverseComparer<TKey, TComparer>(comparer));
         }
 
         /// <summary>
@@ -667,21 +740,24 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="configuredSource">A configured async-enumerable sequence to sort.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> OrderByDescending<TSource, TCaptureKey, TKey, TComparer>(
             this ConfiguredAsyncEnumerable<TSource> configuredSource,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), new Internal.ReverseComparer<TKey>(comparer ?? Comparer<TKey>.Default));
+            return Internal.OrderHelper<TSource, TKey>.OrderByAwait(configuredSource.GetAsyncEnumerator(), Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), new Internal.ReverseComparer<TKey, TComparer>(comparer));
         }
         #endregion OrderBy
 
@@ -698,7 +774,7 @@ namespace Proto.Promises.Linq
         public static OrderedAsyncEnumerable<TSource> ThenBy<TSource, TKey>(
             this OrderedAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector)
-            => ThenBy(source, keySelector, comparer: null);
+            => ThenBy(source, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Performs a subsequent ordering of the elements in an async-enumerable sequence in ascending order according to a specified key selector function.
@@ -715,26 +791,29 @@ namespace Proto.Promises.Linq
             this OrderedAsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector)
-            => ThenBy(source, keyCaptureValue, keySelector, comparer: null);
+            => ThenBy(source, keyCaptureValue, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Performs a subsequent ordering of the elements in an async-enumerable sequence in ascending order according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An ordered async-enumerable sequence that contains elements to sort.</param>
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> ThenBy<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> ThenBy<TSource, TKey, TComparer>(
             this OrderedAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.ThenBy(source, Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer ?? Comparer<TKey>.Default);
+            return Internal.OrderHelper<TSource, TKey>.ThenBy(source, Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
 
         /// <summary>
@@ -743,21 +822,24 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An ordered async-enumerable sequence that contains elements to sort.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> ThenBy<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> ThenBy<TSource, TCaptureKey, TKey, TComparer>(
             this OrderedAsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.ThenBy(source, Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer ?? Comparer<TKey>.Default);
+            return Internal.OrderHelper<TSource, TKey>.ThenBy(source, Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
 
         /// <summary>
@@ -772,7 +854,7 @@ namespace Proto.Promises.Linq
         public static OrderedAsyncEnumerable<TSource> ThenBy<TSource, TKey>(
             this OrderedAsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector)
-            => ThenBy<TSource, TKey>(source, keySelector, comparer: null);
+            => ThenBy<TSource, TKey, IComparer<TKey>>(source, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Performs a subsequent ordering of the elements in an async-enumerable sequence in ascending order according to a specified key selector function.
@@ -789,26 +871,29 @@ namespace Proto.Promises.Linq
             this OrderedAsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector)
-            => ThenBy<TSource, TCaptureKey, TKey>(source, keyCaptureValue, keySelector, comparer: null);
+            => ThenBy<TSource, TCaptureKey, TKey, IComparer<TKey>>(source, keyCaptureValue, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Performs a subsequent ordering of the elements in an async-enumerable sequence in ascending order according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An ordered async-enumerable sequence that contains elements to sort.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> ThenBy<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> ThenBy<TSource, TKey, TComparer>(
             this OrderedAsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.ThenByAwait(source, Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer ?? Comparer<TKey>.Default);
+            return Internal.OrderHelper<TSource, TKey>.ThenByAwait(source, Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), comparer);
         }
 
         /// <summary>
@@ -817,21 +902,24 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An ordered async-enumerable sequence that contains elements to sort.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> ThenBy<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> ThenBy<TSource, TCaptureKey, TKey, TComparer>(
             this OrderedAsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.ThenByAwait(source, Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer ?? Comparer<TKey>.Default);
+            return Internal.OrderHelper<TSource, TKey>.ThenByAwait(source, Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), comparer);
         }
 
         /// <summary>
@@ -846,7 +934,7 @@ namespace Proto.Promises.Linq
         public static OrderedAsyncEnumerable<TSource> ThenByDescending<TSource, TKey>(
             this OrderedAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector)
-            => ThenByDescending(source, keySelector, comparer: null);
+            => ThenByDescending(source, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Performs a subsequent ordering of the elements in an async-enumerable sequence in descending order according to a specified key selector function.
@@ -863,26 +951,29 @@ namespace Proto.Promises.Linq
             this OrderedAsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector)
-            => ThenByDescending(source, keyCaptureValue, keySelector, comparer: null);
+            => ThenByDescending(source, keyCaptureValue, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Performs a subsequent ordering of the elements in an async-enumerable sequence in descending order according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An ordered async-enumerable sequence that contains elements to sort.</param>
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> ThenByDescending<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> ThenByDescending<TSource, TKey, TComparer>(
             this OrderedAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.ThenBy(source, Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), new Internal.ReverseComparer<TKey>(comparer ?? Comparer<TKey>.Default));
+            return Internal.OrderHelper<TSource, TKey>.ThenBy(source, Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), new Internal.ReverseComparer<TKey, TComparer>(comparer));
         }
 
         /// <summary>
@@ -891,21 +982,24 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An ordered async-enumerable sequence that contains elements to sort.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> ThenByDescending<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> ThenByDescending<TSource, TCaptureKey, TKey, TComparer>(
             this OrderedAsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, TKey> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.ThenBy(source, Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), new Internal.ReverseComparer<TKey>(comparer ?? Comparer<TKey>.Default));
+            return Internal.OrderHelper<TSource, TKey>.ThenBy(source, Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), new Internal.ReverseComparer<TKey, TComparer>(comparer));
         }
 
         /// <summary>
@@ -920,7 +1014,7 @@ namespace Proto.Promises.Linq
         public static OrderedAsyncEnumerable<TSource> ThenByDescending<TSource, TKey>(
             this OrderedAsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector)
-            => ThenByDescending<TSource, TKey>(source, keySelector, comparer: null);
+            => ThenByDescending<TSource, TKey, IComparer<TKey>>(source, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Performs a subsequent ordering of the elements in an async-enumerable sequence in descending order according to a specified key selector function.
@@ -937,26 +1031,29 @@ namespace Proto.Promises.Linq
             this OrderedAsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector)
-            => ThenByDescending<TSource, TCaptureKey, TKey>(source, keyCaptureValue, keySelector, comparer: null);
+            => ThenByDescending<TSource, TCaptureKey, TKey, IComparer<TKey>>(source, keyCaptureValue, keySelector, Comparer<TKey>.Default);
 
         /// <summary>
         /// Performs a subsequent ordering of the elements in an async-enumerable sequence in descending order according to a specified key selector function, and a comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An ordered async-enumerable sequence that contains elements to sort.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> ThenByDescending<TSource, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> ThenByDescending<TSource, TKey, TComparer>(
             this OrderedAsyncEnumerable<TSource> source,
             Func<TSource, Promise<TKey>> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.ThenByAwait(source, Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), new Internal.ReverseComparer<TKey>(comparer ?? Comparer<TKey>.Default));
+            return Internal.OrderHelper<TSource, TKey>.ThenByAwait(source, Internal.PromiseRefBase.DelegateWrapper.Create(keySelector), new Internal.ReverseComparer<TKey, TComparer>(comparer));
         }
 
         /// <summary>
@@ -965,21 +1062,24 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TCaptureKey">The type of the captured value that will be passed to the key selector.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by the <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TComparer">The type of the comparer.</typeparam>
         /// <param name="source">An ordered async-enumerable sequence that contains elements to sort.</param>
         /// <param name="keyCaptureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An asynchronous function to extract a key from an element.</param>
         /// <param name="comparer">A comparer to compare keys. If null, the default comparer will be used.</param>
         /// <returns>An <see cref="OrderedAsyncEnumerable{T}"/> whose elements are sorted.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null.</exception>
-        public static OrderedAsyncEnumerable<TSource> ThenByDescending<TSource, TCaptureKey, TKey>(
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> or <paramref name="comparer"/> is null.</exception>
+        public static OrderedAsyncEnumerable<TSource> ThenByDescending<TSource, TCaptureKey, TKey, TComparer>(
             this OrderedAsyncEnumerable<TSource> source,
             TCaptureKey keyCaptureValue,
             Func<TCaptureKey, TSource, Promise<TKey>> keySelector,
-            IComparer<TKey> comparer)
+            TComparer comparer)
+            where TComparer : IComparer<TKey>
         {
             ValidateArgument(keySelector, nameof(keySelector), 1);
+            ValidateArgument(comparer, nameof(comparer), 1);
 
-            return Internal.OrderHelper<TSource, TKey>.ThenByAwait(source, Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), new Internal.ReverseComparer<TKey>(comparer ?? Comparer<TKey>.Default));
+            return Internal.OrderHelper<TSource, TKey>.ThenByAwait(source, Internal.PromiseRefBase.DelegateWrapper.Create(keyCaptureValue, keySelector), new Internal.ReverseComparer<TKey, TComparer>(comparer));
         }
         #endregion ThenBy
     }

--- a/Package/Tests/CoreTests/APIs/Linq/Operators/GroupByTests.cs
+++ b/Package/Tests/CoreTests/APIs/Linq/Operators/GroupByTests.cs
@@ -43,113 +43,138 @@ namespace ProtoPromiseTests.APIs.Linq
         {
             var enumerable = AsyncEnumerable.Return(42);
             var captureValue = "captureValue";
+            var nullComparer = default(IEqualityComparer<int>);
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, default(Func<int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(default(Func<int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, default(Func<string, int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, default(Func<string, int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, default(Func<int, int>), x => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, x => 0, default(Func<int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, default(Func<int, int>), x => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, x => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(default(Func<int, int>), x => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => 0, default(Func<int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(default(Func<int, int>), x => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => 0, x => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, default(Func<string, int, int>), x => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, (cv, x) => 0, default(Func<int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, default(Func<string, int, int>), x => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, (cv, x) => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, default(Func<string, int, int>), x => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => 0, default(Func<int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, default(Func<string, int, int>), x => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => 0, x => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, default(Func<int, int>), captureValue, (cv, x) => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, x => 0, captureValue, default(Func<string, int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, default(Func<int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, x => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(default(Func<int, int>), captureValue, (cv, x) => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => 0, captureValue, default(Func<string, int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(default(Func<int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => 0, captureValue, (cv, x) => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
-
-
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, default(Func<int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
-
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, default(Func<string, int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
-
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, default(Func<int, Promise<int>>), x => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, x => Promise.Resolved(0), default(Func<int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, default(Func<int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, x => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
-
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
-
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
-
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable, captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => 0, captureValue, (cv, x) => 0, nullComparer));
 
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(default(Func<int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => Promise.Resolved(0), nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, default(Func<string, int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, int>), x => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => 0, default(Func<int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, int>), x => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(default(Func<int, Promise<int>>), x => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => Promise.Resolved(0), default(Func<int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(default(Func<int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => Promise.Resolved(0), x => Promise.Resolved(0), nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, int>), x => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => 0, default(Func<int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, int>), x => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => Promise.Resolved(0), x => Promise.Resolved(0), nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, int>), captureValue, (cv, x) => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => 0, captureValue, default(Func<string, int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(x => Promise.Resolved(0), captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.GroupBy(captureValue, (cv, x) => Promise.Resolved(0), captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(default(Func<int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, default(Func<string, int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, Promise<int>>), x => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => Promise.Resolved(0), default(Func<int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(default(Func<int, int>), x => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => 0, default(Func<int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(default(Func<int, int>), x => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => 0, x => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, default(Func<string, int, int>), x => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => 0, default(Func<int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, default(Func<string, int, int>), x => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => 0, x => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(default(Func<int, int>), captureValue, (cv, x) => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => 0, captureValue, default(Func<string, int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(default(Func<int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => 0, captureValue, (cv, x) => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.GroupBy(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => 0, captureValue, (cv, x) => 0, nullComparer));
+
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(default(Func<int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => Promise.Resolved(0), nullComparer));
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, default(Func<string, int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(default(Func<int, Promise<int>>), x => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => Promise.Resolved(0), default(Func<int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(default(Func<int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => Promise.Resolved(0), x => Promise.Resolved(0), nullComparer));
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => Promise.Resolved(0), x => Promise.Resolved(0), nullComparer));
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(x => Promise.Resolved(0), captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).GroupBy(captureValue, (cv, x) => Promise.Resolved(0), captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
             enumerable.GetAsyncEnumerator().DisposeAsync().Forget();
         }
@@ -172,22 +197,38 @@ namespace ProtoPromiseTests.APIs.Linq
             if (!captureKey)
             {
                 return async
-                    ? asyncEnumerable.GroupBy(async x => keySelector(x), equalityComparer)
-                    : asyncEnumerable.GroupBy(keySelector, equalityComparer);
+                    ? equalityComparer != null
+                        ? asyncEnumerable.GroupBy(async x => keySelector(x), equalityComparer)
+                        : asyncEnumerable.GroupBy(async x => keySelector(x))
+                    : equalityComparer != null
+                        ? asyncEnumerable.GroupBy(keySelector, equalityComparer)
+                        : asyncEnumerable.GroupBy(keySelector);
             }
             else
             {
                 return async
-                    ? asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, equalityComparer)
-                    : asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, equalityComparer);
+                    ? equalityComparer != null
+                        ? asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, equalityComparer)
+                        : asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        })
+                    : equalityComparer != null
+                        ? asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, equalityComparer)
+                        : asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        });
             }
         }
 
@@ -211,24 +252,42 @@ namespace ProtoPromiseTests.APIs.Linq
                 if (!captureElement)
                 {
                     return async
-                        ? asyncEnumerable.GroupBy(async x => keySelector(x), async x => elementSelector(x), equalityComparer)
-                        : asyncEnumerable.GroupBy(keySelector, elementSelector, equalityComparer);
+                        ? equalityComparer != null
+                            ? asyncEnumerable.GroupBy(async x => keySelector(x), async x => elementSelector(x), equalityComparer)
+                            : asyncEnumerable.GroupBy(async x => keySelector(x), async x => elementSelector(x))
+                        : equalityComparer != null
+                            ? asyncEnumerable.GroupBy(keySelector, elementSelector, equalityComparer)
+                            : asyncEnumerable.GroupBy(keySelector, elementSelector);
                 }
                 else
                 {
                     return async
-                        ? asyncEnumerable.GroupBy(async x => keySelector(x),
+                        ? equalityComparer != null
+                            ? asyncEnumerable.GroupBy(async x => keySelector(x),
                             elementCapture, async (cv, x) =>
                             {
                                 Assert.AreEqual(elementCapture, cv);
                                 return elementSelector(x);
                             }, equalityComparer)
-                        : asyncEnumerable.GroupBy(x => keySelector(x),
+                            : asyncEnumerable.GroupBy(async x => keySelector(x),
+                            elementCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(elementCapture, cv);
+                                return elementSelector(x);
+                            })
+                        : equalityComparer != null
+                            ? asyncEnumerable.GroupBy(x => keySelector(x),
                             elementCapture, (cv, x) =>
                             {
                                 Assert.AreEqual(elementCapture, cv);
                                 return elementSelector(x);
-                            }, equalityComparer);
+                            }, equalityComparer)
+                            : asyncEnumerable.GroupBy(x => keySelector(x),
+                            elementCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(elementCapture, cv);
+                                return elementSelector(x);
+                            });
                 }
             }
             else
@@ -236,40 +295,74 @@ namespace ProtoPromiseTests.APIs.Linq
                 if (!captureElement)
                 {
                     return async
-                        ? asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
-                        {
-                            Assert.AreEqual(keyCapture, cv);
-                            return keySelector(x);
-                        }, async x => elementSelector(x), equalityComparer)
-                        : asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
-                        {
-                            Assert.AreEqual(keyCapture, cv);
-                            return keySelector(x);
-                        }, elementSelector, equalityComparer);
+                        ? equalityComparer != null
+                            ? asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            }, async x => elementSelector(x), equalityComparer)
+                            : asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            }, async x => elementSelector(x))
+                        : equalityComparer != null
+                            ? asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            }, elementSelector, equalityComparer)
+                            : asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            }, elementSelector);
                 }
                 else
                 {
                     return async
-                        ? asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
-                        {
-                            Assert.AreEqual(keyCapture, cv);
-                            return keySelector(x);
-                        },
+                        ? equalityComparer != null
+                            ? asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            },
                             elementCapture, async (cv, x) =>
                             {
                                 Assert.AreEqual(elementCapture, cv);
                                 return elementSelector(x);
                             }, equalityComparer)
-                        : asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
-                        {
-                            Assert.AreEqual(keyCapture, cv);
-                            return keySelector(x);
-                        },
+                            : asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            },
+                            elementCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(elementCapture, cv);
+                                return elementSelector(x);
+                            })
+                        : equalityComparer != null
+                            ? asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            },
                             elementCapture, (cv, x) =>
                             {
                                 Assert.AreEqual(elementCapture, cv);
                                 return elementSelector(x);
-                            }, equalityComparer);
+                            }, equalityComparer)
+                            : asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            },
+                            elementCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(elementCapture, cv);
+                                return elementSelector(x);
+                            });
                 }
             }
         }
@@ -277,29 +370,45 @@ namespace ProtoPromiseTests.APIs.Linq
         private static AsyncEnumerable<Grouping<TKey, TSource>> GroupBy<TSource, TKey>(ConfiguredAsyncEnumerable<TSource> asyncEnumerable,
             bool async,
             Func<TSource, TKey> keySelector, bool captureKey,
-            IEqualityComparer<TKey> equalityComparer)
+            IEqualityComparer<TKey> equalityComparer = null)
         {
             const string keyCapture = "keyCapture";
 
             if (!captureKey)
             {
                 return async
-                    ? asyncEnumerable.GroupBy(async x => keySelector(x), equalityComparer)
-                    : asyncEnumerable.GroupBy(keySelector, equalityComparer);
+                    ? equalityComparer != null
+                        ? asyncEnumerable.GroupBy(async x => keySelector(x), equalityComparer)
+                        : asyncEnumerable.GroupBy(async x => keySelector(x))
+                    : equalityComparer != null
+                        ? asyncEnumerable.GroupBy(keySelector, equalityComparer)
+                        : asyncEnumerable.GroupBy(keySelector);
             }
             else
             {
                 return async
-                    ? asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, equalityComparer)
-                    : asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, equalityComparer);
+                    ? equalityComparer != null
+                        ? asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, equalityComparer)
+                        : asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        })
+                    : equalityComparer != null
+                        ? asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, equalityComparer)
+                        : asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        });
             }
         }
 
@@ -307,7 +416,7 @@ namespace ProtoPromiseTests.APIs.Linq
             bool async,
             Func<TSource, TKey> keySelector, bool captureKey,
             Func<TSource, TElement> elementSelector, bool captureElement,
-            IEqualityComparer<TKey> equalityComparer)
+            IEqualityComparer<TKey> equalityComparer = null)
         {
             const string keyCapture = "keyCapture";
             const string elementCapture = "elementCapture";
@@ -317,24 +426,42 @@ namespace ProtoPromiseTests.APIs.Linq
                 if (!captureElement)
                 {
                     return async
-                        ? asyncEnumerable.GroupBy(async x => keySelector(x), async x => elementSelector(x), equalityComparer)
-                        : asyncEnumerable.GroupBy(keySelector, elementSelector, equalityComparer);
+                        ? equalityComparer != null
+                            ? asyncEnumerable.GroupBy(async x => keySelector(x), async x => elementSelector(x), equalityComparer)
+                            : asyncEnumerable.GroupBy(async x => keySelector(x), async x => elementSelector(x))
+                        : equalityComparer != null
+                            ? asyncEnumerable.GroupBy(keySelector, elementSelector, equalityComparer)
+                            : asyncEnumerable.GroupBy(keySelector, elementSelector);
                 }
                 else
                 {
                     return async
-                        ? asyncEnumerable.GroupBy(async x => keySelector(x),
+                        ? equalityComparer != null
+                            ? asyncEnumerable.GroupBy(async x => keySelector(x),
                             elementCapture, async (cv, x) =>
                             {
                                 Assert.AreEqual(elementCapture, cv);
                                 return elementSelector(x);
                             }, equalityComparer)
-                        : asyncEnumerable.GroupBy(x => keySelector(x),
+                            : asyncEnumerable.GroupBy(async x => keySelector(x),
+                            elementCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(elementCapture, cv);
+                                return elementSelector(x);
+                            })
+                        : equalityComparer != null
+                            ? asyncEnumerable.GroupBy(x => keySelector(x),
                             elementCapture, (cv, x) =>
                             {
                                 Assert.AreEqual(elementCapture, cv);
                                 return elementSelector(x);
-                            }, equalityComparer);
+                            }, equalityComparer)
+                            : asyncEnumerable.GroupBy(x => keySelector(x),
+                            elementCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(elementCapture, cv);
+                                return elementSelector(x);
+                            });
                 }
             }
             else
@@ -342,49 +469,89 @@ namespace ProtoPromiseTests.APIs.Linq
                 if (!captureElement)
                 {
                     return async
-                        ? asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
-                        {
-                            Assert.AreEqual(keyCapture, cv);
-                            return keySelector(x);
-                        }, async x => elementSelector(x), equalityComparer)
-                        : asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
-                        {
-                            Assert.AreEqual(keyCapture, cv);
-                            return keySelector(x);
-                        }, elementSelector, equalityComparer);
+                        ? equalityComparer != null
+                            ? asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            }, async x => elementSelector(x), equalityComparer)
+                            : asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            }, async x => elementSelector(x))
+                        : equalityComparer != null
+                            ? asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            }, elementSelector, equalityComparer)
+                            : asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            }, elementSelector);
                 }
                 else
                 {
                     return async
-                        ? asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
-                        {
-                            Assert.AreEqual(keyCapture, cv);
-                            return keySelector(x);
-                        },
+                        ? equalityComparer != null
+                            ? asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            },
                             elementCapture, async (cv, x) =>
                             {
                                 Assert.AreEqual(elementCapture, cv);
                                 return elementSelector(x);
                             }, equalityComparer)
-                        : asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
-                        {
-                            Assert.AreEqual(keyCapture, cv);
-                            return keySelector(x);
-                        },
+                            : asyncEnumerable.GroupBy(keyCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            },
+                            elementCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(elementCapture, cv);
+                                return elementSelector(x);
+                            })
+                        : equalityComparer != null
+                            ? asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            },
                             elementCapture, (cv, x) =>
                             {
                                 Assert.AreEqual(elementCapture, cv);
                                 return elementSelector(x);
-                            }, equalityComparer);
+                            }, equalityComparer)
+                            : asyncEnumerable.GroupBy(keyCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            },
+                            elementCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(elementCapture, cv);
+                                return elementSelector(x);
+                            });
                 }
             }
+        }
+
+        private static IEqualityComparer<T> GetDefaultOrNullComparer<T>(bool defaultComparer)
+        {
+            return defaultComparer ? EqualityComparer<T>.Default : null;
         }
 
         [Test]
         public void GroupBy_KeySelector_Sync_Simple1(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
@@ -398,7 +565,7 @@ namespace ProtoPromiseTests.APIs.Linq
                     new { Name = "Eric", Age = 42 },
                 };
 
-                var e = GroupBy(xs.ToAsyncEnumerable(), configured, async, x => x.Age / 10, captureKey).GetAsyncEnumerator();
+                var e = GroupBy(xs.ToAsyncEnumerable(), configured, async, x => x.Age / 10, captureKey, equalityComparer: GetDefaultOrNullComparer<int>(withComparer)).GetAsyncEnumerator();
 
                 Assert.True(await e.MoveNextAsync());
                 Assert.AreEqual(2, e.Current.Key);
@@ -437,7 +604,8 @@ namespace ProtoPromiseTests.APIs.Linq
         public void GroupBy_KeySelector_Sync_Simple2_TempCollectionIsStillValidAfterMoveNextAsyncUntilDisposeAsync(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
@@ -451,7 +619,7 @@ namespace ProtoPromiseTests.APIs.Linq
                     new { Name = "Eric", Age = 42 },
                 };
 
-                var e = GroupBy(xs.ToAsyncEnumerable(), configured, async, x => x.Age / 10, captureKey).GetAsyncEnumerator();
+                var e = GroupBy(xs.ToAsyncEnumerable(), configured, async, x => x.Age / 10, captureKey, equalityComparer: GetDefaultOrNullComparer<int>(withComparer)).GetAsyncEnumerator();
                 Assert.True(await e.MoveNextAsync());
                 var g1 = e.Current;
 
@@ -497,7 +665,8 @@ namespace ProtoPromiseTests.APIs.Linq
         public void GroupBy_KeySelector_Sync_Simple2_TempCollectionToArrayIsPersistedAfterMoveNextAndDisposeAsync(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
@@ -511,7 +680,7 @@ namespace ProtoPromiseTests.APIs.Linq
                     new { Name = "Eric", Age = 42 },
                 };
 
-                var e = GroupBy(xs.ToAsyncEnumerable(), configured, async, x => x.Age / 10, captureKey).GetAsyncEnumerator();
+                var e = GroupBy(xs.ToAsyncEnumerable(), configured, async, x => x.Age / 10, captureKey, equalityComparer: GetDefaultOrNullComparer<int>(withComparer)).GetAsyncEnumerator();
                 Assert.True(await e.MoveNextAsync());
                 var g1k = e.Current.Key;
                 var g1a = e.Current.Elements.ToArray();
@@ -557,11 +726,12 @@ namespace ProtoPromiseTests.APIs.Linq
         public void GroupBy_KeySelector_Sync_Empty(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
-                var e = GroupBy(AsyncEnumerable.Empty<int>(), configured, async, x => x, captureKey).GetAsyncEnumerator();
+                var e = GroupBy(AsyncEnumerable.Empty<int>(), configured, async, x => x, captureKey, equalityComparer: GetDefaultOrNullComparer<int>(withComparer)).GetAsyncEnumerator();
                 Assert.False(await e.MoveNextAsync());
                 await e.DisposeAsync();
             }, SynchronizationOption.Synchronous)
@@ -588,12 +758,13 @@ namespace ProtoPromiseTests.APIs.Linq
         public void GroupBy_KeySelector_Sync_Throws_Source2(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var ex = new Exception("Bang!");
-                var e = GroupBy(GetXs(ex).ToAsyncEnumerable(), configured, async, x => x, captureKey).GetAsyncEnumerator();
+                var e = GroupBy(GetXs(ex).ToAsyncEnumerable(), configured, async, x => x, captureKey, equalityComparer: GetDefaultOrNullComparer<int>(withComparer)).GetAsyncEnumerator();
                 await TestHelper.AssertThrowsAsync(() => e.MoveNextAsync(), ex);
                 await e.DisposeAsync();
             }, SynchronizationOption.Synchronous)
@@ -611,12 +782,13 @@ namespace ProtoPromiseTests.APIs.Linq
         public void GroupBy_KeySelector_Sync_Throws_KeySelector1(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var ex = new Exception("Bang!");
-                var e = GroupBy(AsyncEnumerable.Return(42), configured, async, x => { throw ex; return x; }, captureKey).GetAsyncEnumerator();
+                var e = GroupBy(AsyncEnumerable.Return(42), configured, async, x => { throw ex; return x; }, captureKey, equalityComparer: GetDefaultOrNullComparer<int>(withComparer)).GetAsyncEnumerator();
                 await TestHelper.AssertThrowsAsync(() => e.MoveNextAsync(), ex);
                 await e.DisposeAsync();
             }, SynchronizationOption.Synchronous)
@@ -627,12 +799,13 @@ namespace ProtoPromiseTests.APIs.Linq
         public void GroupBy_KeySelector_Sync_Throws_KeySelector2(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var ex = new Exception("Bang!");
-                var e = GroupBy(new[] { 1, 2, 3 }.ToAsyncEnumerable(), configured, async, x => { if (x == 3) throw ex; return x; }, captureKey).GetAsyncEnumerator();
+                var e = GroupBy(new[] { 1, 2, 3 }.ToAsyncEnumerable(), configured, async, x => { if (x == 3) throw ex; return x; }, captureKey, equalityComparer: GetDefaultOrNullComparer<int>(withComparer)).GetAsyncEnumerator();
                 await TestHelper.AssertThrowsAsync(() => e.MoveNextAsync(), ex);
                 await e.DisposeAsync();
             }, SynchronizationOption.Synchronous)
@@ -702,11 +875,12 @@ namespace ProtoPromiseTests.APIs.Linq
             [Values] bool configured,
             [Values] bool async,
             [Values] bool captureKey,
-            [Values] bool captureElement)
+            [Values] bool captureElement,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
-                var e = GroupBy(AsyncEnumerable.Range(0, 10), configured, async, x => x % 3, captureKey, x => (char) ('a' + x), captureElement).GetAsyncEnumerator();
+                var e = GroupBy(AsyncEnumerable.Range(0, 10), configured, async, x => x % 3, captureKey, x => (char) ('a' + x), captureElement, equalityComparer: GetDefaultOrNullComparer<int>(withComparer)).GetAsyncEnumerator();
 
                 Assert.True(await e.MoveNextAsync());
                 var g1 = e.Current;

--- a/Package/Tests/CoreTests/APIs/Linq/Operators/OrderByTests.cs
+++ b/Package/Tests/CoreTests/APIs/Linq/Operators/OrderByTests.cs
@@ -42,22 +42,38 @@ namespace ProtoPromiseTests.APIs.Linq
             if (!captureKey)
             {
                 return async
-                    ? asyncEnumerable.OrderBy(async x => keySelector(x), comparer)
-                    : asyncEnumerable.OrderBy(keySelector, comparer);
+                    ? comparer != null
+                        ? asyncEnumerable.OrderBy(async x => keySelector(x), comparer)
+                        : asyncEnumerable.OrderBy(async x => keySelector(x))
+                    : comparer != null
+                        ? asyncEnumerable.OrderBy(keySelector, comparer)
+                        : asyncEnumerable.OrderBy(keySelector);
             }
             else
             {
                 return async
-                    ? asyncEnumerable.OrderBy(keyCapture, async (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, comparer)
-                    : asyncEnumerable.OrderBy(keyCapture, (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, comparer);
+                    ? comparer != null
+                        ? asyncEnumerable.OrderBy(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, comparer)
+                        : asyncEnumerable.OrderBy(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        })
+                    : comparer != null
+                        ? asyncEnumerable.OrderBy(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, comparer)
+                        : asyncEnumerable.OrderBy(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        });
             }
         }
 
@@ -71,22 +87,38 @@ namespace ProtoPromiseTests.APIs.Linq
             if (!captureKey)
             {
                 return async
-                    ? asyncEnumerable.OrderBy(async x => keySelector(x), comparer)
-                    : asyncEnumerable.OrderBy(keySelector, comparer);
+                    ? comparer != null
+                        ? asyncEnumerable.OrderBy(async x => keySelector(x), comparer)
+                        : asyncEnumerable.OrderBy(async x => keySelector(x))
+                    : comparer != null
+                        ? asyncEnumerable.OrderBy(keySelector, comparer)
+                        : asyncEnumerable.OrderBy(keySelector);
             }
             else
             {
                 return async
-                    ? asyncEnumerable.OrderBy(keyCapture, async (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, comparer)
-                    : asyncEnumerable.OrderBy(keyCapture, (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, comparer);
+                    ? comparer != null
+                        ? asyncEnumerable.OrderBy(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, comparer)
+                        : asyncEnumerable.OrderBy(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        })
+                    : comparer != null
+                        ? asyncEnumerable.OrderBy(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, comparer)
+                        : asyncEnumerable.OrderBy(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        });
             }
         }
 
@@ -106,22 +138,38 @@ namespace ProtoPromiseTests.APIs.Linq
             if (!captureKey)
             {
                 return async
-                    ? asyncEnumerable.OrderByDescending(async x => keySelector(x), comparer)
-                    : asyncEnumerable.OrderByDescending(keySelector, comparer);
+                    ? comparer != null
+                        ? asyncEnumerable.OrderByDescending(async x => keySelector(x), comparer)
+                        : asyncEnumerable.OrderByDescending(async x => keySelector(x))
+                    : comparer != null
+                        ? asyncEnumerable.OrderByDescending(keySelector, comparer)
+                        : asyncEnumerable.OrderByDescending(keySelector);
             }
             else
             {
                 return async
-                    ? asyncEnumerable.OrderByDescending(keyCapture, async (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, comparer)
-                    : asyncEnumerable.OrderByDescending(keyCapture, (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, comparer);
+                    ? comparer != null
+                        ? asyncEnumerable.OrderByDescending(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, comparer)
+                        : asyncEnumerable.OrderByDescending(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        })
+                    : comparer != null
+                        ? asyncEnumerable.OrderByDescending(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, comparer)
+                        : asyncEnumerable.OrderByDescending(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        });
             }
         }
 
@@ -135,22 +183,38 @@ namespace ProtoPromiseTests.APIs.Linq
             if (!captureKey)
             {
                 return async
-                    ? asyncEnumerable.OrderByDescending(async x => keySelector(x), comparer)
-                    : asyncEnumerable.OrderByDescending(keySelector, comparer);
+                    ? comparer != null
+                        ? asyncEnumerable.OrderByDescending(async x => keySelector(x), comparer)
+                        : asyncEnumerable.OrderByDescending(async x => keySelector(x))
+                    : comparer != null
+                        ? asyncEnumerable.OrderByDescending(keySelector, comparer)
+                        : asyncEnumerable.OrderByDescending(keySelector);
             }
             else
             {
                 return async
-                    ? asyncEnumerable.OrderByDescending(keyCapture, async (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, comparer)
-                    : asyncEnumerable.OrderByDescending(keyCapture, (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, comparer);
+                    ? comparer != null
+                        ? asyncEnumerable.OrderByDescending(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, comparer)
+                        : asyncEnumerable.OrderByDescending(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        })
+                    : comparer != null
+                        ? asyncEnumerable.OrderByDescending(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, comparer)
+                        : asyncEnumerable.OrderByDescending(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        });
             }
         }
 
@@ -164,22 +228,38 @@ namespace ProtoPromiseTests.APIs.Linq
             if (!captureKey)
             {
                 return async
-                    ? orderedAsyncEnumerable.ThenBy(async x => keySelector(x), comparer)
-                    : orderedAsyncEnumerable.ThenBy(keySelector, comparer);
+                    ? comparer != null
+                        ? orderedAsyncEnumerable.ThenBy(async x => keySelector(x), comparer)
+                        : orderedAsyncEnumerable.ThenBy(async x => keySelector(x))
+                    : comparer != null
+                        ? orderedAsyncEnumerable.ThenBy(keySelector, comparer)
+                        : orderedAsyncEnumerable.ThenBy(keySelector);
             }
             else
             {
                 return async
-                    ? orderedAsyncEnumerable.ThenBy(keyCapture, async (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, comparer)
-                    : orderedAsyncEnumerable.ThenBy(keyCapture, (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, comparer);
+                    ? comparer != null
+                        ? orderedAsyncEnumerable.ThenBy(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, comparer)
+                        : orderedAsyncEnumerable.ThenBy(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        })
+                    : comparer != null
+                        ? orderedAsyncEnumerable.ThenBy(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, comparer)
+                        : orderedAsyncEnumerable.ThenBy(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        });
             }
         }
 
@@ -193,22 +273,38 @@ namespace ProtoPromiseTests.APIs.Linq
             if (!captureKey)
             {
                 return async
-                    ? orderedAsyncEnumerable.ThenByDescending(async x => keySelector(x), comparer)
-                    : orderedAsyncEnumerable.ThenByDescending(keySelector, comparer);
+                    ? comparer != null
+                        ? orderedAsyncEnumerable.ThenByDescending(async x => keySelector(x), comparer)
+                        : orderedAsyncEnumerable.ThenByDescending(async x => keySelector(x))
+                    : comparer != null
+                        ? orderedAsyncEnumerable.ThenByDescending(keySelector, comparer)
+                        : orderedAsyncEnumerable.ThenByDescending(keySelector);
             }
             else
             {
                 return async
-                    ? orderedAsyncEnumerable.ThenByDescending(keyCapture, async (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, comparer)
-                    : orderedAsyncEnumerable.ThenByDescending(keyCapture, (cv, x) =>
-                    {
-                        Assert.AreEqual(keyCapture, cv);
-                        return keySelector(x);
-                    }, comparer);
+                    ? comparer != null
+                        ? orderedAsyncEnumerable.ThenByDescending(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, comparer)
+                        : orderedAsyncEnumerable.ThenByDescending(keyCapture, async (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        })
+                    : comparer != null
+                        ? orderedAsyncEnumerable.ThenByDescending(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        }, comparer)
+                        : orderedAsyncEnumerable.ThenByDescending(keyCapture, (cv, x) =>
+                        {
+                            Assert.AreEqual(keyCapture, cv);
+                            return keySelector(x);
+                        });
             }
         }
 
@@ -217,8 +313,12 @@ namespace ProtoPromiseTests.APIs.Linq
             IComparer<TSource> comparer = null)
         {
             return configured
-                ? asyncEnumerable.ConfigureAwait(SynchronizationOption.Foreground).Order(comparer)
-                : asyncEnumerable.Order(comparer);
+                ? comparer != null
+                    ? asyncEnumerable.ConfigureAwait(SynchronizationOption.Foreground).Order(comparer)
+                    : asyncEnumerable.ConfigureAwait(SynchronizationOption.Foreground).Order()
+                : comparer != null
+                    ? asyncEnumerable.Order(comparer)
+                    : asyncEnumerable.Order();
         }
 
         public static OrderedAsyncEnumerable<TSource> OrderDescending<TSource>(this AsyncEnumerable<TSource> asyncEnumerable,
@@ -226,8 +326,12 @@ namespace ProtoPromiseTests.APIs.Linq
             IComparer<TSource> comparer = null)
         {
             return configured
-                ? asyncEnumerable.ConfigureAwait(SynchronizationOption.Foreground).OrderDescending(comparer)
-                : asyncEnumerable.OrderDescending(comparer);
+                ? comparer != null
+                    ? asyncEnumerable.ConfigureAwait(SynchronizationOption.Foreground).OrderDescending(comparer)
+                    : asyncEnumerable.ConfigureAwait(SynchronizationOption.Foreground).OrderDescending()
+                : comparer != null
+                    ? asyncEnumerable.OrderDescending(comparer)
+                    : asyncEnumerable.OrderDescending();
         }
     }
 
@@ -247,34 +351,58 @@ namespace ProtoPromiseTests.APIs.Linq
 
 #if PROMISE_DEBUG
         [Test]
+        public void Order_NullArgumentThrows()
+        {
+            var enumerable = AsyncEnumerable.Return(42);
+            var nullComparer = default(IComparer<int>);
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.Order(nullComparer));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderDescending(nullComparer));
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).Order(nullComparer));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderDescending(nullComparer));
+
+            enumerable.GetAsyncEnumerator().DisposeAsync().Forget();
+        }
+
+        [Test]
         public void OrderBy_NullArgumentThrows()
         {
             var enumerable = AsyncEnumerable.Return(42);
             var captureValue = "captureValue";
+            var nullComparer = default(IComparer<int>);
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderBy(default(Func<int, int>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderBy(default(Func<int, int>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderBy(x => 0, nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderBy(captureValue, default(Func<string, int, int>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderBy(captureValue, default(Func<string, int, int>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderBy(captureValue, (cv, x) => 0, nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderBy(default(Func<int, Promise<int>>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderBy(default(Func<int, Promise<int>>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderBy(x => Promise.Resolved(0), nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderBy(captureValue, default(Func<string, int, Promise<int>>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderBy(captureValue, default(Func<string, int, Promise<int>>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderBy(captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderBy(default(Func<int, int>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderBy(default(Func<int, int>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderBy(x => 0, nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderBy(captureValue, default(Func<string, int, int>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderBy(captureValue, default(Func<string, int, int>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderBy(captureValue, (cv, x) => 0, nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderBy(default(Func<int, Promise<int>>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderBy(default(Func<int, Promise<int>>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderBy(x => Promise.Resolved(0), nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderBy(captureValue, default(Func<string, int, Promise<int>>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderBy(captureValue, default(Func<string, int, Promise<int>>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderBy(captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
             enumerable.GetAsyncEnumerator().DisposeAsync().Forget();
         }
@@ -284,30 +412,39 @@ namespace ProtoPromiseTests.APIs.Linq
         {
             var enumerable = AsyncEnumerable.Return(42);
             var captureValue = "captureValue";
+            var nullComparer = default(IComparer<int>);
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderByDescending(default(Func<int, int>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderByDescending(default(Func<int, int>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderByDescending(x => 0, nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderByDescending(captureValue, default(Func<string, int, int>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderByDescending(captureValue, default(Func<string, int, int>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderByDescending(captureValue, (cv, x) => 0, nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderByDescending(default(Func<int, Promise<int>>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderByDescending(default(Func<int, Promise<int>>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderByDescending(x => Promise.Resolved(0), nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderByDescending(captureValue, default(Func<string, int, Promise<int>>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderByDescending(captureValue, default(Func<string, int, Promise<int>>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.OrderByDescending(captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderByDescending(default(Func<int, int>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderByDescending(default(Func<int, int>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderByDescending(x => 0, nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderByDescending(captureValue, default(Func<string, int, int>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderByDescending(captureValue, default(Func<string, int, int>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderByDescending(captureValue, (cv, x) => 0, nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderByDescending(default(Func<int, Promise<int>>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderByDescending(default(Func<int, Promise<int>>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderByDescending(x => Promise.Resolved(0), nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderByDescending(captureValue, default(Func<string, int, Promise<int>>)));
             Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderByDescending(captureValue, default(Func<string, int, Promise<int>>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).OrderByDescending(captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
             enumerable.GetAsyncEnumerator().DisposeAsync().Forget();
         }
@@ -317,18 +454,23 @@ namespace ProtoPromiseTests.APIs.Linq
         {
             var orderedEnumerable = AsyncEnumerable.Return(42).Order();
             var captureValue = "captureValue";
+            var nullComparer = default(IComparer<int>);
 
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenBy(default(Func<int, int>)));
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenBy(default(Func<int, int>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenBy(x => 0, nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenBy(captureValue, default(Func<string, int, int>)));
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenBy(captureValue, default(Func<string, int, int>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenBy(captureValue, (cv, x) => 0, nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenBy(default(Func<int, Promise<int>>)));
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenBy(default(Func<int, Promise<int>>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenBy(x => Promise.Resolved(0), nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenBy(captureValue, default(Func<string, int, Promise<int>>)));
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenBy(captureValue, default(Func<string, int, Promise<int>>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenBy(captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
             var enumerator = orderedEnumerable.GetAsyncEnumerator();
             enumerator.MoveNextAsync().Forget();
@@ -340,18 +482,23 @@ namespace ProtoPromiseTests.APIs.Linq
         {
             var orderedEnumerable = AsyncEnumerable.Return(42).Order();
             var captureValue = "captureValue";
+            var nullComparer = default(IComparer<int>);
 
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenByDescending(default(Func<int, int>)));
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenByDescending(default(Func<int, int>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenByDescending(x => 0, nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenByDescending(captureValue, default(Func<string, int, int>)));
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenByDescending(captureValue, default(Func<string, int, int>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenByDescending(captureValue, (cv, x) => 0, nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenByDescending(default(Func<int, Promise<int>>)));
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenByDescending(default(Func<int, Promise<int>>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenByDescending(x => Promise.Resolved(0), nullComparer));
 
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenByDescending(captureValue, default(Func<string, int, Promise<int>>)));
             Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenByDescending(captureValue, default(Func<string, int, Promise<int>>), Comparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => orderedEnumerable.ThenByDescending(captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
             var enumerator = orderedEnumerable.GetAsyncEnumerator();
             enumerator.MoveNextAsync().Forget();
@@ -359,16 +506,22 @@ namespace ProtoPromiseTests.APIs.Linq
         }
 #endif //PROMISE_DEBUG
 
+        private static IComparer<T> GetDefaultOrNullComparer<T>(bool defaultComparer)
+        {
+            return defaultComparer ? Comparer<T>.Default : null;
+        }
+
         [Test]
         public void OrderBy_Empty(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var asyncEnumerator = AsyncEnumerable.Empty<int>()
-                    .OrderBy(configured, async, x => x, captureKey)
+                    .OrderBy(configured, async, x => x, captureKey, comparer: GetDefaultOrNullComparer<int>(withComparer))
                     .GetAsyncEnumerator();
                 Assert.False(await asyncEnumerator.MoveNextAsync());
                 await asyncEnumerator.DisposeAsync();
@@ -380,13 +533,14 @@ namespace ProtoPromiseTests.APIs.Linq
         public void OrderBy1(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var asyncEnumerator = new[] { 2, 6, 1, 5, 7, 8, 9, 3, 4, 0 }
                     .ToAsyncEnumerable()
-                    .OrderBy(configured, async, x => x, captureKey)
+                    .OrderBy(configured, async, x => x, captureKey, comparer: GetDefaultOrNullComparer<int>(withComparer))
                     .GetAsyncEnumerator();
                 for (var i = 0; i < 10; i++)
                 {
@@ -403,14 +557,15 @@ namespace ProtoPromiseTests.APIs.Linq
         public void OrderBy2(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var ex = new Exception("Bang!");
                 var asyncEnumerator = new[] { 2, 6, 1, 5, 7, 8, 9, 3, 4, 0 }
                     .ToAsyncEnumerable()
-                    .OrderBy(configured, async, x => { throw ex; return x; }, captureKey)
+                    .OrderBy(configured, async, x => { throw ex; return x; }, captureKey, comparer: GetDefaultOrNullComparer<int>(withComparer))
                     .GetAsyncEnumerator();
                 await TestHelper.AssertThrowsAsync(() => asyncEnumerator.MoveNextAsync(), ex);
                 await asyncEnumerator.DisposeAsync();
@@ -422,14 +577,15 @@ namespace ProtoPromiseTests.APIs.Linq
         public void ThenBy1(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var asyncEnumerator = new[] { 2, 6, 1, 5, 7, 8, 9, 3, 4, 0 }
                     .ToAsyncEnumerable()
                     .OrderBy(x => 0)
-                    .ThenBy(async, x => x, captureKey)
+                    .ThenBy(async, x => x, captureKey, comparer: GetDefaultOrNullComparer<int>(withComparer))
                     .GetAsyncEnumerator();
                 for (var i = 0; i < 10; i++)
                 {
@@ -446,7 +602,8 @@ namespace ProtoPromiseTests.APIs.Linq
         public void ThenBy2(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
@@ -454,7 +611,7 @@ namespace ProtoPromiseTests.APIs.Linq
                 var asyncEnumerator = new[] { 2, 6, 1, 5, 7, 8, 9, 3, 4, 0 }
                     .ToAsyncEnumerable()
                     .OrderBy(x => x)
-                    .ThenBy(async, x => { throw ex; return x; }, captureKey)
+                    .ThenBy(async, x => { throw ex; return x; }, captureKey, comparer: GetDefaultOrNullComparer<int>(withComparer))
                     .GetAsyncEnumerator();
                 await TestHelper.AssertThrowsAsync(() => asyncEnumerator.MoveNextAsync(), ex);
                 await asyncEnumerator.DisposeAsync();
@@ -466,13 +623,14 @@ namespace ProtoPromiseTests.APIs.Linq
         public void OrderByDescending1(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var asyncEnumerator = new[] { 2, 6, 1, 5, 7, 8, 9, 3, 4, 0 }
                     .ToAsyncEnumerable()
-                    .OrderByDescending(configured, async, x => x, captureKey)
+                    .OrderByDescending(configured, async, x => x, captureKey, comparer: GetDefaultOrNullComparer<int>(withComparer))
                     .GetAsyncEnumerator();
                 for (var i = 9; i >= 0; i--)
                 {
@@ -489,14 +647,15 @@ namespace ProtoPromiseTests.APIs.Linq
         public void OrderByDescending2(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var ex = new Exception("Bang!");
                 var asyncEnumerator = new[] { 2, 6, 1, 5, 7, 8, 9, 3, 4, 0 }
                     .ToAsyncEnumerable()
-                    .OrderByDescending(configured, async, x => { throw ex; return x; }, captureKey)
+                    .OrderByDescending(configured, async, x => { throw ex; return x; }, captureKey, comparer: GetDefaultOrNullComparer<int>(withComparer))
                     .GetAsyncEnumerator();
                 await TestHelper.AssertThrowsAsync(() => asyncEnumerator.MoveNextAsync(), ex);
                 await asyncEnumerator.DisposeAsync();
@@ -508,14 +667,15 @@ namespace ProtoPromiseTests.APIs.Linq
         public void ThenByDescending1(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var asyncEnumerator = new[] { 2, 6, 1, 5, 7, 8, 9, 3, 4, 0 }
                     .ToAsyncEnumerable()
                     .OrderBy(x => 0)
-                    .ThenByDescending(async, x => x, captureKey)
+                    .ThenByDescending(async, x => x, captureKey, comparer: GetDefaultOrNullComparer<int>(withComparer))
                     .GetAsyncEnumerator();
                 for (var i = 9; i >= 0; i--)
                     {
@@ -532,7 +692,8 @@ namespace ProtoPromiseTests.APIs.Linq
         public void ThenByDescending2(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
@@ -540,7 +701,7 @@ namespace ProtoPromiseTests.APIs.Linq
                 var asyncEnumerator = new[] { 2, 6, 1, 5, 7, 8, 9, 3, 4, 0 }
                     .ToAsyncEnumerable()
                     .OrderBy(x => x)
-                    .ThenByDescending(async, x => { throw ex; return x; }, captureKey)
+                    .ThenByDescending(async, x => { throw ex; return x; }, captureKey, comparer: GetDefaultOrNullComparer<int>(withComparer))
                     .GetAsyncEnumerator();
                 await TestHelper.AssertThrowsAsync(() => asyncEnumerator.MoveNextAsync(), ex);
                 await asyncEnumerator.DisposeAsync();
@@ -554,7 +715,9 @@ namespace ProtoPromiseTests.APIs.Linq
             [Values] bool asyncOrderBy,
             [Values] bool captureKeyOrderBy,
             [Values] bool asyncThenBy,
-            [Values] bool captureKeyThenBy)
+            [Values] bool captureKeyThenBy,
+            [Values] bool withOrderByComparer,
+            [Values] bool withThenByComparer)
         {
             Promise.Run(async () =>
             {
@@ -571,7 +734,9 @@ namespace ProtoPromiseTests.APIs.Linq
                 var ys = xs.ToAsyncEnumerable();
 
                 var ress = xs.OrderBy(x => x.Name).ThenBy(x => x.Age).ToArray();
-                var resa = ys.OrderBy(configured, asyncOrderBy, x => x.Name, captureKeyOrderBy).ThenBy(asyncThenBy, x => x.Age, captureKeyThenBy).GetAsyncEnumerator();
+                var resa = ys.OrderBy(configured, asyncOrderBy, x => x.Name, captureKeyOrderBy, comparer: GetDefaultOrNullComparer<string>(withOrderByComparer))
+                    .ThenBy(asyncThenBy, x => x.Age, captureKeyThenBy, comparer: GetDefaultOrNullComparer<int>(withThenByComparer))
+                    .GetAsyncEnumerator();
 
                 Assert.True(await resa.MoveNextAsync());
                 Assert.AreEqual(ress[0], resa.Current);
@@ -600,7 +765,9 @@ namespace ProtoPromiseTests.APIs.Linq
             [Values] bool asyncOrderBy,
             [Values] bool captureKeyOrderBy,
             [Values] bool asyncThenBy,
-            [Values] bool captureKeyThenBy)
+            [Values] bool captureKeyThenBy,
+            [Values] bool withOrderByComparer,
+            [Values] bool withThenByComparer)
         {
             Promise.Run(async () =>
             {
@@ -617,7 +784,9 @@ namespace ProtoPromiseTests.APIs.Linq
                 var ys = xs.ToAsyncEnumerable();
 
                 var ress = xs.OrderBy(x => x.Name).ThenByDescending(x => x.Age).ToArray();
-                var resa = ys.OrderBy(configured, asyncOrderBy, x => x.Name, captureKeyOrderBy).ThenByDescending(asyncThenBy, x => x.Age, captureKeyThenBy).GetAsyncEnumerator();
+                var resa = ys.OrderBy(configured, asyncOrderBy, x => x.Name, captureKeyOrderBy, comparer: GetDefaultOrNullComparer<string>(withOrderByComparer))
+                    .ThenByDescending(asyncThenBy, x => x.Age, captureKeyThenBy, comparer: GetDefaultOrNullComparer<int>(withThenByComparer))
+                    .GetAsyncEnumerator();
 
                 Assert.True(await resa.MoveNextAsync());
                 Assert.AreEqual(ress[0], resa.Current);
@@ -646,7 +815,9 @@ namespace ProtoPromiseTests.APIs.Linq
             [Values] bool asyncOrderBy,
             [Values] bool captureKeyOrderBy,
             [Values] bool asyncThenBy,
-            [Values] bool captureKeyThenBy)
+            [Values] bool captureKeyThenBy,
+            [Values] bool withOrderByComparer,
+            [Values] bool withThenByComparer)
         {
             Promise.Run(async () =>
             {
@@ -663,7 +834,9 @@ namespace ProtoPromiseTests.APIs.Linq
                 var ys = xs.ToAsyncEnumerable();
 
                 var ress = xs.OrderByDescending(x => x.Name).ThenBy(x => x.Age).ToArray();
-                var resa = ys.OrderByDescending(configured, asyncOrderBy, x => x.Name, captureKeyOrderBy).ThenBy(asyncThenBy, x => x.Age, captureKeyThenBy).GetAsyncEnumerator();
+                var resa = ys.OrderByDescending(configured, asyncOrderBy, x => x.Name, captureKeyOrderBy, comparer: GetDefaultOrNullComparer<string>(withOrderByComparer))
+                    .ThenBy(asyncThenBy, x => x.Age, captureKeyThenBy, comparer: GetDefaultOrNullComparer<int>(withThenByComparer))
+                    .GetAsyncEnumerator();
 
                 Assert.True(await resa.MoveNextAsync());
                 Assert.AreEqual(ress[0], resa.Current);
@@ -692,7 +865,9 @@ namespace ProtoPromiseTests.APIs.Linq
             [Values] bool asyncOrderBy,
             [Values] bool captureKeyOrderBy,
             [Values] bool asyncThenBy,
-            [Values] bool captureKeyThenBy)
+            [Values] bool captureKeyThenBy,
+            [Values] bool withOrderByComparer,
+            [Values] bool withThenByComparer)
         {
             Promise.Run(async () =>
             {
@@ -709,7 +884,9 @@ namespace ProtoPromiseTests.APIs.Linq
                 var ys = xs.ToAsyncEnumerable();
 
                 var ress = xs.OrderByDescending(x => x.Name).ThenByDescending(x => x.Age).ToArray();
-                var resa = ys.OrderByDescending(configured, asyncOrderBy, x => x.Name, captureKeyOrderBy).ThenByDescending(asyncThenBy, x => x.Age, captureKeyThenBy).GetAsyncEnumerator();
+                var resa = ys.OrderByDescending(configured, asyncOrderBy, x => x.Name, captureKeyOrderBy, comparer: GetDefaultOrNullComparer<string>(withOrderByComparer))
+                    .ThenByDescending(asyncThenBy, x => x.Age, captureKeyThenBy, comparer: GetDefaultOrNullComparer<int>(withThenByComparer))
+                    .GetAsyncEnumerator();
 
                 Assert.True(await resa.MoveNextAsync());
                 Assert.AreEqual(ress[0], resa.Current);
@@ -735,13 +912,12 @@ namespace ProtoPromiseTests.APIs.Linq
         [Test]
         public void Order_Empty(
             [Values] bool configured,
-            [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var asyncEnumerator = AsyncEnumerable.Empty<int>()
-                    .Order()
+                    .Order(configured, GetDefaultOrNullComparer<int>(withComparer))
                     .GetAsyncEnumerator();
                 Assert.False(await asyncEnumerator.MoveNextAsync());
                 await asyncEnumerator.DisposeAsync();
@@ -752,14 +928,13 @@ namespace ProtoPromiseTests.APIs.Linq
         [Test]
         public void Order(
             [Values] bool configured,
-            [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var asyncEnumerator = new[] { 2, 6, 1, 5, 7, 8, 9, 3, 4, 0 }
                     .ToAsyncEnumerable()
-                    .Order()
+                    .Order(configured, GetDefaultOrNullComparer<int>(withComparer))
                     .GetAsyncEnumerator();
                 for (var i = 0; i < 10; i++)
                 {
@@ -773,16 +948,31 @@ namespace ProtoPromiseTests.APIs.Linq
         }
 
         [Test]
+        public void OrderDescending_Empty(
+            [Values] bool configured,
+            [Values] bool withComparer)
+        {
+            Promise.Run(async () =>
+            {
+                var asyncEnumerator = AsyncEnumerable.Empty<int>()
+                    .OrderDescending(configured, GetDefaultOrNullComparer<int>(withComparer))
+                    .GetAsyncEnumerator();
+                Assert.False(await asyncEnumerator.MoveNextAsync());
+                await asyncEnumerator.DisposeAsync();
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
         public void OrderDescending(
             [Values] bool configured,
-            [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var asyncEnumerator = new[] { 2, 6, 1, 5, 7, 8, 9, 3, 4, 0 }
                     .ToAsyncEnumerable()
-                    .OrderDescending()
+                    .OrderDescending(configured, GetDefaultOrNullComparer<int>(withComparer))
                     .GetAsyncEnumerator();
                 for (var i = 9; i >= 0; i--)
                 {
@@ -813,7 +1003,8 @@ namespace ProtoPromiseTests.APIs.Linq
         public void OrderThenBy(
             [Values] bool configured,
             [Values] bool asyncThenBy,
-            [Values] bool captureKeyThenBy)
+            [Values] bool captureKeyThenBy,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
@@ -830,7 +1021,9 @@ namespace ProtoPromiseTests.APIs.Linq
                 var ys = xs.ToAsyncEnumerable();
 
                 var ress = xs.OrderBy(x => x.Name).ThenBy(x => x.Age).ToArray();
-                var resa = ys.Order(configured, new PersonFirstNameComparer()).ThenBy(asyncThenBy, x => x.Age, captureKeyThenBy).GetAsyncEnumerator();
+                var resa = ys.Order(configured, new PersonFirstNameComparer())
+                    .ThenBy(asyncThenBy, x => x.Age, captureKeyThenBy, comparer: GetDefaultOrNullComparer<int>(withComparer))
+                    .GetAsyncEnumerator();
 
                 Assert.True(await resa.MoveNextAsync());
                 Assert.AreEqual(ress[0], resa.Current);
@@ -857,7 +1050,8 @@ namespace ProtoPromiseTests.APIs.Linq
         public void OrderThenByDescending(
             [Values] bool configured,
             [Values] bool asyncThenBy,
-            [Values] bool captureKeyThenBy)
+            [Values] bool captureKeyThenBy,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
@@ -874,7 +1068,9 @@ namespace ProtoPromiseTests.APIs.Linq
                 var ys = xs.ToAsyncEnumerable();
 
                 var ress = xs.OrderBy(x => x.Name).ThenByDescending(x => x.Age).ToArray();
-                var resa = ys.Order(configured, new PersonFirstNameComparer()).ThenByDescending(asyncThenBy, x => x.Age, captureKeyThenBy).GetAsyncEnumerator();
+                var resa = ys.Order(configured, new PersonFirstNameComparer())
+                    .ThenByDescending(asyncThenBy, x => x.Age, captureKeyThenBy, comparer: GetDefaultOrNullComparer<int>(withComparer))
+                    .GetAsyncEnumerator();
 
                 Assert.True(await resa.MoveNextAsync());
                 Assert.AreEqual(ress[0], resa.Current);
@@ -901,7 +1097,8 @@ namespace ProtoPromiseTests.APIs.Linq
         public void OrderDescendingThenBy(
             [Values] bool configured,
             [Values] bool asyncThenBy,
-            [Values] bool captureKeyThenBy)
+            [Values] bool captureKeyThenBy,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
@@ -918,7 +1115,9 @@ namespace ProtoPromiseTests.APIs.Linq
                 var ys = xs.ToAsyncEnumerable();
 
                 var ress = xs.OrderByDescending(x => x.Name).ThenBy(x => x.Age).ToArray();
-                var resa = ys.OrderDescending(configured, new PersonFirstNameComparer()).ThenBy(asyncThenBy, x => x.Age, captureKeyThenBy).GetAsyncEnumerator();
+                var resa = ys.OrderDescending(configured, new PersonFirstNameComparer())
+                    .ThenBy(asyncThenBy, x => x.Age, captureKeyThenBy, comparer: GetDefaultOrNullComparer<int>(withComparer))
+                    .GetAsyncEnumerator();
 
                 Assert.True(await resa.MoveNextAsync());
                 Assert.AreEqual(ress[0], resa.Current);
@@ -945,7 +1144,8 @@ namespace ProtoPromiseTests.APIs.Linq
         public void OrderDescendingThenByDescending(
             [Values] bool configured,
             [Values] bool asyncThenBy,
-            [Values] bool captureKeyThenBy)
+            [Values] bool captureKeyThenBy,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
@@ -962,7 +1162,9 @@ namespace ProtoPromiseTests.APIs.Linq
                 var ys = xs.ToAsyncEnumerable();
 
                 var ress = xs.OrderByDescending(x => x.Name).ThenByDescending(x => x.Age).ToArray();
-                var resa = ys.OrderDescending(configured, new PersonFirstNameComparer()).ThenByDescending(asyncThenBy, x => x.Age, captureKeyThenBy).GetAsyncEnumerator();
+                var resa = ys.OrderDescending(configured, new PersonFirstNameComparer())
+                    .ThenByDescending(asyncThenBy, x => x.Age, captureKeyThenBy, comparer: GetDefaultOrNullComparer<int>(withComparer))
+                    .GetAsyncEnumerator();
 
                 Assert.True(await resa.MoveNextAsync());
                 Assert.AreEqual(ress[0], resa.Current);

--- a/Package/Tests/CoreTests/APIs/Linq/Operators/ToLookupAsyncTests.cs
+++ b/Package/Tests/CoreTests/APIs/Linq/Operators/ToLookupAsyncTests.cs
@@ -41,113 +41,138 @@ namespace ProtoPromiseTests.APIs.Linq
         {
             var enumerable = AsyncEnumerable.Return(42);
             var captureValue = "captureValue";
+            var nullComparer = default(IEqualityComparer<int>);
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, default(Func<int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(default(Func<int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, default(Func<string, int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, default(Func<string, int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, default(Func<int, int>), x => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, x => 0, default(Func<int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, default(Func<int, int>), x => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, x => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(default(Func<int, int>), x => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => 0, default(Func<int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(default(Func<int, int>), x => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => 0, x => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, default(Func<string, int, int>), x => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, (cv, x) => 0, default(Func<int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, default(Func<string, int, int>), x => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, (cv, x) => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, default(Func<string, int, int>), x => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => 0, default(Func<int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, default(Func<string, int, int>), x => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => 0, x => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, default(Func<int, int>), captureValue, (cv, x) => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, x => 0, captureValue, default(Func<string, int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, default(Func<int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, x => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(default(Func<int, int>), captureValue, (cv, x) => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => 0, captureValue, default(Func<string, int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(default(Func<int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => 0, captureValue, (cv, x) => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
-
-
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, default(Func<int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
-
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, default(Func<string, int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
-
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, default(Func<int, Promise<int>>), x => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, x => Promise.Resolved(0), default(Func<int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, default(Func<int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, x => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
-
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
-
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
-
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable, captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => 0, captureValue, (cv, x) => 0, nullComparer));
 
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(default(Func<int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => Promise.Resolved(0), nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, default(Func<string, int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, int>), x => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => 0, default(Func<int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, int>), x => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(default(Func<int, Promise<int>>), x => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => Promise.Resolved(0), default(Func<int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(default(Func<int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => Promise.Resolved(0), x => Promise.Resolved(0), nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, int>), x => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => 0, default(Func<int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, int>), x => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), x => Promise.Resolved(0), nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, int>), captureValue, (cv, x) => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => 0, captureValue, default(Func<string, int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(x => Promise.Resolved(0), captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(default(Func<int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, default(Func<string, int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, Promise<int>>), x => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => Promise.Resolved(0), default(Func<int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(default(Func<int, int>), x => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => 0, default(Func<int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(default(Func<int, int>), x => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => 0, x => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, default(Func<string, int, int>), x => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => 0, default(Func<int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, default(Func<string, int, int>), x => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => 0, default(Func<int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => 0, x => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(default(Func<int, int>), captureValue, (cv, x) => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => 0, captureValue, default(Func<string, int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(default(Func<int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => 0, captureValue, (cv, x) => 0, nullComparer));
 
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
-            Assert.Catch<System.ArgumentNullException>(() => AsyncEnumerable.ToLookupAsync(enumerable.ConfigureAwait(SynchronizationOption.Synchronous), captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, default(Func<string, int, int>), captureValue, (cv, x) => 0, EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => 0, captureValue, default(Func<string, int, int>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => 0, captureValue, (cv, x) => 0, nullComparer));
+
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(default(Func<int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => Promise.Resolved(0), nullComparer));
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, default(Func<string, int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(default(Func<int, Promise<int>>), x => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => Promise.Resolved(0), default(Func<int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(default(Func<int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => Promise.Resolved(0), x => Promise.Resolved(0), nullComparer));
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, default(Func<string, int, Promise<int>>), x => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), default(Func<int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), x => Promise.Resolved(0), nullComparer));
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(default(Func<int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(x => Promise.Resolved(0), captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
+
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>)));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, default(Func<string, int, Promise<int>>), captureValue, (cv, x) => Promise.Resolved(0), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), captureValue, default(Func<string, int, Promise<int>>), EqualityComparer<int>.Default));
+            Assert.Catch<System.ArgumentNullException>(() => enumerable.ConfigureAwait(SynchronizationOption.Synchronous).ToLookupAsync(captureValue, (cv, x) => Promise.Resolved(0), captureValue, (cv, x) => Promise.Resolved(0), nullComparer));
 
             enumerable.GetAsyncEnumerator().DisposeAsync().Forget();
         }
@@ -174,22 +199,38 @@ namespace ProtoPromiseTests.APIs.Linq
                 if (!captureKey)
                 {
                     return async
-                        ? asyncEnumerable.ToLookupAsync(async x => keySelector(x), equalityComparer)
-                        : asyncEnumerable.ToLookupAsync(keySelector, equalityComparer);
+                        ? equalityComparer != null
+                            ? asyncEnumerable.ToLookupAsync(async x => keySelector(x), equalityComparer)
+                            : asyncEnumerable.ToLookupAsync(async x => keySelector(x))
+                        : equalityComparer != null
+                            ? asyncEnumerable.ToLookupAsync(keySelector, equalityComparer)
+                            : asyncEnumerable.ToLookupAsync(keySelector);
                 }
                 else
                 {
                     return async
-                        ? asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
-                        {
-                            Assert.AreEqual(keyCapture, cv);
-                            return keySelector(x);
-                        }, equalityComparer)
-                        : asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
-                        {
-                            Assert.AreEqual(keyCapture, cv);
-                            return keySelector(x);
-                        }, equalityComparer);
+                        ? equalityComparer != null
+                            ? asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            }, equalityComparer)
+                            : asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            })
+                        : equalityComparer != null
+                            ? asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            }, equalityComparer)
+                            : asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            });
                 }
             }
             else
@@ -199,24 +240,42 @@ namespace ProtoPromiseTests.APIs.Linq
                     if (!captureElement)
                     {
                         return async
-                            ? asyncEnumerable.ToLookupAsync(async x => keySelector(x), async x => elementSelector(x), equalityComparer)
-                            : asyncEnumerable.ToLookupAsync(keySelector, elementSelector, equalityComparer);
+                            ? equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(async x => keySelector(x), async x => elementSelector(x), equalityComparer)
+                                : asyncEnumerable.ToLookupAsync(async x => keySelector(x), async x => elementSelector(x))
+                            : equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(keySelector, elementSelector, equalityComparer)
+                                : asyncEnumerable.ToLookupAsync(keySelector, elementSelector);
                     }
                     else
                     {
                         return async
-                            ? asyncEnumerable.ToLookupAsync(async x => keySelector(x),
+                            ? equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(async x => keySelector(x),
                                 elementCapture, async (cv, x) =>
                                 {
                                     Assert.AreEqual(elementCapture, cv);
                                     return elementSelector(x);
                                 }, equalityComparer)
-                            : asyncEnumerable.ToLookupAsync(x => keySelector(x),
+                                : asyncEnumerable.ToLookupAsync(async x => keySelector(x),
+                                elementCapture, async (cv, x) =>
+                                {
+                                    Assert.AreEqual(elementCapture, cv);
+                                    return elementSelector(x);
+                                })
+                            : equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(x => keySelector(x),
                                 elementCapture, (cv, x) =>
                                 {
                                     Assert.AreEqual(elementCapture, cv);
                                     return elementSelector(x);
-                                }, equalityComparer);
+                                }, equalityComparer)
+                                : asyncEnumerable.ToLookupAsync(x => keySelector(x),
+                                elementCapture, (cv, x) =>
+                                {
+                                    Assert.AreEqual(elementCapture, cv);
+                                    return elementSelector(x);
+                                });
                     }
                 }
                 else
@@ -224,21 +283,34 @@ namespace ProtoPromiseTests.APIs.Linq
                     if (!captureElement)
                     {
                         return async
-                            ? asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
+                            ? equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
                                 {
                                     Assert.AreEqual(keyCapture, cv);
                                     return keySelector(x);
                                 }, async x => elementSelector(x), equalityComparer)
-                            : asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                                : asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
                                 {
                                     Assert.AreEqual(keyCapture, cv);
                                     return keySelector(x);
-                                }, elementSelector, equalityComparer);
+                                }, async x => elementSelector(x))
+                            : equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                                {
+                                    Assert.AreEqual(keyCapture, cv);
+                                    return keySelector(x);
+                                }, elementSelector, equalityComparer)
+                                : asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                                {
+                                    Assert.AreEqual(keyCapture, cv);
+                                    return keySelector(x);
+                                }, elementSelector);
                     }
                     else
                     {
                         return async
-                            ? asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
+                            ? equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
                                 {
                                     Assert.AreEqual(keyCapture, cv);
                                     return keySelector(x);
@@ -248,7 +320,18 @@ namespace ProtoPromiseTests.APIs.Linq
                                     Assert.AreEqual(elementCapture, cv);
                                     return elementSelector(x);
                                 }, equalityComparer)
-                            : asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                                : asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
+                                {
+                                    Assert.AreEqual(keyCapture, cv);
+                                    return keySelector(x);
+                                },
+                                elementCapture, async (cv, x) =>
+                                {
+                                    Assert.AreEqual(elementCapture, cv);
+                                    return elementSelector(x);
+                                })
+                            : equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
                                 {
                                     Assert.AreEqual(keyCapture, cv);
                                     return keySelector(x);
@@ -257,7 +340,17 @@ namespace ProtoPromiseTests.APIs.Linq
                                 {
                                     Assert.AreEqual(elementCapture, cv);
                                     return elementSelector(x);
-                                }, equalityComparer);
+                                }, equalityComparer)
+                                : asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                                {
+                                    Assert.AreEqual(keyCapture, cv);
+                                    return keySelector(x);
+                                },
+                                elementCapture, (cv, x) =>
+                                {
+                                    Assert.AreEqual(elementCapture, cv);
+                                    return elementSelector(x);
+                                });
                     }
                 }
             }
@@ -276,22 +369,38 @@ namespace ProtoPromiseTests.APIs.Linq
                 if (!captureKey)
                 {
                     return async
-                        ? asyncEnumerable.ToLookupAsync(async x => keySelector(x), equalityComparer)
-                        : asyncEnumerable.ToLookupAsync(keySelector, equalityComparer);
+                        ? equalityComparer != null
+                            ? asyncEnumerable.ToLookupAsync(async x => keySelector(x), equalityComparer)
+                            : asyncEnumerable.ToLookupAsync(async x => keySelector(x))
+                        : equalityComparer != null
+                            ? asyncEnumerable.ToLookupAsync(keySelector, equalityComparer)
+                            : asyncEnumerable.ToLookupAsync(keySelector);
                 }
                 else
                 {
                     return async
-                        ? asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
-                        {
-                            Assert.AreEqual(keyCapture, cv);
-                            return keySelector(x);
-                        }, equalityComparer)
-                        : asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
-                        {
-                            Assert.AreEqual(keyCapture, cv);
-                            return keySelector(x);
-                        }, equalityComparer);
+                        ? equalityComparer != null
+                            ? asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            }, equalityComparer)
+                            : asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            })
+                        : equalityComparer != null
+                            ? asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            }, equalityComparer)
+                            : asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                            {
+                                Assert.AreEqual(keyCapture, cv);
+                                return keySelector(x);
+                            });
                 }
             }
             else
@@ -301,24 +410,42 @@ namespace ProtoPromiseTests.APIs.Linq
                     if (!captureElement)
                     {
                         return async
-                            ? asyncEnumerable.ToLookupAsync(async x => keySelector(x), async x => elementSelector(x), equalityComparer)
-                            : asyncEnumerable.ToLookupAsync(keySelector, elementSelector, equalityComparer);
+                            ? equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(async x => keySelector(x), async x => elementSelector(x), equalityComparer)
+                                : asyncEnumerable.ToLookupAsync(async x => keySelector(x), async x => elementSelector(x))
+                            : equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(keySelector, elementSelector, equalityComparer)
+                                : asyncEnumerable.ToLookupAsync(keySelector, elementSelector);
                     }
                     else
                     {
                         return async
-                            ? asyncEnumerable.ToLookupAsync(async x => keySelector(x),
+                            ? equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(async x => keySelector(x),
                                 elementCapture, async (cv, x) =>
                                 {
                                     Assert.AreEqual(elementCapture, cv);
                                     return elementSelector(x);
                                 }, equalityComparer)
-                            : asyncEnumerable.ToLookupAsync(x => keySelector(x),
+                                : asyncEnumerable.ToLookupAsync(async x => keySelector(x),
+                                elementCapture, async (cv, x) =>
+                                {
+                                    Assert.AreEqual(elementCapture, cv);
+                                    return elementSelector(x);
+                                })
+                            : equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(x => keySelector(x),
                                 elementCapture, (cv, x) =>
                                 {
                                     Assert.AreEqual(elementCapture, cv);
                                     return elementSelector(x);
-                                }, equalityComparer);
+                                }, equalityComparer)
+                                : asyncEnumerable.ToLookupAsync(x => keySelector(x),
+                                elementCapture, (cv, x) =>
+                                {
+                                    Assert.AreEqual(elementCapture, cv);
+                                    return elementSelector(x);
+                                });
                     }
                 }
                 else
@@ -326,55 +453,95 @@ namespace ProtoPromiseTests.APIs.Linq
                     if (!captureElement)
                     {
                         return async
-                            ? asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
-                            {
-                                Assert.AreEqual(keyCapture, cv);
-                                return keySelector(x);
-                            }, async x => elementSelector(x), equalityComparer)
-                            : asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
-                            {
-                                Assert.AreEqual(keyCapture, cv);
-                                return keySelector(x);
-                            }, elementSelector, equalityComparer);
+                            ? equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
+                                {
+                                    Assert.AreEqual(keyCapture, cv);
+                                    return keySelector(x);
+                                }, async x => elementSelector(x), equalityComparer)
+                                : asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
+                                {
+                                    Assert.AreEqual(keyCapture, cv);
+                                    return keySelector(x);
+                                }, async x => elementSelector(x))
+                            : equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                                {
+                                    Assert.AreEqual(keyCapture, cv);
+                                    return keySelector(x);
+                                }, elementSelector, equalityComparer)
+                                : asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                                {
+                                    Assert.AreEqual(keyCapture, cv);
+                                    return keySelector(x);
+                                }, elementSelector);
                     }
                     else
                     {
                         return async
-                            ? asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
-                            {
-                                Assert.AreEqual(keyCapture, cv);
-                                return keySelector(x);
-                            },
+                            ? equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
+                                {
+                                    Assert.AreEqual(keyCapture, cv);
+                                    return keySelector(x);
+                                },
                                 elementCapture, async (cv, x) =>
                                 {
                                     Assert.AreEqual(elementCapture, cv);
                                     return elementSelector(x);
                                 }, equalityComparer)
-                            : asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
-                            {
-                                Assert.AreEqual(keyCapture, cv);
-                                return keySelector(x);
-                            },
+                                : asyncEnumerable.ToLookupAsync(keyCapture, async (cv, x) =>
+                                {
+                                    Assert.AreEqual(keyCapture, cv);
+                                    return keySelector(x);
+                                },
+                                elementCapture, async (cv, x) =>
+                                {
+                                    Assert.AreEqual(elementCapture, cv);
+                                    return elementSelector(x);
+                                })
+                            : equalityComparer != null
+                                ? asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                                {
+                                    Assert.AreEqual(keyCapture, cv);
+                                    return keySelector(x);
+                                },
                                 elementCapture, (cv, x) =>
                                 {
                                     Assert.AreEqual(elementCapture, cv);
                                     return elementSelector(x);
-                                }, equalityComparer);
+                                }, equalityComparer)
+                                : asyncEnumerable.ToLookupAsync(keyCapture, (cv, x) =>
+                                {
+                                    Assert.AreEqual(keyCapture, cv);
+                                    return keySelector(x);
+                                },
+                                elementCapture, (cv, x) =>
+                                {
+                                    Assert.AreEqual(elementCapture, cv);
+                                    return elementSelector(x);
+                                });
                     }
                 }
             }
+        }
+
+        private static IEqualityComparer<T> GetDefaultOrNullComparer<T>(bool defaultComparer)
+        {
+            return defaultComparer ? EqualityComparer<T>.Default : null;
         }
 
         [Test]
         public void ToLookup1Async(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var xs = new[] { 1, 4 }.ToAsyncEnumerable();
-                var res = await ToLookupAsync(xs, configured, async, x => x % 2, captureKey);
+                var res = await ToLookupAsync(xs, configured, async, x => x % 2, captureKey, equalityComparer: GetDefaultOrNullComparer<int>(withComparer));
                 Assert.True(res.Contains(0));
                 Assert.True(res.Contains(1));
                 CollectionAssert.Contains(res[0], 4);
@@ -388,12 +555,13 @@ namespace ProtoPromiseTests.APIs.Linq
         public void ToLookup2Async(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var xs = new[] { 1, 4, 2 }.ToAsyncEnumerable();
-                var res = await ToLookupAsync(xs, configured, async, x => x % 2, captureKey);
+                var res = await ToLookupAsync(xs, configured, async, x => x % 2, captureKey, equalityComparer: GetDefaultOrNullComparer<int>(withComparer));
                 Assert.True(res.Contains(0));
                 Assert.True(res.Contains(1));
                 CollectionAssert.Contains(res[0], 4);
@@ -409,12 +577,13 @@ namespace ProtoPromiseTests.APIs.Linq
             [Values] bool configured,
             [Values] bool async,
             [Values] bool captureKey,
-            [Values] bool captureElement)
+            [Values] bool captureElement,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var xs = new[] { 1, 4 }.ToAsyncEnumerable();
-                var res = await ToLookupAsync(xs, configured, async, x => x % 2, captureKey, x => x + 1, captureElement);
+                var res = await ToLookupAsync(xs, configured, async, x => x % 2, captureKey, x => x + 1, captureElement, equalityComparer: GetDefaultOrNullComparer<int>(withComparer));
                 Assert.True(res.Contains(0));
                 Assert.True(res.Contains(1));
                 CollectionAssert.Contains(res[0], 5);
@@ -429,12 +598,13 @@ namespace ProtoPromiseTests.APIs.Linq
             [Values] bool configured,
             [Values] bool async,
             [Values] bool captureKey,
-            [Values] bool captureElement)
+            [Values] bool captureElement,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var xs = new[] { 1, 4, 2 }.ToAsyncEnumerable();
-                var res = await ToLookupAsync(xs, configured, async, x => x % 2, captureKey, x => x + 1, captureElement);
+                var res = await ToLookupAsync(xs, configured, async, x => x % 2, captureKey, x => x + 1, captureElement, equalityComparer: GetDefaultOrNullComparer<int>(withComparer));
                 Assert.True(res.Contains(0));
                 Assert.True(res.Contains(1));
                 CollectionAssert.Contains(res[0], 5);
@@ -488,12 +658,13 @@ namespace ProtoPromiseTests.APIs.Linq
         public void ToLookup7Async(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var xs = new[] { 1, 4, 2 }.ToAsyncEnumerable();
-                var res = await ToLookupAsync(xs, configured, async, x => x % 2, captureKey);
+                var res = await ToLookupAsync(xs, configured, async, x => x % 2, captureKey, equalityComparer: GetDefaultOrNullComparer<int>(withComparer));
                 foreach (var g in res)
                     Assert.True(g.Key == 0 || g.Key == 1);
             }, SynchronizationOption.Synchronous)
@@ -504,12 +675,13 @@ namespace ProtoPromiseTests.APIs.Linq
         public void ToLookup8Async(
             [Values] bool configured,
             [Values] bool async,
-            [Values] bool captureKey)
+            [Values] bool captureKey,
+            [Values] bool withComparer)
         {
             Promise.Run(async () =>
             {
                 var xs = new[] { 1, 4, 2 }.ToAsyncEnumerable();
-                var res = await ToLookupAsync(xs, configured, async, x => x % 2, captureKey);
+                var res = await ToLookupAsync(xs, configured, async, x => x % 2, captureKey, equalityComparer: GetDefaultOrNullComparer<int>(withComparer));
 #pragma warning disable IDE0007 // Use implicit type
                 foreach (IGrouping<int, int> g in (IEnumerable) res)
                 {


### PR DESCRIPTION
This way struct comparers can be used without boxing.