### PR TITLE
Spin lock in async synchronization primitives

### DIFF
--- a/Package/Core/Cancelations/CancelationToken.cs
+++ b/Package/Core/Cancelations/CancelationToken.cs
@@ -126,6 +126,20 @@ namespace Proto.Promises
         }
 
         /// <summary>
+        /// Try to register a cancelable that will be canceled when this <see cref="CancelationToken"/> is canceled.
+        /// If this is already canceled, the <paramref name="cancelable"/> will not be invoked and <paramref name="alreadyCanceled"/> will be set to <see langword="true"/>.
+        /// </summary>
+        /// <param name="cancelable">The cancelable to be canceled when the <see cref="CancelationToken"/> is canceled.</param>
+        /// <param name="cancelationRegistration">The <see cref="CancelationRegistration"/> instance that can be used to unregister the callback.</param>
+        /// <param name="alreadyCanceled">If true, this was already canceled and the <paramref name="cancelable"/> will not be invoked.</param>
+        /// <returns>true if <paramref name="cancelable"/> was registered successfully or this was already canceled, false otherwise.</returns>
+        public bool TryRegisterWithoutImmediateInvoke<TCancelable>(TCancelable cancelable, out CancelationRegistration cancelationRegistration, out bool alreadyCanceled) where TCancelable : ICancelable
+        {
+            ValidateArgument(cancelable, "cancelable", 1);
+            return Internal.CancelationRef.TryRegister(_ref, _id, cancelable, out cancelationRegistration, out alreadyCanceled);
+        }
+
+        /// <summary>
         /// Register a delegate that will be invoked when this <see cref="CancelationToken"/> is canceled.
         /// If this is already canceled, the callback will be invoked immediately.
         /// </summary>

--- a/Package/Core/InternalShared/DebugInternal.cs
+++ b/Package/Core/InternalShared/DebugInternal.cs
@@ -105,6 +105,9 @@ namespace Proto.Promises
         static partial void ClearCurrentInvoker();
 #if PROMISE_DEBUG
         static partial void SetCreatedStacktrace(ITraceable traceable, int skipFrames)
+            => SetCreatedStacktraceImpl(traceable, skipFrames);
+
+        internal static void SetCreatedStacktraceImpl(ITraceable traceable, int skipFrames)
         {
             StackTrace stackTrace = Promise.Config.DebugCausalityTracer == Promise.TraceLevel.All
                 ? GetStackTrace(skipFrames + 1)

--- a/Package/Core/Threading/AsyncAutoResetEvent.cs
+++ b/Package/Core/Threading/AsyncAutoResetEvent.cs
@@ -16,20 +16,8 @@ namespace Proto.Promises.Threading
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode, StackTraceHidden]
 #endif
-    public sealed class AsyncAutoResetEvent
+    public sealed partial class AsyncAutoResetEvent
     {
-        // We wrap the impl with another class so that we can lock on it safely.
-        private readonly Internal.AsyncAutoResetEventInternal _impl;
-
-        /// <summary>
-        /// Creates an async-compatible auto-reset event.
-        /// </summary>
-        /// <param name="initialState">Whether the auto-reset event is initially set or unset.</param>
-        public AsyncAutoResetEvent(bool initialState)
-        {
-            _impl = new Internal.AsyncAutoResetEventInternal(initialState);
-        }
-
         /// <summary>
         /// Creates an async-compatible auto-reset event that is initially unset.
         /// </summary>
@@ -38,12 +26,24 @@ namespace Proto.Promises.Threading
         }
 
         /// <summary>
+        /// Creates an async-compatible auto-reset event.
+        /// </summary>
+        /// <param name="initialState">Whether the auto-reset event is initially set or unset.</param>
+        public AsyncAutoResetEvent(bool initialState)
+        {
+            _isSet = initialState;
+            SetCreatedStacktrace();
+        }
+
+        partial void SetCreatedStacktrace();
+
+        /// <summary>
         /// Whether this event is currently set.
         /// </summary>
         public bool IsSet
         {
             [MethodImpl(Internal.InlineOption)]
-            get { return _impl._isSet; }
+            get => _isSet;
         }
 
         /// <summary>
@@ -51,9 +51,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync()
-        {
-            return _impl.WaitAsync();
-        }
+            => WaitAsyncImpl();
 
         /// <summary>
         /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -65,18 +63,14 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
-        {
-            return _impl.TryWaitAsync(cancelationToken);
-        }
+            => TryWaitAsyncImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously wait for this event to be set.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public void Wait()
-        {
-            _impl.Wait();
-        }
+            => WaitImpl();
 
         /// <summary>
         /// Synchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -88,9 +82,7 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public bool TryWait(CancelationToken cancelationToken)
-        {
-            return _impl.TryWait(cancelationToken);
-        }
+            => TryWaitImpl(cancelationToken);
 
         /// <summary>
         /// Sets this event, completing a waiter.
@@ -101,9 +93,7 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public void Set()
-        {
-            _impl.Set();
-        }
+            => SetImpl();
 
         /// <summary>
         /// Resets this event.
@@ -113,9 +103,7 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public void Reset()
-        {
-            _impl.Reset();
-        }
+            => ResetImpl();
 
         /// <summary>
         /// Asynchronous infrastructure support. This method permits instances of <see cref="AsyncAutoResetEvent"/> to be awaited.

--- a/Package/Core/Threading/AsyncConditionVariable.cs
+++ b/Package/Core/Threading/AsyncConditionVariable.cs
@@ -26,7 +26,7 @@ namespace Proto.Promises.Threading
     {
         // These must not be readonly.
         internal Internal.ValueLinkedQueue<Internal.IAsyncLockPromise> _queue = new Internal.ValueLinkedQueue<Internal.IAsyncLockPromise>();
-        volatile internal Internal.AsyncLockInternal _lock;
+        volatile internal AsyncLock _lock;
 
         /// <summary>
         /// Creates a new async-compatible condition variable.

--- a/Package/Core/Threading/AsyncCountdownEvent.cs
+++ b/Package/Core/Threading/AsyncCountdownEvent.cs
@@ -18,11 +18,8 @@ namespace Proto.Promises.Threading
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode, StackTraceHidden]
 #endif
-    public sealed class AsyncCountdownEvent
+    public sealed partial class AsyncCountdownEvent
     {
-        // We wrap the impl with another class so that we can lock on it safely.
-        private readonly Internal.AsyncCountdownEventInternal _impl;
-
         /// <summary>
         /// Creates an async-compatible countdown event.
         /// </summary>
@@ -34,8 +31,12 @@ namespace Proto.Promises.Threading
                 throw new ArgumentOutOfRangeException("initialCount", "initialCount must be greater than or equal to 0.", Internal.GetFormattedStacktrace(1));
             }
 
-            _impl = new Internal.AsyncCountdownEventInternal(initialCount);
+            _initialCount = initialCount;
+            _currentCount = initialCount;
+            SetCreatedStacktrace();
         }
+
+        partial void SetCreatedStacktrace();
 
         /// <summary>
         /// Gets the number of remaining signals required to set the event.
@@ -43,7 +44,7 @@ namespace Proto.Promises.Threading
         public int CurrentCount
         {
             [MethodImpl(Internal.InlineOption)]
-            get { return _impl._currentCount; }
+            get => _currentCount;
         }
 
         /// <summary>
@@ -52,7 +53,7 @@ namespace Proto.Promises.Threading
         public int InitialCount
         {
             [MethodImpl(Internal.InlineOption)]
-            get { return _impl._initialCount; }
+            get => _initialCount;
         }
 
         /// <summary>
