### PR TITLE
Promise merge cleanup

### DIFF
--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -323,7 +323,7 @@ namespace Proto.Promises
             {
             }
 
-            partial class RacePromiseWithIndex<TResult> : RacePromise<ValueTuple<int, TResult>>
+            partial class RacePromiseWithIndex<TResult> : RacePromise<(int, TResult)>
             {
             }
 
@@ -332,7 +332,7 @@ namespace Proto.Promises
                 protected int _waitCount; // int for Interlocked since it doesn't support uint on older runtimes.
             }
 
-            partial class FirstPromiseWithIndex<TResult> : FirstPromise<ValueTuple<int, TResult>>
+            partial class FirstPromiseWithIndex<TResult> : FirstPromise<(int, TResult)>
             {
             }
 


### PR DESCRIPTION
Pass through `valueContainer` list in some `Promise.AllSettled<T>` functions.
Fixed `valueContainer` type in some `Promise.AllSettled` functions.
Refactored to use `GetResultDelegate` instead of `GetResultContainerDelegate`.
Cleaned up ValueTuple usages to use new C# 7 syntax.