### PR TITLE
Optimize `Promise.{All, Merge, Race, First}`

### DIFF
--- a/Package/Core/InternalShared/DebugInternal.cs
+++ b/Package/Core/InternalShared/DebugInternal.cs
@@ -338,7 +338,7 @@ namespace Proto.Promises
                     }
                 }
 
-                partial void ValidateNoPending()
+                private void ValidateNoPending()
                 {
                     lock (_pendingPromises)
                     {
@@ -363,6 +363,12 @@ namespace Proto.Promises
                     {
                         _pendingPromises.Remove(completePromise);
                     }
+                }
+
+                new protected void Dispose()
+                {
+                    ValidateNoPending();
+                    base.Dispose();
                 }
             }
 

--- a/Package/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/Package/Core/InternalShared/HelperFunctionsInternal.cs
@@ -160,8 +160,8 @@ namespace Proto.Promises
                         {
                             uValue -= addOrSubtract;
                         }
-                        newValue = (int) uValue;
                     }
+                    newValue = (int) uValue;
                 } while (Interlocked.CompareExchange(ref location, newValue, initialValue) != initialValue);
                 return newValue;
             }

--- a/Package/Core/Promises/Internal/MergeInternal.cs
+++ b/Package/Core/Promises/Internal/MergeInternal.cs
@@ -41,6 +41,74 @@ namespace Proto.Promises
         internal delegate void GetResultContainerDelegate<TResult>(PromiseRefBase handler, IRejectContainer rejectContainer, Promise.State state, int index, ref TResult result);
 #endif
 
+        [MethodImpl(InlineOption)]
+        internal static void PrepareForMerge<TResult>(Promise promise, in TResult result, ref uint pendingCount,
+            ref PromiseRefBase.MergePromiseT<TResult> mergePromise, GetResultDelegate<TResult> getResultDelegate)
+        {
+            if (promise._ref != null)
+            {
+                checked { ++pendingCount; }
+                if (mergePromise == null)
+                {
+                    mergePromise = PromiseRefBase.GetOrCreateMergePromise(result, getResultDelegate);
+                }
+                mergePromise.AddWaiter(promise._ref, promise._id);
+            }
+        }
+
+        [MethodImpl(InlineOption)]
+        internal static void PrepareForMerge<T, TResult>(Promise<T> promise, ref T value, in TResult result, ref uint pendingCount, int index,
+            ref PromiseRefBase.MergePromiseT<TResult> mergePromise, GetResultDelegate<TResult> getResultDelegate)
+        {
+            if (promise._ref == null)
+            {
+                value = promise._result;
+            }
+            else
+            {
+                checked { ++pendingCount; }
+                if (mergePromise == null)
+                {
+                    mergePromise = PromiseRefBase.GetOrCreateMergePromise(result, getResultDelegate);
+                }
+                mergePromise.AddWaiterWithIndex(promise._ref, promise._id, index);
+            }
+        }
+
+        [MethodImpl(InlineOption)]
+        internal static void PrepareForMergeSettled<TResult>(Promise promise, in TResult result, ref uint pendingCount, int index,
+            ref PromiseRefBase.MergeSettledPromise<TResult> mergePromise, GetResultContainerDelegate<TResult> getResultDelegate)
+        {
+            if (promise._ref != null)
+            {
+                checked { ++pendingCount; }
+                if (mergePromise == null)
+                {
+                    mergePromise = PromiseRefBase.GetOrCreateMergeSettledPromise(result, getResultDelegate);
+                }
+                mergePromise.AddWaiterWithIndex(promise._ref, promise._id, index);
+            }
+        }
+
+        [MethodImpl(InlineOption)]
+        internal static void PrepareForMergeSettled<T, TResult>(Promise<T> promise, ref Promise<T>.ResultContainer value, in TResult result, ref uint pendingCount, int index,
+            ref PromiseRefBase.MergeSettledPromise<TResult> mergePromise, GetResultContainerDelegate<TResult> getResultDelegate)
+        {
+            if (promise._ref == null)
+            {
+                value = promise._result;
+            }
+            else
+            {
+                checked { ++pendingCount; }
+                if (mergePromise == null)
+                {
+                    mergePromise = PromiseRefBase.GetOrCreateMergeSettledPromise(result, getResultDelegate);
+                }
+                mergePromise.AddWaiterWithIndex(promise._ref, promise._id, index);
+            }
+        }
+
         partial class PromiseRefBase
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
@@ -48,58 +116,114 @@ namespace Proto.Promises
 #endif
             internal abstract partial class MultiHandleablePromiseBase<TResult> : PromiseSingleAwait<TResult>
             {
-                partial void ValidateNoPending();
                 partial void AddPending(PromiseRefBase pendingPromise);
                 partial void RemoveComplete(PromiseRefBase completePromise);
 
                 internal override void Handle(PromiseRefBase handler, Promise.State state) { throw new System.InvalidOperationException(); }
 
-                // When each promise is completed, we decrement the wait count until it reaches zero before we handle the next waiter.
-                // If a promise completes with a state that should complete this promise before all the other promises were complete,
-                // we instead swap the count to 0 so that it will be marked complete early, and future completions will decrement into negative and never read 0 again.
-                // (Merge reject/cancel, or First resolve, Race always tries to set complete).
+                [MethodImpl(InlineOption)]
+                new protected void Reset()
+                {
+                    _isComplete = 0; // false
+                    _retainCounter = 1; // Start with 1 so this won't be disposed while promises are still being hooked up.
+                    base.Reset();
+                }
+
                 [MethodImpl(InlineOption)]
                 protected bool TrySetComplete(PromiseRefBase completePromise)
                 {
                     RemoveComplete(completePromise);
-                    return Interlocked.Exchange(ref _waitCount, 0) > 0;
+                    return Interlocked.Exchange(ref _isComplete, 1) == 0;
                 }
 
                 [MethodImpl(InlineOption)]
-                protected bool RemoveWaiterAndGetIsComplete(PromiseRefBase completePromise)
+                protected bool RemoveWaiterAndGetIsComplete(PromiseRefBase completePromise, ref int waitCount)
                 {
-                    RemoveComplete(completePromise);
-                    // No overflow check as we expect the count to be able to go negative.
-                    return Interlocked.Add(ref _waitCount, -1) == 0;
-                }
-
-                internal void Setup(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits)
-                {
-                    _waitCount = pendingAwaits;
-                    _retainCounter = pendingAwaits;
-                    Reset();
-
-                    foreach (var passThrough in promisePassThroughs)
+                    if (InterlockedAddWithUnsignedOverflowCheck(ref waitCount, -1) == 0)
                     {
-                        AddPending(passThrough.Owner);
-                        passThrough.SetTargetAndAddToOwner(this);
+                        return TrySetComplete(completePromise);
                     }
+                    RemoveComplete(completePromise);
+                    return false;
                 }
 
-                new protected void Dispose()
+                internal void AddWaiterWithIndex(PromiseRefBase promise, short id, int index)
                 {
-                    ValidateNoPending();
-                    base.Dispose();
+                    InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, 1);
+                    AddPending(promise);
+                    var passthrough = PromisePassThrough.GetOrCreate(promise, this, index);
+                    promise.HookupNewWaiter(id, passthrough);
+                }
+
+                internal void AddWaiter(PromiseRefBase promise, short id)
+                {
+                    InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, 1);
+                    AddPending(promise);
+                    promise.HookupNewWaiter(id, this);
+                }
+
+                protected void MarkReady(uint totalWaiters, ref int waitCount, Promise.State stateIfComplete)
+                {
+                    // This method is called after all promises have been hooked up to this,
+                    // so that we only need to do this Interlocked loop once, instead of for each promise.
+                    // _waitCount is set to -1 when this is created, so we need to subtract how many promises have already completed.
+                    // Promises can complete concurrently on other threads, which is why we need to do this with an Interlocked loop.
+                    unchecked
+                    {
+                        int previousWaitCount = Volatile.Read(ref waitCount);
+                        while (true)
+                        {
+                            uint completedCount = uint.MaxValue - (uint) previousWaitCount;
+                            uint newWaitCount = totalWaiters - completedCount;
+                            if (newWaitCount == 0)
+                            {
+                                // All promises already completed.
+                                if (_isComplete == 0)
+                                {
+                                    _next = PromiseCompletionSentinel.s_instance;
+                                    SetCompletionState(_rejectContainer == null ? stateIfComplete : Promise.State.Rejected);
+                                }
+                                break;
+                            }
+                            int oldCount = Interlocked.CompareExchange(ref waitCount, (int) newWaitCount, previousWaitCount);
+                            if (oldCount == previousWaitCount)
+                            {
+                                break;
+                            }
+                            previousWaitCount = oldCount;
+                        }
+                    }
                 }
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal sealed class MergePromiseVoid : MultiHandleablePromiseBase<VoidResult>
+            internal abstract partial class MergePromiseBase<TResult> : MultiHandleablePromiseBase<TResult>
             {
                 [MethodImpl(InlineOption)]
-                private static MergePromiseVoid GetOrCreate()
+                new protected void Reset()
+                {
+                    _waitCount = -1; // uint.MaxValue
+                    base.Reset();
+                }
+
+                [MethodImpl(InlineOption)]
+                protected bool RemoveWaiterAndGetIsComplete(PromiseRefBase completePromise)
+                    => RemoveWaiterAndGetIsComplete(completePromise, ref _waitCount);
+
+                [MethodImpl(InlineOption)]
+                internal void MarkReady(uint totalWaiters)
+                    => MarkReady(totalWaiters, ref _waitCount, Promise.State.Resolved);
+            }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            internal sealed partial class MergePromiseVoid : MergePromiseBase<VoidResult>
+            {
+                [MethodImpl(InlineOption)]
+                private static MergePromiseVoid GetOrCreateInstance()
                 {
                     var obj = ObjectPool.TryTakeOrInvalid<MergePromiseVoid>();
                     return obj == InvalidAwaitSentinel.s_instance
@@ -108,10 +232,65 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal static MergePromiseVoid GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits)
+                internal static MergePromiseVoid GetOrCreate()
                 {
+                    var promise = GetOrCreateInstance();
+                    promise.Reset();
+                    return promise;
+                }
+
+                internal override void MaybeDispose()
+                {
+                    if (InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1) == 0)
+                    {
+                        Dispose();
+                        ObjectPool.MaybeRepool(this);
+                    }
+                }
+
+                internal override void Handle(PromiseRefBase handler, Promise.State state)
+                {
+                    handler.SetCompletionState(state);
+                    bool isComplete = state == Promise.State.Resolved
+                        ? RemoveWaiterAndGetIsComplete(handler)
+                        : TrySetComplete(handler);
+                    if (isComplete)
+                    {
+                        _rejectContainer = handler._rejectContainer;
+                        handler.SuppressRejection = true;
+                        handler.MaybeDispose();
+                        InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
+                        HandleNextInternal(state);
+                        return;
+                    }
+                    handler.MaybeReportUnhandledAndDispose(state);
+                    MaybeDispose();
+                }
+            }
+
+            internal static MergePromiseVoid GetOrCreateAllPromiseVoid()
+                => MergePromiseVoid.GetOrCreate();
+
+            internal sealed partial class MergePromiseT<TResult> : MergePromiseBase<TResult>
+            {
+                private static GetResultDelegate<TResult> s_getResult;
+
+                [MethodImpl(InlineOption)]
+                private static MergePromiseT<TResult> GetOrCreate()
+                {
+                    var obj = ObjectPool.TryTakeOrInvalid<MergePromiseT<TResult>>();
+                    return obj == InvalidAwaitSentinel.s_instance
+                        ? new MergePromiseT<TResult>()
+                        : obj.UnsafeAs<MergePromiseT<TResult>>();
+                }
+
+                [MethodImpl(InlineOption)]
+                internal static MergePromiseT<TResult> GetOrCreate(in TResult value, GetResultDelegate<TResult> getResultFunc)
+                {
+                    s_getResult = getResultFunc;
                     var promise = GetOrCreate();
-                    promise.Setup(promisePassThroughs, pendingAwaits);
+                    promise.Reset();
+                    promise._result = value;
                     return promise;
                 }
 
@@ -126,66 +305,7 @@ namespace Proto.Promises
 
                 internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
                 {
-                    bool isComplete = state == Promise.State.Resolved
-                        ? RemoveWaiterAndGetIsComplete(handler)
-                        : TrySetComplete(handler);
-                    if (isComplete)
-                    {
-                        _rejectContainer = handler._rejectContainer;
-                        handler.SuppressRejection = true;
-                        handler.MaybeDispose();
-                        HandleNextInternal(state);
-                        return;
-                    }
-                    handler.MaybeReportUnhandledAndDispose(state);
-                    MaybeDispose();
-                }
-            }
-
-            internal static MultiHandleablePromiseBase<VoidResult> GetOrCreateAllPromiseVoid(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits)
-            {
-                return MergePromiseVoid.GetOrCreate(promisePassThroughs, pendingAwaits);
-            }
-
-            internal sealed class MergePromiseT<TResult> : MultiHandleablePromiseBase<TResult>
-            {
-                private static GetResultDelegate<TResult> s_getResult;
-
-                [MethodImpl(InlineOption)]
-                private static MergePromiseT<TResult> GetOrCreate()
-                {
-                    // We take the base type instead of the concrete type because the base type re-pools with its type.
-                    var obj = ObjectPool.TryTakeOrInvalid<MergePromiseT<TResult>>();
-                    return obj == InvalidAwaitSentinel.s_instance
-                        ? new MergePromiseT<TResult>()
-                        : obj.UnsafeAs<MergePromiseT<TResult>>();
-                }
-
-                [MethodImpl(InlineOption)]
-                internal static MergePromiseT<TResult> GetOrCreate(
-                    ValueLinkedStack<PromisePassThrough> promisePassThroughs,
-                    in TResult value,
-                    int pendingAwaits,
-                    GetResultDelegate<TResult> getResultFunc)
-                {
-                    s_getResult = getResultFunc;
-                    var promise = GetOrCreate();
-                    promise._result = value;
-                    promise.Setup(promisePassThroughs, pendingAwaits);
-                    return promise;
-                }
-
-                internal override void MaybeDispose()
-                {
-                    if (InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1) == 0)
-                    {
-                        Dispose();
-                        ObjectPool.MaybeRepool(this);
-                    }
-                }
-
-                internal override sealed void Handle(PromiseRefBase handler, Promise.State state, int index)
-                {
+                    handler.SetCompletionState(state);
                     bool isComplete;
                     if (state == Promise.State.Resolved)
                     {
@@ -201,6 +321,27 @@ namespace Proto.Promises
                         _rejectContainer = handler._rejectContainer;
                         handler.SuppressRejection = true;
                         handler.MaybeDispose();
+                        InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
+                        HandleNextInternal(state);
+                        return;
+                    }
+                    handler.MaybeReportUnhandledAndDispose(state);
+                    MaybeDispose();
+                }
+
+                internal override void Handle(PromiseRefBase handler, Promise.State state)
+                {
+                    // This is called from void promises. They don't need to update any value, so they have no index.
+                    handler.SetCompletionState(state);
+                    bool isComplete = state == Promise.State.Resolved
+                        ? RemoveWaiterAndGetIsComplete(handler)
+                        : TrySetComplete(handler);
+                    if (isComplete)
+                    {
+                        _rejectContainer = handler._rejectContainer;
+                        handler.SuppressRejection = true;
+                        handler.MaybeDispose();
+                        InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
                         HandleNextInternal(state);
                         return;
                     }
@@ -210,23 +351,16 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static MultiHandleablePromiseBase<TResult> GetOrCreateMergePromise<TResult>(
-                ValueLinkedStack<PromisePassThrough> promisePassThroughs,
-                in TResult value,
-                int pendingAwaits,
-                GetResultDelegate<TResult> getResultFunc)
-            {
-                return MergePromiseT<TResult>.GetOrCreate(promisePassThroughs, value, pendingAwaits, getResultFunc);
-            }
+            internal static MergePromiseT<TResult> GetOrCreateMergePromise<TResult>(in TResult value, GetResultDelegate<TResult> getResultFunc)
+                => MergePromiseT<TResult>.GetOrCreate(value, getResultFunc);
 
-            internal sealed partial class MergeSettledPromise<TResult> : MultiHandleablePromiseBase<TResult>
+            internal sealed partial class MergeSettledPromise<TResult> : MergePromiseBase<TResult>
             {
                 private static GetResultContainerDelegate<TResult> s_getResult;
 
                 [MethodImpl(InlineOption)]
                 private static MergeSettledPromise<TResult> GetOrCreate()
                 {
-                    // We take the base type instead of the concrete type because the base type re-pools with its type.
                     var obj = ObjectPool.TryTakeOrInvalid<MergeSettledPromise<TResult>>();
                     return obj == InvalidAwaitSentinel.s_instance
                         ? new MergeSettledPromise<TResult>()
@@ -234,16 +368,12 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal static MergeSettledPromise<TResult> GetOrCreate(
-                    ValueLinkedStack<PromisePassThrough> promisePassThroughs,
-                    in TResult value,
-                    int pendingAwaits,
-                    GetResultContainerDelegate<TResult> getResultFunc)
+                internal static MergeSettledPromise<TResult> GetOrCreate(in TResult value, GetResultContainerDelegate<TResult> getResultFunc)
                 {
                     s_getResult = getResultFunc;
                     var promise = GetOrCreate();
+                    promise.Reset();
                     promise._result = value;
-                    promise.Setup(promisePassThroughs, pendingAwaits);
                     return promise;
                 }
 
@@ -256,14 +386,16 @@ namespace Proto.Promises
                     }
                 }
 
-                internal override sealed void Handle(PromiseRefBase handler, Promise.State state, int index)
+                internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
                 {
+                    handler.SetCompletionState(state);
                     _rejectContainer = handler._rejectContainer;
                     s_getResult.Invoke(handler, _rejectContainer, state, index, ref _result);
                     handler.SuppressRejection = true;
                     handler.MaybeDispose();
                     if (RemoveWaiterAndGetIsComplete(handler))
                     {
+                        InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
                         HandleNextInternal(Promise.State.Resolved);
                         return;
                     }
@@ -272,14 +404,8 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static MergeSettledPromise<TResult> GetOrCreateMergeSettledPromise<TResult>(
-                ValueLinkedStack<PromisePassThrough> promisePassThroughs,
-                in TResult value,
-                int pendingAwaits,
-                GetResultContainerDelegate<TResult> getResultFunc)
-            {
-                return MergeSettledPromise<TResult>.GetOrCreate(promisePassThroughs, value, pendingAwaits, getResultFunc);
-            }
+            internal static MergeSettledPromise<TResult> GetOrCreateMergeSettledPromise<TResult>(in TResult value, GetResultContainerDelegate<TResult> getResultFunc)
+                => MergeSettledPromise<TResult>.GetOrCreate(value, getResultFunc);
         } // class PromiseRefBase
     } // class Internal
 }

