### PR TITLE
Optimize async Promise

### DIFF
--- a/Package/Core/Promises/CompilerServices/AsyncPromiseMethodBuilders.cs
+++ b/Package/Core/Promises/CompilerServices/AsyncPromiseMethodBuilders.cs
@@ -64,6 +64,14 @@ namespace Proto.Promises
 #endif
         public partial struct AsyncPromiseMethodBuilder
         {
+            /// <summary>Gets the <see cref="Promise"/> for this builder.</summary>
+            /// <returns>The <see cref="Promise"/> representing the builder's asynchronous operation.</returns>
+            public Promise Task
+            {
+                [MethodImpl(Internal.InlineOption)]
+                get => new Promise(_ref, _id);
+            }
+
             /// <summary>
             /// Schedules the specified state machine to be pushed forward when the specified awaiter completes.
             /// </summary>
@@ -75,7 +83,7 @@ namespace Proto.Promises
             public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
                 where TAwaiter : INotifyCompletion
                 where TStateMachine : IAsyncStateMachine
-                => Internal.PromiseRefBase.AsyncPromiseRef<Internal.VoidResult>.AwaitOnCompleted(ref awaiter, ref stateMachine, ref _ref);
+                => Internal.PromiseRefBase.AsyncPromiseRef<Internal.VoidResult>.AwaitOnCompleted(ref awaiter, ref stateMachine, ref _ref, ref _id);
 
             /// <summary>
             /// Schedules the specified state machine to be pushed forward when the specified awaiter completes.
@@ -89,7 +97,7 @@ namespace Proto.Promises
             public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
                 where TAwaiter : ICriticalNotifyCompletion
                 where TStateMachine : IAsyncStateMachine
-                => Internal.PromiseRefBase.AsyncPromiseRef<Internal.VoidResult>.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref _ref);
+                => Internal.PromiseRefBase.AsyncPromiseRef<Internal.VoidResult>.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref _ref, ref _id);
 
             /// <summary>Initiates the builder's execution with the associated state machine.</summary>
             /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
@@ -125,6 +133,14 @@ namespace Proto.Promises
 #endif
         public partial struct AsyncPromiseMethodBuilder<T>
         {
+            /// <summary>Gets the <see cref="Promise{T}"/> for this builder.</summary>
+            /// <returns>The <see cref="Promise{T}"/> representing the builder's asynchronous operation.</returns>
+            public Promise<T> Task
+            {
+                [MethodImpl(Internal.InlineOption)]
+                get => new Promise<T>(_ref, _id, _result);
+            }
+
             /// <summary>
             /// Schedules the specified state machine to be pushed forward when the specified awaiter completes.
             /// </summary>
@@ -136,7 +152,7 @@ namespace Proto.Promises
             public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
                 where TAwaiter : INotifyCompletion
                 where TStateMachine : IAsyncStateMachine
-                => Internal.PromiseRefBase.AsyncPromiseRef<T>.AwaitOnCompleted(ref awaiter, ref stateMachine, ref _ref);
+                => Internal.PromiseRefBase.AsyncPromiseRef<T>.AwaitOnCompleted(ref awaiter, ref stateMachine, ref _ref, ref _id);
 
             /// <summary>
             /// Schedules the specified state machine to be pushed forward when the specified awaiter completes.
@@ -150,7 +166,7 @@ namespace Proto.Promises
             public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
                 where TAwaiter : ICriticalNotifyCompletion
                 where TStateMachine : IAsyncStateMachine
-                => Internal.PromiseRefBase.AsyncPromiseRef<T>.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref _ref);
+                => Internal.PromiseRefBase.AsyncPromiseRef<T>.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref _ref, ref _id);
 
             /// <summary>Initiates the builder's execution with the associated state machine.</summary>
             /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
@@ -174,14 +190,7 @@ namespace Proto.Promises
             private AsyncPromiseMethodBuilder(Internal.PromiseRefBase.AsyncPromiseRef<Internal.VoidResult> promise)
             {
                 _ref = promise;
-            }
-
-            /// <summary>Gets the <see cref="Promise"/> for this builder.</summary>
-            /// <returns>The <see cref="Promise"/> representing the builder's asynchronous operation.</returns>
-            public Promise Task
-            {
-                [MethodImpl(Internal.InlineOption)]
-                get => new Promise(_ref, _ref.Id);
+                _id = promise.Id;
             }
 
             /// <summary>Initializes a new <see cref="AsyncPromiseMethodBuilder"/>.</summary>