@@ -79,7 +80,7 @@ namespace Proto.Promises.Threading
         [MethodImpl(Internal.InlineOption)]
         public void AddCount(int signalCount)
         {
-            if (!TryAddCount(signalCount))
+            if (!TryAddCountImpl(signalCount))
             {
                 throw new InvalidOperationException("AsyncCountdownEvent.AddCount: The AsyncCountdownEvent is already set.", Internal.GetFormattedStacktrace(1));
             }
@@ -92,9 +93,7 @@ namespace Proto.Promises.Threading
         /// <exception cref="InvalidOperationException"><see cref="CurrentCount"/> is equal to or greater than <see cref="int.MaxValue"/>.</exception>
         [MethodImpl(Internal.InlineOption)]
         public bool TryAddCount()
-        {
-            return _impl.TryAddCount(1);
-        }
+            => TryAddCountImpl(1);
 
         /// <summary>
         /// Attempts to increment <see cref="CurrentCount"/> by a specified value.
@@ -105,27 +104,21 @@ namespace Proto.Promises.Threading
         /// <exception cref="InvalidOperationException"><see cref="CurrentCount"/> + <paramref name="signalCount"/> is equal to or greater than <see cref="int.MaxValue"/>.</exception>
         [MethodImpl(Internal.InlineOption)]
         public bool TryAddCount(int signalCount)
-        {
-            return _impl.TryAddCount(signalCount);
-        }
+            => TryAddCountImpl(signalCount);
 
         /// <summary>
         /// Resets the <see cref="CurrentCount"/> to the value of <see cref="InitialCount"/>.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public void Reset()
-        {
-            _impl.Reset();
-        }
+            => ResetImpl();
 
         /// <summary>
         /// Resets the <see cref="InitialCount"/> and <see cref="CurrentCount"/> to a specified value.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public void Reset(int count)
-        {
-            _impl.Reset(count);
-        }
+            => ResetImpl(count);
 
         /// <summary>
         /// Registers a signal with the <see cref="AsyncCountdownEvent"/>, decrementing the value of <see cref="CurrentCount"/>.
@@ -134,9 +127,7 @@ namespace Proto.Promises.Threading
         /// <exception cref="InvalidOperationException">The current instance is already set.</exception>
         [MethodImpl(Internal.InlineOption)]
         public bool Signal()
-        {
-            return _impl.Signal(1);
-        }
+            => SignalImpl(1);
 
         /// <summary>
         /// Registers multiple signals with the <see cref="AsyncCountdownEvent"/>, decrementing the value of <see cref="CurrentCount"/> by the specified amount.
@@ -147,18 +138,14 @@ namespace Proto.Promises.Threading
         /// <exception cref="InvalidOperationException">The current instance is already set, or <paramref name="signalCount"/> is greater than <see cref="CurrentCount"/>.</exception>
         [MethodImpl(Internal.InlineOption)]
         public bool Signal(int signalCount)
-        {
-            return _impl.Signal(signalCount);
-        }
+            => SignalImpl(signalCount);
 
         /// <summary>
         /// Asynchronously wait for this event to be set.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync()
-        {
-            return _impl.WaitAsync();
-        }
+            => WaitAsyncImpl();
 
         /// <summary>
         /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -170,18 +157,14 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
-        {
-            return _impl.TryWaitAsync(cancelationToken);
-        }
+            => TryWaitAsyncImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously wait for this event to be set.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public void Wait()
-        {
-            _impl.Wait();
-        }
+            => WaitImpl();
 
         /// <summary>
         /// Synchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -193,9 +176,7 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public bool TryWait(CancelationToken cancelationToken)
-        {
-            return _impl.TryWait(cancelationToken);
-        }
+            => TryWaitImpl(cancelationToken);
 
         /// <summary>
         /// Asynchronous infrastructure support. This method permits instances of <see cref="AsyncManualResetEvent"/> to be awaited.

--- a/Package/Core/Threading/AsyncLock.cs
+++ b/Package/Core/Threading/AsyncLock.cs
@@ -62,10 +62,7 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<Key> LockAsync()
-        {
-            return _impl.LockAsync();
-        }
+        public Promise<Key> LockAsync() => LockAsyncImpl();
 
         /// <summary>
         /// Asynchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
@@ -74,19 +71,13 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<Key> LockAsync(CancelationToken cancelationToken)
-        {
-            return _impl.LockAsync(cancelationToken);
-        }
+        public Promise<Key> LockAsync(CancelationToken cancelationToken) => LockAsyncImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously acquire the lock. Returns the key that will release the lock when it is disposed.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
-        public Key Lock()
-        {
-            return _impl.Lock();
-        }
+        public Key Lock() => LockImpl();
 
         /// <summary>
         /// Synchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
@@ -94,10 +85,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, a <see cref="CanceledException"/> will be thrown.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Key Lock(CancelationToken cancelationToken)
-        {
-            return _impl.Lock(cancelationToken);
-        }
+        public Key Lock(CancelationToken cancelationToken) => LockImpl(cancelationToken);
 
         /// <summary>
         /// A disposable object used to release the associated <see cref="AsyncLock"/>.

--- a/Package/Core/Threading/AsyncManualResetEvent.cs
+++ b/Package/Core/Threading/AsyncManualResetEvent.cs
@@ -16,19 +16,19 @@ namespace Proto.Promises.Threading
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode, StackTraceHidden]
 #endif
-    public sealed class AsyncManualResetEvent
+    public sealed partial class AsyncManualResetEvent
     {
-        // We wrap the impl with another class so that we can lock on it safely.
-        private readonly Internal.AsyncManualResetEventInternal _impl;
-
         /// <summary>
         /// Creates an async-compatible manual-reset event.
         /// </summary>
         /// <param name="initialState">Whether the manual-reset event is initially set or unset.</param>
         public AsyncManualResetEvent(bool initialState)
         {
-            _impl = new Internal.AsyncManualResetEventInternal(initialState);
+            _isSet = initialState;
+            SetCreatedStacktrace();
         }
+
+        partial void SetCreatedStacktrace();
 
         /// <summary>
         /// Creates an async-compatible manual-reset event that is initially unset.
@@ -43,7 +43,7 @@ namespace Proto.Promises.Threading
         public bool IsSet
         {
             [MethodImpl(Internal.InlineOption)]
-            get { return _impl._isSet; }
+            get => _isSet;
         }
 
         /// <summary>
@@ -51,9 +51,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync()
-        {
-            return _impl.WaitAsync();
-        }
+            => WaitAsyncImpl();
 
         /// <summary>
         /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -65,18 +63,14 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
-        {
-            return _impl.TryWaitAsync(cancelationToken);
-        }
+            => TryWaitAsyncImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously wait for this event to be set.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public void Wait()
-        {
-            _impl.Wait();
-        }
+            => WaitImpl();
 
         /// <summary>
         /// Synchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -88,9 +82,7 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public bool TryWait(CancelationToken cancelationToken)
-        {
-            return _impl.TryWait(cancelationToken);
-        }
+            => TryWaitImpl(cancelationToken);
 
         /// <summary>
         /// Sets this event, completing every wait.
@@ -100,9 +92,7 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public void Set()
-        {
-            _impl.Set();
-        }
+            => SetImpl();
 
         /// <summary>
         /// Resets this event.
@@ -112,9 +102,7 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public void Reset()
-        {
-            _impl.Reset();
-        }
+            => _isSet = false;
 
         /// <summary>
         /// Asynchronous infrastructure support. This method permits instances of <see cref="AsyncManualResetEvent"/> to be awaited.

--- a/Package/Core/Threading/AsyncMonitor.cs
+++ b/Package/Core/Threading/AsyncMonitor.cs
@@ -24,7 +24,7 @@ namespace Proto.Promises.Threading
 #endif
     public static class AsyncMonitor
     {
-        private static readonly ConditionalWeakTable<Internal.AsyncLockInternal, AsyncConditionVariable> s_condVarTable = new ConditionalWeakTable<Internal.AsyncLockInternal, AsyncConditionVariable>();
+        private static readonly ConditionalWeakTable<AsyncLock, AsyncConditionVariable> s_condVarTable = new ConditionalWeakTable<AsyncLock, AsyncConditionVariable>();
 
         /// <summary>
         /// Asynchronously acquire the lock on the specified <see cref="AsyncLock"/>.
@@ -34,9 +34,7 @@ namespace Proto.Promises.Threading
         /// <param name="asyncLock">The async lock instance that is being entered.</param>
         [MethodImpl(Internal.InlineOption)]
         public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock)
-        {
-            return asyncLock.LockAsync();
-        }
+            => asyncLock.LockAsync();
 
         /// <summary>
         /// Asynchronously acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
@@ -47,9 +45,7 @@ namespace Proto.Promises.Threading
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         [MethodImpl(Internal.InlineOption)]
         public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken)
-        {
-            return asyncLock.LockAsync(cancelationToken);
-        }
+            => asyncLock.LockAsync(cancelationToken);
 
         /// <summary>
         /// Synchronously acquire the lock on the specified <see cref="AsyncLock"/>.
@@ -58,9 +54,7 @@ namespace Proto.Promises.Threading
         /// <param name="asyncLock">The async lock instance that is being entered.</param>
         [MethodImpl(Internal.InlineOption)]
         public static AsyncLock.Key Enter(AsyncLock asyncLock)
-        {
-            return asyncLock.Lock();
-        }
+            => asyncLock.Lock();
 
         /// <summary>
         /// Synchronously acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
@@ -70,9 +64,7 @@ namespace Proto.Promises.Threading
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, a <see cref="CanceledException"/> will be thrown.</param>
         [MethodImpl(Internal.InlineOption)]
         public static AsyncLock.Key Enter(AsyncLock asyncLock, CancelationToken cancelationToken)
-        {
-            return asyncLock.Lock(cancelationToken);
-        }
+            => asyncLock.Lock(cancelationToken);
 
         /// <summary>
         /// Synchronously try to acquire the lock on the specified <see cref="AsyncLock"/>. If successful, <paramref name="key"/> is the key that will release the lock when it is disposed.
@@ -83,9 +75,7 @@ namespace Proto.Promises.Threading
         /// <returns><see langword="true"/> if the lock was acquired, <see langword="false"/> otherwise.</returns>
         [MethodImpl(Internal.InlineOption)]
         public static bool TryEnter(AsyncLock asyncLock, out AsyncLock.Key key)
-        {
-            return asyncLock.TryEnter(out key);
-        }
+            => asyncLock.TryEnterImpl(out key);
 
         /// <summary>
         /// Asynchronously try to acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
@@ -102,9 +92,7 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public static Promise<(bool didEnter, AsyncLock.Key key)> TryEnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken)
-        {
-            return asyncLock.TryEnterAsync(cancelationToken);
-        }
+            => asyncLock.TryEnterAsyncImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously try to acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
@@ -121,18 +109,14 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public static bool TryEnter(AsyncLock asyncLock, out AsyncLock.Key key, CancelationToken cancelationToken)
-        {
-            return asyncLock.TryEnter(out key, cancelationToken);
-        }
+            => asyncLock.TryEnterImpl(out key, cancelationToken);
 
         /// <summary>
         /// Release the lock on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public static void Exit(AsyncLock.Key asyncLockKey)
-        {
-            asyncLockKey.Dispose();
-        }
+            => asyncLockKey.Dispose();
 
         /// <summary>
         /// Release the lock and asynchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.
@@ -143,9 +127,7 @@ namespace Proto.Promises.Threading
         /// A <see cref="Promise"/> that will be resolved when the lock is re-acquired.
         /// </returns>
         public static Promise WaitAsync(AsyncLock.Key asyncLockKey)
-        {
-            return GetConditionVariable(asyncLockKey).WaitAsync(asyncLockKey);
-        }
+            => GetConditionVariable(asyncLockKey).WaitAsync(asyncLockKey);
 
         /// <summary>
         /// Release the lock and asynchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>, while observing a <see cref="CancelationToken"/>.
@@ -159,9 +141,7 @@ namespace Proto.Promises.Threading
         /// <see langword="false"/> if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
         /// </returns>
         public static Promise<bool> TryWaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken)
-        {
-            return GetConditionVariable(asyncLockKey).TryWaitAsync(asyncLockKey, cancelationToken);
-        }
+            => GetConditionVariable(asyncLockKey).TryWaitAsync(asyncLockKey, cancelationToken);
 
         /// <summary>
         /// Release the lock and synchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.
@@ -169,9 +149,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
         public static void Wait(AsyncLock.Key asyncLockKey)