--- a/Package/Core/Promises/Internal/ParallelAsyncInternal.cs
+++ b/Package/Core/Promises/Internal/ParallelAsyncInternal.cs
@@ -105,6 +105,7 @@ namespace Proto.Promises
 
                 internal override void MaybeDispose()
                 {
+                    ValidateNoPending();
                     Dispose();
                     _body = default(TParallelBody);
                     _synchronizationContext = null;
@@ -358,7 +359,7 @@ namespace Proto.Promises
 
                 internal override void Handle(PromiseRefBase handler, Promise.State state)
                 {
-                    RemovePending(handler);
+                    RemoveComplete(handler);
                     var rejectContainer = handler._rejectContainer;
                     handler.SuppressRejection = true;
                     handler.SetCompletionState(state);
@@ -506,7 +507,7 @@ namespace Proto.Promises
 
                 void IDelegateContinue.Invoke(PromiseRefBase handler, IRejectContainer rejectContainer, Promise.State state, PromiseRefBase owner)
                 {
-                    RemovePending(handler);
+                    RemoveComplete(handler);
                     if (state == Promise.State.Rejected)
                     {
                         RecordRejection(rejectContainer);
@@ -519,8 +520,9 @@ namespace Proto.Promises
                     OnComplete();
                 }
 
+                partial void ValidateNoPending();
                 partial void AddPending(PromiseRefBase pendingPromise);
-                partial void RemovePending(PromiseRefBase completePromise);
+                partial void RemoveComplete(PromiseRefBase completePromise);
             } // class PromiseParallelForEach
         } // class PromiseRefBase
     } // class Internal

--- a/Package/Core/Promises/Internal/ParallelInternal.cs
+++ b/Package/Core/Promises/Internal/ParallelInternal.cs
@@ -261,6 +261,7 @@ namespace Proto.Promises
 
                 internal override void MaybeDispose()
                 {
+                    ValidateNoPending();
                     Dispose();
                     _body = default(TParallelBody);
                     _synchronizationContext = null;
@@ -382,7 +383,7 @@ namespace Proto.Promises
 
                 internal override void Handle(PromiseRefBase handler, Promise.State state)
                 {
-                    RemovePending(handler);
+                    RemoveComplete(handler);
                     var rejectContainer = handler._rejectContainer;
                     handler.SuppressRejection = true;
                     handler.SetCompletionState(state);
@@ -459,8 +460,9 @@ namespace Proto.Promises
                     }
                 }
 
+                partial void ValidateNoPending();
                 partial void AddPending(PromiseRefBase pendingPromise);
-                partial void RemovePending(PromiseRefBase completePromise);
+                partial void RemoveComplete(PromiseRefBase completePromise);
             } // class PromiseParallelForEach
         } // class PromiseRefBase
     } // class Internal

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -354,10 +354,6 @@ namespace Proto.Promises
             {
                 protected int _waitCount;
                 protected int _retainCounter;
-                // TODO: progress was removed, we probably don't need to store the passthroughs anymore.
-                // We store the passthroughs for lazy progress subscribe.
-                // The passthroughs will be released when this has fully released if a progress listener did not do it already.
-                protected ValueLinkedStack<PromisePassThrough> _passThroughs;
             }
 
             partial class RacePromise<TResult> : MultiHandleablePromiseBase<TResult>
@@ -378,6 +374,8 @@ namespace Proto.Promises
 
             partial class PromisePassThrough : HandleablePromiseBase
             {
+                // TODO: we can store target in _next field, and we only need to store owner in DEBUG mode.
+                // We also probably don't need to store id anymore if we hook up directly to the MultiHandleablePromiseBase.
                 private PromiseRefBase _owner;
                 private HandleablePromiseBase _target;
                 private int _index;

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -378,11 +378,7 @@ namespace Proto.Promises
                 protected int _waitCount; // int for Interlocked since it doesn't support uint on older runtimes.
             }
 
-            partial class MergePromiseVoid : MergePromiseBase<VoidResult>
-            {
-            }
-
-            partial class MergePromiseT<TResult> : MergePromiseBase<TResult>
+            partial class MergePromise<TResult> : MergePromiseBase<TResult>
             {
             }
 

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -352,8 +352,8 @@ namespace Proto.Promises
 #region Multi Promises
             partial class MultiHandleablePromiseBase<TResult> : PromiseSingleAwait<TResult>
             {
-                protected int _waitCount;
                 protected int _retainCounter;
+                protected int _isComplete; // Flag used to indicate that the promise has already been completed. int for Interlocked.
             }
 
             partial class RacePromise<TResult> : MultiHandleablePromiseBase<TResult>
@@ -366,21 +366,35 @@ namespace Proto.Promises
 
             partial class FirstPromise<TResult> : RacePromise<TResult>
             {
+                protected int _waitCount; // int for Interlocked since it doesn't support uint on older runtimes.
             }
 
             partial class FirstPromiseWithIndex<TResult> : FirstPromise<ValueTuple<int, TResult>>
             {
             }
 
+            partial class MergePromiseBase<TResult> : MultiHandleablePromiseBase<TResult>
+            {
+                protected int _waitCount; // int for Interlocked since it doesn't support uint on older runtimes.
+            }
+
+            partial class MergePromiseVoid : MergePromiseBase<VoidResult>
+            {
+            }
+
+            partial class MergePromiseT<TResult> : MergePromiseBase<TResult>
+            {
+            }
+
+            partial class MergeSettledPromise<TResult> : MergePromiseBase<TResult>
+            {
+            }
+
             partial class PromisePassThrough : HandleablePromiseBase
             {
-                // TODO: we can store target in _next field, and we only need to store owner in DEBUG mode.
-                // We also probably don't need to store id anymore if we hook up directly to the MultiHandleablePromiseBase.
-                private PromiseRefBase _owner;
-                private HandleablePromiseBase _target;
                 private int _index;
-                private short _id;
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                private PromiseRefBase _owner;
                 private bool _disposed;
 #endif
             }

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -8,6 +8,7 @@
 #pragma warning disable IDE0018 // Inline variable declaration
 #pragma warning disable IDE0031 // Use null propagation
 #pragma warning disable IDE0034 // Simplify 'default' expression
+#pragma warning disable IDE0074 // Use compound assignment
 #pragma warning disable IDE0083 // Use pattern matching
 #pragma warning disable IDE0250 // Make struct 'readonly'
 #pragma warning disable IDE0251 // Make member 'readonly'
@@ -2090,49 +2091,21 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal sealed partial class PromisePassThrough : HandleablePromiseBase, ILinked<PromisePassThrough>
+            internal sealed partial class PromisePassThrough : HandleablePromiseBase
             {
-                PromisePassThrough ILinked<PromisePassThrough>.Next
-                {
-                    [MethodImpl(InlineOption)]
-                    get { return _next.UnsafeAs<PromisePassThrough>(); }
-                    [MethodImpl(InlineOption)]
-                    set { _next = value; }
-                }
-
-                internal PromiseRefBase Owner
-                {
-                    [MethodImpl(InlineOption)]
-                    get
-                    {
-                        ThrowIfInPool(this);
-                        return _owner;
-                    }
-                }
-
-                private PromisePassThrough() { }
-
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
                 ~PromisePassThrough()
                 {
-                    try
+                    if (!_disposed)
                     {
-                        if (!_disposed)
-                        {
-                            // For debugging. This should never happen.
-                            string message = "A PromisePassThrough was garbage collected without it being released."
-                                + " _id: " + _id + ", _index: " + _index + ", Owner: " + Owner
-                                ;
-                            ReportRejection(new UnreleasedObjectException(message), Owner);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        // This should never happen.
-                        ReportRejection(e, Owner);
+                        // For debugging. This should never happen.
+                        string message = $"A PromisePassThrough was garbage collected without it being released. _index: {_index}, _owner: {_owner}, _next: {_next}";
+                        ReportRejection(new UnreleasedObjectException(message), _owner);
                     }
                 }
 #endif
+
+                private PromisePassThrough() { }
 
                 [MethodImpl(InlineOption)]
                 private static PromisePassThrough GetOrCreate()
@@ -2143,32 +2116,24 @@ namespace Proto.Promises
                         : obj.UnsafeAs<PromisePassThrough>();
                 }
 
-                internal static PromisePassThrough GetOrCreate(Promise owner, int index)
+                [MethodImpl(InlineOption)]
+                internal static PromisePassThrough GetOrCreate(PromiseRefBase owner, PromiseRefBase target, int index)
                 {
                     var passThrough = GetOrCreate();
-                    passThrough._next = null;
-                    passThrough._owner = owner._ref;
-                    passThrough._id = owner._id;
+                    passThrough._next = target;
                     passThrough._index = index;
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    passThrough._owner = owner;
                     passThrough._disposed = false;
 #endif
                     return passThrough;
                 }
 
-                internal void SetTargetAndAddToOwner(PromiseRefBase target)
-                {
-                    ThrowIfInPool(this);
-                    _target = target;
-                    _owner.HookupNewWaiter(_id, this);
-                }
-
                 internal override void Handle(PromiseRefBase handler, Promise.State state)
                 {
-                    var target = _target;
+                    var target = _next;
                     var index = _index;
                     Dispose();
-                    handler.SetCompletionState(state);
                     target.Handle(handler, state, index);
                 }
 
@@ -2177,80 +2142,13 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
 
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    _owner = null;
                     _disposed = true;
 #endif
-                    _owner = null;
-                    _target = null;
                     ObjectPool.MaybeRepool(this);
                 }
-            } // PromisePassThrough
-
-            internal static void MaybeMarkAwaitedAndDispose(PromiseRefBase promise, short id, bool suppressRejection)
-            {
-                if (promise != null)
-                {
-                    // Suppress rejection before dispose, since the dispose checks the flag. This may still set the flag if the id doesn't match, but that's not a big deal if it happens.
-                    // We only enable SuppressRejection, never disable.
-                    promise.SuppressRejection |= suppressRejection;
-                    promise.MaybeMarkAwaitedAndDispose(id);
-                }
-            }
-        } // PromiseRefBase
-
-        [MethodImpl(InlineOption)]
-        internal static void MaybeMarkAwaitedAndDispose(PromiseRefBase promise, short id, bool suppressRejection)
-        {
-            PromiseRefBase.MaybeMarkAwaitedAndDispose(promise, id, suppressRejection);
-        }
-
-        internal static void PrepareForMerge(Promise promise, ref ValueLinkedStack<PromiseRefBase.PromisePassThrough> passThroughs, int index, ref int pendingAwaits)
-        {
-            if (promise._ref != null)
-            {
-                passThroughs.Push(PromiseRefBase.PromisePassThrough.GetOrCreate(promise, index));
-                checked
-                {
-                    ++pendingAwaits;
-                }
-            }
-        }
-
-        internal static void PrepareForMerge<T>(Promise<T> promise, ref T value, ref ValueLinkedStack<PromiseRefBase.PromisePassThrough> passThroughs, int index, ref int pendingAwaits)
-        {
-            if (promise._ref == null)
-            {
-                value = promise._result;
-            }
-            else
-            {
-                passThroughs.Push(PromiseRefBase.PromisePassThrough.GetOrCreate(promise, index));
-                checked
-                {
-                    ++pendingAwaits;
-                }
-            }
-        }
-
-        internal static bool TryPrepareForRace(Promise promise, ref ValueLinkedStack<PromiseRefBase.PromisePassThrough> passThroughs, int index)
-        {
-            if (promise._ref != null)
-            {
-                passThroughs.Push(PromiseRefBase.PromisePassThrough.GetOrCreate(promise, index));
-                return true;
-            }
-            return false;
-        }
-
-        internal static bool TryPrepareForRace<T>(Promise<T> promise, ref T value, ref ValueLinkedStack<PromiseRefBase.PromisePassThrough> passThroughs, int index)
-        {
-            if (promise._ref == null)
-            {
-                value = promise._result;
-                return false;
-            }
-            passThroughs.Push(PromiseRefBase.PromisePassThrough.GetOrCreate(promise, index));
-            return true;
-        }
+            } // class PromisePassThrough
+        } // class PromiseRefBase
 
         [MethodImpl(InlineOption)]
         internal static Promise CreateCanceled()
@@ -2279,5 +2177,5 @@ namespace Proto.Promises
 #endif
             return new Promise<T>(promise, promise.Id);
         }
-    } // Internal
+    } // class Internal
 }

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -8,7 +8,6 @@
 #pragma warning disable IDE0018 // Inline variable declaration
 #pragma warning disable IDE0031 // Use null propagation
 #pragma warning disable IDE0034 // Simplify 'default' expression
-#pragma warning disable IDE0074 // Use compound assignment
 #pragma warning disable IDE0083 // Use pattern matching
 #pragma warning disable IDE0250 // Make struct 'readonly'
 #pragma warning disable IDE0251 // Make member 'readonly'

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -2110,26 +2110,6 @@ namespace Proto.Promises
                     }
                 }
 
-                internal int Index
-                {
-                    [MethodImpl(InlineOption)]
-                    get
-                    {
-                        ThrowIfInPool(this);
-                        return _index;
-                    }
-                }
-
-                internal short Id
-                {
-                    [MethodImpl(InlineOption)]
-                    get
-                    {
-                        ThrowIfInPool(this);
-                        return _id;
-                    }
-                }
-
                 private PromisePassThrough() { }
 
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
@@ -2185,9 +2165,11 @@ namespace Proto.Promises
 
                 internal override void Handle(PromiseRefBase handler, Promise.State state)
                 {
-                    ThrowIfInPool(this);
+                    var target = _target;
+                    var index = _index;
+                    Dispose();
                     handler.SetCompletionState(state);
-                    _target.Handle(handler, state, Index);
+                    target.Handle(handler, state, index);
                 }
 
                 internal void Dispose()

--- a/Package/Core/Promises/Internal/RaceInternal.cs
+++ b/Package/Core/Promises/Internal/RaceInternal.cs
@@ -36,7 +36,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                private static RacePromise<TResult> GetOrCreate()
+                private static RacePromise<TResult> GetOrCreateInstance()
                 {
                     var obj = ObjectPool.TryTakeOrInvalid<RacePromise<TResult>>();
                     return obj == InvalidAwaitSentinel.s_instance
@@ -44,21 +44,23 @@ namespace Proto.Promises
                         : obj.UnsafeAs<RacePromise<TResult>>();
                 }
 
-                internal static RacePromise<TResult> GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits)
+                internal static RacePromise<TResult> GetOrCreate()
                 {
-                    var promise = GetOrCreate();
-                    promise.Setup(promisePassThroughs, pendingAwaits);
+                    var promise = GetOrCreateInstance();
+                    promise.Reset();
                     return promise;
                 }
 