@@ -211,14 +220,7 @@ namespace Proto.Promises
             private AsyncPromiseMethodBuilder(Internal.PromiseRefBase.AsyncPromiseRef<T> promise)
             {
                 _ref = promise;
-            }
-
-            /// <summary>Gets the <see cref="Promise{T}"/> for this builder.</summary>
-            /// <returns>The <see cref="Promise{T}"/> representing the builder's asynchronous operation.</returns>
-            public Promise<T> Task
-            {
-                [MethodImpl(Internal.InlineOption)]
-                get => new Promise<T>(_ref, _ref.Id);
+                _id = promise.Id;
             }
 
             /// <summary>Initializes a new <see cref="AsyncPromiseMethodBuilder{T}"/>.</summary>
@@ -248,14 +250,6 @@ namespace Proto.Promises
         // This code could be used for DEBUG mode, but IL2CPP requires the non-optimized code even in RELEASE mode, and I don't want to add extra unnecessary null checks there.
         partial struct AsyncPromiseMethodBuilder
         {
-            /// <summary>Gets the <see cref="Promise"/> for this builder.</summary>
-            /// <returns>The <see cref="Promise"/> representing the builder's asynchronous operation.</returns>
-            public Promise Task
-            {
-                [MethodImpl(Internal.InlineOption)]
-                get => _ref == null ? Promise.Resolved() : new Promise(_ref, _ref.Id);
-            }
-
             /// <summary>Initializes a new <see cref="AsyncPromiseMethodBuilder"/>.</summary>
             /// <returns>The initialized <see cref="AsyncPromiseMethodBuilder"/>.</returns>
             [MethodImpl(Internal.InlineOption)]
@@ -271,6 +265,7 @@ namespace Proto.Promises
                 if (_ref == null)
                 {
                     _ref = Internal.PromiseRefBase.AsyncPromiseRef<Internal.VoidResult>.GetOrCreate();
+                    _id = _ref.Id;
                 }
                 _ref.SetException(exception);
             }
@@ -285,14 +280,6 @@ namespace Proto.Promises
 
         partial struct AsyncPromiseMethodBuilder<T>
         {
-            /// <summary>Gets the <see cref="Promise{T}"/> for this builder.</summary>
-            /// <returns>The <see cref="Promise{T}"/> representing the builder's asynchronous operation.</returns>
-            public Promise<T> Task
-            {
-                [MethodImpl(Internal.InlineOption)]
-                get => _ref == null ? new Promise<T>(_result) : new Promise<T>(_ref, _ref.Id);
-            }
-
             /// <summary>Initializes a new <see cref="AsyncPromiseMethodBuilder{T}"/>.</summary>
             /// <returns>The initialized <see cref="AsyncPromiseMethodBuilder{T}"/>.</returns>
             [MethodImpl(Internal.InlineOption)]
@@ -308,6 +295,7 @@ namespace Proto.Promises
                 if (_ref == null)
                 {
                     _ref = Internal.PromiseRefBase.AsyncPromiseRef<T>.GetOrCreate();
+                    _id = _ref.Id;
                 }
                 _ref.SetException(exception);
             }

