### PR TITLE
SynchronizationContext cleanup

### DIFF
--- a/Package/Core/Linq/CompilerServices/ConfiguredAsyncEnumerable.cs
+++ b/Package/Core/Linq/CompilerServices/ConfiguredAsyncEnumerable.cs
@@ -222,7 +222,7 @@ namespace Proto.Promises.CompilerServices
                                 Internal.GetFormattedStacktrace(2));
                         }
                         // We ignore the _forceAsync flag here.
-                        return synchronizationContext == Internal.ts_currentContext
+                        return synchronizationContext == Promise.Manager.ThreadStaticSynchronizationContext
                             ? default
                             : new SwitchToConfiguredContextAwaiter(synchronizationContext);
                     }
@@ -243,7 +243,7 @@ namespace Proto.Promises.CompilerServices
                     synchronizationContext = Internal.BackgroundSynchronizationContextSentinel.s_instance;
                 }
                 // We ignore the _forceAsync flag here.
-                return synchronizationContext == Internal.ts_currentContext
+                return synchronizationContext == Promise.Manager.ThreadStaticSynchronizationContext
                     ? default
                     : new SwitchToConfiguredContextAwaiter(synchronizationContext);
             }
@@ -348,7 +348,7 @@ namespace Proto.Promises.CompilerServices
         public bool IsCompleted
         {
             [MethodImpl(Internal.InlineOption)]
-            get => _context == null | _context == Internal.ts_currentContext;
+            get => _context == null | _context == Promise.Manager.ThreadStaticSynchronizationContext;
         }
 
         [MethodImpl(Internal.InlineOption)]

--- a/Package/Core/Promises/CompilerServices/PromiseSwitchContextAwaiter.cs
+++ b/Package/Core/Promises/CompilerServices/PromiseSwitchContextAwaiter.cs
@@ -49,7 +49,7 @@ namespace Proto.Promises.Async.CompilerServices
             [MethodImpl(Internal.InlineOption)]
             get
             {
-                return !_forceAsync & _context == Internal.ts_currentContext;
+                return !_forceAsync & _context == Promise.Manager.ThreadStaticSynchronizationContext;
             }
         }
 

--- a/Package/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/Package/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -347,7 +347,7 @@ namespace Proto.Promises
                         }
                     }
 
-                    if (!forceAsync & synchronizationContext == ts_currentContext)
+                    if (!forceAsync & synchronizationContext == Promise.Manager.ThreadStaticSynchronizationContext)
                     {
                         return InvokeCallbackDirect(runner);
                     }
@@ -393,7 +393,7 @@ namespace Proto.Promises
                         }
                     }
 
-                    if (!forceAsync & synchronizationContext == ts_currentContext)
+                    if (!forceAsync & synchronizationContext == Promise.Manager.ThreadStaticSynchronizationContext)
                     {
                         return InvokeCallbackAndAdoptDirect(runner);
                     }
@@ -1116,7 +1116,7 @@ namespace Proto.Promises
                         }
                     }
 
-                    if (!forceAsync & synchronizationContext == ts_currentContext)
+                    if (!forceAsync & synchronizationContext == Promise.Manager.ThreadStaticSynchronizationContext)
                     {
                         return InvokeCallbackDirect(runner);
                     }
@@ -1162,7 +1162,7 @@ namespace Proto.Promises
                         }
                     }
 
-                    if (!forceAsync & synchronizationContext == ts_currentContext)
+                    if (!forceAsync & synchronizationContext == Promise.Manager.ThreadStaticSynchronizationContext)
                     {
                         return InvokeCallbackAndAdoptDirect(runner);
                     }

--- a/Package/Core/Promises/Internal/DeferredInternal.cs
+++ b/Package/Core/Promises/Internal/DeferredInternal.cs
@@ -228,13 +228,12 @@ namespace Proto.Promises
                         }
                     }
 
-                    if (!forceAsync & context == ts_currentContext)
+                    if (!forceAsync & context == Promise.Manager.ThreadStaticSynchronizationContext)
                     {
                         Run();
                         return;
                     }
 
-                    _synchronizationContext = context;
                     ScheduleContextCallback(context, this,
                         obj => obj.UnsafeAs<DeferredNewPromise<TResult, TDelegate>>().Run(),
                         obj => obj.UnsafeAs<DeferredNewPromise<TResult, TDelegate>>().Run()
@@ -248,10 +247,6 @@ namespace Proto.Promises
                     var deferredId = DeferredId;
                     var runner = _runner;
                     _runner = default(TDelegate);
-
-                    var currentContext = ts_currentContext;
-                    ts_currentContext = _synchronizationContext;
-                    _synchronizationContext = null;
 
                     SetCurrentInvoker(this);
                     try
@@ -279,7 +274,6 @@ namespace Proto.Promises
                         }
                     }
                     ClearCurrentInvoker();