-                internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
+                internal override void Handle(PromiseRefBase handler, Promise.State state)
                 {
+                    handler.SetCompletionState(state);
                     if (TrySetComplete(handler))
                     {
                         _result = handler.GetResult<TResult>();
                         _rejectContainer = handler._rejectContainer;
                         handler.SuppressRejection = true;
                         handler.MaybeDispose();
+                        InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
                         HandleNextInternal(state);
                         return;
                     }
@@ -89,7 +91,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                private static RacePromiseWithIndexVoid GetOrCreate()
+                private static RacePromiseWithIndexVoid GetOrCreateInstance()
                 {
                     var obj = ObjectPool.TryTakeOrInvalid<RacePromiseWithIndexVoid>();
                     return obj == InvalidAwaitSentinel.s_instance
@@ -97,21 +99,23 @@ namespace Proto.Promises
                         : obj.UnsafeAs<RacePromiseWithIndexVoid>();
                 }
 
-                new internal static RacePromiseWithIndexVoid GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits)
+                new internal static RacePromiseWithIndexVoid GetOrCreate()
                 {
-                    var promise = GetOrCreate();
-                    promise.Setup(promisePassThroughs, pendingAwaits);
+                    var promise = GetOrCreateInstance();
+                    promise.Reset();
                     return promise;
                 }
 
                 internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
                 {
+                    handler.SetCompletionState(state);
                     if (TrySetComplete(handler))
                     {
                         _result = index;
                         _rejectContainer = handler._rejectContainer;
                         handler.SuppressRejection = true;
                         handler.MaybeDispose();
+                        InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
                         HandleNextInternal(state);
                         return;
                     }
@@ -123,7 +127,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal sealed partial class RacePromiseWithIndex<TResult> : RacePromise<ValueTuple<int, TResult>>
+            internal sealed partial class RacePromiseWithIndex<TResult> : RacePromise<(int, TResult)>
             {
                 private RacePromiseWithIndex() { }
 
@@ -142,7 +146,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                private static RacePromiseWithIndex<TResult> GetOrCreate()
+                private static RacePromiseWithIndex<TResult> GetOrCreateInstance()
                 {
                     var obj = ObjectPool.TryTakeOrInvalid<RacePromiseWithIndex<TResult>>();
                     return obj == InvalidAwaitSentinel.s_instance
@@ -150,21 +154,23 @@ namespace Proto.Promises
                         : obj.UnsafeAs<RacePromiseWithIndex<TResult>>();
                 }
 
-                new internal static RacePromiseWithIndex<TResult> GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits)
+                new internal static RacePromiseWithIndex<TResult> GetOrCreate()
                 {
-                    var promise = GetOrCreate();
-                    promise.Setup(promisePassThroughs, pendingAwaits);
+                    var promise = GetOrCreateInstance();
+                    promise.Reset();
                     return promise;
                 }
 
                 internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
                 {
+                    handler.SetCompletionState(state);
                     if (TrySetComplete(handler))
                     {
-                        _result = new ValueTuple<int, TResult>(index, handler.GetResult<TResult>());
+                        _result = (index, handler.GetResult<TResult>());
                         _rejectContainer = handler._rejectContainer;
                         handler.SuppressRejection = true;
                         handler.MaybeDispose();
+                        InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
                         HandleNextInternal(state);
                         return;
                     }
@@ -195,7 +201,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                private static FirstPromise<TResult> GetOrCreate()
+                private static FirstPromise<TResult> GetOrCreateInstance()
                 {
                     var obj = ObjectPool.TryTakeOrInvalid<FirstPromise<TResult>>();
                     return obj == InvalidAwaitSentinel.s_instance
@@ -203,24 +209,41 @@ namespace Proto.Promises
                         : obj.UnsafeAs<FirstPromise<TResult>>();
                 }
 
-                new internal static FirstPromise<TResult> GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits)
+                new internal static FirstPromise<TResult> GetOrCreate()
                 {
-                    var promise = GetOrCreate();
-                    promise.Setup(promisePassThroughs, pendingAwaits);
+                    var promise = GetOrCreateInstance();
+                    promise.Reset();
                     return promise;
                 }
 
-                internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
+                [MethodImpl(InlineOption)]
+                new protected void Reset()
                 {
+                    _waitCount = -1; // uint.MaxValue
+                    base.Reset();
+                }
+
+                [MethodImpl(InlineOption)]
+                protected bool RemoveWaiterAndGetIsComplete(PromiseRefBase completePromise)
+                    => RemoveWaiterAndGetIsComplete(completePromise, ref _waitCount);
+
+                [MethodImpl(InlineOption)]
+                internal void MarkReady(uint totalWaiters)
+                    => MarkReady(totalWaiters, ref _waitCount, Promise.State.Canceled);
+
+                internal override void Handle(PromiseRefBase handler, Promise.State state)
+                {
+                    handler.SetCompletionState(state);
                     bool isComplete = state == Promise.State.Resolved
                         ? TrySetComplete(handler)
                         : RemoveWaiterAndGetIsComplete(handler);
+                    _rejectContainer = handler._rejectContainer;
                     handler.SuppressRejection = true;
                     if (isComplete)
                     {
                         _result = handler.GetResult<TResult>();
-                        _rejectContainer = handler._rejectContainer;
                         handler.MaybeDispose();
+                        InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
                         HandleNextInternal(state);
                         return;
                     }
@@ -251,7 +274,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                private static FirstPromiseWithIndexVoid GetOrCreate()
+                private static FirstPromiseWithIndexVoid GetOrCreateInstance()
                 {
                     var obj = ObjectPool.TryTakeOrInvalid<FirstPromiseWithIndexVoid>();
                     return obj == InvalidAwaitSentinel.s_instance
@@ -259,24 +282,26 @@ namespace Proto.Promises
                         : obj.UnsafeAs<FirstPromiseWithIndexVoid>();
                 }
 
-                new internal static FirstPromiseWithIndexVoid GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits)
+                new internal static FirstPromiseWithIndexVoid GetOrCreate()
                 {
-                    var promise = GetOrCreate();
-                    promise.Setup(promisePassThroughs, pendingAwaits);
+                    var promise = GetOrCreateInstance();
+                    promise.Reset();
                     return promise;
                 }
 
                 internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
                 {
+                    handler.SetCompletionState(state);
                     bool isComplete = handler.State == Promise.State.Resolved
                         ? TrySetComplete(handler)
                         : RemoveWaiterAndGetIsComplete(handler);
+                    _rejectContainer = handler._rejectContainer;
                     handler.SuppressRejection = true;
                     if (isComplete)
                     {
                         _result = index;
-                        _rejectContainer = handler._rejectContainer;
                         handler.MaybeDispose();
+                        InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
                         HandleNextInternal(state);
                         return;
                     }
@@ -288,7 +313,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal sealed partial class FirstPromiseWithIndex<TResult> : FirstPromise<ValueTuple<int, TResult>>
+            internal sealed partial class FirstPromiseWithIndex<TResult> : FirstPromise<(int, TResult)>
             {
                 private FirstPromiseWithIndex() { }
 
@@ -307,7 +332,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                private static FirstPromiseWithIndex<TResult> GetOrCreate()
+                private static FirstPromiseWithIndex<TResult> GetOrCreateInstance()
                 {
                     var obj = ObjectPool.TryTakeOrInvalid<FirstPromiseWithIndex<TResult>>();
                     return obj == InvalidAwaitSentinel.s_instance
@@ -315,24 +340,26 @@ namespace Proto.Promises
                         : obj.UnsafeAs<FirstPromiseWithIndex<TResult>>();
                 }
 
-                new internal static FirstPromiseWithIndex<TResult> GetOrCreate(ValueLinkedStack<PromisePassThrough> promisePassThroughs, int pendingAwaits)
+                new internal static FirstPromiseWithIndex<TResult> GetOrCreate()
                 {
-                    var promise = GetOrCreate();
-                    promise.Setup(promisePassThroughs, pendingAwaits);
+                    var promise = GetOrCreateInstance();
+                    promise.Reset();
                     return promise;
                 }
 
                 internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
                 {
+                    handler.SetCompletionState(state);
                     bool isComplete = handler.State == Promise.State.Resolved
                         ? TrySetComplete(handler)
                         : RemoveWaiterAndGetIsComplete(handler);
+                    _rejectContainer = handler._rejectContainer;
                     handler.SuppressRejection = true;
                     if (isComplete)
                     {
-                        _result = new ValueTuple<int, TResult>(index, handler.GetResult<TResult>());
-                        _rejectContainer = handler._rejectContainer;
+                        _result = (index, handler.GetResult<TResult>());
                         handler.MaybeDispose();
+                        InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
                         HandleNextInternal(state);
                         return;
                     }

--- a/Package/Core/Promises/Internal/RaceInternal.cs
+++ b/Package/Core/Promises/Internal/RaceInternal.cs
@@ -53,7 +53,7 @@ namespace Proto.Promises
 
                 internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
                 {
-                    if (TrySetComplete())
+                    if (TrySetComplete(handler))
                     {
                         _result = handler.GetResult<TResult>();
                         _rejectContainer = handler._rejectContainer;
@@ -106,7 +106,7 @@ namespace Proto.Promises
 
                 internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
                 {
-                    if (TrySetComplete())
+                    if (TrySetComplete(handler))
                     {
                         _result = index;
                         _rejectContainer = handler._rejectContainer;
@@ -159,7 +159,7 @@ namespace Proto.Promises
 
                 internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
                 {
-                    if (TrySetComplete())
+                    if (TrySetComplete(handler))
                     {
                         _result = new ValueTuple<int, TResult>(index, handler.GetResult<TResult>());
                         _rejectContainer = handler._rejectContainer;
@@ -213,8 +213,8 @@ namespace Proto.Promises
                 internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
                 {
                     bool isComplete = state == Promise.State.Resolved
-                        ? TrySetComplete()
-                        : RemoveWaiterAndGetIsComplete();
+                        ? TrySetComplete(handler)
+                        : RemoveWaiterAndGetIsComplete(handler);
                     handler.SuppressRejection = true;
                     if (isComplete)
                     {
@@ -269,8 +269,8 @@ namespace Proto.Promises
                 internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
                 {
                     bool isComplete = handler.State == Promise.State.Resolved
-                        ? TrySetComplete()
-                        : RemoveWaiterAndGetIsComplete();
+                        ? TrySetComplete(handler)
+                        : RemoveWaiterAndGetIsComplete(handler);
                     handler.SuppressRejection = true;
                     if (isComplete)
                     {
@@ -325,8 +325,8 @@ namespace Proto.Promises
                 internal override void Handle(PromiseRefBase handler, Promise.State state, int index)
                 {
                     bool isComplete = handler.State == Promise.State.Resolved
-                        ? TrySetComplete()
-                        : RemoveWaiterAndGetIsComplete();
+                        ? TrySetComplete(handler)
+                        : RemoveWaiterAndGetIsComplete(handler);
                     handler.SuppressRejection = true;
                     if (isComplete)
                     {

--- a/Package/Core/Promises/PromiseStaticMerge.cs
+++ b/Package/Core/Promises/PromiseStaticMerge.cs
@@ -303,7 +303,7 @@ namespace Proto.Promises
             ref (T1, T2) valueRef = ref value;
             uint pendingCount = 0;
             var mergeResultFunc = MergeResultFuncs.GetTwo<T1, T2>();
-            Internal.PromiseRefBase.MergePromiseT<(T1, T2)> promise = null;
+            Internal.PromiseRefBase.MergePromise<(T1, T2)> promise = null;
 
             Internal.PrepareForMerge(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
             // It would be nice to be able to ref-reassign inside the PrepareForMerge helper to avoid an extra branch,
@@ -333,7 +333,7 @@ namespace Proto.Promises
             ref (T1, T2) valueRef = ref value;
             uint pendingCount = 0;
             var mergeResultFunc = MergeResultFuncs.GetTwo<T1, T2>();
-            Internal.PromiseRefBase.MergePromiseT<(T1, T2)> promise = null;
+            Internal.PromiseRefBase.MergePromise<(T1, T2)> promise = null;
 
             Internal.PrepareForMerge(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
             // It would be nice to be able to ref-reassign inside the PrepareForMerge helper to avoid an extra branch,
@@ -406,7 +406,7 @@ namespace Proto.Promises
             ref (T1, T2, T3) valueRef = ref value;
             uint pendingCount = 0;
             var mergeResultFunc = MergeResultFuncs.GetThree<T1, T2, T3>();
-            Internal.PromiseRefBase.MergePromiseT<(T1, T2, T3)> promise = null;
+            Internal.PromiseRefBase.MergePromise<(T1, T2, T3)> promise = null;
 
             Internal.PrepareForMerge(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
             // It would be nice to be able to ref-reassign inside the PrepareForMerge helper to avoid extra branches,
@@ -439,7 +439,7 @@ namespace Proto.Promises
             ref (T1, T2, T3) valueRef = ref value;
             uint pendingCount = 0;
             var mergeResultFunc = MergeResultFuncs.GetThree<T1, T2, T3>();
-            Internal.PromiseRefBase.MergePromiseT<(T1, T2, T3)> promise = null;
+            Internal.PromiseRefBase.MergePromise<(T1, T2, T3)> promise = null;
 
             Internal.PrepareForMerge(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
             // It would be nice to be able to ref-reassign inside the PrepareForMerge helper to avoid extra branches,
@@ -518,7 +518,7 @@ namespace Proto.Promises
             ref (T1, T2, T3, T4) valueRef = ref value;
             uint pendingCount = 0;
             var mergeResultFunc = MergeResultFuncs.GetFour<T1, T2, T3, T4>();
-            Internal.PromiseRefBase.MergePromiseT<(T1, T2, T3, T4)> promise = null;
+            Internal.PromiseRefBase.MergePromise<(T1, T2, T3, T4)> promise = null;
 
             Internal.PrepareForMerge(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
             // It would be nice to be able to ref-reassign inside the PrepareForMerge helper to avoid extra branches,
@@ -554,7 +554,7 @@ namespace Proto.Promises
             ref (T1, T2, T3, T4) valueRef = ref value;
             uint pendingCount = 0;
             var mergeResultFunc = MergeResultFuncs.GetFour<T1, T2, T3, T4>();
-            Internal.PromiseRefBase.MergePromiseT<(T1, T2, T3, T4)> promise = null;
+            Internal.PromiseRefBase.MergePromise<(T1, T2, T3, T4)> promise = null;
 
             Internal.PrepareForMerge(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
             // It would be nice to be able to ref-reassign inside the PrepareForMerge helper to avoid extra branches,
@@ -639,7 +639,7 @@ namespace Proto.Promises
             ref (T1, T2, T3, T4, T5) valueRef = ref value;
             uint pendingCount = 0;
             var mergeResultFunc = MergeResultFuncs.GetFive<T1, T2, T3, T4, T5>();
-            Internal.PromiseRefBase.MergePromiseT<(T1, T2, T3, T4, T5)> promise = null;
+            Internal.PromiseRefBase.MergePromise<(T1, T2, T3, T4, T5)> promise = null;
 
             Internal.PrepareForMerge(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
             // It would be nice to be able to ref-reassign inside the PrepareForMerge helper to avoid extra branches,
@@ -678,7 +678,7 @@ namespace Proto.Promises
             ref (T1, T2, T3, T4, T5) valueRef = ref value;
             uint pendingCount = 0;
             var mergeResultFunc = MergeResultFuncs.GetFive<T1, T2, T3, T4, T5>();
-            Internal.PromiseRefBase.MergePromiseT<(T1, T2, T3, T4, T5)> promise = null;
+            Internal.PromiseRefBase.MergePromise<(T1, T2, T3, T4, T5)> promise = null;
 
             Internal.PrepareForMerge(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
             // It would be nice to be able to ref-reassign inside the PrepareForMerge helper to avoid extra branches,
@@ -769,7 +769,7 @@ namespace Proto.Promises
             ref (T1, T2, T3, T4, T5, T6) valueRef = ref value;
             uint pendingCount = 0;
             var mergeResultFunc = MergeResultFuncs.GetSix<T1, T2, T3, T4, T5, T6>();
-            Internal.PromiseRefBase.MergePromiseT<(T1, T2, T3, T4, T5, T6)> promise = null;
+            Internal.PromiseRefBase.MergePromise<(T1, T2, T3, T4, T5, T6)> promise = null;
 
             Internal.PrepareForMerge(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
             // It would be nice to be able to ref-reassign inside the PrepareForMerge helper to avoid extra branches,
@@ -811,7 +811,7 @@ namespace Proto.Promises
             ref (T1, T2, T3, T4, T5, T6) valueRef = ref value;
             uint pendingCount = 0;
             var mergeResultFunc = MergeResultFuncs.GetSix<T1, T2, T3, T4, T5, T6>();
-            Internal.PromiseRefBase.MergePromiseT<(T1, T2, T3, T4, T5, T6)> promise = null;
+            Internal.PromiseRefBase.MergePromise<(T1, T2, T3, T4, T5, T6)> promise = null;
 
             Internal.PrepareForMerge(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
             // It would be nice to be able to ref-reassign inside the PrepareForMerge helper to avoid extra branches,
@@ -908,7 +908,7 @@ namespace Proto.Promises
             ref (T1, T2, T3, T4, T5, T6, T7) valueRef = ref value;
             uint pendingCount = 0;
             var mergeResultFunc = MergeResultFuncs.GetSeven<T1, T2, T3, T4, T5, T6, T7>();
-            Internal.PromiseRefBase.MergePromiseT<(T1, T2, T3, T4, T5, T6, T7)> promise = null;
+            Internal.PromiseRefBase.MergePromise<(T1, T2, T3, T4, T5, T6, T7)> promise = null;
 
             Internal.PrepareForMerge(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
             // It would be nice to be able to ref-reassign inside the PrepareForMerge helper to avoid extra branches,
@@ -953,7 +953,7 @@ namespace Proto.Promises
             ref (T1, T2, T3, T4, T5, T6, T7) valueRef = ref value;
             uint pendingCount = 0;
             var mergeResultFunc = MergeResultFuncs.GetSeven<T1, T2, T3, T4, T5, T6, T7>();
-            Internal.PromiseRefBase.MergePromiseT<(T1, T2, T3, T4, T5, T6, T7)> promise = null;
+            Internal.PromiseRefBase.MergePromise<(T1, T2, T3, T4, T5, T6, T7)> promise = null;
 
             Internal.PrepareForMerge(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
             // It would be nice to be able to ref-reassign inside the PrepareForMerge helper to avoid extra branches,

--- a/Package/Core/Promises/PromiseStaticMerge.cs
+++ b/Package/Core/Promises/PromiseStaticMerge.cs
@@ -21,20 +21,9 @@ namespace Proto.Promises
         /// </summary>
         public static Promise All(Promise promise1, Promise promise2)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
-
-            if (pendingCount == 0)
-            {
-                return Resolved();
-            }
-            var promise = Internal.PromiseRefBase.GetOrCreateAllPromiseVoid(passThroughs, pendingCount);
-            return new Promise(promise, promise.Id);
+            return All(Internal.GetEnumerator(promise1, promise2));
         }
 
         /// <summary>
@@ -43,22 +32,10 @@ namespace Proto.Promises
         /// </summary>
         public static Promise All(Promise promise1, Promise promise2, Promise promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
-
-            if (pendingCount == 0)
-            {
-                return Resolved();
-            }
-            var promise = Internal.PromiseRefBase.GetOrCreateAllPromiseVoid(passThroughs, pendingCount);
-            return new Promise(promise, promise.Id);
+            return All(Internal.GetEnumerator(promise1, promise2, promise3));
         }
 
         /// <summary>
@@ -67,24 +44,11 @@ namespace Proto.Promises
         /// </summary>
         public static Promise All(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
-
-            if (pendingCount == 0)
-            {
-                return Resolved();
-            }
-            var promise = Internal.PromiseRefBase.GetOrCreateAllPromiseVoid(passThroughs, pendingCount);
-            return new Promise(promise, promise.Id);
+            return All(Internal.GetEnumerator(promise1, promise2, promise3, promise4));
         }
 
         /// <summary>

--- a/Package/Core/Promises/PromiseStaticMergeSettled.cs
+++ b/Package/Core/Promises/PromiseStaticMergeSettled.cs
@@ -40,41 +40,9 @@ namespace Proto.Promises
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new 1 will be created.</param>
         public static Promise<IList<ResultContainer>> AllSettled(Promise promise1, Promise promise2, IList<ResultContainer> valueContainer = null)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
-
-            if (valueContainer == null)
-            {
-                valueContainer = new ResultContainer[2];
-            }
-            else
-            {
-                // Make sure list has the same count as promises.
-                int listSize = valueContainer.Count;
-                while (listSize > 2)
-                {
-                    valueContainer.RemoveAt(--listSize);
-                }
-                while (listSize < 2)
-                {
-                    valueContainer.Add(default(ResultContainer));
-                    ++listSize;
-                }
-            }
-            valueContainer[0] = ResultContainer.Resolved;
-            valueContainer[1] = ResultContainer.Resolved;
-
-            if (pendingCount == 0)
-            {
-                return Resolved(valueContainer);
-            }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, valueContainer, pendingCount, GetAllResultContainerFunc);
-            return new Promise<IList<ResultContainer>>(promise, promise.Id);
+            return AllSettled(Internal.GetEnumerator(promise1, promise2));
         }
 
         /// <summary>
@@ -86,44 +54,10 @@ namespace Proto.Promises
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new 1 will be created.</param>
         public static Promise<IList<ResultContainer>> AllSettled(Promise promise1, Promise promise2, Promise promise3, IList<ResultContainer> valueContainer = null)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
-
-            if (valueContainer == null)
-            {
-                valueContainer = new ResultContainer[3];
-            }
-            else
-            {
-                // Make sure list has the same count as promises.
-                int listSize = valueContainer.Count;
-                while (listSize > 3)
-                {
-                    valueContainer.RemoveAt(--listSize);
-                }
-                while (listSize < 3)
-                {
-                    valueContainer.Add(default(ResultContainer));
-                    ++listSize;
-                }
-            }
-            valueContainer[0] = ResultContainer.Resolved;
-            valueContainer[1] = ResultContainer.Resolved;
-            valueContainer[2] = ResultContainer.Resolved;
-
-            if (pendingCount == 0)
-            {
-                return Resolved(valueContainer);
-            }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, valueContainer, pendingCount, GetAllResultContainerFunc);
-            return new Promise<IList<ResultContainer>>(promise, promise.Id);
+            return AllSettled(Internal.GetEnumerator(promise1, promise2, promise3));
         }
 
         /// <summary>
@@ -136,47 +70,11 @@ namespace Proto.Promises
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new 1 will be created.</param>
         public static Promise<IList<ResultContainer>> AllSettled(Promise promise1, Promise promise2, Promise promise3, Promise promise4, IList<ResultContainer> valueContainer = null)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
-
-            if (valueContainer == null)
-            {
-                valueContainer = new ResultContainer[4];
-            }
-            else
-            {
-                // Make sure list has the same count as promises.
-                int listSize = valueContainer.Count;
-                while (listSize > 4)
-                {
-                    valueContainer.RemoveAt(--listSize);
-                }
-                while (listSize < 4)
-                {
-                    valueContainer.Add(default(ResultContainer));
-                    ++listSize;
-                }
-            }
-            valueContainer[0] = ResultContainer.Resolved;
-            valueContainer[1] = ResultContainer.Resolved;
-            valueContainer[2] = ResultContainer.Resolved;
-            valueContainer[3] = ResultContainer.Resolved;
-
-            if (pendingCount == 0)
-            {
-                return Resolved(valueContainer);
-            }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, valueContainer, pendingCount, GetAllResultContainerFunc);
-            return new Promise<IList<ResultContainer>>(promise, promise.Id);
+            return AllSettled(Internal.GetEnumerator(promise1, promise2, promise3, promise4));
         }
 
         /// <summary>

--- a/Package/Core/Promises/PromiseStaticMergeSettled.cs
+++ b/Package/Core/Promises/PromiseStaticMergeSettled.cs
@@ -4,7 +4,6 @@
 #undef PROMISE_DEBUG
 #endif
 
-#pragma warning disable IDE0034 // Simplify 'default' expression
 #pragma warning disable IDE0074 // Use compound assignment
 
 using System;
@@ -26,7 +25,7 @@ namespace Proto.Promises
         private static unsafe Internal.GetResultContainerDelegate<IList<ResultContainer>> GetAllResultContainerFunc
         {
             [MethodImpl(Internal.InlineOption)]
-            get { return new(&GetAllResultContainer); }
+            get => new(&GetAllResultContainer);
         }
 #else
         private static readonly Internal.GetResultContainerDelegate<IList<ResultContainer>> GetAllResultContainerFunc = GetAllResultContainer;
@@ -37,7 +36,7 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promise1">The first promise to combine.</param>
         /// <param name="promise2">The second promise to combine.</param>
-        /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new 1 will be created.</param>
+        /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
         public static Promise<IList<ResultContainer>> AllSettled(Promise promise1, Promise promise2, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promise1, "promise1", 1);
@@ -51,7 +50,7 @@ namespace Proto.Promises
         /// <param name="promise1">The first promise to combine.</param>
         /// <param name="promise2">The second promise to combine.</param>
         /// <param name="promise3">The third promise to combine.</param>
-        /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new 1 will be created.</param>
+        /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
         public static Promise<IList<ResultContainer>> AllSettled(Promise promise1, Promise promise2, Promise promise3, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promise1, "promise1", 1);
@@ -67,7 +66,7 @@ namespace Proto.Promises
         /// <param name="promise2">The second promise to combine.</param>
         /// <param name="promise3">The third promise to combine.</param>
         /// <param name="promise4">The 4th promise to combine.</param>
-        /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new 1 will be created.</param>
+        /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
         public static Promise<IList<ResultContainer>> AllSettled(Promise promise1, Promise promise2, Promise promise3, Promise promise4, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promise1, "promise1", 1);
@@ -89,7 +88,7 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve with a list of <see cref="ResultContainer"/>s in the same order as <paramref name="promises"/> when they have all completed.
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
-        /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new 1 will be created.</param>
+        /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
         public static Promise<IList<ResultContainer>> AllSettled(Promise[] promises, IList<ResultContainer> valueContainer = null)
         {
             return AllSettled(promises.GetGenericEnumerator(), valueContainer);
@@ -99,7 +98,7 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve with a list of <see cref="ResultContainer"/>s in the same order as <paramref name="promises"/> when they have all completed.
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
-        /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new 1 will be created.</param>
+        /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
         public static Promise<IList<ResultContainer>> AllSettled(IEnumerable<Promise> promises, IList<ResultContainer> valueContainer = null)
         {
             return AllSettled(promises.GetEnumerator(), valueContainer);
@@ -109,52 +108,83 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve with a list of <see cref="ResultContainer"/>s in the same order as <paramref name="promises"/> when they have all completed.
         /// </summary>
         /// <param name="promises">The enumerator of promises to combine.</param>
-        /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new 1 will be created.</param>
+        /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
         public static Promise<IList<ResultContainer>> AllSettled<TEnumerator>(TEnumerator promises, IList<ResultContainer> valueContainer = null) where TEnumerator : IEnumerator<Promise>
         {
             ValidateArgument(promises, "promises", 1);
 
             using (promises)
             {
-                var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-                int pendingCount = 0;
-
                 if (valueContainer == null)
                 {
                     valueContainer = new List<ResultContainer>();
                 }
 
                 int i = 0;
+                int index;
                 int listSize = valueContainer.Count;
+                Promise p;
                 while (promises.MoveNext())
                 {
-                    var p = promises.Current;
-                    ValidateElement(p, "promises", 1);
-                    Internal.PrepareForMerge(p, ref passThroughs, i, ref pendingCount);
+                    index = i;
+                    ++i;
                     // Make sure list has the same count as promises.
-                    if (listSize < (i + 1))
+                    if (listSize < i)
                     {
                         ++listSize;
-                        valueContainer.Add(ResultContainer.Resolved);
+                        valueContainer.Add(default);
+                    }
+                    p = promises.Current;
+                    if (p._ref == null)
+                    {
+                        valueContainer[index] = ResultContainer.Resolved;
                     }
                     else
                     {
-                        valueContainer[i] = ResultContainer.Resolved;
+                        goto HookupMaybePending;
                     }
+                }
+                // No non-resolved promises.
+                // Make sure list has the same count as promises.
+                while (listSize > i)
+                {
+                    valueContainer.RemoveAt(--listSize);
+                }
+                return Resolved(valueContainer);
+
+            HookupMaybePending:
+                ValidateElement(p, "promises", 1);
+                var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(valueContainer, GetAllResultContainerFunc);
+                uint pendingCount = 1;
+                promise.AddWaiterWithIndex(p._ref, p._id, index);
+                while (promises.MoveNext())
+                {
+                    index = i;
                     ++i;
+                    // Make sure list has the same count as promises.
+                    if (listSize < i)
+                    {
+                        ++listSize;
+                        valueContainer.Add(default);
+                    }
+                    p = promises.Current;
+                    ValidateElement(p, "promises", 1);
+                    if (p._ref == null)
+                    {
+                        valueContainer[index] = ResultContainer.Resolved;
+                    }
+                    else
+                    {
+                        checked { ++pendingCount; }
+                        promise.AddWaiterWithIndex(p._ref, p._id, index);
+                    }
                 }
                 // Make sure list has the same count as promises.
                 while (listSize > i)
                 {
                     valueContainer.RemoveAt(--listSize);
                 }
-
-                if (pendingCount == 0)
-                {
-                    return Resolved(valueContainer);
-                }
-
-                var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, valueContainer, pendingCount, GetAllResultContainerFunc);
+                promise.MarkReady(pendingCount);
                 return new Promise<IList<ResultContainer>>(promise, promise.Id);
             }
         }
@@ -270,21 +300,31 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<ResultContainer, ResultContainer>> MergeSettled(Promise promise1, Promise promise2)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
 
-            var value = new ValueTuple<ResultContainer, ResultContainer>(ResultContainer.Resolved, ResultContainer.Resolved);
+            (ResultContainer, ResultContainer)
+                value = default;
+            ref (ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled2();
+            Internal.PromiseRefBase.MergeSettledPromise<(ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled2());
-            return new Promise<ValueTuple<ResultContainer, ResultContainer>>(promise, promise.Id);
+            promise.MarkReady(pendingCount);
+            return new Promise<(ResultContainer, ResultContainer)>(
+                promise, promise.Id);
         }
 
         private static partial class MergeResultFuncs
@@ -332,22 +372,31 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, ResultContainer>> MergeSettled<T1>(Promise<T1> promise1, Promise promise2)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, ResultContainer>(v0, ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled1<T1>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled1<T1>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, ResultContainer>>(promise, promise.Id);
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, ResultContainer)>(
+                promise, promise.Id);
         }
 
         private static partial class MergeResultFuncs
@@ -396,23 +445,31 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer>> MergeSettled<T1, T2>(Promise<T1> promise1, Promise<T2> promise2)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer>(v0, v1);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled0<T1, T2>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled0<T1, T2>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer>>(promise, promise.Id);
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer)>(
+                promise, promise.Id);
         }
 
         #endregion // 2Args
@@ -468,26 +525,34 @@ namespace Proto.Promises
         public static Promise<ValueTuple<ResultContainer, ResultContainer, ResultContainer>> MergeSettled(
             Promise promise1, Promise promise2, Promise promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
 
-            var value = new ValueTuple<ResultContainer, ResultContainer, ResultContainer>(
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled3();
+            Internal.PromiseRefBase.MergeSettledPromise<(ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled3());
-            return new Promise<ValueTuple<ResultContainer, ResultContainer, ResultContainer>>(promise, promise.Id);
+            promise.MarkReady(pendingCount);
+            return new Promise<(ResultContainer, ResultContainer, ResultContainer)>(
+                promise, promise.Id);
         }
 
         private static partial class MergeResultFuncs
@@ -539,27 +604,33 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1>(
             Promise<T1> promise1, Promise promise2, Promise promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled2<T1>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled2<T1>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -612,28 +683,33 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer>> MergeSettled<T1, T2>(
             Promise<T1> promise1, Promise<T2> promise2, Promise promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled1<T1, T2>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled1<T1, T2>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -686,29 +762,33 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer>> MergeSettled<T1, T2, T3>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer>(
-                v0,
-                v1,
-                v2);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled0<T1, T2, T3>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled0<T1, T2, T3>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -768,29 +848,37 @@ namespace Proto.Promises
         public static Promise<ValueTuple<ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled(
             Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
 
-            var value = new ValueTuple<ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled4();
+            Internal.PromiseRefBase.MergeSettledPromise<(ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled4());
-            return new Promise<ValueTuple<ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(promise, promise.Id);
+            promise.MarkReady(pendingCount);
+            return new Promise<(ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
+                promise, promise.Id);
         }
 
         private static partial class MergeResultFuncs
@@ -845,30 +933,36 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1>(
             Promise<T1> promise1, Promise promise2, Promise promise3, Promise promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled3<T1>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled3<T1>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -924,31 +1018,36 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1, T2>(
             Promise<T1> promise1, Promise<T2> promise2, Promise promise3, Promise promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled2<T1, T2>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled2<T1, T2>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -1005,32 +1104,36 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer>> MergeSettled<T1, T2, T3>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                v2,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled1<T1, T2, T3>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled1<T1, T2, T3>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -1087,33 +1190,36 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer>> MergeSettled<T1, T2, T3, T4>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            var v3 = default(T4);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer>(
-                v0,
-                v1,
-                v2,
-                v3);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled0<T1, T2, T3, T4>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, ref valueRef.Item4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled0<T1, T2, T3, T4>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -1176,32 +1282,40 @@ namespace Proto.Promises
         public static Promise<ValueTuple<ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled(
             Promise promise1, Promise promise2, Promise promise3, Promise promise4, Promise promise5)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
 
-            var value = new ValueTuple<ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled5();
+            Internal.PromiseRefBase.MergeSettledPromise<(ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled5());
-            return new Promise<ValueTuple<ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(promise, promise.Id);
+            promise.MarkReady(pendingCount);
+            return new Promise<(ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
+                promise, promise.Id);
         }
 
         private static partial class MergeResultFuncs
@@ -1259,33 +1373,39 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1>(
             Promise<T1> promise1, Promise promise2, Promise promise3, Promise promise4, Promise promise5)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled4<T1>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled4<T1>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -1344,34 +1464,39 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1, T2>(
             Promise<T1> promise1, Promise<T2> promise2, Promise promise3, Promise promise4, Promise promise5)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled3<T1, T2>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled3<T1, T2>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -1431,35 +1556,39 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1, T2, T3>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise promise4, Promise promise5)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                v2,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled2<T1, T2, T3>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled2<T1, T2, T3>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -1519,36 +1648,39 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer>> MergeSettled<T1, T2, T3, T4>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise promise5)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            var v3 = default(T4);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                v2,
-                v3,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled1<T1, T2, T3, T4>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, ref valueRef.Item4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled1<T1, T2, T3, T4>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -1608,33 +1740,39 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer>> MergeSettled<T1, T2, T3, T4, T5>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            var v3 = default(T4);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            var v4 = default(T5);
-            Internal.PrepareForMerge(promise5, ref v4, ref passThroughs, 4, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer>(
-                v0, v1, v2, v3, v4);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled0<T1, T2, T3, T4, T5>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, ref valueRef.Item4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, ref valueRef.Item5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled0<T1, T2, T3, T4, T5>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -1700,35 +1838,43 @@ namespace Proto.Promises
         public static Promise<ValueTuple<ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled(
             Promise promise1, Promise promise2, Promise promise3, Promise promise4, Promise promise5, Promise promise6)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount);
 
-            var value = new ValueTuple<ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled6();
+            Internal.PromiseRefBase.MergeSettledPromise<(ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled6());
-            return new Promise<ValueTuple<ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(promise, promise.Id);
+            promise.MarkReady(pendingCount);
+            return new Promise<(ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
+                promise, promise.Id);
         }
 
         private static partial class MergeResultFuncs
@@ -1789,36 +1935,42 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1>(
             Promise<T1> promise1, Promise promise2, Promise promise3, Promise promise4, Promise promise5, Promise promise6)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled5<T1>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled5<T1>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -1881,37 +2033,42 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1, T2>(
             Promise<T1> promise1, Promise<T2> promise2, Promise promise3, Promise promise4, Promise promise5, Promise promise6)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled4<T1, T2>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled4<T1, T2>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -1974,38 +2131,42 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1, T2, T3>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise promise4, Promise promise5, Promise promise6)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                v2,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled3<T1, T2, T3>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled3<T1, T2, T3>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -2068,39 +2229,42 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1, T2, T3, T4>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise promise5, Promise promise6)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            var v3 = default(T4);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                v2,
-                v3,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled2<T1, T2, T3, T4>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, ref valueRef.Item4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled2<T1, T2, T3, T4>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -2163,40 +2327,42 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer>> MergeSettled<T1, T2, T3, T4, T5>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise promise6)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            var v3 = default(T4);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            var v4 = default(T5);
-            Internal.PrepareForMerge(promise5, ref v4, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                v2,
-                v3,
-                v4,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled1<T1, T2, T3, T4, T5>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, ref valueRef.Item4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, ref valueRef.Item5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled1<T1, T2, T3, T4, T5>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -2259,36 +2425,42 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer>> MergeSettled<T1, T2, T3, T4, T5, T6>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            var v3 = default(T4);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            var v4 = default(T5);
-            Internal.PrepareForMerge(promise5, ref v4, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            var v5 = default(T6);
-            Internal.PrepareForMerge(promise6, ref v5, ref passThroughs, 5, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer>(
-                v0, v1, v2, v3, v4, v5);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled0<T1, T2, T3, T4, T5, T6>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, ref valueRef.Item4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, ref valueRef.Item5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, ref valueRef.Item6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled0<T1, T2, T3, T4, T5, T6>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -2358,38 +2530,46 @@ namespace Proto.Promises
         public static Promise<ValueTuple<ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled(
             Promise promise1, Promise promise2, Promise promise3, Promise promise4, Promise promise5, Promise promise6, Promise promise7)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            Internal.PrepareForMerge(promise1, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount);
             ValidateArgument(promise7, "promise7", 1);
-            Internal.PrepareForMerge(promise7, ref passThroughs, 6, ref pendingCount);
 
-            var value = new ValueTuple<ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled7();
+            Internal.PromiseRefBase.MergeSettledPromise<(ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise7, valueRef, ref pendingCount, 6, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled7());
-            return new Promise<ValueTuple<ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(promise, promise.Id);
+            promise.MarkReady(pendingCount);
+            return new Promise<(ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
+                promise, promise.Id);
         }
 
         private static partial class MergeResultFuncs
@@ -2454,39 +2634,45 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1>(
             Promise<T1> promise1, Promise promise2, Promise promise3, Promise promise4, Promise promise5, Promise promise6, Promise promise7)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            Internal.PrepareForMerge(promise2, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount);
             ValidateArgument(promise7, "promise7", 1);
-            Internal.PrepareForMerge(promise7, ref passThroughs, 6, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled6<T1>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise7, valueRef, ref pendingCount, 6, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled6<T1>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -2552,40 +2738,45 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1, T2>(
             Promise<T1> promise1, Promise<T2> promise2, Promise promise3, Promise promise4, Promise promise5, Promise promise6, Promise promise7)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            Internal.PrepareForMerge(promise3, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount);
             ValidateArgument(promise7, "promise7", 1);
-            Internal.PrepareForMerge(promise7, ref passThroughs, 6, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled5<T1, T2>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise7, valueRef, ref pendingCount, 6, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled5<T1, T2>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -2651,41 +2842,45 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1, T2, T3>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise promise4, Promise promise5, Promise promise6, Promise promise7)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            Internal.PrepareForMerge(promise4, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount);
             ValidateArgument(promise7, "promise7", 1);
-            Internal.PrepareForMerge(promise7, ref passThroughs, 6, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                v2,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled4<T1, T2, T3>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise7, valueRef, ref pendingCount, 6, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled4<T1, T2, T3>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -2751,42 +2946,45 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1, T2, T3, T4>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise promise5, Promise promise6, Promise promise7)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            var v3 = default(T4);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            Internal.PrepareForMerge(promise5, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount);
             ValidateArgument(promise7, "promise7", 1);
-            Internal.PrepareForMerge(promise7, ref passThroughs, 6, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                v2,
-                v3,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled3<T1, T2, T3, T4>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, ref valueRef.Item4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise7, valueRef, ref pendingCount, 6, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled3<T1, T2, T3, T4>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -2852,43 +3050,45 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer, ResultContainer>> MergeSettled<T1, T2, T3, T4, T5>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise promise6, Promise promise7)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            var v3 = default(T4);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            var v4 = default(T5);
-            Internal.PrepareForMerge(promise5, ref v4, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            Internal.PrepareForMerge(promise6, ref passThroughs, 5, ref pendingCount);
             ValidateArgument(promise7, "promise7", 1);
-            Internal.PrepareForMerge(promise7, ref passThroughs, 6, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                v2,
-                v3,
-                v4,
-                ResultContainer.Resolved,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled2<T1, T2, T3, T4, T5>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, ref valueRef.Item4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, ref valueRef.Item5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise7, valueRef, ref pendingCount, 6, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled2<T1, T2, T3, T4, T5>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -2954,44 +3154,45 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, ResultContainer>> MergeSettled<T1, T2, T3, T4, T5, T6>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6, Promise promise7)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            var v3 = default(T4);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            var v4 = default(T5);
-            Internal.PrepareForMerge(promise5, ref v4, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            var v5 = default(T6);
-            Internal.PrepareForMerge(promise6, ref v5, ref passThroughs, 5, ref pendingCount);
             ValidateArgument(promise7, "promise7", 1);
-            Internal.PrepareForMerge(promise7, ref passThroughs, 6, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, ResultContainer>(
-                v0,
-                v1,
-                v2,
-                v3,
-                v4,
-                v5,
-                ResultContainer.Resolved);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled1<T1, T2, T3, T4, T5, T6>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, ref valueRef.Item4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, ref valueRef.Item5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, ref valueRef.Item6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise7, valueRef, ref pendingCount, 6, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled1<T1, T2, T3, T4, T5, T6>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, ResultContainer)>(
                 promise, promise.Id);
         }
 
@@ -3057,39 +3258,45 @@ namespace Proto.Promises
         public static Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, Promise<T7>.ResultContainer>> MergeSettled<T1, T2, T3, T4, T5, T6, T7>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6, Promise<T7> promise7)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            var v0 = default(T1);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            var v1 = default(T2);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            var v2 = default(T3);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            var v3 = default(T4);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount);
             ValidateArgument(promise5, "promise5", 1);
-            var v4 = default(T5);
-            Internal.PrepareForMerge(promise5, ref v4, ref passThroughs, 4, ref pendingCount);
             ValidateArgument(promise6, "promise6", 1);
-            var v5 = default(T6);
-            Internal.PrepareForMerge(promise6, ref v5, ref passThroughs, 5, ref pendingCount);
             ValidateArgument(promise7, "promise7", 1);
-            var v6 = default(T7);
-            Internal.PrepareForMerge(promise7, ref v6, ref passThroughs, 6, ref pendingCount);
 
-            var value = new ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, Promise<T7>.ResultContainer>(
-                v0, v1, v2, v3, v4, v5, v6);
+            (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, Promise<T7>.ResultContainer)
+                value = default;
+            ref (Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, Promise<T7>.ResultContainer)
+                valueRef = ref value;
+            uint pendingCount = 0;
+            var mergeResultFunc = MergeResultFuncs.GetSettled0<T1, T2, T3, T4, T5, T6, T7>();
+            Internal.PromiseRefBase.MergeSettledPromise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, Promise<T7>.ResultContainer)>
+                promise = null;
+
+            Internal.PrepareForMergeSettled(promise1, ref valueRef.Item1, valueRef, ref pendingCount, 0, ref promise, mergeResultFunc);
+            // It would be nice to be able to ref-reassign inside the PrepareForMergeSettled helper to avoid extra branches,
+            // but unfortunately C# doesn't support ref to ref parameters (or ref fields in ref structs yet).
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise2, ref valueRef.Item2, valueRef, ref pendingCount, 1, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise3, ref valueRef.Item3, valueRef, ref pendingCount, 2, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise4, ref valueRef.Item4, valueRef, ref pendingCount, 3, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise5, ref valueRef.Item5, valueRef, ref pendingCount, 4, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise6, ref valueRef.Item6, valueRef, ref pendingCount, 5, ref promise, mergeResultFunc);
+            valueRef = promise == null ? ref value : ref promise._result;
+            Internal.PrepareForMergeSettled(promise7, ref valueRef.Item7, valueRef, ref pendingCount, 6, ref promise, mergeResultFunc);
+
             if (pendingCount == 0)
             {
                 return Resolved(value);
             }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, value, pendingCount, MergeResultFuncs.GetSettled0<T1, T2, T3, T4, T5, T6, T7>());
-            return new Promise<ValueTuple<Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, Promise<T7>.ResultContainer>>(
+            promise.MarkReady(pendingCount);
+            return new Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, Promise<T7>.ResultContainer)>(
                 promise, promise.Id);
         }
 

--- a/Package/Core/Promises/PromiseStaticRace.cs
+++ b/Package/Core/Promises/PromiseStaticRace.cs
@@ -21,21 +21,9 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Race(Promise promise1, Promise promise2)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
-            if (promise1._ref == null | promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                return Resolved();
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-
-            var promise = Internal.PromiseRefBase.RacePromise<Internal.VoidResult>.GetOrCreate(passThroughs, 2);
-            return new Promise(promise, promise.Id);
+            return Race(Internal.GetEnumerator(promise1, promise2));
         }
 
         /// <summary>
@@ -44,24 +32,10 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Race(Promise promise1, Promise promise2, Promise promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
-            if (promise1._ref == null | promise2._ref == null | promise3._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                return Resolved();
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-
-            var promise = Internal.PromiseRefBase.RacePromise<Internal.VoidResult>.GetOrCreate(passThroughs, 3);
-            return new Promise(promise, promise.Id);
+            return Race(Internal.GetEnumerator(promise1, promise2, promise3));
         }
 
         /// <summary>
@@ -70,27 +44,11 @@ namespace Proto.Promises
         /// </summary>
         public static Promise Race(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
             ValidateArgument(promise4, "promise4", 1);
-            if (promise1._ref == null | promise2._ref == null | promise3._ref == null | promise4._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, false);
-                return Resolved();
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise4, 3));
-
-            var promise = Internal.PromiseRefBase.RacePromise<Internal.VoidResult>.GetOrCreate(passThroughs, 4);
-            return new Promise(promise, promise.Id);
+            return Race(Internal.GetEnumerator(promise1, promise2, promise3, promise4));
         }
 
         /// <summary>
@@ -163,22 +121,10 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<int> RaceWithIndex(Promise promise1, Promise promise2)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
 
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
-            if (promise1._ref == null | promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                int resolveIndex = promise1._ref == null ? 0 : 1;
-                return Resolved(resolveIndex);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-
-            var promise = Internal.PromiseRefBase.RacePromiseWithIndexVoid.GetOrCreate(passThroughs, 2);
-            return new Promise<int>(promise, promise.Id);
+            return RaceWithIndex(Internal.GetEnumerator(promise1, promise2));
         }
 
         /// <summary>
@@ -187,27 +133,10 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<int> RaceWithIndex(Promise promise1, Promise promise2, Promise promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
-            if (promise1._ref == null | promise2._ref == null | promise3._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                int resolveIndex = promise1._ref == null ? 0
-                    : promise2._ref == null ? 1
-                    : 2;
-                return Resolved(resolveIndex);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-
-            var promise = Internal.PromiseRefBase.RacePromiseWithIndexVoid.GetOrCreate(passThroughs, 3);
-            return new Promise<int>(promise, promise.Id);
+            return RaceWithIndex(Internal.GetEnumerator(promise1, promise2, promise3));
         }
 
         /// <summary>
@@ -216,31 +145,11 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<int> RaceWithIndex(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
             ValidateArgument(promise4, "promise4", 1);
-            if (promise1._ref == null | promise2._ref == null | promise3._ref == null | promise4._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, false);
-                int resolveIndex = promise1._ref == null ? 0
-                    : promise2._ref == null ? 1
-                    : promise3._ref == null ? 2
-                    : 3;
-                return Resolved(resolveIndex);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise4, 3));
-
-            var promise = Internal.PromiseRefBase.RacePromiseWithIndexVoid.GetOrCreate(passThroughs, 4);
-            return new Promise<int>(promise, promise.Id);
+            return RaceWithIndex(Internal.GetEnumerator(promise1, promise2, promise3, promise4));
         }
 
         /// <summary>
@@ -343,21 +252,9 @@ namespace Proto.Promises
         /// </summary>
         public static Promise First(Promise promise1, Promise promise2)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
-            if (promise1._ref == null | promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, true);
-                return Resolved();
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-
-            var promise = Internal.PromiseRefBase.FirstPromise<Internal.VoidResult>.GetOrCreate(passThroughs, 2);
-            return new Promise(promise, promise.Id);
+            return First(Internal.GetEnumerator(promise1, promise2));
         }
 
         /// <summary>
@@ -366,24 +263,10 @@ namespace Proto.Promises
         /// </summary>
         public static Promise First(Promise promise1, Promise promise2, Promise promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
-            if (promise1._ref == null | promise2._ref == null | promise3._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, true);
-                return Resolved();
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-
-            var promise = Internal.PromiseRefBase.FirstPromise<Internal.VoidResult>.GetOrCreate(passThroughs, 3);
-            return new Promise(promise, promise.Id);
+            return First(Internal.GetEnumerator(promise1, promise2, promise3));
         }
 
         /// <summary>
@@ -392,27 +275,11 @@ namespace Proto.Promises
         /// </summary>
         public static Promise First(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
             ValidateArgument(promise4, "promise4", 1);
-            if (promise1._ref == null | promise2._ref == null | promise3._ref == null | promise4._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, true);
-                return Resolved();
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise4, 3));
-
-            var promise = Internal.PromiseRefBase.FirstPromise<Internal.VoidResult>.GetOrCreate(passThroughs, 4);
-            return new Promise(promise, promise.Id);
+            return First(Internal.GetEnumerator(promise1, promise2, promise3, promise4));
         }
 
         /// <summary>
@@ -485,22 +352,9 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<int> FirstWithIndex(Promise promise1, Promise promise2)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
-            if (promise1._ref == null | promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                int resolveIndex = promise1._ref == null ? 0 : 1;
-                return Resolved(resolveIndex);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-
-            var promise = Internal.PromiseRefBase.FirstPromiseWithIndexVoid.GetOrCreate(passThroughs, 2);
-            return new Promise<int>(promise, promise.Id);
+            return FirstWithIndex(Internal.GetEnumerator(promise1, promise2));
         }
 
         /// <summary>
@@ -509,27 +363,10 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<int> FirstWithIndex(Promise promise1, Promise promise2, Promise promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
-            if (promise1._ref == null | promise2._ref == null | promise3._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                int resolveIndex = promise1._ref == null ? 0
-                    : promise2._ref == null ? 1
-                    : 2;
-                return Resolved(resolveIndex);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-
-            var promise = Internal.PromiseRefBase.FirstPromiseWithIndexVoid.GetOrCreate(passThroughs, 3);
-            return new Promise<int>(promise, promise.Id);
+            return FirstWithIndex(Internal.GetEnumerator(promise1, promise2, promise3));
         }
 
         /// <summary>
@@ -538,31 +375,11 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<int> FirstWithIndex(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
             ValidateArgument(promise4, "promise4", 1);
-            if (promise1._ref == null | promise2._ref == null | promise3._ref == null | promise4._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, false);
-                int resolveIndex = promise1._ref == null ? 0
-                    : promise2._ref == null ? 1
-                    : promise3._ref == null ? 2
-                    : 3;
-                return Resolved(resolveIndex);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise4, 3));
-
-            var promise = Internal.PromiseRefBase.FirstPromiseWithIndexVoid.GetOrCreate(passThroughs, 4);
-            return new Promise<int>(promise, promise.Id);
+            return FirstWithIndex(Internal.GetEnumerator(promise1, promise2, promise3, promise4));
         }
 
         /// <summary>
@@ -665,27 +482,9 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<(int winIndex, T result)> RaceWithIndex<T>(Promise<T> promise1, Promise<T> promise2)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
-            if (promise1._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                var result = new ValueTuple<int, T>(0, promise1._result);
-                return Resolved(result);
-            }
-            if (promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                var result = new ValueTuple<int, T>(1, promise1._result);
-                return Resolved(result);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-
-            var promise = Internal.PromiseRefBase.RacePromiseWithIndex<T>.GetOrCreate(passThroughs, 2);
-            return new Promise<ValueTuple<int, T>>(promise, promise.Id);
+            return RaceWithIndex<T, Internal.Enumerator<Promise<T>, Internal.TwoItems<Promise<T>>>>(Internal.GetEnumerator(promise1, promise2));
         }
 
         /// <summary>
@@ -694,38 +493,10 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<(int winIndex, T result)> RaceWithIndex<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
-            if (promise1._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                var result = new ValueTuple<int, T>(0, promise1._result);
-                return Resolved(result);
-            }
-            if (promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                var result = new ValueTuple<int, T>(1, promise1._result);
-                return Resolved(result);
-            }
-            if (promise3._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                var result = new ValueTuple<int, T>(2, promise1._result);
-                return Resolved(result);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-
-            var promise = Internal.PromiseRefBase.RacePromiseWithIndex<T>.GetOrCreate(passThroughs, 3);
-            return new Promise<ValueTuple<int, T>>(promise, promise.Id);
+            return RaceWithIndex<T, Internal.Enumerator<Promise<T>, Internal.ThreeItems<Promise<T>>>>(Internal.GetEnumerator(promise1, promise2, promise3));
         }
 
         /// <summary>
@@ -734,51 +505,11 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<(int winIndex, T result)> RaceWithIndex<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
             ValidateArgument(promise4, "promise4", 1);
-            if (promise1._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, false);
-                var result = new ValueTuple<int, T>(0, promise1._result);
-                return Resolved(result);
-            }
-            if (promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, false);
-                var result = new ValueTuple<int, T>(1, promise1._result);
-                return Resolved(result);
-            }
-            if (promise3._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, false);
-                var result = new ValueTuple<int, T>(2, promise1._result);
-                return Resolved(result);
-            }
-            if (promise4._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                var result = new ValueTuple<int, T>(3, promise1._result);
-                return Resolved(result);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise4, 3));
-
-            var promise = Internal.PromiseRefBase.RacePromiseWithIndex<T>.GetOrCreate(passThroughs, 4);
-            return new Promise<ValueTuple<int, T>>(promise, promise.Id);
+            return RaceWithIndex<T, Internal.Enumerator<Promise<T>, Internal.FourItems<Promise<T>>>>(Internal.GetEnumerator(promise1, promise2, promise3, promise4));
         }
 
         /// <summary>
@@ -852,27 +583,9 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<(int winIndex, T result)> FirstWithIndex<T>(Promise<T> promise1, Promise<T> promise2)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
-            if (promise1._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                var result = new ValueTuple<int, T>(0, promise1._result);
-                return Resolved(result);
-            }
-            if (promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                var result = new ValueTuple<int, T>(1, promise1._result);
-                return Resolved(result);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-
-            var promise = Internal.PromiseRefBase.FirstPromiseWithIndex<T>.GetOrCreate(passThroughs, 2);
-            return new Promise<ValueTuple<int, T>>(promise, promise.Id);
+            return FirstWithIndex<T, Internal.Enumerator<Promise<T>, Internal.TwoItems<Promise<T>>>>(Internal.GetEnumerator(promise1, promise2));
         }
 
         /// <summary>
@@ -881,38 +594,10 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<(int winIndex, T result)> FirstWithIndex<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
-            if (promise1._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                var result = new ValueTuple<int, T>(0, promise1._result);
-                return Resolved(result);
-            }
-            if (promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                var result = new ValueTuple<int, T>(1, promise1._result);
-                return Resolved(result);
-            }
-            if (promise3._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                var result = new ValueTuple<int, T>(2, promise1._result);
-                return Resolved(result);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-
-            var promise = Internal.PromiseRefBase.FirstPromiseWithIndex<T>.GetOrCreate(passThroughs, 3);
-            return new Promise<ValueTuple<int, T>>(promise, promise.Id);
+            return FirstWithIndex<T, Internal.Enumerator<Promise<T>, Internal.ThreeItems<Promise<T>>>>(Internal.GetEnumerator(promise1, promise2, promise3));
         }
 
         /// <summary>
@@ -921,51 +606,11 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<(int winIndex, T result)> FirstWithIndex<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
             ValidateArgument(promise4, "promise4", 1);
-            if (promise1._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, false);
-                var result = new ValueTuple<int, T>(0, promise1._result);
-                return Resolved(result);
-            }
-            if (promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, false);
-                var result = new ValueTuple<int, T>(1, promise1._result);
-                return Resolved(result);
-            }
-            if (promise3._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, false);
-                var result = new ValueTuple<int, T>(2, promise1._result);
-                return Resolved(result);
-            }
-            if (promise4._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                var result = new ValueTuple<int, T>(3, promise1._result);
-                return Resolved(result);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise4, 3));
-
-            var promise = Internal.PromiseRefBase.FirstPromiseWithIndex<T>.GetOrCreate(passThroughs, 4);
-            return new Promise<ValueTuple<int, T>>(promise, promise.Id);
+            return FirstWithIndex<T, Internal.Enumerator<Promise<T>, Internal.FourItems<Promise<T>>>>(Internal.GetEnumerator(promise1, promise2, promise3, promise4));
         }
 
         /// <summary>