-        {
-            GetConditionVariable(asyncLockKey).Wait(asyncLockKey);
-        }
+            => GetConditionVariable(asyncLockKey).Wait(asyncLockKey);
 
         /// <summary>
         /// Release the lock and synchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>, while observing a <see cref="CancelationToken"/>.
@@ -184,34 +162,28 @@ namespace Proto.Promises.Threading
         /// <see langword="false"/> if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
         /// </returns>
         public static bool TryWait(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken)
-        {
-            return GetConditionVariable(asyncLockKey).TryWait(asyncLockKey, cancelationToken);
-        }
+            => GetConditionVariable(asyncLockKey).TryWait(asyncLockKey, cancelationToken);
 
         /// <summary>
         /// Send a signal to a single waiter on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.
         /// </summary>
         /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
         public static void Pulse(AsyncLock.Key asyncLockKey)
-        {
-            GetConditionVariable(asyncLockKey).Notify(asyncLockKey);
-        }
+            => GetConditionVariable(asyncLockKey).Notify(asyncLockKey);
 
         /// <summary>
         /// Send a signal to all waiters on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.
         /// </summary>
         /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
         public static void PulseAll(AsyncLock.Key asyncLockKey)
-        {
-            GetConditionVariable(asyncLockKey).NotifyAll(asyncLockKey);
-        }
+            => GetConditionVariable(asyncLockKey).NotifyAll(asyncLockKey);
 
         private static AsyncConditionVariable GetConditionVariable(AsyncLock.Key asyncLockKey)
         {
             var impl = asyncLockKey._owner;
             if (impl == null)
             {
-                Internal.AsyncLockInternal.ThrowInvalidKey(2);
+                AsyncLock.ThrowInvalidKey(2);
             }
             return s_condVarTable.GetOrCreateValue(impl);
         }

--- a/Package/Core/Threading/AsyncReaderWriterLock.cs
+++ b/Package/Core/Threading/AsyncReaderWriterLock.cs
@@ -61,9 +61,6 @@ namespace Proto.Promises.Threading
             PrioritizeUpgradeableReaders
         }
 
-        // We wrap the impl with another class so that we can lock on it safely.
-        private readonly Internal.AsyncReaderWriterLockInternal _impl;
-
         /// <summary>
         /// Creates a new async-compatible reader/writer lock that does not support re-entrancy, with a balanced contention strategy.
         /// </summary>
@@ -79,7 +76,7 @@ namespace Proto.Promises.Threading
         /// </remarks>
         public AsyncReaderWriterLock(ContentionStrategy contentionStrategy)
         {
-            _impl = new Internal.AsyncReaderWriterLockInternal(contentionStrategy);
+            _smallFields = new SmallFields(contentionStrategy);
         }
 
         /// <summary>
@@ -88,9 +85,7 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         public Promise<ReaderKey> ReaderLockAsync()
-        {
-            return _impl.ReaderLockAsync();
-        }
+            => ReaderLockAsyncImpl();
 
         /// <summary>
         /// Asynchronously acquire the lock as a reader, while observing a <see cref="CancelationToken"/>.
@@ -99,18 +94,14 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         public Promise<ReaderKey> ReaderLockAsync(CancelationToken cancelationToken)
-        {
-            return _impl.ReaderLockAsync(cancelationToken);
-        }
+            => ReaderLockAsyncImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously acquire the lock as a reader.
         /// Returns the key that will release the lock when it is disposed.
         /// </summary>
         public ReaderKey ReaderLock()
-        {
-            return _impl.ReaderLock();
-        }
+            => ReaderLockImpl();
 
         /// <summary>
         /// Synchronously acquire the lock as a reader, while observing a <see cref="CancelationToken"/>.
@@ -118,9 +109,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, a <see cref="CanceledException"/> will be thrown.</param>
         public ReaderKey ReaderLock(CancelationToken cancelationToken)
-        {
-            return _impl.ReaderLock(cancelationToken);
-        }
+            => ReaderLockImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously try to acquire the lock as a reader.
@@ -129,9 +118,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="readerKey">If successful, the key that will release the lock when it is disposed.</param>
         public bool TryEnterReaderLock(out ReaderKey readerKey)
-        {
-            return _impl.TryEnterReaderLock(out readerKey);
-        }
+            => TryEnterReaderLockImpl(out readerKey);
 
         /// <summary>
         /// Asynchronously try to acquire the lock as a reader, while observing a <see cref="CancelationToken"/>.
@@ -146,9 +133,7 @@ namespace Proto.Promises.Threading
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public Promise<(bool didEnter, ReaderKey readerKey)> TryEnterReaderLockAsync(CancelationToken cancelationToken)
-        {
-            return _impl.TryEnterReaderLockAsync(cancelationToken);
-        }
+            => TryEnterReaderLockAsyncImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously try to acquire the lock as a reader, while observing a <see cref="CancelationToken"/>.
@@ -162,9 +147,7 @@ namespace Proto.Promises.Threading
         /// If the reader lock is available, this will return <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public bool TryEnterReaderLock(out ReaderKey readerKey, CancelationToken cancelationToken)
-        {
-            return _impl.TryEnterReaderLock(out readerKey, cancelationToken);
-        }
+            => TryEnterReaderLockImpl(out readerKey, cancelationToken);
 
         /// <summary>
         /// Asynchronously acquire the lock as a writer.
@@ -172,9 +155,7 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         public Promise<WriterKey> WriterLockAsync()
-        {
-            return _impl.WriterLockAsync();
-        }
+            => WriterLockAsyncImpl();
 
         /// <summary>
         /// Asynchronously acquire the lock as a writer, while observing a <see cref="CancelationToken"/>.
@@ -183,18 +164,14 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         public Promise<WriterKey> WriterLockAsync(CancelationToken cancelationToken)
-        {
-            return _impl.WriterLockAsync(cancelationToken);
-        }
+            => WriterLockAsyncImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously acquire the lock as a writer.
         /// Returns the key that will release the lock when it is disposed.
         /// </summary>
         public WriterKey WriterLock()
-        {
-            return _impl.WriterLock();
-        }
+            => WriterLockImpl();
 
         /// <summary>
         /// Synchronously acquire the lock as a writer, while observing a <see cref="CancelationToken"/>.
@@ -202,9 +179,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, a <see cref="CanceledException"/> will be thrown.</param>
         public WriterKey WriterLock(CancelationToken cancelationToken)
-        {
-            return _impl.WriterLock(cancelationToken);
-        }
+            => WriterLockImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously try to acquire the lock as a writer.
@@ -213,9 +188,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="writerKey">If successful, the key that will release the lock when it is disposed.</param>
         public bool TryEnterWriterLock(out WriterKey writerKey)
-        {
-            return _impl.TryEnterWriterLock(out writerKey);
-        }
+            => TryEnterWriterLockImpl(out writerKey);
 
         /// <summary>
         /// Asynchronously try to acquire the lock as a writer, while observing a <see cref="CancelationToken"/>.
@@ -230,9 +203,7 @@ namespace Proto.Promises.Threading
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public Promise<(bool didEnter, WriterKey writerKey)> TryEnterWriterLockAsync(CancelationToken cancelationToken)
-        {
-            return _impl.TryEnterWriterLockAsync(cancelationToken);
-        }
+            => TryEnterWriterLockAsyncImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously try to acquire the lock as a writer, while observing a <see cref="CancelationToken"/>.
@@ -246,9 +217,7 @@ namespace Proto.Promises.Threading
         /// If the reader lock is available, this will return <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public bool TryEnterWriterLock(out WriterKey writerKey, CancelationToken cancelationToken)
-        {
-            return _impl.TryEnterWriterLock(out writerKey, cancelationToken);
-        }
+            => TryEnterWriterLockImpl(out writerKey, cancelationToken);
 
         /// <summary>
         /// Asynchronously acquire the lock as an upgradeable reader.
@@ -260,9 +229,7 @@ namespace Proto.Promises.Threading
         /// Only 1 upgradeable reader lock may be entered at a time.
         /// </remarks>
         public Promise<UpgradeableReaderKey> UpgradeableReaderLockAsync()
-        {
-            return _impl.UpgradeableReaderLockAsync();
-        }
+            => UpgradeableReaderLockAsyncImpl();
 
         /// <summary>
         /// Asynchronously acquire the lock as an upgradeable reader, while observing a <see cref="CancelationToken"/>.
@@ -275,9 +242,7 @@ namespace Proto.Promises.Threading
         /// Only 1 upgradeable reader lock may be entered at a time.
         /// </remarks>
         public Promise<UpgradeableReaderKey> UpgradeableReaderLockAsync(CancelationToken cancelationToken)
-        {
-            return _impl.UpgradeableReaderLockAsync(cancelationToken);
-        }
+            => UpgradeableReaderLockAsyncImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously acquire the lock as an upgradeable reader.
@@ -288,9 +253,7 @@ namespace Proto.Promises.Threading
         /// Only 1 upgradeable reader lock may be entered at a time.
         /// </remarks>
         public UpgradeableReaderKey UpgradeableReaderLock()
-        {
-            return _impl.UpgradeableReaderLock();
-        }
+            => UpgradeableReaderLockImpl();
 
         /// <summary>
         /// Synchronously acquire the lock as an upgradeable reader, while observing a <see cref="CancelationToken"/>.
@@ -302,9 +265,7 @@ namespace Proto.Promises.Threading
         /// Only 1 upgradeable reader lock may be entered at a time.
         /// </remarks>
         public UpgradeableReaderKey UpgradeableReaderLock(CancelationToken cancelationToken)
-        {
-            return _impl.UpgradeableReaderLock(cancelationToken);
-        }
+            => UpgradeableReaderLockImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously try to acquire the lock as an upgradeable reader.
@@ -317,9 +278,7 @@ namespace Proto.Promises.Threading
         /// Only 1 upgradeable reader lock may be entered at a time.
         /// </remarks>
         public bool TryEnterUpgradeableReaderLock(out UpgradeableReaderKey readerKey)
-        {
-            return _impl.TryEnterUpgradeableReaderLock(out readerKey);
-        }
+            => TryEnterUpgradeableReaderLockImpl(out readerKey);
 
         /// <summary>
         /// Asynchronously try to acquire the lock as an upgradeable reader, while observing a <see cref="CancelationToken"/>.