-                    ts_currentContext = currentContext;
                 }
             }
         } // class PromiseRef

--- a/Package/Core/Promises/Internal/ParallelAsyncInternal.cs
+++ b/Package/Core/Promises/Internal/ParallelAsyncInternal.cs
@@ -249,9 +249,6 @@ namespace Proto.Promises
 
                 private void ExecuteWorker(bool fromMoveNext)
                 {
-                    var currentContext = ts_currentContext;
-                    ts_currentContext = _synchronizationContext;
-                    
                     SetCurrentInvoker(this);
                     try
                     {
@@ -270,8 +267,6 @@ namespace Proto.Promises
                         MaybeComplete(1);
                     }
                     ClearCurrentInvoker();
-
-                    ts_currentContext = currentContext;
                 }
 
                 private void WorkerBody(bool fromMoveNext)

--- a/Package/Core/Promises/Internal/ParallelInternal.cs
+++ b/Package/Core/Promises/Internal/ParallelInternal.cs
@@ -319,9 +319,6 @@ namespace Proto.Promises
 
                 private void ExecuteWorker(bool launchNext)
                 {
-                    var currentContext = ts_currentContext;
-                    ts_currentContext = _synchronizationContext;
-                    
                     SetCurrentInvoker(this);
                     try
                     {
@@ -340,8 +337,6 @@ namespace Proto.Promises
                         MaybeComplete();
                     }
                     ClearCurrentInvoker();
-
-                    ts_currentContext = currentContext;
                 }
 
                 private void WorkerBody(bool launchNext)

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -176,14 +176,12 @@ namespace Proto.Promises
             partial class RunPromise<TResult, TDelegate> : PromiseSingleAwait<TResult>
                 where TDelegate : IDelegateRun
             {
-                private SynchronizationContext _synchronizationContext;
                 private TDelegate _runner;
             }
 
             partial class RunWaitPromise<TResult, TDelegate> : PromiseWaitPromise<TResult>
                 where TDelegate : IDelegateRunPromise
             {
-                private SynchronizationContext _synchronizationContext;
                 private TDelegate _runner;
             }
 
@@ -211,7 +209,6 @@ namespace Proto.Promises
             partial class DeferredNewPromise<TResult, TDelegate> : DeferredPromise<TResult>
                 where TDelegate : IDelegateNew<TResult>
             {
-                private SynchronizationContext _synchronizationContext;
                 private TDelegate _runner;
             }
 

--- a/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
@@ -62,12 +62,7 @@ namespace Proto.Promises
 
                 private void HandleFromContext()
                 {
-                    var currentContext = ts_currentContext;
-                    ts_currentContext = _callerContext;
-
                     HandleNextInternal(_tempState);
-
-                    ts_currentContext = currentContext;
                 }
 
                 internal void MaybeHookupCancelation(CancelationToken cancelationToken)

--- a/Package/Core/Utilities/Internal/ProgressInternal.cs
+++ b/Package/Core/Utilities/Internal/ProgressInternal.cs
@@ -213,7 +213,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             private bool ShouldInvokeSynchronous()
             {
-                return _invokeContext == null | (_invokeContext == ts_currentContext & !_forceAsync);
+                return _invokeContext == null | (!_forceAsync & _invokeContext == Promise.Manager.ThreadStaticSynchronizationContext);
             }
 
             [MethodImpl(InlineOption)]
@@ -330,17 +330,12 @@ namespace Proto.Promises
                 // Exit the lock before invoking so we're not holding the lock while user code runs.
                 _smallFields._locker.Exit();
 
-                var currentContext = ts_currentContext;
-                ts_currentContext = _invokeContext;
-
                 if (!_canceled & !cancelationToken.IsCancelationRequested)
                 {
                     InvokeAndCatch(progress);
                 }
 
                 AfterInvoke();
-
-                ts_currentContext = currentContext;
             }
 
             void ICancelable.Cancel()

--- a/Package/Tests/CoreTests/APIs/Utilities/ProgressTests.cs
+++ b/Package/Tests/CoreTests/APIs/Utilities/ProgressTests.cs
@@ -137,7 +137,9 @@ namespace ProtoPromiseTests.APIs.Utilities
             Thread foregroundThread = Thread.CurrentThread;
             ThreadHelper threadHelper = new ThreadHelper();
 