--- a/Package/Core/Promises/PromiseTStatic.cs
+++ b/Package/Core/Promises/PromiseTStatic.cs
@@ -23,27 +23,9 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> Race(Promise<T> promise1, Promise<T> promise2)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
-            if (promise1._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                T value = promise1._result;
-                return Resolved(value);
-            }
-            if (promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                T value = promise2._result;
-                return Resolved(value);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-
-            var promise = Internal.PromiseRefBase.RacePromise<T>.GetOrCreate(passThroughs, 2);
-            return new Promise<T>(promise, promise.Id);
+            return Race(Internal.GetEnumerator(promise1, promise2));
         }
 
         /// <summary>
@@ -52,38 +34,10 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> Race(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
-            if (promise1._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                T value = promise1._result;
-                return Resolved(value);
-            }
-            if (promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                T value = promise2._result;
-                return Resolved(value);
-            }
-            if (promise3._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                T value = promise3._result;
-                return Resolved(value);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-
-            var promise = Internal.PromiseRefBase.RacePromise<T>.GetOrCreate(passThroughs, 3);
-            return new Promise<T>(promise, promise.Id);
+            return Race(Internal.GetEnumerator(promise1, promise2, promise3));
         }
 
         /// <summary>
@@ -92,51 +46,11 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> Race(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
             ValidateArgument(promise4, "promise4", 1);
-            if (promise1._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, false);
-                T value = promise1._result;
-                return Resolved(value);
-            }
-            if (promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, false);
-                T value = promise2._result;
-                return Resolved(value);
-            }
-            if (promise3._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, false);
-                T value = promise3._result;
-                return Resolved(value);
-            }
-            if (promise4._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, false);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, false);
-                T value = promise4._result;
-                return Resolved(value);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise4, 3));
-
-            var promise = Internal.PromiseRefBase.RacePromise<T>.GetOrCreate(passThroughs, 4);
-            return new Promise<T>(promise, promise.Id);
+            return Race(Internal.GetEnumerator(promise1, promise2, promise3, promise4));
         }
 
         /// <summary>
