### PR TITLE
Add `AsyncEnumerable.AverageAsync` extensions

### DIFF
--- a/Package/Core/Linq/Operators/AverageAsync.cs
+++ b/Package/Core/Linq/Operators/AverageAsync.cs
@@ -1,0 +1,456 @@
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+using Proto.Promises.Async.CompilerServices;
+using System;
+
+namespace Proto.Promises.Linq
+{
+#if CSHARP_7_3_OR_NEWER
+    partial class AsyncEnumerable
+    {
+        /// <summary>
+        /// Computes the average of an async-enumerable sequence of <see cref="int"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="int"/> values to calculate the average of.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the average of the sequence of values.</returns>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements.</exception>
+        public static Promise<double> AverageAsync(this AsyncEnumerable<int> source)
+        {
+            return Core(source.GetAsyncEnumerator());
+
+            async Promise<double> Core(AsyncEnumerator<int> asyncEnumerator)
+            {
+                try
+                {
+                    if (!await asyncEnumerator.MoveNextAsync())
+                    {
+                        throw new InvalidOperationException("source contains no elements.");
+                    }
+
+                    long sum = asyncEnumerator.Current;
+                    long count = 1;
+                    checked
+                    {
+                        while (await asyncEnumerator.MoveNextAsync())
+                        {
+                            sum += asyncEnumerator.Current;
+                            ++count;
+                        }
+                    }
+
+                    return (double) sum / count;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the average of an async-enumerable sequence of <see cref="long"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="long"/> values to calculate the average of.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the average of the sequence of values.</returns>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements.</exception>
+        public static Promise<double> AverageAsync(this AsyncEnumerable<long> source)
+        {
+            return Core(source.GetAsyncEnumerator());
+
+            async Promise<double> Core(AsyncEnumerator<long> asyncEnumerator)
+            {
+                try
+                {
+                    if (!await asyncEnumerator.MoveNextAsync())
+                    {
+                        throw new InvalidOperationException("source contains no elements.");
+                    }
+
+                    long sum = asyncEnumerator.Current;
+                    long count = 1;
+                    checked
+                    {
+                        while (await asyncEnumerator.MoveNextAsync())
+                        {
+                            sum += asyncEnumerator.Current;
+                            ++count;
+                        }
+                    }
+
+                    return (double) sum / count;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the average of an async-enumerable sequence of <see cref="float"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="float"/> values to calculate the average of.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the average of the sequence of values.</returns>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements.</exception>
+        public static Promise<float> AverageAsync(this AsyncEnumerable<float> source)
+        {
+            return Core(source.GetAsyncEnumerator());
+
+            async Promise<float> Core(AsyncEnumerator<float> asyncEnumerator)
+            {
+                try
+                {
+                    if (!await asyncEnumerator.MoveNextAsync())
+                    {
+                        throw new InvalidOperationException("source contains no elements.");
+                    }
+
+                    double sum = asyncEnumerator.Current;
+                    long count = 1;
+                    checked
+                    {
+                        while (await asyncEnumerator.MoveNextAsync())
+                        {
+                            sum += asyncEnumerator.Current;
+                            ++count;
+                        }
+                    }
+
+                    return (float) (sum / count);
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the average of an async-enumerable sequence of <see cref="double"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="double"/> values to calculate the average of.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the average of the sequence of values.</returns>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements.</exception>
+        public static Promise<double> AverageAsync(this AsyncEnumerable<double> source)
+        {
+            return Core(source.GetAsyncEnumerator());
+
+            async Promise<double> Core(AsyncEnumerator<double> asyncEnumerator)
+            {
+                try
+                {
+                    if (!await asyncEnumerator.MoveNextAsync())
+                    {
+                        throw new InvalidOperationException("source contains no elements.");
+                    }
+
+                    double sum = asyncEnumerator.Current;
+                    long count = 1;
+                    checked
+                    {
+                        while (await asyncEnumerator.MoveNextAsync())
+                        {
+                            sum += asyncEnumerator.Current;
+                            ++count;
+                        }
+                    }
+
+                    return sum / count;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the average of an async-enumerable sequence of <see cref="decimal"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="decimal"/> values to calculate the average of.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the average of the sequence of values.</returns>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements.</exception>
+        public static Promise<decimal> AverageAsync(this AsyncEnumerable<decimal> source)
+        {
+            return Core(source.GetAsyncEnumerator());
+
+            async Promise<decimal> Core(AsyncEnumerator<decimal> asyncEnumerator)
+            {
+                try
+                {
+                    if (!await asyncEnumerator.MoveNextAsync())
+                    {
+                        throw new InvalidOperationException("source contains no elements.");
+                    }
+
+                    decimal sum = asyncEnumerator.Current;
+                    long count = 1;
+                    checked
+                    {
+                        while (await asyncEnumerator.MoveNextAsync())
+                        {
+                            sum += asyncEnumerator.Current;
+                            ++count;
+                        }
+                    }
+
+                    return sum / count;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the average of an async-enumerable sequence of nullable <see cref="int"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="int"/> values to calculate the average of.</param>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> resulting in the average of the sequence of values,
+        /// or <see langword="null"/> if the source sequence is empty or contains only values that are <see langword="null"/>.
+        /// </returns>
+        public static Promise<double?> AverageAsync(this AsyncEnumerable<int?> source)
+        {
+            return Core(source.GetAsyncEnumerator());
+
+            async Promise<double?> Core(AsyncEnumerator<int?> asyncEnumerator)
+            {
+                try
+                {
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        int? v = asyncEnumerator.Current;
+                        if (v.HasValue)
+                        {
+                            long sum = v.GetValueOrDefault();
+                            long count = 1;
+                            checked
+                            {
+                                while (await asyncEnumerator.MoveNextAsync())
+                                {
+                                    v = asyncEnumerator.Current;
+                                    if (v.HasValue)
+                                    {
+                                        sum += v.GetValueOrDefault();
+                                        ++count;
+                                    }
+                                }
+                            }
+
+                            return (double) sum / count;
+                        }
+                    }
+
+                    return null;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the average of an async-enumerable sequence of nullable <see cref="long"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="long"/> values to calculate the average of.</param>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> resulting in the average of the sequence of values,
+        /// or <see langword="null"/> if the source sequence is empty or contains only values that are <see langword="null"/>.
+        /// </returns>
+        public static Promise<double?> AverageAsync(this AsyncEnumerable<long?> source)
+        {
+            return Core(source.GetAsyncEnumerator());
+
+            async Promise<double?> Core(AsyncEnumerator<long?> asyncEnumerator)
+            {
+                try
+                {
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        long? v = asyncEnumerator.Current;
+                        if (v.HasValue)
+                        {
+                            long sum = v.GetValueOrDefault();
+                            long count = 1;
+                            checked
+                            {
+                                while (await asyncEnumerator.MoveNextAsync())
+                                {
+                                    v = asyncEnumerator.Current;
+                                    if (v.HasValue)
+                                    {
+                                        sum += v.GetValueOrDefault();
+                                        ++count;
+                                    }
+                                }
+                            }
+
+                            return (double) sum / count;
+                        }
+                    }
+
+                    return null;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the average of an async-enumerable sequence of nullable <see cref="float"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="float"/> values to calculate the average of.</param>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> resulting in the average of the sequence of values,
+        /// or <see langword="null"/> if the source sequence is empty or contains only values that are <see langword="null"/>.
+        /// </returns>
+        public static Promise<float?> AverageAsync(this AsyncEnumerable<float?> source)
+        {
+            return Core(source.GetAsyncEnumerator());
+
+            async Promise<float?> Core(AsyncEnumerator<float?> asyncEnumerator)
+            {
+                try
+                {
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        float? v = asyncEnumerator.Current;
+                        if (v.HasValue)
+                        {
+                            double sum = v.GetValueOrDefault();
+                            long count = 1;
+                            checked
+                            {
+                                while (await asyncEnumerator.MoveNextAsync())
+                                {
+                                    v = asyncEnumerator.Current;
+                                    if (v.HasValue)
+                                    {
+                                        sum += v.GetValueOrDefault();
+                                        ++count;
+                                    }
+                                }
+                            }
+
+                            return (float) (sum / count);
+                        }
+                    }
+
+                    return null;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the average of an async-enumerable sequence of nullable <see cref="double"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="double"/> values to calculate the average of.</param>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> resulting in the average of the sequence of values,
+        /// or <see langword="null"/> if the source sequence is empty or contains only values that are <see langword="null"/>.
+        /// </returns>
+        public static Promise<double?> AverageAsync(this AsyncEnumerable<double?> source)
+        {
+            return Core(source.GetAsyncEnumerator());
+
+            async Promise<double?> Core(AsyncEnumerator<double?> asyncEnumerator)
+            {
+                try
+                {
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        double? v = asyncEnumerator.Current;
+                        if (v.HasValue)
+                        {
+                            double sum = v.GetValueOrDefault();
+                            long count = 1;
+                            checked
+                            {
+                                while (await asyncEnumerator.MoveNextAsync())
+                                {
+                                    v = asyncEnumerator.Current;
+                                    if (v.HasValue)
+                                    {
+                                        sum += v.GetValueOrDefault();
+                                        ++count;
+                                    }
+                                }
+                            }
+
+                            return sum / count;
+                        }
+                    }
+
+                    return null;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the average of an async-enumerable sequence of nullable <see cref="decimal"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="decimal"/> values to calculate the average of.</param>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> resulting in the average of the sequence of values,
+        /// or <see langword="null"/> if the source sequence is empty or contains only values that are <see langword="null"/>.
+        /// </returns>
+        public static Promise<decimal?> AverageAsync(this AsyncEnumerable<decimal?> source)
+        {
+            return Core(source.GetAsyncEnumerator());
+
+            async Promise<decimal?> Core(AsyncEnumerator<decimal?> asyncEnumerator)
+            {
+                try
+                {
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        decimal? v = asyncEnumerator.Current;
+                        if (v.HasValue)
+                        {
+                            decimal sum = v.GetValueOrDefault();
+                            long count = 1;
+                            checked
+                            {
+                                while (await asyncEnumerator.MoveNextAsync())
+                                {
+                                    v = asyncEnumerator.Current;
+                                    if (v.HasValue)
+                                    {
+                                        sum += v.GetValueOrDefault();
+                                        ++count;
+                                    }
+                                }
+                            }
+
+                            return sum / count;
+                        }
+                    }
+
+                    return null;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+    }
+#endif // CSHARP_7_3_OR_NEWER
+}

--- a/Package/Core/Linq/Operators/AverageAsync.cs.meta
+++ b/Package/Core/Linq/Operators/AverageAsync.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1baec0c757ad6d41b6e34f9c77a396f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Tests/CoreTests/APIs/Linq/Operators/AverageAsyncTests.cs
+++ b/Package/Tests/CoreTests/APIs/Linq/Operators/AverageAsyncTests.cs
@@ -1,0 +1,267 @@
+﻿#if CSHARP_7_3_OR_NEWER
+
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+using NUnit.Framework;
+using Proto.Promises;
+using Proto.Promises.Async.CompilerServices;
+using Proto.Promises.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace ProtoPromiseTests.APIs.Linq
+{
+    public class AverageAsyncTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            TestHelper.Setup();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void AverageAsync_Int32_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new int[0].ToAsyncEnumerable();
+                await TestHelper.AssertThrowsAsync<System.InvalidOperationException>(() => ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Int32_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new int[] { 2, 3, 5, 7, 11, 13, 17, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Average(), await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Int32_Nullable_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new int?[0].ToAsyncEnumerable();
+                Assert.IsNull(await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Int32_Nullable_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new int?[] { 2, 3, 5, 7, null, 11, 13, 17, null, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Average(), await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Int64_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new long[0].ToAsyncEnumerable();
+                await TestHelper.AssertThrowsAsync<System.InvalidOperationException>(() => ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Int64_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new long[] { 2, 3, 5, 7, 11, 13, 17, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Average(), await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Int64_Nullable_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new long?[0].ToAsyncEnumerable();
+                Assert.IsNull(await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Int64_Nullable_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new long?[] { 2, 3, 5, 7, null, 11, 13, 17, null, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Average(), await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Single_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new float[0].ToAsyncEnumerable();
+                await TestHelper.AssertThrowsAsync<System.InvalidOperationException>(() => ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Single_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new float[] { 2, 3, 5, 7, 11, 13, 17, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Average(), await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Single_Nullable_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new float?[0].ToAsyncEnumerable();
+                Assert.IsNull(await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Single_Nullable_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new float?[] { 2, 3, 5, 7, null, 11, 13, 17, null, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Average(), await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Double_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new double[0].ToAsyncEnumerable();
+                await TestHelper.AssertThrowsAsync<System.InvalidOperationException>(() => ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Double_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new double[] { 2, 3, 5, 7, 11, 13, 17, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Average(), await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Double_Nullable_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new double?[0].ToAsyncEnumerable();
+                Assert.IsNull(await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Double_Nullable_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new double?[] { 2, 3, 5, 7, null, 11, 13, 17, null, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Average(), await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Decimal_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new decimal[0].ToAsyncEnumerable();
+                await TestHelper.AssertThrowsAsync<System.InvalidOperationException>(() => ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Decimal_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new decimal[] { 2, 3, 5, 7, 11, 13, 17, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Average(), await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Decimal_Nullable_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new decimal?[0].ToAsyncEnumerable();
+                Assert.IsNull(await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AverageAsync_Decimal_Nullable_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new decimal?[] { 2, 3, 5, 7, null, 11, 13, 17, null, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Average(), await ys.AverageAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+    }
+}
+
+#endif

--- a/Package/Tests/CoreTests/APIs/Linq/Operators/AverageAsyncTests.cs.meta
+++ b/Package/Tests/CoreTests/APIs/Linq/Operators/AverageAsyncTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87298a30c7b181341983ef45079ace88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#294 

I left out overloads with selector functions that System.Linq has, because it resulted in an extra 80 overloads (90 total!). Users can simply use `.Select` query before the `.AverageAsync` instead.