-            ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationCallbackType, v => TestHelper.AssertCallbackContext(synchronizationCallbackType, synchronizationReportType, foregroundThread));
+            ProgressHelper progressHelper = new ProgressHelper(progressType, synchronizationCallbackType,
+                v => TestHelper.AssertCallbackContext(synchronizationCallbackType, synchronizationReportType, foregroundThread),
+                forceAsync: true);
             var progress = progressHelper.ToProgress();
             var progressToken = progress.Token;
 
@@ -329,7 +331,7 @@ namespace ProtoPromiseTests.APIs.Utilities
 
             for (int i = 0; i < MultiProgressCount; ++i)
             {
-                progressHelpers[i] = new ProgressHelper(progressType, synchronizationType);
+                progressHelpers[i] = new ProgressHelper(progressType, synchronizationType, forceAsync: true);
                 progresses[i] = progressHelpers[i].ToProgress();
                 multiProgress.Add(progresses[i].Token);
                 progressHelpers[i].AssertCurrentProgress(double.NaN, false, false);

--- a/Package/Tests/CoreTests/Concurrency/Linq/AsyncEnumerableMergeConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/Linq/AsyncEnumerableMergeConcurrencyTests.cs
@@ -36,7 +36,7 @@ namespace ProtoPromiseTests.Concurrency.Linq
                 {
                     for (int j = 0; j < 10; ++j)
                     {
-                        await Promise.SwitchToBackgroundAwait();
+                        await Promise.SwitchToBackgroundAwait(forceAsync: true);
 
                         // Make all threads yield at the same time.
                         barrier.SignalAndWait();
@@ -68,7 +68,7 @@ namespace ProtoPromiseTests.Concurrency.Linq
                     barrier.AddParticipant();
                     for (int j = 0; j < 10; ++j)
                     {
-                        await Promise.SwitchToBackgroundAwait();
+                        await Promise.SwitchToBackgroundAwait(forceAsync: true);
 
                         // Make all threads yield at the same time.
                         barrier.SignalAndWait();
@@ -84,7 +84,7 @@ namespace ProtoPromiseTests.Concurrency.Linq
                 barrier.AddParticipant();
                 for (int i = 0; i < enumerableCount; ++i)
                 {
-                    await Promise.SwitchToBackgroundAwait();
+                    await Promise.SwitchToBackgroundAwait(forceAsync: true);
 
                     // Make all threads yield at the same time.
                     barrier.SignalAndWait();

--- a/Package/Tests/CoreTests/Concurrency/Utilities/ProgressConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/Utilities/ProgressConcurrencyTests.cs
@@ -41,7 +41,7 @@ namespace ProtoPromiseTests.Concurrency.Utilities
                 // Setup
                 () =>
                 {
-                    progressHelper = new ProgressHelper(progressType, synchronizationType);
+                    progressHelper = new ProgressHelper(progressType, synchronizationType, forceAsync: true);
                     progress = progressHelper.ToProgress();
                     progressToken = progress.Token;
 
@@ -83,7 +83,7 @@ namespace ProtoPromiseTests.Concurrency.Utilities
                 // Setup
                 () =>
                 {
-                    progressHelper = new ProgressHelper(progressType, synchronizationType);
+                    progressHelper = new ProgressHelper(progressType, synchronizationType, forceAsync: true);
                     progress = progressHelper.ToProgress();
                     progressToken = progress.Token;
 
@@ -132,7 +132,7 @@ namespace ProtoPromiseTests.Concurrency.Utilities
                 {
                     cancelationSource = CancelationSource.New();
                     cancelationToken = cancelationSource.Token;
-                    progressHelper = new ProgressHelper(progressType, synchronizationType);
+                    progressHelper = new ProgressHelper(progressType, synchronizationType, forceAsync: true);
                     progress = progressHelper.ToProgress(cancelationToken);
                     progressToken = progress.Token;
 
@@ -185,7 +185,7 @@ namespace ProtoPromiseTests.Concurrency.Utilities
                 // Setup
                 () =>
                 {
-                    progressHelper = new ProgressHelper(progressType, synchronizationType);
+                    progressHelper = new ProgressHelper(progressType, synchronizationType, forceAsync: true);
                     progress = progressHelper.ToProgress();
                     var progressToken = progress.Token;
                     progressMerger = Progress.NewMergeBuilder(progressToken.Slice(0d, 0.3d));

--- a/Package/Tests/Helpers/BackgroundSynchronizationContext.cs
+++ b/Package/Tests/Helpers/BackgroundSynchronizationContext.cs
@@ -57,6 +57,7 @@ namespace ProtoPromiseTests
 
             private void ThreadAction()
             {
+                Promise.Manager.ThreadStaticSynchronizationContext = _owner;
                 while (true)
                 {
                     BackgroundSynchronizationContext owner = _owner;


### PR DESCRIPTION
We only read the thread static synchronization context now instead of writing it twice on every post.