@@ -209,27 +123,9 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> First(Promise<T> promise1, Promise<T> promise2)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
-            if (promise1._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, true);
-                T value = promise1._result;
-                return Resolved(value);
-            }
-            if (promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, true);
-                T value = promise2._result;
-                return Resolved(value);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-
-            var promise = Internal.PromiseRefBase.FirstPromise<T>.GetOrCreate(passThroughs, 2);
-            return new Promise<T>(promise, promise.Id);
+            return First(Internal.GetEnumerator(promise1, promise2));
         }
 
         /// <summary>
@@ -238,38 +134,10 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> First(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
-            if (promise1._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, true);
-                T value = promise1._result;
-                return Resolved(value);
-            }
-            if (promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, true);
-                T value = promise2._result;
-                return Resolved(value);
-            }
-            if (promise3._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, true);
-                T value = promise3._result;
-                return Resolved(value);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-
-            var promise = Internal.PromiseRefBase.FirstPromise<T>.GetOrCreate(passThroughs, 3);
-            return new Promise<T>(promise, promise.Id);
+            return First(Internal.GetEnumerator(promise1, promise2, promise3));
         }
 
         /// <summary>
@@ -278,51 +146,11 @@ namespace Proto.Promises
         /// </summary>
         public static Promise<T> First(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-
             ValidateArgument(promise1, "promise1", 1);
             ValidateArgument(promise2, "promise2", 1);
             ValidateArgument(promise3, "promise3", 1);
             ValidateArgument(promise4, "promise4", 1);
-            if (promise1._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, true);
-                T value = promise1._result;
-                return Resolved(value);
-            }
-            if (promise2._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, true);
-                T value = promise2._result;
-                return Resolved(value);
-            }
-            if (promise3._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise4._ref, promise4._id, true);
-                T value = promise3._result;
-                return Resolved(value);
-            }
-            if (promise4._ref == null)
-            {
-                Internal.MaybeMarkAwaitedAndDispose(promise1._ref, promise1._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise2._ref, promise2._id, true);
-                Internal.MaybeMarkAwaitedAndDispose(promise3._ref, promise3._id, true);
-                T value = promise4._result;
-                return Resolved(value);
-            }
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise1, 0));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise2, 1));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise3, 2));
-            passThroughs.Push(Internal.PromiseRefBase.PromisePassThrough.GetOrCreate(promise4, 3));
-
-            var promise = Internal.PromiseRefBase.FirstPromise<T>.GetOrCreate(passThroughs, 4);
-            return new Promise<T>(promise, promise.Id);
+            return First(Internal.GetEnumerator(promise1, promise2, promise3, promise4));
         }
 
         /// <summary>