@@ -334,9 +293,7 @@ namespace Proto.Promises.Threading
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public Promise<(bool didEnter, UpgradeableReaderKey readerKey)> TryEnterUpgradeableReaderLockAsync(CancelationToken cancelationToken)
-        {
-            return _impl.TryEnterUpgradeableReaderLockAsync(cancelationToken);
-        }
+            => TryEnterUpgradeableReaderLockAsyncImpl(cancelationToken);
 
         /// <summary>
         /// Synchronously try to acquire the lock as an upgradeable reader, while observing a <see cref="CancelationToken"/>.
@@ -350,9 +307,7 @@ namespace Proto.Promises.Threading
         /// If the reader lock is available, this will return <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public bool TryEnterUpgradeableReaderLock(out UpgradeableReaderKey readerKey, CancelationToken cancelationToken)
-        {
-            return _impl.TryEnterUpgradeableReaderLock(out readerKey, cancelationToken);
-        }
+            => TryEnterUpgradeableReaderLockImpl(out readerKey, cancelationToken);
 
         /// <summary>
         /// Asynchronously upgrade the lock from an upgradeable reader lock to a writer lock.
@@ -361,9 +316,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="readerKey">The key required to upgrade the lock.</param>
         public Promise<UpgradedWriterKey> UpgradeToWriterLockAsync(UpgradeableReaderKey readerKey)
-        {
-            return _impl.UpgradeToWriterLockAsync(readerKey);
-        }
+            => UpgradeToWriterLockAsyncImpl(readerKey);
 
         /// <summary>
         /// Asynchronously upgrade the lock from an upgradeable reader lock to a writer lock, while observing a <see cref="CancelationToken"/>.
@@ -373,9 +326,7 @@ namespace Proto.Promises.Threading
         /// <param name="readerKey">The key required to upgrade the lock.</param>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the upgrade. If the token is canceled before the lock has been upgraded, the returned <see cref="Promise{T}"/> will be canceled.</param>
         public Promise<UpgradedWriterKey> UpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, CancelationToken cancelationToken)
-        {
-            return _impl.UpgradeToWriterLockAsync(readerKey, cancelationToken);
-        }
+            => UpgradeToWriterLockAsyncImpl(readerKey, cancelationToken);
 
         /// <summary>
         /// Synchronously upgrade the lock from an upgradeable reader lock to a writer lock.
@@ -383,9 +334,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="readerKey">The key required to upgrade the lock.</param>
         public UpgradedWriterKey UpgradeToWriterLock(UpgradeableReaderKey readerKey)
-        {
-            return _impl.UpgradeToWriterLock(readerKey);
-        }
+            => UpgradeToWriterLockImpl(readerKey);
 
         /// <summary>
         /// Synchronously upgrade the lock from an upgradeable reader lock to a writer lock, while observing a <see cref="CancelationToken"/>.
@@ -394,9 +343,7 @@ namespace Proto.Promises.Threading
         /// <param name="readerKey">The key required to upgrade the lock.</param>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the upgrade. If the token is canceled before the lock has been upgraded, a <see cref="CanceledException"/> will be thrown.</param>
         public UpgradedWriterKey UpgradeToWriterLock(UpgradeableReaderKey readerKey, CancelationToken cancelationToken)
-        {
-            return _impl.UpgradeToWriterLock(readerKey, cancelationToken);
-        }
+            => UpgradeToWriterLockImpl(readerKey, cancelationToken);
 
         /// <summary>
         /// Synchronously try to upgrade the lock from an upgradeable reader lock to a writer lock.
@@ -406,9 +353,7 @@ namespace Proto.Promises.Threading
         /// <param name="readerKey">The key required to upgrade the lock.</param>
         /// <param name="upgradedWriterKey">If successful, the key that will downgrade the lock to an upgradeable reader lock when it is disposed.</param>
         public bool TryUpgradeToWriterLock(UpgradeableReaderKey readerKey, out UpgradedWriterKey upgradedWriterKey)
-        {
-            return _impl.TryUpgradeToWriterLock(readerKey, out upgradedWriterKey);
-        }
+            => TryUpgradeToWriterLockImpl(readerKey, out upgradedWriterKey);
 
         /// <summary>
         /// Asynchronously try to upgrade the lock from an upgradeable reader lock to a writer lock, while observing a <see cref="CancelationToken"/>.
@@ -424,9 +369,7 @@ namespace Proto.Promises.Threading
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public Promise<(bool didEnter, UpgradedWriterKey upgradedWriterKey)> TryUpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, CancelationToken cancelationToken)
-        {
-            return _impl.TryUpgradeToWriterLockAsync(readerKey, cancelationToken);
-        }
+            => TryUpgradeToWriterLockAsyncImpl(readerKey, cancelationToken);
 
         /// <summary>
         /// Synchronously try to upgrade the lock from an upgradeable reader lock to a writer lock, while observing a <see cref="CancelationToken"/>.
@@ -441,9 +384,7 @@ namespace Proto.Promises.Threading
         /// If the reader lock is available, this will return <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public bool TryUpgradeToWriterLock(UpgradeableReaderKey readerKey, out UpgradedWriterKey upgradedWriterKey, CancelationToken cancelationToken)
-        {
-            return _impl.TryUpgradeToWriterLock(readerKey, out upgradedWriterKey, cancelationToken);
-        }
+            => TryUpgradeToWriterLockImpl(readerKey, out upgradedWriterKey, cancelationToken);
 
         /// <summary>
         /// A disposable object used to release the reader lock on the associated <see cref="AsyncReaderWriterLock"/>.

--- a/Package/Core/Threading/AsyncSemaphore.cs
+++ b/Package/Core/Threading/AsyncSemaphore.cs
@@ -13,7 +13,7 @@ using System.Runtime.CompilerServices;
 namespace Proto.Promises.Threading
 {
     /// <summary>
-    /// An async-compatible manual-reset event.
+    /// An async-compatible Semaphore.
     /// </summary>
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode, StackTraceHidden]

--- a/Package/Core/Threading/Internal/AsyncAutoResetEventInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncAutoResetEventInternal.cs
@@ -19,7 +19,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
-        internal sealed class AsyncAutoResetEventPromise : AsyncEventPromise<AsyncAutoResetEventInternal>
+        internal sealed class AsyncAutoResetEventPromise : AsyncEventPromise<Threading.AsyncAutoResetEvent>
         {
             [MethodImpl(InlineOption)]
             private static AsyncAutoResetEventPromise GetOrCreate()
@@ -31,7 +31,7 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static AsyncAutoResetEventPromise GetOrCreate(AsyncAutoResetEventInternal owner, SynchronizationContext callerContext)
+            internal static AsyncAutoResetEventPromise GetOrCreate(Threading.AsyncAutoResetEvent owner, SynchronizationContext callerContext)
             {
                 var promise = GetOrCreate();
                 promise.Reset(callerContext);
@@ -71,38 +71,35 @@ namespace Proto.Promises
                 Continue();
             }
         }
+    } // class Internal
 
-#if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode, StackTraceHidden]
-#endif
-        internal sealed class AsyncAutoResetEventInternal : ITraceable
+    namespace Threading
+    {
+        partial class AsyncAutoResetEvent : Internal.ITraceable
         {
-            // This must not be readonly.
-            private ValueLinkedQueue<AsyncEventPromiseBase> _waiterQueue = new ValueLinkedQueue<AsyncEventPromiseBase>();
-            volatile internal bool _isSet;
-
-            internal AsyncAutoResetEventInternal(bool initialState)
-            {
-                _isSet = initialState;
-                SetCreatedStacktrace(this, 2);
-            }
+            // These must not be readonly.
+            private Internal.ValueLinkedQueue<Internal.AsyncEventPromiseBase> _waiterQueue = new Internal.ValueLinkedQueue<Internal.AsyncEventPromiseBase>();
+            private Internal.SpinLocker _locker = new Internal.SpinLocker();
+            volatile private bool _isSet;
 
 #if PROMISE_DEBUG
-            CausalityTrace ITraceable.Trace { get; set; }
+            partial void SetCreatedStacktrace() => Internal.SetCreatedStacktraceImpl(this, 2);
 
-            ~AsyncAutoResetEventInternal()
+            Internal.CausalityTrace Internal.ITraceable.Trace { get; set; }
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+            ~AsyncAutoResetEvent()
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
             {
-                ValueLinkedStack<AsyncEventPromiseBase> waiters;
-                lock (this)
-                {
-                    waiters = _waiterQueue.MoveElementsToStack();
-                }
+                _locker.Enter();
+                var waiters = _waiterQueue.MoveElementsToStack();
+                _locker.Exit();
                 if (waiters.IsEmpty)
                 {
                     return;
                 }
 
-                var rejectContainer = CreateRejectContainer(new Threading.AbandonedResetEventException("An AsyncAutoResetEvent was collected with waiters still pending."), int.MinValue, null, this);
+                var rejectContainer = Internal.CreateRejectContainer(new AbandonedResetEventException("An AsyncAutoResetEvent was collected with waiters still pending."), int.MinValue, null, this);
                 do
                 {
                     waiters.Pop().Reject(rejectContainer);
@@ -111,54 +108,59 @@ namespace Proto.Promises
             }
 #endif // PROMISE_DEBUG
 
-            internal Promise WaitAsync()
+            private Promise WaitAsyncImpl()
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
-                AsyncEventPromiseBase promise;
-                lock (this)
+                Internal.AsyncAutoResetEventPromise promise;
+                _locker.Enter();
                 {
                     if (_isSet)
                     {
                         _isSet = false;
+                        _locker.Exit();
                         return Promise.Resolved();
                     }
 
-                    promise = AsyncAutoResetEventPromise.GetOrCreate(this, CaptureContext());
+                    promise = Internal.AsyncAutoResetEventPromise.GetOrCreate(this, Internal.CaptureContext());
                     _waiterQueue.Enqueue(promise);
                 }
+                _locker.Exit();
                 return new Promise(promise, promise.Id);
             }
 
-            internal Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
+            private Promise<bool> TryWaitAsyncImpl(CancelationToken cancelationToken)
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
 
                 // Immediately query the cancelation state before entering the lock.
                 bool isCanceled = cancelationToken.IsCancelationRequested;
 
-                AsyncAutoResetEventPromise promise;
-                lock (this)
+                Internal.AsyncAutoResetEventPromise promise;
+                _locker.Enter();
                 {
                     bool isSet = _isSet;
                     if (isSet | isCanceled)
                     {
                         _isSet = false;
+                        _locker.Exit();
                         return Promise.Resolved(isSet);
                     }
 
-                    promise = AsyncAutoResetEventPromise.GetOrCreate(this, CaptureContext());
+                    promise = Internal.AsyncAutoResetEventPromise.GetOrCreate(this, Internal.CaptureContext());
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
                         _isSet = false;
+                        _locker.Exit();
                         promise.DisposeImmediate();
                         return Promise.Resolved(isSet);
                     }
                     _waiterQueue.Enqueue(promise);
                 }
+                _locker.Exit();
                 return new Promise<bool>(promise, promise.Id);
             }
 