--- a/Package/Core/Promises/Internal/AsyncInternal.cs
+++ b/Package/Core/Promises/Internal/AsyncInternal.cs
@@ -93,11 +93,11 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption | AggressiveOptimizationOption)]
-                internal static void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine, ref AsyncPromiseRef<TResult> _ref)
+                internal static void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine, ref AsyncPromiseRef<TResult> _ref, ref short id)
                     where TAwaiter : INotifyCompletion
                     where TStateMachine : IAsyncStateMachine
                 {
-                    SetStateMachine(ref stateMachine, ref _ref);
+                    SetStateMachine(ref stateMachine, ref _ref, ref id);
 #if NETCOREAPP
                     // These checks and cast are eliminated by the JIT.
 #pragma warning disable IDE0038 // Use pattern matching
@@ -117,11 +117,11 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption | AggressiveOptimizationOption)]
-                internal static void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine, ref AsyncPromiseRef<TResult> _ref)
+                internal static void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine, ref AsyncPromiseRef<TResult> _ref, ref short id)
                     where TAwaiter : ICriticalNotifyCompletion
                     where TStateMachine : IAsyncStateMachine
                 {
-                    SetStateMachine(ref stateMachine, ref _ref);
+                    SetStateMachine(ref stateMachine, ref _ref, ref id);
 #if NETCOREAPP
                     // These checks and cast are eliminated by the JIT.
 #pragma warning disable IDE0038 // Use pattern matching
@@ -249,7 +249,9 @@ namespace Proto.Promises
                 private PromiseMethodContinuer _continuer;
 
                 [MethodImpl(InlineOption)]
-                private static void SetStateMachine<TStateMachine>(ref TStateMachine stateMachine, ref AsyncPromiseRef<TResult> _ref) where TStateMachine : IAsyncStateMachine
+#pragma warning disable IDE0060 // Remove unused parameter
+                private static void SetStateMachine<TStateMachine>(ref TStateMachine stateMachine, ref AsyncPromiseRef<TResult> _ref, ref short id) where TStateMachine : IAsyncStateMachine
+#pragma warning restore IDE0060 // Remove unused parameter
                 {
                     if (_ref._continuer == null)
                     {
@@ -308,10 +310,11 @@ namespace Proto.Promises
                             : obj.UnsafeAs<AsyncPromiseRefMachine<TStateMachine>>();
                     }
 
-                    internal static void SetStateMachine(ref TStateMachine stateMachine, ref AsyncPromiseRef<TResult> _ref)
+                    internal static void SetStateMachine(ref TStateMachine stateMachine, ref AsyncPromiseRef<TResult> _ref, ref short id)
                     {
                         var promise = GetOrCreate();
                         promise.Reset();
+                        id = promise.Id;
                         // ORDER VERY IMPORTANT, ref must be set before copying stateMachine.
                         _ref = promise;
                         promise._stateMachine = stateMachine;
@@ -356,11 +359,11 @@ namespace Proto.Promises
                 protected AsyncPromiseRef() { }
 
                 [MethodImpl(InlineOption)]
-                private static void SetStateMachine<TStateMachine>(ref TStateMachine stateMachine, ref AsyncPromiseRef<TResult> _ref) where TStateMachine : IAsyncStateMachine
+                private static void SetStateMachine<TStateMachine>(ref TStateMachine stateMachine, ref AsyncPromiseRef<TResult> _ref, ref short id) where TStateMachine : IAsyncStateMachine
                 {
                     if (_ref == null)
                     {
-                        AsyncPromiseRefMachine<TStateMachine>.SetStateMachine(ref stateMachine, ref _ref);
+                        AsyncPromiseRefMachine<TStateMachine>.SetStateMachine(ref stateMachine, ref _ref, ref id);
                     }
                     if (Promise.Config.AsyncFlowExecutionContextEnabled)
                     {

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -50,7 +50,7 @@ namespace Proto.Promises
         }
 
         [MethodImpl(Internal.InlineOption)]
-        internal Promise(Internal.PromiseRefBase.PromiseRef<T> promiseRef, short id, T result)
+        internal Promise(Internal.PromiseRefBase.PromiseRef<T> promiseRef, short id, in T result)
         {
             _ref = promiseRef;
             _result = result;
@@ -58,7 +58,7 @@ namespace Proto.Promises
         }
 
         [MethodImpl(Internal.InlineOption)]
-        internal Promise(T result)
+        internal Promise(in T result)
         {
             _ref = null;
             _id = 0;
@@ -399,16 +399,20 @@ namespace Proto.Promises
     {
         partial struct AsyncPromiseMethodBuilder
         {
-            // This must not be readonly.
+            // These must not be readonly.
             private Internal.PromiseRefBase.AsyncPromiseRef<Internal.VoidResult> _ref;
+            private short _id;
         }
 
         partial struct AsyncPromiseMethodBuilder<T>
         {
             // These must not be readonly.
             private Internal.PromiseRefBase.AsyncPromiseRef<T> _ref;
+            private short _id;
 #if OPTIMIZED_ASYNC_MODE
             private T _result;
+#else
+            private T _result => default;
 #endif
         }
     }


### PR DESCRIPTION
Trade-off increased memory to remove a branch, resulting in faster synchronous completions (asynchronous completion times are negligible).

develop

|       Method | Pending |       Mean | Allocated | Survived |
|------------- |-------- |-----------:|----------:|---------:|
| AsyncAwait |   False |   334.0 ns |         - |        - |
| AsyncAwait |    True | 1,602.5 ns |         - |    624 B |

PR

|       Method | Pending |       Mean | Allocated | Survived |
|------------- |-------- |-----------:|----------:|---------:|
| AsyncAwait |   False |   304.0 ns |         - |        - |
| AsyncAwait |    True | 1,611.2 ns |         - |    648 B |