@@ -529,43 +357,9 @@ namespace Proto.Promises
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
         public static Promise<IList<T>> All(Promise<T> promise1, Promise<T> promise2, IList<T> valueContainer = null)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            T v0 = default(T);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            T v1 = default(T);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
-
-            if (valueContainer == null)
-            {
-                valueContainer = new T[2] { v0, v1 };
-            }
-            else
-            {
-                // Make sure list has the same count as promises.
-                int listSize = valueContainer.Count;
-                while (listSize > 2)
-                {
-                    valueContainer.RemoveAt(--listSize);
-                }
-                while (listSize < 2)
-                {
-                    valueContainer.Add(default(T));
-                    ++listSize;
-                }
-                valueContainer[0] = v0;
-                valueContainer[1] = v1;
-            }
-
-            if (pendingCount == 0)
-            {
-                return Promise.Resolved(valueContainer);
-            }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergePromise(passThroughs, valueContainer, pendingCount, GetAllResultFunc);
-            return new Promise<IList<T>>(promise, promise.Id);
+            return All(Internal.GetEnumerator(promise1, promise2), valueContainer);
         }
 
         /// <summary>
@@ -578,47 +372,10 @@ namespace Proto.Promises
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
         public static Promise<IList<T>> All(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, IList<T> valueContainer = null)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            T v0 = default(T);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            T v1 = default(T);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            T v2 = default(T);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
-
-            if (valueContainer == null)
-            {
-                valueContainer = new T[3] { v0, v1, v2 };
-            }
-            else
-            {
-                // Make sure list has the same count as promises.
-                int listSize = valueContainer.Count;
-                while (listSize > 3)
-                {
-                    valueContainer.RemoveAt(--listSize);
-                }
-                while (listSize < 3)
-                {
-                    valueContainer.Add(default(T));
-                    ++listSize;
-                }
-                valueContainer[0] = v0;
-                valueContainer[1] = v1;
-                valueContainer[2] = v2;
-            }
-
-            if (pendingCount == 0)
-            {
-                return Promise.Resolved(valueContainer);
-            }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergePromise(passThroughs, valueContainer, pendingCount, GetAllResultFunc);
-            return new Promise<IList<T>>(promise, promise.Id);
+            return All(Internal.GetEnumerator(promise1, promise2, promise3), valueContainer);
         }
 
         /// <summary>
@@ -632,51 +389,11 @@ namespace Proto.Promises
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
         public static Promise<IList<T>> All(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4, IList<T> valueContainer = null)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            T v0 = default(T);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            T v1 = default(T);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            T v2 = default(T);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            T v3 = default(T);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount);
-
-            if (valueContainer == null)
-            {
-                valueContainer = new T[4] { v0, v1, v2, v3 };
-            }
-            else
-            {
-                // Make sure list has the same count as promises.
-                int listSize = valueContainer.Count;
-                while (listSize > 4)
-                {
-                    valueContainer.RemoveAt(--listSize);
-                }
-                while (listSize < 4)
-                {
-                    valueContainer.Add(default(T));
-                    ++listSize;
-                }
-                valueContainer[0] = v0;
-                valueContainer[1] = v1;
-                valueContainer[2] = v2;
-                valueContainer[3] = v3;
-            }
-
-            if (pendingCount == 0)
-            {
-                return Promise.Resolved(valueContainer);
-            }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergePromise(passThroughs, valueContainer, pendingCount, GetAllResultFunc);
-            return new Promise<IList<T>>(promise, promise.Id);
+            return All(Internal.GetEnumerator(promise1, promise2, promise3, promise4), valueContainer);
         }
 
         /// <summary>
@@ -790,43 +507,9 @@ namespace Proto.Promises
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
         public static Promise<IList<ResultContainer>> AllSettled(Promise<T> promise1, Promise<T> promise2, IList<ResultContainer> valueContainer = null)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            T v0 = default(T);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            T v1 = default(T);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
-
-            if (valueContainer == null)
-            {
-                valueContainer = new ResultContainer[2] { v0, v1 };
-            }
-            else
-            {
-                // Make sure list has the same count as promises.
-                int listSize = valueContainer.Count;
-                while (listSize > 2)
-                {
-                    valueContainer.RemoveAt(--listSize);
-                }
-                while (listSize < 2)
-                {
-                    valueContainer.Add(default(ResultContainer));
-                    ++listSize;
-                }
-                valueContainer[0] = v0;
-                valueContainer[1] = v1;
-            }
-
-            if (pendingCount == 0)
-            {
-                return Promise.Resolved(valueContainer);
-            }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, valueContainer, pendingCount, GetAllResultContainerFunc);
-            return new Promise<IList<ResultContainer>>(promise, promise.Id);
+            return AllSettled(Internal.GetEnumerator(promise1, promise2), valueContainer);
         }
 
         /// <summary>
@@ -838,47 +521,10 @@ namespace Proto.Promises
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
         public static Promise<IList<ResultContainer>> AllSettled(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, IList<ResultContainer> valueContainer = null)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            T v0 = default(T);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            T v1 = default(T);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            T v2 = default(T);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
-
-            if (valueContainer == null)
-            {
-                valueContainer = new ResultContainer[3] { v0, v1, v2 };
-            }
-            else
-            {
-                // Make sure list has the same count as promises.
-                int listSize = valueContainer.Count;
-                while (listSize > 3)
-                {
-                    valueContainer.RemoveAt(--listSize);
-                }
-                while (listSize < 3)
-                {
-                    valueContainer.Add(default(T));
-                    ++listSize;
-                }
-                valueContainer[0] = v0;
-                valueContainer[1] = v1;
-                valueContainer[2] = v2;
-            }
-
-            if (pendingCount == 0)
-            {
-                return Promise.Resolved(valueContainer);
-            }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, valueContainer, pendingCount, GetAllResultContainerFunc);
-            return new Promise<IList<ResultContainer>>(promise, promise.Id);
+            return AllSettled(Internal.GetEnumerator(promise1, promise2, promise3), valueContainer);
         }
 
         /// <summary>
@@ -891,51 +537,11 @@ namespace Proto.Promises
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
         public static Promise<IList<ResultContainer>> AllSettled(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4, IList<ResultContainer> valueContainer = null)
         {
-            var passThroughs = new Internal.ValueLinkedStack<Internal.PromiseRefBase.PromisePassThrough>();
-            int pendingCount = 0;
-
             ValidateArgument(promise1, "promise1", 1);
-            T v0 = default(T);
-            Internal.PrepareForMerge(promise1, ref v0, ref passThroughs, 0, ref pendingCount);
             ValidateArgument(promise2, "promise2", 1);
-            T v1 = default(T);
-            Internal.PrepareForMerge(promise2, ref v1, ref passThroughs, 1, ref pendingCount);
             ValidateArgument(promise3, "promise3", 1);
-            T v2 = default(T);
-            Internal.PrepareForMerge(promise3, ref v2, ref passThroughs, 2, ref pendingCount);
             ValidateArgument(promise4, "promise4", 1);
-            T v3 = default(T);
-            Internal.PrepareForMerge(promise4, ref v3, ref passThroughs, 3, ref pendingCount);
-
-            if (valueContainer == null)
-            {
-                valueContainer = new ResultContainer[4] { v0, v1, v2, v3 };
-            }
-            else
-            {
-                // Make sure list has the same count as promises.
-                int listSize = valueContainer.Count;
-                while (listSize > 4)
-                {
-                    valueContainer.RemoveAt(--listSize);
-                }
-                while (listSize < 4)
-                {
-                    valueContainer.Add(default(T));
-                    ++listSize;
-                }
-                valueContainer[0] = v0;
-                valueContainer[1] = v1;
-                valueContainer[2] = v2;
-                valueContainer[3] = v3;
-            }
-
-            if (pendingCount == 0)
-            {
-                return Promise.Resolved(valueContainer);
-            }
-            var promise = Internal.PromiseRefBase.GetOrCreateMergeSettledPromise(passThroughs, valueContainer, pendingCount, GetAllResultContainerFunc);
-            return new Promise<IList<ResultContainer>>(promise, promise.Id);
+            return AllSettled(Internal.GetEnumerator(promise1, promise2, promise3, promise4), valueContainer);
         }
 
         /// <summary>

--- a/Package/Tests/CoreTests/APIs/FirstTests.cs
+++ b/Package/Tests/CoreTests/APIs/FirstTests.cs
@@ -24,38 +24,40 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void FirstIsResolvedWhenFirstPromiseIsResolvedFirst_void()
+        public void FirstIsResolvedWhenFirstPromiseIsResolvedFirst_void(
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
+            var resolvedPromise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, "Error", out var deferred1, out _);
+            var resolvedPromise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise.First(deferred1.Promise, deferred2.Promise)
+            Promise.First(resolvedPromise1, resolvedPromise2)
                 .Then(() =>
                 {
                     resolved = true;
                 })
                 .Forget();
 
-            deferred1.Resolve();
+            deferred1.TryResolve();
 
             Assert.IsTrue(resolved);
 
-            deferred2.Resolve();
+            deferred2.TryResolve();
 
             Assert.IsTrue(resolved);
         }
 
         [Test]