-            internal void Wait()
+            private void WaitImpl()
             {
                 // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
                 var spinner = new SpinWait();
@@ -167,23 +169,25 @@ namespace Proto.Promises
                     spinner.SpinOnce();
                 }
 
-                AsyncEventPromiseBase promise;
-                lock (this)
+                Internal.AsyncAutoResetEventPromise promise;
+                _locker.Enter();
                 {
                     if (_isSet)
                     {
                         _isSet = false;
+                        _locker.Exit();
                         return;
                     }
-                    promise = AsyncAutoResetEventPromise.GetOrCreate(this, null);
+                    promise = Internal.AsyncAutoResetEventPromise.GetOrCreate(this, null);
                     _waiterQueue.Enqueue(promise);
                 }
+                _locker.Exit();
                 Promise.ResultContainer resultContainer;
-                PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
+                Internal.PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
                 resultContainer.RethrowIfRejected();
             }
 
-            internal bool TryWait(CancelationToken cancelationToken)
+            private bool TryWaitImpl(CancelationToken cancelationToken)
             {
                 // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
                 var spinner = new SpinWait();
@@ -194,59 +198,64 @@ namespace Proto.Promises
                     isCanceled = cancelationToken.IsCancelationRequested;
                 }
 
-                AsyncAutoResetEventPromise promise;
-                lock (this)
+                Internal.AsyncAutoResetEventPromise promise;
+                _locker.Enter();
                 {
                     bool isSet = _isSet;
                     if (isSet | isCanceled)
                     {
                         _isSet = false;
+                        _locker.Exit();
                         return isSet;
                     }
 
-                    promise = AsyncAutoResetEventPromise.GetOrCreate(this, null);
+                    promise = Internal.AsyncAutoResetEventPromise.GetOrCreate(this, null);
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
                         _isSet = false;
+                        _locker.Exit();
                         promise.DisposeImmediate();
                         return isSet;
                     }
                     _waiterQueue.Enqueue(promise);
                 }
+                _locker.Exit();
                 Promise<bool>.ResultContainer resultContainer;
-                PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
+                Internal.PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
                 resultContainer.RethrowIfRejected();
                 return resultContainer.Value;
             }
 
-            internal void Set()
+            private void SetImpl()
             {
-                AsyncEventPromiseBase waiter;
-                lock (this)
+                Internal.AsyncEventPromiseBase waiter;
+                _locker.Enter();
                 {
                     if (_waiterQueue.IsEmpty)
                     {
                         _isSet = true;
+                        _locker.Exit();
                         return;
                     }
                     waiter = _waiterQueue.Dequeue();
                 }
+                _locker.Exit();
                 waiter.Resolve();
             }
 
-            [MethodImpl(InlineOption)]
-            internal void Reset()
+            [MethodImpl(Internal.InlineOption)]
+            private void ResetImpl()
             {
                 _isSet = false;
             }
 
-            internal bool TryRemoveWaiter(AsyncEventPromiseBase waiter)
+            internal bool TryRemoveWaiter(Internal.AsyncEventPromiseBase waiter)
             {
-                lock (this)
-                {
-                    return _waiterQueue.TryRemove(waiter);
-                }
+                _locker.Enter();
+                var removed = _waiterQueue.TryRemove(waiter);
+                _locker.Exit();
+                return removed;
             }
-        } // class AsyncAutoResetEventInternal
-    } // class Internal
+        } // class AsyncAutoResetEvent
+    } // namespace Threading
 } // namespace Proto.Promises

--- a/Package/Core/Threading/Internal/AsyncCountdownEventInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncCountdownEventInternal.cs
@@ -20,7 +20,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
-        internal sealed class AsyncCountdownEventPromise : AsyncEventPromise<AsyncCountdownEventInternal>
+        internal sealed class AsyncCountdownEventPromise : AsyncEventPromise<Threading.AsyncCountdownEvent>
         {
             [MethodImpl(InlineOption)]
             private static AsyncCountdownEventPromise GetOrCreate()
@@ -32,7 +32,7 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static AsyncCountdownEventPromise GetOrCreate(AsyncCountdownEventInternal owner, SynchronizationContext callerContext)
+            internal static AsyncCountdownEventPromise GetOrCreate(Threading.AsyncCountdownEvent owner, SynchronizationContext callerContext)
             {
                 var promise = GetOrCreate();
                 promise.Reset(callerContext);
@@ -72,40 +72,36 @@ namespace Proto.Promises
                 Continue();
             }
         }
+    } // class Internal
 
-#if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode, StackTraceHidden]
-#endif
-        internal sealed class AsyncCountdownEventInternal : ITraceable
+    namespace Threading
+    {
+        partial class AsyncCountdownEvent : Internal.ITraceable
         {
-            // This must not be readonly.
-            private ValueLinkedQueue<AsyncEventPromiseBase> _waiters = new ValueLinkedQueue<AsyncEventPromiseBase>();
-            internal int _initialCount;
-            volatile internal int _currentCount;
-
-            internal AsyncCountdownEventInternal(int initialCount)
-            {
-                _initialCount = initialCount;
-                _currentCount = initialCount;
-                SetCreatedStacktrace(this, 2);
-            }
+            // These must not be readonly.
+            private Internal.ValueLinkedQueue<Internal.AsyncEventPromiseBase> _waiters = new Internal.ValueLinkedQueue<Internal.AsyncEventPromiseBase>();
+            private Internal.SpinLocker _locker = new Internal.SpinLocker();
+            private int _initialCount;
+            volatile private int _currentCount;
 
 #if PROMISE_DEBUG
-            CausalityTrace ITraceable.Trace { get; set; }
+            partial void SetCreatedStacktrace() => Internal.SetCreatedStacktraceImpl(this, 2);
 
-            ~AsyncCountdownEventInternal()
+            Internal.CausalityTrace Internal.ITraceable.Trace { get; set; }
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+            ~AsyncCountdownEvent()
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
             {
-                ValueLinkedStack<AsyncEventPromiseBase> waiters;
-                lock (this)
-                {
-                    waiters = _waiters.MoveElementsToStack();
-                }
+                _locker.Enter();
+                var waiters = _waiters.MoveElementsToStack();
+                _locker.Exit();
                 if (waiters.IsEmpty)
                 {
                     return;
                 }
 
-                var rejectContainer = CreateRejectContainer(new Threading.AbandonedResetEventException("An AsyncCountdownEvent was collected with waiters still pending."), int.MinValue, null, this);
+                var rejectContainer = Internal.CreateRejectContainer(new AbandonedResetEventException("An AsyncCountdownEvent was collected with waiters still pending."), int.MinValue, null, this);
                 do
                 {
                     waiters.Pop().Reject(rejectContainer);
@@ -114,7 +110,7 @@ namespace Proto.Promises
             }
 #endif // PROMISE_DEBUG
 
-            internal Promise WaitAsync()
+            private Promise WaitAsyncImpl()
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
                 if (_currentCount == 0)
@@ -122,21 +118,23 @@ namespace Proto.Promises
                     return Promise.Resolved();
                 }
 
-                AsyncCountdownEventPromise promise;
-                lock (this)
+                Internal.AsyncCountdownEventPromise promise;
+                _locker.Enter();
                 {
                     // Check the count again inside the lock to resolve race condition with Signal().
                     if (_currentCount == 0)
                     {
+                        _locker.Exit();
                         return Promise.Resolved();
                     }
-                    promise = AsyncCountdownEventPromise.GetOrCreate(this, CaptureContext());
+                    promise = Internal.AsyncCountdownEventPromise.GetOrCreate(this, Internal.CaptureContext());
                     _waiters.Enqueue(promise);
                 }
+                _locker.Exit();
                 return new Promise(promise, promise.Id);
             }
 
-            internal Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
+            private Promise<bool> TryWaitAsyncImpl(CancelationToken cancelationToken)
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
                 bool isSet = _currentCount == 0;
@@ -145,26 +143,29 @@ namespace Proto.Promises
                     return Promise.Resolved(isSet);
                 }
 
-                AsyncCountdownEventPromise promise;
-                lock (this)
+                Internal.AsyncCountdownEventPromise promise;
+                _locker.Enter();
                 {
                     // Check the count again inside the lock to resolve race condition with Signal().
                     if (_currentCount == 0)
                     {
+                        _locker.Exit();
                         return Promise.Resolved(true);
                     }
-                    promise = AsyncCountdownEventPromise.GetOrCreate(this, CaptureContext());
+                    promise = Internal.AsyncCountdownEventPromise.GetOrCreate(this, Internal.CaptureContext());
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
                         promise.DisposeImmediate();
+                        _locker.Exit();
                         return Promise.Resolved(false);
                     }
                     _waiters.Enqueue(promise);
                 }
+                _locker.Exit();
                 return new Promise<bool>(promise, promise.Id);
             }
 
-            internal void Wait()
+            private void WaitImpl()
             {
                 // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
                 var spinner = new SpinWait();
@@ -180,23 +181,25 @@ namespace Proto.Promises
                     return;
                 }
 
