### PR TITLE
Add `AsyncEnumerable.SumAsync` extensions

### DIFF
--- a/Package/Core/Linq/Operators/SumAsync.cs
+++ b/Package/Core/Linq/Operators/SumAsync.cs
@@ -1,0 +1,332 @@
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+#pragma warning disable IDE0062 // Make local function 'static'
+
+namespace Proto.Promises.Linq
+{
+#if CSHARP_7_3_OR_NEWER
+    partial class AsyncEnumerable
+    {
+        /// <summary>
+        /// Computes the sum of an async-enumerable sequence of <see cref="int"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="int"/> values to calculate the sum of.</param>
+        /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the sum of the values in the async-enumerable sequence.</returns>
+        /// <remarks>The result will be zero if <paramref name="source"/> contains no elements.</remarks>
+        public static Promise<int> SumAsync(this AsyncEnumerable<int> source, CancelationToken cancelationToken = default)
+        {
+            return Core(source.GetAsyncEnumerator(cancelationToken));
+
+            async Promise<int> Core(AsyncEnumerator<int> asyncEnumerator)
+            {
+                try
+                {
+                    int sum = 0;
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        checked
+                        {
+                            sum += asyncEnumerator.Current;
+                        }
+                    }
+                    return sum;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the sum of an async-enumerable sequence of <see cref="long"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="long"/> values to calculate the sum of.</param>
+        /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the sum of the values in the async-enumerable sequence.</returns>
+        /// <remarks>The result will be zero if <paramref name="source"/> contains no elements.</remarks>
+        public static Promise<long> SumAsync(this AsyncEnumerable<long> source, CancelationToken cancelationToken = default)
+        {
+            return Core(source.GetAsyncEnumerator(cancelationToken));
+
+            async Promise<long> Core(AsyncEnumerator<long> asyncEnumerator)
+            {
+                try
+                {
+                    long sum = 0;
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        checked
+                        {
+                            sum += asyncEnumerator.Current;
+                        }
+                    }
+                    return sum;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the sum of an async-enumerable sequence of <see cref="float"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="float"/> values to calculate the sum of.</param>
+        /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the sum of the values in the async-enumerable sequence.</returns>
+        /// <remarks>The result will be zero if <paramref name="source"/> contains no elements.</remarks>
+        public static Promise<float> SumAsync(this AsyncEnumerable<float> source, CancelationToken cancelationToken = default)
+        {
+            return Core(source.GetAsyncEnumerator(cancelationToken));
+
+            async Promise<float> Core(AsyncEnumerator<float> asyncEnumerator)
+            {
+                try
+                {
+                    float sum = 0;
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        sum += asyncEnumerator.Current;
+                    }
+                    return sum;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the sum of an async-enumerable sequence of <see cref="double"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="double"/> values to calculate the sum of.</param>
+        /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the sum of the values in the async-enumerable sequence.</returns>
+        /// <remarks>The result will be zero if <paramref name="source"/> contains no elements.</remarks>
+        public static Promise<double> SumAsync(this AsyncEnumerable<double> source, CancelationToken cancelationToken = default)
+        {
+            return Core(source.GetAsyncEnumerator(cancelationToken));
+
+            async Promise<double> Core(AsyncEnumerator<double> asyncEnumerator)
+            {
+                try
+                {
+                    double sum = 0;
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        sum += asyncEnumerator.Current;
+                    }
+                    return sum;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the sum of an async-enumerable sequence of <see cref="decimal"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="decimal"/> values to calculate the sum of.</param>
+        /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the sum of the values in the async-enumerable sequence.</returns>
+        /// <remarks>The result will be zero if <paramref name="source"/> contains no elements.</remarks>
+        public static Promise<decimal> SumAsync(this AsyncEnumerable<decimal> source, CancelationToken cancelationToken = default)
+        {
+            return Core(source.GetAsyncEnumerator(cancelationToken));
+
+            async Promise<decimal> Core(AsyncEnumerator<decimal> asyncEnumerator)
+            {
+                try
+                {
+                    decimal sum = 0;
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        sum += asyncEnumerator.Current;
+                    }
+                    return sum;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the sum of an async-enumerable sequence of nullable <see cref="int"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="int"/> values to calculate the sum of.</param>
+        /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the sum of the values in the async-enumerable sequence.</returns>
+        /// <remarks>
+        /// Items in <paramref name="source"/> that are <see langword="null"/> are excluded from the computation of the sum.
+        /// The result will be zero if <paramref name="source"/> contains no elements or all elements are <see langword="null"/>.
+        /// </remarks>
+        public static Promise<int> SumAsync(this AsyncEnumerable<int?> source, CancelationToken cancelationToken = default)
+        {
+            return Core(source.GetAsyncEnumerator(cancelationToken));
+
+            async Promise<int> Core(AsyncEnumerator<int?> asyncEnumerator)
+            {
+                try
+                {
+                    int sum = 0;
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        checked
+                        {
+                            sum += asyncEnumerator.Current.GetValueOrDefault();
+                        }
+                    }
+                    return sum;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the sum of an async-enumerable sequence of nullable <see cref="long"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="long"/> values to calculate the sum of.</param>
+        /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the sum of the values in the async-enumerable sequence.</returns>
+        /// <remarks>
+        /// Items in <paramref name="source"/> that are <see langword="null"/> are excluded from the computation of the sum.
+        /// The result will be zero if <paramref name="source"/> contains no elements or all elements are <see langword="null"/>.
+        /// </remarks>
+        public static Promise<long> SumAsync(this AsyncEnumerable<long?> source, CancelationToken cancelationToken = default)
+        {
+            return Core(source.GetAsyncEnumerator(cancelationToken));
+
+            async Promise<long> Core(AsyncEnumerator<long?> asyncEnumerator)
+            {
+                try
+                {
+                    long sum = 0;
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        checked
+                        {
+                            sum += asyncEnumerator.Current.GetValueOrDefault();
+                        }
+                    }
+                    return sum;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the sum of an async-enumerable sequence of nullable <see cref="float"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="float"/> values to calculate the sum of.</param>
+        /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the sum of the values in the async-enumerable sequence.</returns>
+        /// <remarks>
+        /// Items in <paramref name="source"/> that are <see langword="null"/> are excluded from the computation of the sum.
+        /// The result will be zero if <paramref name="source"/> contains no elements or all elements are <see langword="null"/>.
+        /// </remarks>
+        public static Promise<float> SumAsync(this AsyncEnumerable<float?> source, CancelationToken cancelationToken = default)
+        {
+            return Core(source.GetAsyncEnumerator(cancelationToken));
+
+            async Promise<float> Core(AsyncEnumerator<float?> asyncEnumerator)
+            {
+                try
+                {
+                    float sum = 0;
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        sum += asyncEnumerator.Current.GetValueOrDefault();
+                    }
+                    return sum;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the sum of an async-enumerable sequence of nullable <see cref="double"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="double"/> values to calculate the sum of.</param>
+        /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the sum of the values in the async-enumerable sequence.</returns>
+        /// <remarks>
+        /// Items in <paramref name="source"/> that are <see langword="null"/> are excluded from the computation of the sum.
+        /// The result will be zero if <paramref name="source"/> contains no elements or all elements are <see langword="null"/>.
+        /// </remarks>
+        public static Promise<double> SumAsync(this AsyncEnumerable<double?> source, CancelationToken cancelationToken = default)
+        {
+            return Core(source.GetAsyncEnumerator(cancelationToken));
+
+            async Promise<double> Core(AsyncEnumerator<double?> asyncEnumerator)
+            {
+                try
+                {
+                    double sum = 0;
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        sum += asyncEnumerator.Current.GetValueOrDefault();
+                    }
+                    return sum;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Computes the sum of an async-enumerable sequence of nullable <see cref="decimal"/> values.
+        /// </summary>
+        /// <param name="source">An async-enumerable sequence of <see cref="decimal"/> values to calculate the sum of.</param>
+        /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
+        /// <returns>A <see cref="Promise{T}"/> resulting in the sum of the values in the async-enumerable sequence.</returns>
+        /// <remarks>
+        /// Items in <paramref name="source"/> that are <see langword="null"/> are excluded from the computation of the sum.
+        /// The result will be zero if <paramref name="source"/> contains no elements or all elements are <see langword="null"/>.
+        /// </remarks>
+        public static Promise<decimal> SumAsync(this AsyncEnumerable<decimal?> source, CancelationToken cancelationToken = default)
+        {
+            return Core(source.GetAsyncEnumerator(cancelationToken));
+
+            async Promise<decimal> Core(AsyncEnumerator<decimal?> asyncEnumerator)
+            {
+                try
+                {
+                    decimal sum = 0;
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        sum += asyncEnumerator.Current.GetValueOrDefault();
+                    }
+                    return sum;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+    }
+#endif // CSHARP_7_3_OR_NEWER
+}

--- a/Package/Core/Linq/Operators/SumAsync.cs.meta
+++ b/Package/Core/Linq/Operators/SumAsync.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7310c9f14c79494f94e8f347e8e5ae4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Tests/CoreTests/APIs/Linq/Operators/SumAsyncTests.cs
+++ b/Package/Tests/CoreTests/APIs/Linq/Operators/SumAsyncTests.cs
@@ -1,0 +1,587 @@
+﻿#if CSHARP_7_3_OR_NEWER
+
+#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+using NUnit.Framework;
+using Proto.Promises;
+using Proto.Promises.CompilerServices;
+using Proto.Promises.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace ProtoPromiseTests.APIs.Linq
+{
+    public class SumAsyncTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            TestHelper.Setup();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            TestHelper.Cleanup();
+        }
+
+        [Test]
+        public void SumAsync_Int32_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new int[0].ToAsyncEnumerable();
+                Assert.Zero(await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Int32_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new int[] { 2, 3, 5, 7, 11, 13, 17, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Sum(), await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Int32_Nullable_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new int?[0].ToAsyncEnumerable();
+                Assert.Zero(await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Int32_Nullable_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new int?[] { 2, 3, 5, 7, null, 11, 13, 17, null, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Sum(), await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Int64_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new long[0].ToAsyncEnumerable();
+                Assert.Zero(await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Int64_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new long[] { 2, 3, 5, 7, 11, 13, 17, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Sum(), await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Int64_Nullable_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new long?[0].ToAsyncEnumerable();
+                Assert.Zero(await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Int64_Nullable_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new long?[] { 2, 3, 5, 7, null, 11, 13, 17, null, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Sum(), await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Single_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new float[0].ToAsyncEnumerable();
+                Assert.Zero(await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Single_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new float[] { 2, 3, 5, 7, 11, 13, 17, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Sum(), await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Single_Nullable_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new float?[0].ToAsyncEnumerable();
+                Assert.Zero(await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Single_Nullable_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new float?[] { 2, 3, 5, 7, null, 11, 13, 17, null, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Sum(), await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Double_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new double[0].ToAsyncEnumerable();
+                Assert.Zero(await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Double_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new double[] { 2, 3, 5, 7, 11, 13, 17, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Sum(), await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Double_Nullable_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new double?[0].ToAsyncEnumerable();
+                Assert.Zero(await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Double_Nullable_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new double?[] { 2, 3, 5, 7, null, 11, 13, 17, null, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Sum(), await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Decimal_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new decimal[0].ToAsyncEnumerable();
+                Assert.Zero(await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Decimal_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new decimal[] { 2, 3, 5, 7, 11, 13, 17, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Sum(), await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Decimal_Nullable_Empty()
+        {
+            Promise.Run(async () =>
+            {
+                var ys = new decimal?[0].ToAsyncEnumerable();
+                Assert.Zero(await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Decimal_Nullable_Many()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new decimal?[] { 2, 3, 5, 7, null, 11, 13, 17, null, 19 };
+                var ys = xs.ToAsyncEnumerable();
+                Assert.AreEqual(xs.Sum(), await ys.SumAsync());
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Int32_Cancel()
+        {
+            Promise.Run(async () =>
+            {
+                var deferred = Promise.NewDeferred();
+                var xs = AsyncEnumerable.Create<int>(async (writer, cancelationToken) =>
+                {
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(0);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(2);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(4);
+                });
+                using (var cancelationSource = CancelationSource.New())
+                {
+                    var ys = xs.SumAsync(cancelationSource.Token);
+                    var def = deferred;
+                    deferred = Promise.NewDeferred();
+                    def.Resolve();
+                    cancelationSource.Cancel();
+                    deferred.Resolve();
+                    await TestHelper.AssertCanceledAsync(() => ys);
+                }
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Int64_Cancel()
+        {
+            Promise.Run(async () =>
+            {
+                var deferred = Promise.NewDeferred();
+                var xs = AsyncEnumerable.Create<long>(async (writer, cancelationToken) =>
+                {
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(0);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(2);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(4);
+                });
+                using (var cancelationSource = CancelationSource.New())
+                {
+                    var ys = xs.SumAsync(cancelationSource.Token);
+                    var def = deferred;
+                    deferred = Promise.NewDeferred();
+                    def.Resolve();
+                    cancelationSource.Cancel();
+                    deferred.Resolve();
+                    await TestHelper.AssertCanceledAsync(() => ys);
+                }
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Single_Cancel()
+        {
+            Promise.Run(async () =>
+            {
+                var deferred = Promise.NewDeferred();
+                var xs = AsyncEnumerable.Create<float>(async (writer, cancelationToken) =>
+                {
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(0);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(2);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(4);
+                });
+                using (var cancelationSource = CancelationSource.New())
+                {
+                    var ys = xs.SumAsync(cancelationSource.Token);
+                    var def = deferred;
+                    deferred = Promise.NewDeferred();
+                    def.Resolve();
+                    cancelationSource.Cancel();
+                    deferred.Resolve();
+                    await TestHelper.AssertCanceledAsync(() => ys);
+                }
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Double_Cancel()
+        {
+            Promise.Run(async () =>
+            {
+                var deferred = Promise.NewDeferred();
+                var xs = AsyncEnumerable.Create<double>(async (writer, cancelationToken) =>
+                {
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(0);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(2);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(4);
+                });
+                using (var cancelationSource = CancelationSource.New())
+                {
+                    var ys = xs.SumAsync(cancelationSource.Token);
+                    var def = deferred;
+                    deferred = Promise.NewDeferred();
+                    def.Resolve();
+                    cancelationSource.Cancel();
+                    deferred.Resolve();
+                    await TestHelper.AssertCanceledAsync(() => ys);
+                }
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Decimal_Cancel()
+        {
+            Promise.Run(async () =>
+            {
+                var deferred = Promise.NewDeferred();
+                var xs = AsyncEnumerable.Create<decimal>(async (writer, cancelationToken) =>
+                {
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(0);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(2);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(4);
+                });
+                using (var cancelationSource = CancelationSource.New())
+                {
+                    var ys = xs.SumAsync(cancelationSource.Token);
+                    var def = deferred;
+                    deferred = Promise.NewDeferred();
+                    def.Resolve();
+                    cancelationSource.Cancel();
+                    deferred.Resolve();
+                    await TestHelper.AssertCanceledAsync(() => ys);
+                }
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Int32_Nullable_Cancel()
+        {
+            Promise.Run(async () =>
+            {
+                var deferred = Promise.NewDeferred();
+                var xs = AsyncEnumerable.Create<int?>(async (writer, cancelationToken) =>
+                {
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(0);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(2);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(4);
+                });
+                using (var cancelationSource = CancelationSource.New())
+                {
+                    var ys = xs.SumAsync(cancelationSource.Token);
+                    var def = deferred;
+                    deferred = Promise.NewDeferred();
+                    def.Resolve();
+                    cancelationSource.Cancel();
+                    deferred.Resolve();
+                    await TestHelper.AssertCanceledAsync(() => ys);
+                }
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Int64_Nullable_Cancel()
+        {
+            Promise.Run(async () =>
+            {
+                var deferred = Promise.NewDeferred();
+                var xs = AsyncEnumerable.Create<long?>(async (writer, cancelationToken) =>
+                {
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(0);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(2);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(4);
+                });
+                using (var cancelationSource = CancelationSource.New())
+                {
+                    var ys = xs.SumAsync(cancelationSource.Token);
+                    var def = deferred;
+                    deferred = Promise.NewDeferred();
+                    def.Resolve();
+                    cancelationSource.Cancel();
+                    deferred.Resolve();
+                    await TestHelper.AssertCanceledAsync(() => ys);
+                }
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Single_Nullable_Cancel()
+        {
+            Promise.Run(async () =>
+            {
+                var deferred = Promise.NewDeferred();
+                var xs = AsyncEnumerable.Create<float?>(async (writer, cancelationToken) =>
+                {
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(0);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(2);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(4);
+                });
+                using (var cancelationSource = CancelationSource.New())
+                {
+                    var ys = xs.SumAsync(cancelationSource.Token);
+                    var def = deferred;
+                    deferred = Promise.NewDeferred();
+                    def.Resolve();
+                    cancelationSource.Cancel();
+                    deferred.Resolve();
+                    await TestHelper.AssertCanceledAsync(() => ys);
+                }
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Double_Nullable_Cancel()
+        {
+            Promise.Run(async () =>
+            {
+                var deferred = Promise.NewDeferred();
+                var xs = AsyncEnumerable.Create<double?>(async (writer, cancelationToken) =>
+                {
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(0);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(2);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(4);
+                });
+                using (var cancelationSource = CancelationSource.New())
+                {
+                    var ys = xs.SumAsync(cancelationSource.Token);
+                    var def = deferred;
+                    deferred = Promise.NewDeferred();
+                    def.Resolve();
+                    cancelationSource.Cancel();
+                    deferred.Resolve();
+                    await TestHelper.AssertCanceledAsync(() => ys);
+                }
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void SumAsync_Decimal_Nullable_Cancel()
+        {
+            Promise.Run(async () =>
+            {
+                var deferred = Promise.NewDeferred();
+                var xs = AsyncEnumerable.Create<decimal?>(async (writer, cancelationToken) =>
+                {
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(0);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(2);
+                    await deferred.Promise;
+                    cancelationToken.ThrowIfCancelationRequested();
+                    await writer.YieldAsync(4);
+                });
+                using (var cancelationSource = CancelationSource.New())
+                {
+                    var ys = xs.SumAsync(cancelationSource.Token);
+                    var def = deferred;
+                    deferred = Promise.NewDeferred();
+                    def.Resolve();
+                    cancelationSource.Cancel();
+                    deferred.Resolve();
+                    await TestHelper.AssertCanceledAsync(() => ys);
+                }
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+    }
+}
+
+#endif

--- a/Package/Tests/CoreTests/APIs/Linq/Operators/SumAsyncTests.cs.meta
+++ b/Package/Tests/CoreTests/APIs/Linq/Operators/SumAsyncTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ecee046971811c543a830df73f00166f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#294 

Same as #343, I left out overloads with selector functions that System.Linq has, because it resulted in an extra 80 overloads (90 total!). Users can simply use `.Select` query before the `.SumAsync` instead.