-        public void FirstIsResolvedWhenFirstPromiseIsResolvedFirst_T()
+        public void FirstIsResolvedWhenFirstPromiseIsResolvedFirst_T(
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
+            var resolvedPromise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, 5, "Error", out var deferred1, out _);
+            var resolvedPromise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, 2, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise<int>.First(deferred1.Promise, deferred2.Promise)
+            Promise<int>.First(resolvedPromise1, resolvedPromise2)
                 .Then(i =>
                 {
                     Assert.AreEqual(5, i);
@@ -63,31 +65,32 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            deferred1.Resolve(5);
+            deferred1.TryResolve(5);
 
             Assert.IsTrue(resolved);
 
-            deferred2.Resolve(1);
+            deferred2.TryResolve(1);
 
             Assert.IsTrue(resolved);
         }
 
         [Test]
-        public void FirstIsResolvedWhenSecondPromiseIsResolvedFirst_void()
+        public void FirstIsResolvedWhenSecondPromiseIsResolvedFirst_void(
+            [Values] bool alreadyResolved)
         {
             var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
+            var resolvedPromise = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise.First(deferred1.Promise, deferred2.Promise)
+            Promise.First(deferred1.Promise, resolvedPromise)
                 .Then(() =>
                 {
                     resolved = true;
                 })
                 .Forget();
 
-            deferred2.Resolve();
+            deferred2.TryResolve();
 
             Assert.IsTrue(resolved);
 
@@ -97,14 +100,15 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void FirstIsResolvedWhenSecondPromiseIsResolvedFirst_T()
+        public void FirstIsResolvedWhenSecondPromiseIsResolvedFirst_T(
+            [Values] bool alreadyResolved)
         {
             var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
+            var resolvedPromise = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, 5, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise<int>.First(deferred1.Promise, deferred2.Promise)
+            Promise<int>.First(deferred1.Promise, resolvedPromise)
                 .Then(i =>
                 {
                     Assert.AreEqual(5, i);
@@ -112,7 +116,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            deferred2.Resolve(5);
+            deferred2.TryResolve(5);
 
             Assert.IsTrue(resolved);
 
@@ -122,38 +126,42 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void FirstIsResolvedWhenFirstPromiseIsRejectedThenSecondPromiseIsResolved_void()
+        public void FirstIsResolvedWhenFirstPromiseIsRejectedThenSecondPromiseIsResolved_void(
+            [Values] bool alreadyRejected,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
+            var rejectPromise = TestHelper.BuildPromise(CompleteType.Reject, alreadyRejected, "Error", out var deferred1, out _);
+            var resolvedPromise = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise.First(deferred1.Promise, deferred2.Promise)
+            Promise.First(rejectPromise, resolvedPromise)
                 .Then(() =>
                 {
                     resolved = true;
                 })
                 .Forget();
 
-            deferred1.Reject("Error");
+            deferred1.TryReject("Error");
 
-            Assert.IsFalse(resolved);
+            Assert.AreEqual(alreadyResolved, resolved);
 
-            deferred2.Resolve();
+            deferred2.TryResolve();
 
             Assert.IsTrue(resolved);
         }
 
         [Test]
-        public void FirstIsResolvedWhenFirstPromiseIsRejectedThenSecondPromiseIsResolved_T()
+        public void FirstIsResolvedWhenFirstPromiseIsRejectedThenSecondPromiseIsResolved_T(
+            [Values] bool alreadyRejected,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
+            var rejectPromise = TestHelper.BuildPromise(CompleteType.Reject, alreadyRejected, 5, "Error", out var deferred1, out _);
+            var resolvedPromise = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, 5, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise<int>.First(deferred1.Promise, deferred2.Promise)
+            Promise<int>.First(rejectPromise, resolvedPromise)
                 .Then(i =>
                 {
                     Assert.AreEqual(5, i);
@@ -161,31 +169,32 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            deferred1.Reject("Error");
+            deferred1.TryReject("Error");
 
-            Assert.IsFalse(resolved);
+            Assert.AreEqual(alreadyResolved, resolved);
 
-            deferred2.Resolve(5);
+            deferred2.TryResolve(5);
 
             Assert.IsTrue(resolved);
         }
 
         [Test]
-        public void FirstIsResolvedWhenSecondPromiseIsRejectedThenFirstPromiseIsResolved_void()
+        public void FirstIsResolvedWhenSecondPromiseIsRejectedThenFirstPromiseIsResolved_void(
+            [Values] bool alreadyRejected)
         {
             var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
+            var rejectPromise = TestHelper.BuildPromise(CompleteType.Reject, alreadyRejected, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise.First(deferred1.Promise, deferred2.Promise)
+            Promise.First(deferred1.Promise, rejectPromise)
                 .Then(() =>
                 {
                     resolved = true;
                 })
                 .Forget();
 
-            deferred2.Reject("Error");
+            deferred2.TryReject("Error");
 
             Assert.IsFalse(resolved);
 
@@ -195,14 +204,15 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void FirstIsResolvedWhenSecondPromiseIsRejectedThenFirstPromiseIsResolved_T()
+        public void FirstIsResolvedWhenSecondPromiseIsRejectedThenFirstPromiseIsResolved_T(
+            [Values] bool alreadyRejected)
         {
             var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
+            var rejectPromise = TestHelper.BuildPromise(CompleteType.Reject, alreadyRejected, 5, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise<int>.First(deferred1.Promise, deferred2.Promise)
+            Promise<int>.First(deferred1.Promise, rejectPromise)
                 .Then(i =>
                 {
                     Assert.AreEqual(5, i);
@@ -210,7 +220,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            deferred2.Reject("Error");
+            deferred2.TryReject("Error");
 
             Assert.IsFalse(resolved);
 
@@ -220,15 +230,16 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void FirstIsRejectedWhenAllPromisesAreRejected_void()
+        public void FirstIsRejectedWhenAllPromisesAreRejected_void(
+            [Values] bool alreadyRejected)
         {
-            var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
-
             bool rejected = false;
             string expected = "Error";
 
-            Promise.First(deferred1.Promise, deferred2.Promise)
+            var rejectPromise1 = TestHelper.BuildPromise(CompleteType.Reject, alreadyRejected, "Different Error", out var deferred1, out _);
+            var rejectPromise2 = TestHelper.BuildPromise(CompleteType.Reject, alreadyRejected, expected, out var deferred2, out _);
+
+            Promise.First(rejectPromise1, rejectPromise2)
                 .Catch((string rej) =>
                 {
                     Assert.AreEqual(expected, rej);
@@ -236,25 +247,26 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            deferred1.Reject("Different Error");
+            deferred1.TryReject("Different Error");
 
-            Assert.IsFalse(rejected);
+            Assert.AreEqual(alreadyRejected, rejected);
 
-            deferred2.Reject(expected);
+            deferred2.TryReject(expected);
 
             Assert.IsTrue(rejected);
         }
 
         [Test]
-        public void FirstIsRejectedWhenAllPromisesAreRejected_T()
+        public void FirstIsRejectedWhenAllPromisesAreRejected_T(
+            [Values] bool alreadyRejected)
         {
-            var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
-
             bool rejected = false;
             string expected = "Error";
 
-            Promise<int>.First(deferred1.Promise, deferred2.Promise)
+            var rejectPromise1 = TestHelper.BuildPromise(CompleteType.Reject, alreadyRejected, 5, "Different Error", out var deferred1, out _);
+            var rejectPromise2 = TestHelper.BuildPromise(CompleteType.Reject, alreadyRejected, 5, expected, out var deferred2, out _);
+
+            Promise<int>.First(rejectPromise1, rejectPromise2)
                 .Catch((string rej) =>
                 {
                     Assert.AreEqual(expected, rej);
@@ -262,54 +274,52 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            deferred1.Reject("Different Error");
+            deferred1.TryReject("Different Error");
 
-            Assert.IsFalse(rejected);
+            Assert.AreEqual(alreadyRejected, rejected);
 
-            deferred2.Reject(expected);
+            deferred2.TryReject(expected);
 
             Assert.IsTrue(rejected);
         }
 
         [Test]
-        public void FirstIsResolvedWhenFirstPromiseIsCanceledThenSecondPromiseIsResolved_void()
+        public void FirstIsResolvedWhenFirstPromiseIsCanceledThenSecondPromiseIsResolved_void(
+            [Values] bool alreadyCanceled,
+            [Values] bool alreadyResolved)
         {
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred();
-            cancelationSource.Token.Register(deferred1);
-            var deferred2 = Promise.NewDeferred();
+            var cancelPromise = TestHelper.BuildPromise(CompleteType.Cancel, alreadyCanceled, "Error", out var deferred1, out _);
+            var resolvedPromise = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise.First(deferred1.Promise, deferred2.Promise)
+            Promise.First(cancelPromise, resolvedPromise)
                 .Then(() =>
                 {
                     resolved = true;
                 })
                 .Forget();
 
-            cancelationSource.Cancel();
+            deferred1.TryCancel();
 
-            Assert.IsFalse(resolved);
+            Assert.AreEqual(alreadyResolved, resolved);
 
-            deferred2.Resolve();
+            deferred2.TryResolve();
 
             Assert.IsTrue(resolved);
-
-            cancelationSource.Dispose();
         }
 
         [Test]
-        public void FirstIsResolvedWhenFirstPromiseIsCanceledThenSecondPromiseIsResolved_T()
+        public void FirstIsResolvedWhenFirstPromiseIsCanceledThenSecondPromiseIsResolved_T(
+            [Values] bool alreadyCanceled,
+            [Values] bool alreadyResolved)
         {
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>();
-            cancelationSource.Token.Register(deferred1);
-            var deferred2 = Promise.NewDeferred<int>();
+            var cancelPromise = TestHelper.BuildPromise(CompleteType.Cancel, alreadyCanceled, 2, "Error", out var deferred1, out _);
+            var resolvedPromise = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, 5, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise<int>.First(deferred1.Promise, deferred2.Promise)
+            Promise<int>.First(cancelPromise, resolvedPromise)
                 .Then(i =>
                 {
                     Assert.AreEqual(5, i);
@@ -317,56 +327,50 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            cancelationSource.Cancel();
+            deferred1.TryCancel();
 
-            Assert.IsFalse(resolved);
+            Assert.AreEqual(alreadyResolved, resolved);
 
-            deferred2.Resolve(5);
+            deferred2.TryResolve(5);
 
             Assert.IsTrue(resolved);
-
-            cancelationSource.Dispose();
         }
 
         [Test]
-        public void FirstIsResolvedWhenSecondPromiseIsCanceledThenFirstPromiseIsResolved_void()
+        public void FirstIsResolvedWhenSecondPromiseIsCanceledThenFirstPromiseIsResolved_void(
+            [Values] bool alreadyCanceled)
         {
             var deferred1 = Promise.NewDeferred();
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred();
-            cancelationSource.Token.Register(deferred2);
+            var cancelPromise = TestHelper.BuildPromise(CompleteType.Cancel, alreadyCanceled, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise.First(deferred1.Promise, deferred2.Promise)
+            Promise.First(deferred1.Promise, cancelPromise)
                 .Then(() =>
                 {
                     resolved = true;
                 })
                 .Forget();
 
-            cancelationSource.Cancel();
+            deferred2.TryCancel();
 
             Assert.IsFalse(resolved);
 
-            deferred1.Resolve();
+            deferred1.TryResolve();
 
             Assert.IsTrue(resolved);
-
-            cancelationSource.Dispose();
         }
 
         [Test]
-        public void FirstIsResolvedWhenSecondPromiseIsCanceledThenFirstPromiseIsResolved_T()
+        public void FirstIsResolvedWhenSecondPromiseIsCanceledThenFirstPromiseIsResolved_T(
+            [Values] bool alreadyCanceled)
         {
             var deferred1 = Promise.NewDeferred<int>();
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>();
-            cancelationSource.Token.Register(deferred2);
+            var cancelPromise = TestHelper.BuildPromise(CompleteType.Cancel, alreadyCanceled, 5, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise<int>.First(deferred1.Promise, deferred2.Promise)
+            Promise<int>.First(deferred1.Promise, cancelPromise)
                 .Then(i =>
                 {
                     Assert.AreEqual(5, i);
@@ -374,73 +378,59 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            cancelationSource.Cancel();
+            deferred2.TryCancel();
 
             Assert.IsFalse(resolved);
 
-            deferred1.Resolve(5);
+            deferred1.TryResolve(5);
 
             Assert.IsTrue(resolved);
-
-            cancelationSource.Dispose();
         }
 
         [Test]
-        public void FirstIsCanceledWhenAllPromisesAreCanceled_void()
+        public void FirstIsCanceledWhenAllPromisesAreCanceled_void(
+            [Values] bool alreadyCanceled)
         {
-            CancelationSource cancelationSource1 = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred();
-            cancelationSource1.Token.Register(deferred1);
-            CancelationSource cancelationSource2 = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred();
-            cancelationSource2.Token.Register(deferred2);
+            var cancelPromise1 = TestHelper.BuildPromise(CompleteType.Cancel, alreadyCanceled, "Error", out var deferred1, out _);
+            var cancelPromise2 = TestHelper.BuildPromise(CompleteType.Cancel, alreadyCanceled, "Error", out var deferred2, out _);
 
             bool canceled = false;
 
-            Promise.First(deferred1.Promise, deferred2.Promise)
+            Promise.First(cancelPromise1, cancelPromise2)
                 .CatchCancelation(() =>
                 {
                     canceled = true;
                 })
                 .Forget();
 
-            cancelationSource1.Cancel();
-            Assert.IsFalse(canceled);
+            deferred1.TryCancel();
+            Assert.AreEqual(alreadyCanceled, canceled);
 
-            cancelationSource2.Cancel();
+            deferred2.TryCancel();
             Assert.IsTrue(canceled);
-
-            cancelationSource1.Dispose();
-            cancelationSource2.Dispose();
         }
 
         [Test]
-        public void FirstIsCanceledWhenAllPromisesAreCanceled_T()
+        public void FirstIsCanceledWhenAllPromisesAreCanceled_T(
+            [Values] bool alreadyCanceled)
         {
-            CancelationSource cancelationSource1 = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>();
-            cancelationSource1.Token.Register(deferred1);
-            CancelationSource cancelationSource2 = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>();
-            cancelationSource2.Token.Register(deferred2);
+            var cancelPromise1 = TestHelper.BuildPromise(CompleteType.Cancel, alreadyCanceled, 5, "Error", out var deferred1, out _);
+            var cancelPromise2 = TestHelper.BuildPromise(CompleteType.Cancel, alreadyCanceled, 5, "Error", out var deferred2, out _);
 
             bool canceled = false;
 
-            Promise<int>.First(deferred1.Promise, deferred2.Promise)
+            Promise<int>.First(cancelPromise1, cancelPromise2)
                 .CatchCancelation(() =>
                 {
                     canceled = true;
                 })
                 .Forget();
 
-            cancelationSource1.Cancel();
-            Assert.IsFalse(canceled);
+            deferred1.TryCancel();
+            Assert.AreEqual(alreadyCanceled, canceled);
 
-            cancelationSource2.Cancel();
+            deferred2.TryCancel();
             Assert.IsTrue(canceled);
-
-            cancelationSource1.Dispose();
-            cancelationSource2.Dispose();
         }
 
         [Test]
@@ -675,22 +665,24 @@ namespace ProtoPromiseTests.APIs
             cancelationSource.Dispose();
         }
 
-        private static void Swap(ref Promise.Deferred deferred1, ref Promise.Deferred deferred2)
+        private static void Swap<T>(ref T a, ref T b)
         {
-            var temp = deferred1;
-            deferred1 = deferred2;
-            deferred2 = temp;
+            var temp = a;
+            a = b;
+            b = temp;
         }
 
         [Test]
-        public void FirstWithIndex_2_void([Values(0, 1)] int winIndex)
+        public void FirstWithIndex_2_void(
+            [Values(0, 1)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, "Error", out var deferred2, out _);
 
             int resultIndex = -1;
 
-            Promise.FirstWithIndex(deferred1.Promise, deferred2.Promise)
+            Promise.FirstWithIndex(promise1, promise2)
                 .Then(index => resultIndex = index)
                 .Forget();
 
@@ -698,51 +690,24 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred2);
             }
-            deferred1.Resolve();
-            deferred2.Resolve();
+            deferred1.TryResolve();
+            deferred2.TryResolve();
 
             Assert.AreEqual(winIndex, resultIndex);
         }
 
         [Test]
-        public void FirstWithIndex_3_void([Values(0, 1, 2)] int winIndex)
+        public void FirstWithIndex_3_void(
+            [Values(0, 1, 2)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
-            var deferred3 = Promise.NewDeferred();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, "Error", out var deferred2, out _);
+            var promise3 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 2, "Error", out var deferred3, out _);
 
             int resultIndex = -1;
 
-            Promise.FirstWithIndex(deferred1.Promise, deferred2.Promise, deferred3.Promise)
-                .Then(index => resultIndex = index)
-                .Forget();
-
-            if (winIndex == 1)
-            {
-                Swap(ref deferred1, ref deferred2);
-            }
-            else if (winIndex == 2)
-            {
-                Swap(ref deferred1, ref deferred3);
-            }
-            deferred1.Resolve();
-            deferred2.Resolve();
-            deferred3.Resolve();
-
-            Assert.AreEqual(winIndex, resultIndex);
-        }
-
-        [Test]
-        public void FirstWithIndex_4_void([Values(0, 1, 2, 3)] int winIndex)
-        {
-            var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
-            var deferred3 = Promise.NewDeferred();
-            var deferred4 = Promise.NewDeferred();
-
-            int resultIndex = -1;
-
-            Promise.FirstWithIndex(deferred1.Promise, deferred2.Promise, deferred3.Promise, deferred4.Promise)
+            Promise.FirstWithIndex(promise1, promise2, promise3)
                 .Then(index => resultIndex = index)
                 .Forget();
 
@@ -754,29 +719,26 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred3);
             }
-            else if (winIndex == 3)
-            {
-                Swap(ref deferred1, ref deferred4);
-            }
-            deferred1.Resolve();
-            deferred2.Resolve();
-            deferred3.Resolve();
-            deferred4.Resolve();
+            deferred1.TryResolve();
+            deferred2.TryResolve();
+            deferred3.TryResolve();
 
             Assert.AreEqual(winIndex, resultIndex);
         }
 
         [Test]
-        public void FirstWithIndex_array_void([Values(0, 1, 2, 3)] int winIndex)
+        public void FirstWithIndex_4_void(
+            [Values(0, 1, 2, 3)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
-            var deferred3 = Promise.NewDeferred();
-            var deferred4 = Promise.NewDeferred();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, "Error", out var deferred2, out _);
+            var promise3 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 2, "Error", out var deferred3, out _);
+            var promise4 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 3, "Error", out var deferred4, out _);
 
             int resultIndex = -1;
 
-            Promise.FirstWithIndex(new Promise[] { deferred1.Promise, deferred2.Promise, deferred3.Promise, deferred4.Promise })
+            Promise.FirstWithIndex(promise1, promise2, promise3, promise4)
                 .Then(index => resultIndex = index)
                 .Forget();
 
@@ -792,31 +754,62 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred4);
             }
-            deferred1.Resolve();
-            deferred2.Resolve();
-            deferred3.Resolve();
-            deferred4.Resolve();
+            deferred1.TryResolve();
+            deferred2.TryResolve();
+            deferred3.TryResolve();
+            deferred4.TryResolve();
 
             Assert.AreEqual(winIndex, resultIndex);
         }
 
-        private static void Swap(ref Promise<int>.Deferred deferred1, ref Promise<int>.Deferred deferred2)
+        [Test]
+        public void FirstWithIndex_array_void(
+            [Values(0, 1, 2, 3)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var temp = deferred1;
-            deferred1 = deferred2;
-            deferred2 = temp;
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, "Error", out var deferred2, out _);
+            var promise3 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 2, "Error", out var deferred3, out _);
+            var promise4 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 3, "Error", out var deferred4, out _);
+
+            int resultIndex = -1;
+
+            Promise.FirstWithIndex(new Promise[] { promise1, promise2, promise3, promise4 })
+                .Then(index => resultIndex = index)
+                .Forget();
+
+            if (winIndex == 1)
+            {
+                Swap(ref deferred1, ref deferred2);
+            }
+            else if (winIndex == 2)
+            {
+                Swap(ref deferred1, ref deferred3);
+            }
+            else if (winIndex == 3)
+            {
+                Swap(ref deferred1, ref deferred4);
+            }
+            deferred1.TryResolve();
+            deferred2.TryResolve();
+            deferred3.TryResolve();
+            deferred4.TryResolve();
+
+            Assert.AreEqual(winIndex, resultIndex);
         }
 
         [Test]
-        public void FirstWithIndex_2_T([Values(0, 1)] int winIndex)
+        public void FirstWithIndex_2_T(
+            [Values(0, 1)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, alreadyResolved && winIndex == 0 ? 1 : 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, alreadyResolved && winIndex == 1 ? 1 : 2, "Error", out var deferred2, out _);
 
             int resultIndex = -1;
             int result = -1;
 
-            Promise.FirstWithIndex(deferred1.Promise, deferred2.Promise)
+            Promise.FirstWithIndex(promise1, promise2)
                 .Then(cv =>
                 {
                     resultIndex = cv.Item1;
@@ -828,24 +821,26 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred2);
             }
-            deferred1.Resolve(1);
-            deferred2.Resolve(2);
+            deferred1.TryResolve(1);
+            deferred2.TryResolve(2);
 
             Assert.AreEqual(winIndex, resultIndex);
             Assert.AreEqual(1, result);
         }
 
         [Test]
-        public void FirstWithIndex_3_T([Values(0, 1, 2)] int winIndex)
+        public void FirstWithIndex_3_T(
+            [Values(0, 1, 2)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
-            var deferred3 = Promise.NewDeferred<int>();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, alreadyResolved && winIndex == 0 ? 1 : 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, alreadyResolved && winIndex == 1 ? 1 : 2, "Error", out var deferred2, out _);
+            var promise3 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 2, alreadyResolved && winIndex == 2 ? 1 : 3, "Error", out var deferred3, out _);
 
             int resultIndex = -1;
             int result = -1;
 
-            Promise.FirstWithIndex(deferred1.Promise, deferred2.Promise, deferred3.Promise)
+            Promise.FirstWithIndex(promise1, promise2, promise3)
                 .Then(cv =>
                 {
                     resultIndex = cv.Item1;
@@ -861,26 +856,28 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred3);
             }
-            deferred1.Resolve(1);
-            deferred2.Resolve(2);
-            deferred3.Resolve(3);
+            deferred1.TryResolve(1);
+            deferred2.TryResolve(2);
+            deferred3.TryResolve(3);
 
             Assert.AreEqual(winIndex, resultIndex);
             Assert.AreEqual(1, result);
         }
 
         [Test]
-        public void FirstWithIndex_4_T([Values(0, 1, 2, 3)] int winIndex)
+        public void FirstWithIndex_4_T(
+            [Values(0, 1, 2, 3)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
-            var deferred3 = Promise.NewDeferred<int>();
-            var deferred4 = Promise.NewDeferred<int>();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, alreadyResolved && winIndex == 0 ? 1 : 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, alreadyResolved && winIndex == 1 ? 1 : 2, "Error", out var deferred2, out _);
+            var promise3 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 2, alreadyResolved && winIndex == 2 ? 1 : 3, "Error", out var deferred3, out _);
+            var promise4 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 3, alreadyResolved && winIndex == 3 ? 1 : 4, "Error", out var deferred4, out _);
 
             int resultIndex = -1;
             int result = -1;
 
-            Promise.FirstWithIndex(deferred1.Promise, deferred2.Promise, deferred3.Promise, deferred4.Promise)
+            Promise.FirstWithIndex(promise1, promise2, promise3, promise4)
                 .Then(cv =>
                 {
                     resultIndex = cv.Item1;
@@ -900,27 +897,29 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred4);
             }
-            deferred1.Resolve(1);
-            deferred2.Resolve(2);
-            deferred3.Resolve(3);
-            deferred4.Resolve(4);
+            deferred1.TryResolve(1);
+            deferred2.TryResolve(2);
+            deferred3.TryResolve(3);
+            deferred4.TryResolve(4);
 
             Assert.AreEqual(winIndex, resultIndex);
             Assert.AreEqual(1, result);
         }
 
         [Test]
-        public void FirstWithIndex_array_T([Values(0, 1, 2, 3)] int winIndex)
+        public void FirstWithIndex_array_T(
+            [Values(0, 1, 2, 3)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
-            var deferred3 = Promise.NewDeferred<int>();
-            var deferred4 = Promise.NewDeferred<int>();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, alreadyResolved && winIndex == 0 ? 1 : 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, alreadyResolved && winIndex == 1 ? 1 : 2, "Error", out var deferred2, out _);
+            var promise3 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 2, alreadyResolved && winIndex == 2 ? 1 : 3, "Error", out var deferred3, out _);
+            var promise4 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 3, alreadyResolved && winIndex == 3 ? 1 : 4, "Error", out var deferred4, out _);
 
             int resultIndex = -1;
             int result = -1;
 
-            Promise.FirstWithIndex(new Promise<int>[] { deferred1.Promise, deferred2.Promise, deferred3.Promise, deferred4.Promise })
+            Promise.FirstWithIndex(new Promise<int>[] { promise1, promise2, promise3, promise4 })
                 .Then(cv =>
                 {
                     resultIndex = cv.Item1;
@@ -940,10 +939,10 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred4);
             }
-            deferred1.Resolve(1);
-            deferred2.Resolve(2);
-            deferred3.Resolve(3);
-            deferred4.Resolve(4);
+            deferred1.TryResolve(1);
+            deferred2.TryResolve(2);
+            deferred3.TryResolve(3);
+            deferred4.TryResolve(4);
 
             Assert.AreEqual(winIndex, resultIndex);
             Assert.AreEqual(1, result);

--- a/Package/Tests/CoreTests/APIs/RaceTests.cs
+++ b/Package/Tests/CoreTests/APIs/RaceTests.cs
@@ -24,38 +24,40 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RaceIsResolvedWhenFirstPromiseIsResolvedFirst_void()
+        public void RaceIsResolvedWhenFirstPromiseIsResolvedFirst_void(
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
+            var resolvedPromise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, "Error", out var deferred1, out _);
+            var resolvedPromise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise.Race(deferred1.Promise, deferred2.Promise)
+            Promise.Race(resolvedPromise1, resolvedPromise2)
                 .Then(() =>
                 {
                     resolved = true;
                 })
                 .Forget();
 
-            deferred1.Resolve();
+            deferred1.TryResolve();
 
             Assert.IsTrue(resolved);
 
-            deferred2.Resolve();
+            deferred2.TryResolve();
 
             Assert.IsTrue(resolved);
         }
 
         [Test]
-        public void RaceIsResolvedWhenFirstPromiseIsResolvedFirst_T()
+        public void RaceIsResolvedWhenFirstPromiseIsResolvedFirst_T(
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
+            var resolvedPromise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, 5, "Error", out var deferred1, out _);
+            var resolvedPromise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, 1, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise<int>.Race(deferred1.Promise, deferred2.Promise)
+            Promise<int>.Race(resolvedPromise1, resolvedPromise2)
                 .Then(i =>
                 {
                     Assert.AreEqual(5, i);
@@ -63,31 +65,32 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            deferred1.Resolve(5);
+            deferred1.TryResolve(5);
 
             Assert.IsTrue(resolved);
 
-            deferred2.Resolve(1);
+            deferred2.TryResolve(1);
 
             Assert.IsTrue(resolved);
         }
 
         [Test]
-        public void RaceIsResolvedWhenSecondPromiseIsResolvedFirst_void()
+        public void RaceIsResolvedWhenSecondPromiseIsResolvedFirst_void(
+            [Values] bool alreadyResolved)
         {
             var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
+            var resolvedPromise = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise.Race(deferred1.Promise, deferred2.Promise)
+            Promise.Race(deferred1.Promise, resolvedPromise)
                 .Then(() =>
                 {
                     resolved = true;
                 })
                 .Forget();
 
-            deferred2.Resolve();
+            deferred2.TryResolve();
 
             Assert.IsTrue(resolved);
 
@@ -97,14 +100,15 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RaceIsResolvedWhenSecondPromiseIsResolvedFirst_T()
+        public void RaceIsResolvedWhenSecondPromiseIsResolvedFirst_T(
+            [Values] bool alreadyResolved)
         {
             var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
+            var resolvedPromise = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved, 5, "Error", out var deferred2, out _);
 
             bool resolved = false;
 
-            Promise<int>.Race(deferred1.Promise, deferred2.Promise)
+            Promise<int>.Race(deferred1.Promise, resolvedPromise)
                 .Then(i =>
                 {
                     Assert.AreEqual(5, i);
@@ -112,7 +116,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            deferred2.Resolve(5);
+            deferred2.TryResolve(5);
 
             Assert.IsTrue(resolved);
 
@@ -122,15 +126,16 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RaceIsRejectedWhenFirstPromiseIsRejectedFirst_void()
+        public void RaceIsRejectedWhenFirstPromiseIsRejectedFirst_void(
+            [Values] bool alreadyRejected)
         {
-            var deferred1 = Promise.NewDeferred();
+            var rejectPromise = TestHelper.BuildPromise(CompleteType.Reject, alreadyRejected, "Error", out var deferred1, out _);
             var deferred2 = Promise.NewDeferred();
 
             bool invoked = false;
             string expected = "Error";
 
-            Promise.Race(deferred1.Promise, deferred2.Promise)
+            Promise.Race(rejectPromise, deferred2.Promise)
                 .Catch((string rej) =>
                 {
                     Assert.AreEqual(expected, rej);
@@ -138,7 +143,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            deferred1.Reject(expected);
+            deferred1.TryReject(expected);
 
             Assert.IsTrue(invoked);
 
@@ -148,15 +153,16 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RaceIsRejectedWhenFirstPromiseIsRejectedFirst_T()
+        public void RaceIsRejectedWhenFirstPromiseIsRejectedFirst_T(
+            [Values] bool alreadyRejected)
         {
-            var deferred1 = Promise.NewDeferred<int>();
+            var rejectPromise = TestHelper.BuildPromise(CompleteType.Reject, alreadyRejected, 5, "Error", out var deferred1, out _);
             var deferred2 = Promise.NewDeferred<int>();
 
             bool invoked = false;
             string expected = "Error";
 
-            Promise<int>.Race(deferred1.Promise, deferred2.Promise)
+            Promise<int>.Race(rejectPromise, deferred2.Promise)
                 .Catch((string rej) =>
                 {
                     Assert.AreEqual(expected, rej);
@@ -164,7 +170,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            deferred1.Reject(expected);
+            deferred1.TryReject(expected);
 
             Assert.IsTrue(invoked);
 
@@ -174,15 +180,16 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RaceIsRejectedWhenSecondPromiseIsRejectedFirst_void()
+        public void RaceIsRejectedWhenSecondPromiseIsRejectedFirst_void(
+            [Values] bool alreadyRejected)
         {
             var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
+            var rejectPromise = TestHelper.BuildPromise(CompleteType.Reject, alreadyRejected, 5, "Error", out var deferred2, out _);
 
             bool invoked = false;
             string expected = "Error";
 
-            Promise.Race(deferred1.Promise, deferred2.Promise)
+            Promise.Race(deferred1.Promise, rejectPromise)
                 .Catch((string rej) =>
                 {
                     Assert.AreEqual(expected, rej);
@@ -190,7 +197,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            deferred2.Reject(expected);
+            deferred2.TryReject(expected);
 
             Assert.IsTrue(invoked);
 
@@ -200,15 +207,16 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RaceIsRejectedWhenSecondPromiseIsRejectedFirst_T()
+        public void RaceIsRejectedWhenSecondPromiseIsRejectedFirst_T(
+            [Values] bool alreadyRejected)
         {
             var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
+            var rejectPromise = TestHelper.BuildPromise(CompleteType.Reject, alreadyRejected, 5, "Error", out var deferred2, out _);
 
             bool invoked = false;
             string expected = "Error";
 
-            Promise<int>.Race(deferred1.Promise, deferred2.Promise)
+            Promise<int>.Race(deferred1.Promise, rejectPromise)
                 .Catch((string rej) =>
                 {
                     Assert.AreEqual(expected, rej);
@@ -216,7 +224,7 @@ namespace ProtoPromiseTests.APIs
                 })
                 .Forget();
 
-            deferred2.Reject(expected);
+            deferred2.TryReject(expected);
 
             Assert.IsTrue(invoked);
 
@@ -226,133 +234,123 @@ namespace ProtoPromiseTests.APIs
         }
 
         [Test]
-        public void RaceIsCanceledWhenFirstPromiseIsCanceledFirst_void()
+        public void RaceIsCanceledWhenFirstPromiseIsCanceledFirst_void(
+            [Values] bool alreadyCanceled)
         {
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred();
-            cancelationSource.Token.Register(deferred1);
+            var cancelPromise = TestHelper.BuildPromise(CompleteType.Cancel, alreadyCanceled, "Error", out var deferred1, out _);
             var deferred2 = Promise.NewDeferred();
 
             bool invoked = false;
 
-            Promise.Race(deferred1.Promise, deferred2.Promise)
+            Promise.Race(cancelPromise, deferred2.Promise)
                 .CatchCancelation(() =>
                 {
                     invoked = true;
                 })
                 .Forget();
 
-            cancelationSource.Cancel();
+            deferred1.TryCancel();
 
             Assert.IsTrue(invoked);
 
             deferred2.Resolve();
 
-            cancelationSource.Dispose();
-
             Assert.IsTrue(invoked);
         }
 
         [Test]
-        public void RaceIsCanceledWhenFirstPromiseIsCanceledFirst_T()
+        public void RaceIsCanceledWhenFirstPromiseIsCanceledFirst_T(
+            [Values] bool alreadyCanceled)
         {
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred1 = Promise.NewDeferred<int>();
-            cancelationSource.Token.Register(deferred1);
+            var cancelPromise = TestHelper.BuildPromise(CompleteType.Cancel, alreadyCanceled, 5, "Error", out var deferred1, out _);
             var deferred2 = Promise.NewDeferred<int>();
 
             bool invoked = false;
 
-            Promise<int>.Race(deferred1.Promise, deferred2.Promise)
+            Promise<int>.Race(cancelPromise, deferred2.Promise)
                 .CatchCancelation(() =>
                 {
                     invoked = true;
                 })
                 .Forget();
 
-            cancelationSource.Cancel();
+            deferred1.TryCancel();
 
             Assert.IsTrue(invoked);
 
             deferred2.Resolve(5);
 
-            cancelationSource.Dispose();
-
             Assert.IsTrue(invoked);
         }
 
         [Test]
-        public void RaceIsCanceledWhenSecondPromiseIsCanceledFirst_void()
+        public void RaceIsCanceledWhenSecondPromiseIsCanceledFirst_void(
+            [Values] bool alreadyCanceled)
         {
             var deferred1 = Promise.NewDeferred();
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred();
-            cancelationSource.Token.Register(deferred2);
+            var cancelPromise = TestHelper.BuildPromise(CompleteType.Cancel, alreadyCanceled, "Error", out var deferred2, out _);
 
             bool invoked = false;
 
-            Promise.Race(deferred1.Promise, deferred2.Promise)
+            Promise.Race(deferred1.Promise, cancelPromise)
                 .CatchCancelation(() =>
                 {
                     invoked = true;
                 })
                 .Forget();
 
-            cancelationSource.Cancel();
+            deferred2.TryCancel();
 
             Assert.IsTrue(invoked);
 
             deferred1.Resolve();
 
-            cancelationSource.Dispose();
-
             Assert.IsTrue(invoked);
         }
 
         [Test]
-        public void RaceIsCanceledWhenSecondPromiseIsCanceledFirst_T()
+        public void RaceIsCanceledWhenSecondPromiseIsCanceledFirst_T(
+            [Values] bool alreadyCanceled)
         {
             var deferred1 = Promise.NewDeferred<int>();
-            CancelationSource cancelationSource = CancelationSource.New();
-            var deferred2 = Promise.NewDeferred<int>();
-            cancelationSource.Token.Register(deferred2);
+            var cancelPromise = TestHelper.BuildPromise(CompleteType.Cancel, alreadyCanceled, 5, "Error", out var deferred2, out _);
 
             bool invoked = false;
 
-            Promise<int>.Race(deferred1.Promise, deferred2.Promise)
+            Promise<int>.Race(deferred1.Promise, cancelPromise)
                 .CatchCancelation(() =>
                 {
                     invoked = true;
                 })
                 .Forget();
 
-            cancelationSource.Cancel();
+            deferred2.TryCancel();
 
             Assert.IsTrue(invoked);
 
             deferred1.Resolve(5);
 
-            cancelationSource.Dispose();
-
             Assert.IsTrue(invoked);
         }
 
-        private static void Swap(ref Promise.Deferred deferred1, ref Promise.Deferred deferred2)
+        private static void Swap<T>(ref T a, ref T b)
         {
-            var temp = deferred1;
-            deferred1 = deferred2;
-            deferred2 = temp;
+            var temp = a;
+            a = b;
+            b = temp;
         }
 
         [Test]
-        public void RaceWithIndex_2_void([Values(0, 1)] int winIndex)
+        public void RaceWithIndex_2_void(
+            [Values(0, 1)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, "Error", out var deferred2, out _);
 
             int resultIndex = -1;
 
-            Promise.RaceWithIndex(deferred1.Promise, deferred2.Promise)
+            Promise.RaceWithIndex(promise1, promise2)
                 .Then(index => resultIndex = index)
                 .Forget();
 
@@ -360,51 +358,24 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred2);
             }
-            deferred1.Resolve();
-            deferred2.Resolve();
+            deferred1.TryResolve();
+            deferred2.TryResolve();
 
             Assert.AreEqual(winIndex, resultIndex);
         }
 
         [Test]
-        public void RaceWithIndex_3_void([Values(0, 1, 2)] int winIndex)
+        public void RaceWithIndex_3_void(
+            [Values(0, 1, 2)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
-            var deferred3 = Promise.NewDeferred();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, "Error", out var deferred2, out _);
+            var promise3 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 2, "Error", out var deferred3, out _);
 
             int resultIndex = -1;
 
-            Promise.RaceWithIndex(deferred1.Promise, deferred2.Promise, deferred3.Promise)
-                .Then(index => resultIndex = index)
-                .Forget();
-
-            if (winIndex == 1)
-            {
-                Swap(ref deferred1, ref deferred2);
-            }
-            else if (winIndex == 2)
-            {
-                Swap(ref deferred1, ref deferred3);
-            }
-            deferred1.Resolve();
-            deferred2.Resolve();
-            deferred3.Resolve();
-
-            Assert.AreEqual(winIndex, resultIndex);
-        }
-
-        [Test]
-        public void RaceWithIndex_4_void([Values(0, 1, 2, 3)] int winIndex)
-        {
-            var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
-            var deferred3 = Promise.NewDeferred();
-            var deferred4 = Promise.NewDeferred();
-
-            int resultIndex = -1;
-
-            Promise.RaceWithIndex(deferred1.Promise, deferred2.Promise, deferred3.Promise, deferred4.Promise)
+            Promise.RaceWithIndex(promise1, promise2, promise3)
                 .Then(index => resultIndex = index)
                 .Forget();
 
@@ -416,29 +387,26 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred3);
             }
-            else if (winIndex == 3)
-            {
-                Swap(ref deferred1, ref deferred4);
-            }
-            deferred1.Resolve();
-            deferred2.Resolve();
-            deferred3.Resolve();
-            deferred4.Resolve();
+            deferred1.TryResolve();
+            deferred2.TryResolve();
+            deferred3.TryResolve();
 
             Assert.AreEqual(winIndex, resultIndex);
         }
 
         [Test]
-        public void RaceWithIndex_array_void([Values(0, 1, 2, 3)] int winIndex)
+        public void RaceWithIndex_4_void(
+            [Values(0, 1, 2, 3)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred();
-            var deferred2 = Promise.NewDeferred();
-            var deferred3 = Promise.NewDeferred();
-            var deferred4 = Promise.NewDeferred();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, "Error", out var deferred2, out _);
+            var promise3 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 2, "Error", out var deferred3, out _);
+            var promise4 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 3, "Error", out var deferred4, out _);
 
             int resultIndex = -1;
 
-            Promise.RaceWithIndex(new Promise[] { deferred1.Promise, deferred2.Promise, deferred3.Promise, deferred4.Promise })
+            Promise.RaceWithIndex(promise1, promise2, promise3, promise4)
                 .Then(index => resultIndex = index)
                 .Forget();
 
@@ -454,31 +422,62 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred4);
             }
-            deferred1.Resolve();
-            deferred2.Resolve();
-            deferred3.Resolve();
-            deferred4.Resolve();
+            deferred1.TryResolve();
+            deferred2.TryResolve();
+            deferred3.TryResolve();
+            deferred4.TryResolve();
 
             Assert.AreEqual(winIndex, resultIndex);
         }
 
-        private static void Swap(ref Promise<int>.Deferred deferred1, ref Promise<int>.Deferred deferred2)
+        [Test]
+        public void RaceWithIndex_array_void(
+            [Values(0, 1, 2, 3)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var temp = deferred1;
-            deferred1 = deferred2;
-            deferred2 = temp;
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, "Error", out var deferred2, out _);
+            var promise3 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 2, "Error", out var deferred3, out _);
+            var promise4 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 3, "Error", out var deferred4, out _);
+
+            int resultIndex = -1;
+
+            Promise.RaceWithIndex(new Promise[] { promise1, promise2, promise3, promise4 })
+                .Then(index => resultIndex = index)
+                .Forget();
+
+            if (winIndex == 1)
+            {
+                Swap(ref deferred1, ref deferred2);
+            }
+            else if (winIndex == 2)
+            {
+                Swap(ref deferred1, ref deferred3);
+            }
+            else if (winIndex == 3)
+            {
+                Swap(ref deferred1, ref deferred4);
+            }
+            deferred1.TryResolve();
+            deferred2.TryResolve();
+            deferred3.TryResolve();
+            deferred4.TryResolve();
+
+            Assert.AreEqual(winIndex, resultIndex);
         }
 
         [Test]
-        public void RaceWithIndex_2_T([Values(0, 1)] int winIndex)
+        public void RaceWithIndex_2_T(
+            [Values(0, 1)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, alreadyResolved && winIndex == 0 ? 1 : 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, alreadyResolved && winIndex == 1 ? 1 : 2, "Error", out var deferred2, out _);
 
             int resultIndex = -1;
             int result = -1;
 
-            Promise.RaceWithIndex(deferred1.Promise, deferred2.Promise)
+            Promise.RaceWithIndex(promise1, promise2)
                 .Then(cv =>
                 {
                     resultIndex = cv.Item1;
@@ -490,24 +489,26 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred2);
             }
-            deferred1.Resolve(1);
-            deferred2.Resolve(2);
+            deferred1.TryResolve(1);
+            deferred2.TryResolve(2);
 
             Assert.AreEqual(winIndex, resultIndex);
             Assert.AreEqual(1, result);
         }
 
         [Test]
-        public void RaceWithIndex_3_T([Values(0, 1, 2)] int winIndex)
+        public void RaceWithIndex_3_T(
+            [Values(0, 1, 2)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
-            var deferred3 = Promise.NewDeferred<int>();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, alreadyResolved && winIndex == 0 ? 1 : 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, alreadyResolved && winIndex == 1 ? 1 : 2, "Error", out var deferred2, out _);
+            var promise3 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 2, alreadyResolved && winIndex == 2 ? 1 : 3, "Error", out var deferred3, out _);
 
             int resultIndex = -1;
             int result = -1;
 
-            Promise.RaceWithIndex(deferred1.Promise, deferred2.Promise, deferred3.Promise)
+            Promise.RaceWithIndex(promise1, promise2, promise3)
                 .Then(cv =>
                 {
                     resultIndex = cv.Item1;
@@ -523,26 +524,28 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred3);
             }
-            deferred1.Resolve(1);
-            deferred2.Resolve(2);
-            deferred3.Resolve(3);
+            deferred1.TryResolve(1);
+            deferred2.TryResolve(2);
+            deferred3.TryResolve(3);
 
             Assert.AreEqual(winIndex, resultIndex);
             Assert.AreEqual(1, result);
         }
 
         [Test]
-        public void RaceWithIndex_4_T([Values(0, 1, 2, 3)] int winIndex)
+        public void RaceWithIndex_4_T(
+            [Values(0, 1, 2, 3)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
-            var deferred3 = Promise.NewDeferred<int>();
-            var deferred4 = Promise.NewDeferred<int>();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, alreadyResolved && winIndex == 0 ? 1 : 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, alreadyResolved && winIndex == 1 ? 1 : 2, "Error", out var deferred2, out _);
+            var promise3 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 2, alreadyResolved && winIndex == 2 ? 1 : 3, "Error", out var deferred3, out _);
+            var promise4 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 3, alreadyResolved && winIndex == 3 ? 1 : 4, "Error", out var deferred4, out _);
 
             int resultIndex = -1;
             int result = -1;
 
-            Promise.RaceWithIndex(deferred1.Promise, deferred2.Promise, deferred3.Promise, deferred4.Promise)
+            Promise.RaceWithIndex(promise1, promise2, promise3, promise4)
                 .Then(cv =>
                 {
                     resultIndex = cv.Item1;
@@ -562,27 +565,29 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred4);
             }
-            deferred1.Resolve(1);
-            deferred2.Resolve(2);
-            deferred3.Resolve(3);
-            deferred4.Resolve(4);
+            deferred1.TryResolve(1);
+            deferred2.TryResolve(2);
+            deferred3.TryResolve(3);
+            deferred4.TryResolve(4);
 
             Assert.AreEqual(winIndex, resultIndex);
             Assert.AreEqual(1, result);
         }
 
         [Test]
-        public void RaceWithIndex_array_T([Values(0, 1, 2, 3)] int winIndex)
+        public void RaceWithIndex_array_T(
+            [Values(0, 1, 2, 3)] int winIndex,
+            [Values] bool alreadyResolved)
         {
-            var deferred1 = Promise.NewDeferred<int>();
-            var deferred2 = Promise.NewDeferred<int>();
-            var deferred3 = Promise.NewDeferred<int>();
-            var deferred4 = Promise.NewDeferred<int>();
+            var promise1 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 0, alreadyResolved && winIndex == 0 ? 1 : 0, "Error", out var deferred1, out _);
+            var promise2 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 1, alreadyResolved && winIndex == 1 ? 1 : 2, "Error", out var deferred2, out _);
+            var promise3 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 2, alreadyResolved && winIndex == 2 ? 1 : 3, "Error", out var deferred3, out _);
+            var promise4 = TestHelper.BuildPromise(CompleteType.Resolve, alreadyResolved && winIndex == 3, alreadyResolved && winIndex == 3 ? 1 : 4, "Error", out var deferred4, out _);
 
             int resultIndex = -1;
             int result = -1;
 
-            Promise.RaceWithIndex(new Promise<int>[] { deferred1.Promise, deferred2.Promise, deferred3.Promise, deferred4.Promise })
+            Promise.RaceWithIndex(new Promise<int>[] { promise1, promise2, promise3, promise4 })
                 .Then(cv =>
                 {
                     resultIndex = cv.Item1;
@@ -602,10 +607,10 @@ namespace ProtoPromiseTests.APIs
             {
                 Swap(ref deferred1, ref deferred4);
             }
-            deferred1.Resolve(1);
-            deferred2.Resolve(2);
-            deferred3.Resolve(3);
-            deferred4.Resolve(4);
+            deferred1.TryResolve(1);
+            deferred2.TryResolve(2);
+            deferred3.TryResolve(3);
+            deferred4.TryResolve(4);
 
             Assert.AreEqual(winIndex, resultIndex);
             Assert.AreEqual(1, result);


### PR DESCRIPTION
Reduced memory of `PromisePassThrough`.
Hook up promises directly instead of using `PromisePassThrough` where possible.
Use internal enumerators to consolidate code instead of special-casing 2-, 3-, and 4-arg overloads.