-                AsyncCountdownEventPromise promise;
-                lock (this)
+                Internal.AsyncCountdownEventPromise promise;
+                _locker.Enter();
                 {
                     // Check the count again inside the lock to resolve race condition with Signal().
                     if (_currentCount == 0)
                     {
+                        _locker.Exit();
                         return;
                     }
-                    promise = AsyncCountdownEventPromise.GetOrCreate(this, null);
+                    promise = Internal.AsyncCountdownEventPromise.GetOrCreate(this, null);
                     _waiters.Enqueue(promise);
                 }
+                _locker.Exit();
                 Promise.ResultContainer resultContainer;
-                PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
+                Internal.PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
                 resultContainer.RethrowIfRejected();
             }
 
-            internal bool TryWait(CancelationToken cancelationToken)
+            private bool TryWaitImpl(CancelationToken cancelationToken)
             {
                 // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
                 var spinner = new SpinWait();
@@ -214,55 +217,61 @@ namespace Proto.Promises
                     return isSet;
                 }
 
-                AsyncCountdownEventPromise promise;
-                lock (this)
+                Internal.AsyncCountdownEventPromise promise;
+                _locker.Enter();
                 {
                     // Check the count again inside the lock to resolve race condition with Signal().
                     if (_currentCount == 0)
                     {
+                        _locker.Exit();
                         return true;
                     }
-                    promise = AsyncCountdownEventPromise.GetOrCreate(this, null);
+                    promise = Internal.AsyncCountdownEventPromise.GetOrCreate(this, null);
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
+                        _locker.Exit();
                         promise.DisposeImmediate();
                         return false;
                     }
                     _waiters.Enqueue(promise);
                 }
+                _locker.Exit();
                 Promise<bool>.ResultContainer resultContainer;
-                PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
+                Internal.PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
                 resultContainer.RethrowIfRejected();
                 return resultContainer.Value;
             }
 
-            internal bool Signal(int signalCount)
+            private bool SignalImpl(int signalCount)
             {
-                ValueLinkedStack<AsyncEventPromiseBase> waiters;
-                lock (this)
+                Internal.ValueLinkedStack<Internal.AsyncEventPromiseBase> waiters;
+                _locker.Enter();
                 {
                     // Read the _currentCount into a local variable to avoid extra unnecessary volatile accesses inside the lock.
                     int current = _currentCount;
                     if (signalCount < 1 | current == 0 | signalCount > current)
                     {
+                        _locker.Exit();
                         if (signalCount < 1)
                         {
-                            throw new ArgumentOutOfRangeException("signalCount", "AsyncCountdownEvent.Signal: signalCount must be greater than or equal to 1.", GetFormattedStacktrace(2));
+                            throw new ArgumentOutOfRangeException("signalCount", "AsyncCountdownEvent.Signal: signalCount must be greater than or equal to 1.", Internal.GetFormattedStacktrace(2));
                         }
                         throw new InvalidOperationException(current == 0
                             ? "AsyncCountdownEvent.Signal: The AsyncCountdownEvent is already set."
-                            : "AsyncCountdownEvent.Signal: signalCount cannot be greater than CurrentCount.", GetFormattedStacktrace(2));
+                            : "AsyncCountdownEvent.Signal: signalCount cannot be greater than CurrentCount.", Internal.GetFormattedStacktrace(2));
                     }
 
                     current -= signalCount;
                     _currentCount = current;
                     if (current != 0)
                     {
+                        _locker.Exit();
                         return false;
                     }
 
                     waiters = _waiters.MoveElementsToStack();
                 }
+                _locker.Exit();
                 while (waiters.IsNotEmpty)
                 {
                     waiters.Pop().Resolve();
@@ -270,71 +279,75 @@ namespace Proto.Promises
                 return true;
             }
 
-            internal void Reset()
+            private void ResetImpl()
             {
-                lock (this)
-                {
-                    _currentCount = _initialCount;
-                }
+                _locker.Enter();
+                _currentCount = _initialCount;
+                _locker.Exit();
             }
 
-            internal void Reset(int count)
+            private void ResetImpl(int count)
             {
                 if (count < 0)
                 {
-                    throw new ArgumentOutOfRangeException("count", "AsyncCountdownEvent.Reset: count must be greater than or equal to 0.", GetFormattedStacktrace(2));
+                    throw new ArgumentOutOfRangeException("count", "AsyncCountdownEvent.Reset: count must be greater than or equal to 0.", Internal.GetFormattedStacktrace(2));
                 }
 
-                ValueLinkedStack<AsyncEventPromiseBase> waiters;
-                lock (this)
+                Internal.ValueLinkedStack<Internal.AsyncEventPromiseBase> waiters;
+                _locker.Enter();
                 {
                     _initialCount = count;
                     _currentCount = count;
-                    
+
                     if (count != 0)
                     {
+                        _locker.Exit();
                         return;
                     }
 
                     waiters = _waiters.MoveElementsToStack();
                 }
+                _locker.Exit();
                 while (waiters.IsNotEmpty)
                 {
                     waiters.Pop().Resolve();
                 }
             }
 
-            internal bool TryAddCount(int signalCount)
+            private bool TryAddCountImpl(int signalCount)
             {
-                lock (this)
+                _locker.Enter();
                 {
                     // Read the _currentCount into a local variable to avoid extra unnecessary volatile accesses inside the lock.
                     int current = _currentCount;
                     if (signalCount < 1 | signalCount > int.MaxValue - current)
                     {
+                        _locker.Exit();
                         if (signalCount < 1)
                         {
-                            throw new ArgumentOutOfRangeException("signalCount", "AsyncCountdownEvent.TryAddCount: signalCount must be greater than or equal to 1.", GetFormattedStacktrace(2));
+                            throw new ArgumentOutOfRangeException("signalCount", "AsyncCountdownEvent.TryAddCount: signalCount must be greater than or equal to 1.", Internal.GetFormattedStacktrace(2));
                         }
-                        throw new InvalidOperationException("AsyncCountdownEvent.TryAddCount: signalCount + CurrentCount exceeded int.MaxValue.", GetFormattedStacktrace(2));
+                        throw new InvalidOperationException("AsyncCountdownEvent.TryAddCount: signalCount + CurrentCount exceeded int.MaxValue.", Internal.GetFormattedStacktrace(2));
                     }
 
                     if (current == 0)
                     {
+                        _locker.Exit();
                         return false;
                     }
                     _currentCount = current + signalCount;
-                    return true;
                 }
+                _locker.Exit();
+                return true;
             }
 
-            internal bool TryRemoveWaiter(AsyncCountdownEventPromise waiter)
+            internal bool TryRemoveWaiter(Internal.AsyncCountdownEventPromise waiter)
             {
-                lock (this)
-                {
-                    return _waiters.TryRemove(waiter);
-                }
+                _locker.Enter();
+                var removed = _waiters.TryRemove(waiter);
+                _locker.Exit();
+                return removed;
             }
-        } // class AsyncCountdownEventInternal
-    } // class Internal
+        } // class AsyncCountdownEvent
+    } // namespace Threading
 } // namespace Proto.Promises

--- a/Package/Core/Threading/Internal/AsyncManualResetEventInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncManualResetEventInternal.cs
@@ -19,7 +19,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
-        internal sealed class AsyncManualResetEventPromise : AsyncEventPromise<AsyncManualResetEventInternal>
+        internal sealed class AsyncManualResetEventPromise : AsyncEventPromise<Threading.AsyncManualResetEvent>
         {
             [MethodImpl(InlineOption)]
             private static AsyncManualResetEventPromise GetOrCreate()
@@ -31,7 +31,7 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static AsyncManualResetEventPromise GetOrCreate(AsyncManualResetEventInternal owner, SynchronizationContext callerContext)
+            internal static AsyncManualResetEventPromise GetOrCreate(Threading.AsyncManualResetEvent owner, SynchronizationContext callerContext)
             {
                 var promise = GetOrCreate();
                 promise.Reset(callerContext);
@@ -71,38 +71,35 @@ namespace Proto.Promises
                 Continue();
             }
         }
+    } // class Internal
 
-#if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode, StackTraceHidden]
-#endif
-        internal sealed class AsyncManualResetEventInternal : ITraceable
+    namespace Threading
+    {
+        partial class AsyncManualResetEvent : Internal.ITraceable
         {
-            // This must not be readonly.
-            private ValueLinkedQueue<AsyncEventPromiseBase> _waiters = new ValueLinkedQueue<AsyncEventPromiseBase>();
+            // These must not be readonly.
+            private Internal.ValueLinkedQueue<Internal.AsyncEventPromiseBase> _waiters = new Internal.ValueLinkedQueue<Internal.AsyncEventPromiseBase>();
+            private Internal.SpinLocker _locker = new Internal.SpinLocker();
             volatile internal bool _isSet;
 
-            internal AsyncManualResetEventInternal(bool initialState)
-            {
-                _isSet = initialState;
-                SetCreatedStacktrace(this, 2);
-            }
-
 #if PROMISE_DEBUG
-            CausalityTrace ITraceable.Trace { get; set; }
+            partial void SetCreatedStacktrace() => Internal.SetCreatedStacktraceImpl(this, 2);
 
-            ~AsyncManualResetEventInternal()
+            Internal.CausalityTrace Internal.ITraceable.Trace { get; set; }
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+            ~AsyncManualResetEvent()
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
             {
-                ValueLinkedStack<AsyncEventPromiseBase> waiters;
-                lock (this)
-                {
-                    waiters = _waiters.MoveElementsToStack();
-                }
+                _locker.Enter();
+                var waiters = _waiters.MoveElementsToStack();
+                _locker.Exit();
                 if (waiters.IsEmpty)
                 {
                     return;
                 }
 
-                var rejectContainer = CreateRejectContainer(new Threading.AbandonedResetEventException("An AsyncManualResetEvent was collected with waiters still pending."), int.MinValue, null, this);
+                var rejectContainer = Internal.CreateRejectContainer(new AbandonedResetEventException("An AsyncManualResetEvent was collected with waiters still pending."), int.MinValue, null, this);
                 do
                 {
                     waiters.Pop().Reject(rejectContainer);
@@ -111,7 +108,7 @@ namespace Proto.Promises
             }
 #endif // PROMISE_DEBUG
 
-            internal Promise WaitAsync()
+            private Promise WaitAsyncImpl()
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
                 if (_isSet)
@@ -119,21 +116,23 @@ namespace Proto.Promises
                     return Promise.Resolved();
                 }
 
-                AsyncManualResetEventPromise promise;
-                lock (this)
+                Internal.AsyncManualResetEventPromise promise;
+                _locker.Enter();
                 {
                     // Check the flag again inside the lock to resolve race condition with Set().
                     if (_isSet)
                     {
+                        _locker.Exit();
                         return Promise.Resolved();
                     }
-                    promise = AsyncManualResetEventPromise.GetOrCreate(this, CaptureContext());
+                    promise = Internal.AsyncManualResetEventPromise.GetOrCreate(this, Internal.CaptureContext());
                     _waiters.Enqueue(promise);
                 }
+                _locker.Exit();
                 return new Promise(promise, promise.Id);
             }
 
-            internal Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
+            private Promise<bool> TryWaitAsyncImpl(CancelationToken cancelationToken)
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
                 bool isSet = _isSet;
@@ -142,26 +141,29 @@ namespace Proto.Promises
                     return Promise.Resolved(isSet);
                 }
 
-                AsyncManualResetEventPromise promise;
-                lock (this)
+                Internal.AsyncManualResetEventPromise promise;
+                _locker.Enter();
                 {
                     // Check the flag again inside the lock to resolve race condition with Set().
                     if (_isSet)
                     {
+                        _locker.Exit();
                         return Promise.Resolved(true);
                     }
-                    promise = AsyncManualResetEventPromise.GetOrCreate(this, CaptureContext());
+                    promise = Internal.AsyncManualResetEventPromise.GetOrCreate(this, Internal.CaptureContext());
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
+                        _locker.Exit();
                         promise.DisposeImmediate();
                         return Promise.Resolved(false);
                     }
                     _waiters.Enqueue(promise);
                 }
+                _locker.Exit();
                 return new Promise<bool>(promise, promise.Id);
             }
 
-            internal void Wait()
+            private void WaitImpl()
             {
                 // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
                 var spinner = new SpinWait();
@@ -177,23 +179,25 @@ namespace Proto.Promises
                     return;
                 }
 
-                AsyncManualResetEventPromise promise;
-                lock (this)
+                Internal.AsyncManualResetEventPromise promise;
+                _locker.Enter();
                 {
                     // Check the flag again inside the lock to resolve race condition with Set().
                     if (_isSet)
                     {
+                        _locker.Exit();
                         return;
                     }
-                    promise = AsyncManualResetEventPromise.GetOrCreate(this, null);
+                    promise = Internal.AsyncManualResetEventPromise.GetOrCreate(this, null);
                     _waiters.Enqueue(promise);
                 }
+                _locker.Exit();
                 Promise.ResultContainer resultContainer;
-                PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
+                Internal.PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
                 resultContainer.RethrowIfRejected();
             }
 
-            internal bool TryWait(CancelationToken cancelationToken)
+            private bool TryWaitImpl(CancelationToken cancelationToken)
             {
                 // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
                 var spinner = new SpinWait();
@@ -211,57 +215,52 @@ namespace Proto.Promises
                     return isSet;
                 }
 
-                AsyncManualResetEventPromise promise;
-                lock (this)
+                Internal.AsyncManualResetEventPromise promise;
+                _locker.Enter();
                 {
                     // Check the flag again inside the lock to resolve race condition with Set().
                     if (_isSet)
                     {
+                        _locker.Exit();
                         return true;
                     }
-                    promise = AsyncManualResetEventPromise.GetOrCreate(this, null);
+                    promise = Internal.AsyncManualResetEventPromise.GetOrCreate(this, null);
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
+                        _locker.Exit();
                         promise.DisposeImmediate();
                         return false;
                     }
                     _waiters.Enqueue(promise);
                 }
+                _locker.Exit();
                 Promise<bool>.ResultContainer resultContainer;
-                PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
+                Internal.PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
                 resultContainer.RethrowIfRejected();
                 return resultContainer.Value;
             }
 
-            internal void Set()
+            private void SetImpl()
             {
                 // Set the field before lock.
                 _isSet = true;
 
-                ValueLinkedStack<AsyncEventPromiseBase> waiters;
-                lock (this)
-                {
-                    waiters = _waiters.MoveElementsToStack();
-                }
+                _locker.Enter();
+                var waiters = _waiters.MoveElementsToStack();
+                _locker.Exit();
                 while (waiters.IsNotEmpty)
                 {
                     waiters.Pop().Resolve();
                 }
             }
 
-            [MethodImpl(InlineOption)]
-            internal void Reset()
+            internal bool TryRemoveWaiter(Internal.AsyncManualResetEventPromise waiter)
             {
-                _isSet = false;
+                _locker.Enter();
+                var removed = _waiters.TryRemove(waiter);
+                _locker.Exit();
+                return removed;
             }
-
-            internal bool TryRemoveWaiter(AsyncManualResetEventPromise waiter)
-            {
-                lock (this)
-                {
-                    return _waiters.TryRemove(waiter);
-                }
-            }
-        } // class AsyncManualResetEventInternal
-    } // class Internal
+        } // class AsyncManualResetEvent
+    } // namespace Threading
 } // namespace Proto.Promises

--- a/Package/Core/Threading/Internal/AsyncManualResetEventInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncManualResetEventInternal.cs
@@ -46,6 +46,13 @@ namespace Proto.Promises
                 ObjectPool.MaybeRepool(this);
             }
 
+            [MethodImpl(InlineOption)]
+            internal void DisposeImmediate()
+            {
+                SetCompletionState(Promise.State.Resolved);
+                MaybeDispose();
+            }
+
             public override void Cancel()
             {
                 ThrowIfInPool(this);
@@ -144,8 +151,12 @@ namespace Proto.Promises
                         return Promise.Resolved(true);
                     }
                     promise = AsyncManualResetEventPromise.GetOrCreate(this, CaptureContext());
+                    if (promise.HookupAndGetIsCanceled(cancelationToken))
+                    {
+                        promise.DisposeImmediate();
+                        return Promise.Resolved(false);
+                    }
                     _waiters.Enqueue(promise);
-                    promise.MaybeHookupCancelation(cancelationToken);
                 }
                 return new Promise<bool>(promise, promise.Id);
             }
@@ -209,8 +220,12 @@ namespace Proto.Promises
                         return true;
                     }
                     promise = AsyncManualResetEventPromise.GetOrCreate(this, null);
+                    if (promise.HookupAndGetIsCanceled(cancelationToken))
+                    {
+                        promise.DisposeImmediate();
+                        return false;
+                    }
                     _waiters.Enqueue(promise);
-                    promise.MaybeHookupCancelation(cancelationToken);
                 }
                 Promise<bool>.ResultContainer resultContainer;
                 PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);

--- a/Package/Core/Threading/Internal/AsyncSemaphoreInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncSemaphoreInternal.cs
@@ -46,6 +46,13 @@ namespace Proto.Promises
                 ObjectPool.MaybeRepool(this);
             }
 
+            [MethodImpl(InlineOption)]
+            internal void DisposeImmediate()
+            {
+                SetCompletionState(Promise.State.Resolved);
+                MaybeDispose();
+            }
+
             public override void Cancel()
             {
                 ThrowIfInPool(this);
@@ -147,8 +154,12 @@ namespace Proto.Promises
                         return Promise.Resolved(false);
                     }
                     promise = AsyncSemaphorePromise.GetOrCreate(this, CaptureContext());
+                    if (promise.HookupAndGetIsCanceled(cancelationToken))
+                    {
+                        promise.DisposeImmediate();
+                        return Promise.Resolved(false);
+                    }
                     _waiters.Enqueue(promise);
-                    promise.MaybeHookupCancelation(cancelationToken);
                 }
                 return new Promise<bool>(promise, promise.Id);
             }
@@ -206,8 +217,12 @@ namespace Proto.Promises
                         return false;
                     }
                     promise = AsyncSemaphorePromise.GetOrCreate(this, null);
+                    if (promise.HookupAndGetIsCanceled(cancelationToken))
+                    {
+                        promise.DisposeImmediate();
+                        return false;
+                    }
                     _waiters.Enqueue(promise);
-                    promise.MaybeHookupCancelation(cancelationToken);
                 }
                 Promise<bool>.ResultContainer resultContainer;
                 PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);

--- a/Package/Core/Threading/Internal/AsyncSemaphoreInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncSemaphoreInternal.cs
@@ -19,7 +19,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
-        internal sealed class AsyncSemaphorePromise : AsyncEventPromise<AsyncSemaphoreInternal>
+        internal sealed class AsyncSemaphorePromise : AsyncEventPromise<Threading.AsyncSemaphore>
         {
             [MethodImpl(InlineOption)]
             private static AsyncSemaphorePromise GetOrCreate()
@@ -31,7 +31,7 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static AsyncSemaphorePromise GetOrCreate(AsyncSemaphoreInternal owner, SynchronizationContext callerContext)
+            internal static AsyncSemaphorePromise GetOrCreate(Threading.AsyncSemaphore owner, SynchronizationContext callerContext)
             {
                 var promise = GetOrCreate();
                 promise.Reset(callerContext);
@@ -71,40 +71,36 @@ namespace Proto.Promises
                 Continue();
             }
         }
+    } // class Internal
 
-#if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode, StackTraceHidden]
-#endif
-        internal sealed class AsyncSemaphoreInternal : ITraceable
+    namespace Threading
+    {
+        partial class AsyncSemaphore : Internal.ITraceable
         {
-            // This must not be readonly.
-            private ValueLinkedQueue<AsyncEventPromiseBase> _waiters = new ValueLinkedQueue<AsyncEventPromiseBase>();
-            volatile internal int _currentCount;
+            // These must not be readonly.
+            private Internal.ValueLinkedQueue<Internal.AsyncEventPromiseBase> _waiters = new Internal.ValueLinkedQueue<Internal.AsyncEventPromiseBase>();
+            private Internal.SpinLocker _locker = new Internal.SpinLocker();
+            volatile private int _currentCount;
             private readonly int _maxCount;
 
-            internal AsyncSemaphoreInternal(int initialCount, int maxCount)
-            {
-                _currentCount = initialCount;
-                _maxCount = maxCount;
-                SetCreatedStacktrace(this, 2);
-            }
-
 #if PROMISE_DEBUG
-            CausalityTrace ITraceable.Trace { get; set; }
+            partial void SetCreatedStacktrace() => Internal.SetCreatedStacktraceImpl(this, 2);
 
-            ~AsyncSemaphoreInternal()
+            Internal.CausalityTrace Internal.ITraceable.Trace { get; set; }
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+            ~AsyncSemaphore()
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
             {
-                ValueLinkedStack<AsyncEventPromiseBase> waiters;
-                lock (this)
-                {
-                    waiters = _waiters.MoveElementsToStack();
-                }
+                _locker.Enter();
+                var waiters = _waiters.MoveElementsToStack();
+                _locker.Exit();
                 if (waiters.IsEmpty)
                 {
                     return;
                 }
 
-                var rejectContainer = CreateRejectContainer(new Threading.AbandonedSemaphoreException("An AsyncSemaphore was collected with waiters still pending."), int.MinValue, null, this);
+                var rejectContainer = Internal.CreateRejectContainer(new AbandonedSemaphoreException("An AsyncSemaphore was collected with waiters still pending."), int.MinValue, null, this);
                 do
                 {
                     waiters.Pop().Reject(rejectContainer);
@@ -113,58 +109,64 @@ namespace Proto.Promises
             }
 #endif // PROMISE_DEBUG
 
-            internal Promise WaitAsync()
+            private Promise WaitAsyncImpl()
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
-                AsyncSemaphorePromise promise;
-                lock (this)
+                Internal.AsyncSemaphorePromise promise;
+                _locker.Enter();
                 {
                     // Read the _currentCount into a local variable to avoid extra unnecessary volatile accesses inside the lock.
                     int current = _currentCount;
                     if (current != 0)
                     {
                         _currentCount = current - 1;
+                        _locker.Exit();
                         return Promise.Resolved();
                     }
-                    promise = AsyncSemaphorePromise.GetOrCreate(this, CaptureContext());
+                    promise = Internal.AsyncSemaphorePromise.GetOrCreate(this, Internal.CaptureContext());
                     _waiters.Enqueue(promise);
                 }
+                _locker.Exit();
                 return new Promise(promise, promise.Id);
             }
 
-            internal Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
+            private Promise<bool> TryWaitAsyncImpl(CancelationToken cancelationToken)
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
 
                 // Immediately query the cancelation state before entering the lock.
                 bool isCanceled = cancelationToken.IsCancelationRequested;
 
-                AsyncSemaphorePromise promise;
-                lock (this)
+                Internal.AsyncSemaphorePromise promise;
+                _locker.Enter();
                 {
                     // Read the _currentCount into a local variable to avoid extra unnecessary volatile accesses inside the lock.
                     int current = _currentCount;
                     if (current != 0)
                     {
                         _currentCount = current - 1;
+                        _locker.Exit();
                         return Promise.Resolved(true);
                     }
                     if (isCanceled)
                     {
+                        _locker.Exit();
                         return Promise.Resolved(false);
                     }
-                    promise = AsyncSemaphorePromise.GetOrCreate(this, CaptureContext());
+                    promise = Internal.AsyncSemaphorePromise.GetOrCreate(this, Internal.CaptureContext());
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
+                        _locker.Exit();
                         promise.DisposeImmediate();
                         return Promise.Resolved(false);
                     }
                     _waiters.Enqueue(promise);
                 }
+                _locker.Exit();
                 return new Promise<bool>(promise, promise.Id);
             }
 
-            internal void WaitSync()
+            private void WaitSyncImpl()
             {
                 // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
                 var spinner = new SpinWait();
@@ -173,25 +175,27 @@ namespace Proto.Promises
                     spinner.SpinOnce();
                 }
 
-                AsyncSemaphorePromise promise;
-                lock (this)
+                Internal.AsyncSemaphorePromise promise;
+                _locker.Enter();
                 {
                     // Read the _currentCount into a local variable to avoid extra unnecessary volatile accesses inside the lock.
                     int current = _currentCount;
                     if (current != 0)
                     {
                         _currentCount = current - 1;
+                        _locker.Exit();
                         return;
                     }
-                    promise = AsyncSemaphorePromise.GetOrCreate(this, null);
+                    promise = Internal.AsyncSemaphorePromise.GetOrCreate(this, null);
                     _waiters.Enqueue(promise);
                 }
+                _locker.Exit();
                 Promise.ResultContainer resultContainer;
-                PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
+                Internal.PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
                 resultContainer.RethrowIfRejected();
             }
 
-            internal bool TryWait(CancelationToken cancelationToken)
+            private bool TryWaitImpl(CancelationToken cancelationToken)
             {
                 // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
                 var spinner = new SpinWait();
@@ -202,86 +206,95 @@ namespace Proto.Promises
                     isCanceled = cancelationToken.IsCancelationRequested;
                 }
 
-                AsyncSemaphorePromise promise;
-                lock (this)
+                Internal.AsyncSemaphorePromise promise;
+                _locker.Enter();
                 {
                     // Read the _currentCount into a local variable to avoid extra unnecessary volatile accesses inside the lock.
                     int current = _currentCount;
                     if (current != 0)
                     {
                         _currentCount = current - 1;
+                        _locker.Exit();
                         return true;
                     }
                     if (isCanceled)
                     {
+                        _locker.Exit();
                         return false;
                     }
-                    promise = AsyncSemaphorePromise.GetOrCreate(this, null);
+                    promise = Internal.AsyncSemaphorePromise.GetOrCreate(this, null);
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
+                        _locker.Exit();
                         promise.DisposeImmediate();
                         return false;
                     }
                     _waiters.Enqueue(promise);
                 }
+                _locker.Exit();
                 Promise<bool>.ResultContainer resultContainer;
-                PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
+                Internal.PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, TimeSpan.FromMilliseconds(Timeout.Infinite), out resultContainer);
                 resultContainer.RethrowIfRejected();
                 return resultContainer.Value;
             }
 
-            internal void Release()
+            private void ReleaseImpl()
             {
                 // Special implementation for Release(1) to remove unnecessary branches.
-                AsyncEventPromiseBase waiter;
-                lock (this)
+                Internal.AsyncEventPromiseBase waiter;
+                _locker.Enter();
                 {
                     // Read the _currentCount into a local variable to avoid extra unnecessary volatile accesses inside the lock.
                     int current = _currentCount;
                     if (_maxCount == current)
                     {
-                        throw new Threading.SemaphoreFullException(GetFormattedStacktrace(2));
+                        _locker.Exit();
+                        throw new SemaphoreFullException(Internal.GetFormattedStacktrace(2));
                     }
 
                     if (_waiters.IsEmpty)
                     {
                         _currentCount = current + 1;
+                        _locker.Exit();
                         return;
                     }
                     waiter = _waiters.Dequeue();
                 }
+                _locker.Exit();
                 waiter.Resolve();
             }
 
-            internal void Release(int releaseCount)
+            private void ReleaseImpl(int releaseCount)
             {
-                ValueLinkedStack<AsyncEventPromiseBase> waiters;
-                lock (this)
+                Internal.ValueLinkedStack<Internal.AsyncEventPromiseBase> waiters;
+                _locker.Enter();
                 {
                     // Read the _currentCount into a local variable to avoid extra unnecessary volatile accesses inside the lock.
                     int current = _currentCount;
                     if (releaseCount > _maxCount - current)
                     {
-                        throw new Threading.SemaphoreFullException(GetFormattedStacktrace(2));
+                        _locker.Exit();
+                        throw new SemaphoreFullException(Internal.GetFormattedStacktrace(2));
                     }
 
                     int waiterCount;
                     waiters = _waiters.MoveElementsToStack(releaseCount, out waiterCount);
                     _currentCount = current + releaseCount - waiterCount;
                 }
+                _locker.Exit();
                 while (waiters.IsNotEmpty)
                 {
                     waiters.Pop().Resolve();
                 }
             }
 
-            internal bool TryRemoveWaiter(AsyncSemaphorePromise waiter)
+            internal bool TryRemoveWaiter(Internal.AsyncSemaphorePromise waiter)
             {
-                lock (this)
-                {
-                    return _waiters.TryRemove(waiter);
-                }
+                _locker.Enter();
+                var removed = _waiters.TryRemove(waiter);
+                _locker.Exit();
+                return removed;
             }
-        } // class AsyncSemaphoreInternal
-    } // class Internal
+        } // class AsyncSemaphore
+    } // namespace Threading
 } // namespace Proto.Promises

--- a/Package/Core/Threading/Internal/SingleConsumerAsyncQueueInternal.cs
+++ b/Package/Core/Threading/Internal/SingleConsumerAsyncQueueInternal.cs
@@ -34,24 +34,20 @@ namespace Proto.Promises
 
             internal Promise<(bool hasValue, T value)> TryDequeueAsync()
             {
-                bool hasValue;
-                T value = default;
                 PromiseRefBase.DeferredPromise<(bool, T)> promise;
 
                 _smallValues._locker.Enter();
                 {
                     if (_smallValues._producerCount == 0)
                     {
-                        hasValue = false;
                         _smallValues._locker.Exit();
-                        return Promise.Resolved((hasValue, value));
+                        return Promise.Resolved((false, default(T)));
                     }
                     if (_queue.Count > 0)
                     {
-                        hasValue = true;
-                        value = _queue.Dequeue();
+                        var value = _queue.Dequeue();
                         _smallValues._locker.Exit();
-                        return Promise.Resolved((hasValue, value));
+                        return Promise.Resolved((true, value));
                     }
                     _waiter = promise = PromiseRefBase.DeferredPromise<(bool, T)>.GetOrCreate();
                 }


### PR DESCRIPTION
Resolves #281

Also added `CancelationToken.TryRegisterWithoutImmediateInvoke<TCancelable>` API.