### PR TITLE
Add Promise Retainer

### DIFF
--- a/Package/Core/Collections/TempCollection.cs
+++ b/Package/Core/Collections/TempCollection.cs
@@ -327,8 +327,7 @@ namespace Proto.Promises.Collections
 #endif
             Array.Clear(_items, 0, _count);
             ArrayPool<T>.Shared.Return(_items, false);
-            _items = null;
-            _count = -1;
+            this = default;
         }
 
         [MethodImpl(Internal.InlineOption)]

--- a/Package/Core/InternalShared/DebugInternal.cs
+++ b/Package/Core/InternalShared/DebugInternal.cs
@@ -233,6 +233,7 @@ namespace Proto.Promises
         {
             if (!promise.IsValid)
             {
+                // TODO: update error message to use GetRetainer.
                 throw new InvalidOperationException("Promise is invalid." +
                     " Call `Preserve()` if you intend to add multiple callbacks or await multiple times on a single promise instance." +
                     " Remember to call `Forget()` when you are finished with it!",

--- a/Package/Core/InternalShared/DebugInternal.cs
+++ b/Package/Core/InternalShared/DebugInternal.cs
@@ -235,8 +235,7 @@ namespace Proto.Promises
             {
                 // TODO: update error message to use GetRetainer.
                 throw new InvalidOperationException("Promise is invalid." +
-                    " Call `Preserve()` if you intend to add multiple callbacks or await multiple times on a single promise instance." +
-                    " Remember to call `Forget()` when you are finished with it!",
+                    " Call `GetRetainer()` if you intend to await multiple times.",
                     GetFormattedStacktrace(skipFrames + 1));
             }
         }
@@ -474,8 +473,7 @@ namespace Proto.Promises
             {
                 throw new InvalidArgumentException(argName,
                     "Promise is invalid." +
-                    " Call `Preserve()` if you intend to add multiple callbacks or await multiple times on a single promise instance." +
-                    " Remember to call `Forget()` when you are finished with it!",
+                    " Call `GetRetainer()` if you intend to await multiple times.",
                     Internal.GetFormattedStacktrace(skipFrames + 1));
             }
         }
@@ -485,9 +483,8 @@ namespace Proto.Promises
             if (!promise.IsValid)
             {
                 throw new InvalidElementException(argName,
-                    string.Format("A promise is invalid in {0}." +
-                    " Call `Preserve()` if you intend to add multiple callbacks or await multiple times on a single promise instance." +
-                    " Remember to call `Forget()` when you are finished with it!", argName),
+                    $"A promise is invalid in {argName}." +
+                    " Call `GetRetainer()` if you intend to await multiple times.",
                     Internal.GetFormattedStacktrace(skipFrames + 1));
             }
         }
@@ -514,8 +511,7 @@ namespace Proto.Promises
             {
                 throw new InvalidArgumentException(argName,
                     "Promise is invalid." +
-                    " Call `Preserve()` if you intend to add multiple callbacks or await multiple times on a single promise instance." +
-                    " Remember to call `Forget()` when you are finished with it!",
+                    " Call `GetRetainer()` if you intend to await multiple times.",
                     Internal.GetFormattedStacktrace(skipFrames + 1));
             }
         }
@@ -525,9 +521,8 @@ namespace Proto.Promises
             if (!promise.IsValid)
             {
                 throw new InvalidElementException(argName,
-                    string.Format("A promise is invalid in {0}." +
-                    " Call `Preserve()` if you intend to add multiple callbacks or await multiple times on a single promise instance." +
-                    " Remember to call `Forget()` when you are finished with it!", argName),
+                    $"A promise is invalid in {argName}." +
+                    " Call `GetRetainer()` if you intend to await multiple times.",
                     Internal.GetFormattedStacktrace(skipFrames + 1));
             }
         }

--- a/Package/Core/InternalShared/DebugInternal.cs
+++ b/Package/Core/InternalShared/DebugInternal.cs
@@ -233,7 +233,6 @@ namespace Proto.Promises
         {
             if (!promise.IsValid)
             {
-                // TODO: update error message to use GetRetainer.
                 throw new InvalidOperationException("Promise is invalid." +
                     " Call `GetRetainer()` if you intend to await multiple times.",
                     GetFormattedStacktrace(skipFrames + 1));

--- a/Package/Core/Linq/Internal/MergeInternal.cs
+++ b/Package/Core/Linq/Internal/MergeInternal.cs
@@ -24,7 +24,7 @@ namespace Proto.Promises
         internal abstract class AsyncEnumerableMergerBase<TValue> : PromiseRefBase.AsyncEnumerableWithIterator<TValue>
         {
             // These must not be readonly.
-            // We queue the successful MoveNextAsync results instead of using Promise.RaceWithIndex, to avoid having to preserve each promise.
+            // We queue the successful MoveNextAsync results instead of using Promise.RaceWithIndex, to avoid having to retain each promise.
             protected SingleConsumerAsyncQueueInternal<int> _readyQueue;
             protected TempCollectionBuilder<AsyncEnumerator<TValue>> _enumerators;
             protected TempCollectionBuilder<(IRejectContainer rejectContainer, Promise disposePromise)> _disposePromises;

--- a/Package/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/Package/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -53,7 +53,9 @@ namespace Proto.Promises
                 {
                     try
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         return resolver.Invoke(CallbackHelperVoid.GetResultFromResolved(resolved)).Duplicate();
+#pragma warning restore CS0618 // Type or member is obsolete
                     }
                     catch (Exception e)
                     {
@@ -250,7 +252,9 @@ namespace Proto.Promises
                     try
                     {
                         resolved._ref?.MaybeMarkAwaitedAndDispose(resolved._id);
+#pragma warning disable CS0618 // Type or member is obsolete
                         return resolver.Invoke().Duplicate();
+#pragma warning restore CS0618 // Type or member is obsolete
                     }
                     catch (Exception e)
                     {
@@ -277,7 +281,9 @@ namespace Proto.Promises
                 {
                     try
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         return runner.Invoke().Duplicate();
+#pragma warning restore CS0618 // Type or member is obsolete
                     }
                     catch (Exception e)
                     {
@@ -613,7 +619,9 @@ namespace Proto.Promises
                 {
                     try
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         return resolver.Invoke(CallbackHelperVoid.GetResultFromResolved(resolved)).Duplicate();
+#pragma warning restore CS0618 // Type or member is obsolete
                     }
                     catch (Exception e)
                     {
@@ -830,7 +838,9 @@ namespace Proto.Promises
                     try
                     {
                         resolved._ref?.MaybeMarkAwaitedAndDispose(resolved._id);
+#pragma warning disable CS0618 // Type or member is obsolete
                         return resolver.Invoke().Duplicate();
+#pragma warning restore CS0618 // Type or member is obsolete
                     }
                     catch (Exception e)
                     {
@@ -857,7 +867,9 @@ namespace Proto.Promises
                 {
                     try
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         return runner.Invoke().Duplicate();
+#pragma warning restore CS0618 // Type or member is obsolete
                     }
                     catch (Exception e)
                     {

--- a/Package/Core/Promises/Internal/CancelInternal.cs
+++ b/Package/Core/Promises/Internal/CancelInternal.cs
@@ -29,6 +29,14 @@ namespace Proto.Promises
                     => MaybeDispose();
             }
 
+            partial class PromiseRetainer<TResult>
+            {
+                internal override void MaybeReportUnhandledAndDispose(Promise.State state)
+                    // We don't report unhandled rejection here unless none of the waiters suppressed.
+                    // This way we only report it once in case multiple waiters were canceled.
+                    => MaybeDispose();
+            }
+
             internal partial struct CancelationHelper
             {
                 [MethodImpl(InlineOption)]

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -151,6 +151,12 @@ namespace Proto.Promises
                 private int _retainCounter;
             }
 
+            partial class PromiseRetainer<TResult> : PromiseRef<TResult>
+            {
+                private TempCollectionBuilder<HandleablePromiseBase> _nextBranches;
+                private int _retainCounter;
+            }
+
             partial class PromiseWaitPromise<TResult> : PromiseSingleAwait<TResult>
             {
             }

--- a/Package/Core/Promises/Internal/PromiseRetainerInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseRetainerInternal.cs
@@ -1,0 +1,209 @@
+﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+#pragma warning disable IDE0016 // Use 'throw' expression
+
+using Proto.Promises.Collections;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Proto.Promises
+{
+    partial class Internal
+    {
+        internal abstract partial class PromiseRefBase
+        {
+#if !PROTO_PROMISE_DEVELOPER_MODE
+            [DebuggerNonUserCode, StackTraceHidden]
+#endif
+            internal sealed partial class PromiseRetainer<TResult> : PromiseRef<TResult>
+            {
+                private PromiseRetainer() { }
+
+                ~PromiseRetainer()
+                {
+                    if (!WasAwaitedOrForgotten)
+                    {
+                        WasAwaitedOrForgotten = true; // Stop base finalizer from adding an extra exception.
+                        string message = "A retained Promise's resources were garbage collected without it being disposed.";
+                        ReportRejection(new UnreleasedObjectException(message), this);
+                    }
+                    else if (_retainCounter != 0 & State != Promise.State.Pending)
+                    {
+                        string message = "A Promise from a retainer was not awaited or forgotten.";
+                        ReportRejection(new UnreleasedObjectException(message), this);
+                    }
+                }
+
+                [MethodImpl(InlineOption)]
+                new private void Reset()
+                {
+                    _retainCounter = 2; // 1 for dispose, 1 for completion.
+                    base.Reset();
+                }
+
+                [MethodImpl(InlineOption)]
+                private static PromiseRetainer<TResult> GetOrCreate()
+                {
+                    var obj = ObjectPool.TryTakeOrInvalid<PromiseRetainer<TResult>>();
+                    return obj == InvalidAwaitSentinel.s_instance
+                        ? new PromiseRetainer<TResult>()
+                        : obj.UnsafeAs<PromiseRetainer<TResult>>();
+                }
+
+                [MethodImpl(InlineOption)]
+                internal static PromiseRetainer<TResult> GetOrCreateAndHookup(PromiseRefBase previous, short id)
+                {
+                    var promise = GetOrCreate();
+                    promise.Reset();
+                    previous.HookupNewPromise(id, promise);
+                    // We create the temp collection after we hook up in case the operation is invalid.
+                    promise._nextBranches = new TempCollectionBuilder<HandleablePromiseBase>(0);
+                    return promise;
+                }
+
+                [MethodImpl(InlineOption)]
+                private void Retain()
+                    => InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, 1);
+
+                internal override void MaybeDispose()
+                {
+                    if (InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1) != 0)
+                    {
+                        return;
+                    }
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                    if (!WasAwaitedOrForgotten)
+                    {
+                        throw new System.InvalidOperationException("PromiseRetainer was MaybeDisposed completely without being properly disposed.");
+                    }
+#endif
+                    _nextBranches.Dispose();
+                    // Rejection maybe wasn't caught.
+                    // We handle this directly here because we don't add the PromiseForgetSentinel to this type when it is disposed.
+                    MaybeReportUnhandledRejection(_rejectContainer, State);
+                    Dispose();
+                    ObjectPool.MaybeRepool(this);
+                }
+
+                internal void Dispose(short promiseId)
+                {
+                    lock (this)
+                    {
+                        if (promiseId != Id | WasAwaitedOrForgotten)
+                        {
+                            throw new ObjectDisposedException("The promise retainer was already disposed.", GetFormattedStacktrace(2));
+                        }
+                        WasAwaitedOrForgotten = true;
+                    }
+                    MaybeDispose();
+                }
+
+                internal override bool GetIsCompleted(short promiseId)
+                {
+                    ValidateId(promiseId, this, 2);
+                    ThrowIfInPool(this);
+                    return State != Promise.State.Pending;
+                }
+
+                internal override PromiseRefBase GetDuplicate(short promiseId)
+                {
+                    ValidateId(promiseId, this, 2);
+                    ThrowIfInPool(this);
+                    return this;
+                }
+
+                internal override PromiseRef<TResult> GetDuplicateT(short promiseId)
+                {
+                    ValidateId(promiseId, this, 2);
+                    ThrowIfInPool(this);
+                    return this;
+                }
+
+                [MethodImpl(InlineOption)]
+                internal override bool GetIsValid(short promiseId)
+                    => promiseId == Id;
+
+                internal override void Forget(short promiseId)
+                    => MaybeMarkAwaitedAndDispose(promiseId);
+
+                internal override void MaybeMarkAwaitedAndDispose(short promiseId)
+                {
+                    ValidateId(promiseId, this, 2);
+                    ThrowIfInPool(this);
+                    MaybeDispose();
+                }
+
+                internal override PromiseRefBase AddWaiter(short promiseId, HandleablePromiseBase waiter, out HandleablePromiseBase previousWaiter)
+                {
+                    lock (this)
+                    {
+                        if (promiseId != Id | WasAwaitedOrForgotten)
+                        {
+                            previousWaiter = InvalidAwaitSentinel.s_instance;
+                            return InvalidAwaitSentinel.s_instance;
+                        }
+                        ThrowIfInPool(this);
+
+                        if (State == Promise.State.Pending)
+                        {
+                            _nextBranches.Add(waiter);
+                            previousWaiter = PendingAwaitSentinel.s_instance;
+                            return null;
+                        }
+                    }
+                    previousWaiter = waiter;
+                    return null;
+                }
+
+                internal override void Handle(PromiseRefBase handler, Promise.State state)
+                {
+                    ThrowIfInPool(this);
+                    handler.SetCompletionState(state);
+                    _rejectContainer = handler._rejectContainer;
+                    handler.SuppressRejection = true;
+                    _result = handler.GetResult<TResult>();
+                    SetCompletionState(state);
+                    handler.MaybeDispose();
+
+                    TempCollectionBuilder<HandleablePromiseBase> branches;
+                    lock (this)
+                    {
+                        branches = _nextBranches;
+                    }
+                    for (int i = 0, max = branches._count; i < max; ++i)
+                    {
+                        branches[i].Handle(this, state);
+                    }
+                    MaybeDispose();
+                }
+
+                internal Promise<TResult> WaitAsync(short promiseId)
+                {
+                    lock (this)
+                    {
+                        if (!GetIsValid(promiseId))
+                        {
+                            throw new ObjectDisposedException("The promise retainer was already disposed.", GetFormattedStacktrace(2));
+                        }
+
+                        Retain();
+                    }
+#if PROMISE_DEBUG
+                    // In DEBUG mode, we return a duplicate so that its usage will be validated properly.
+                    var duplicatePromise = PromiseDuplicate<TResult>.GetOrCreate();
+                    HookupNewPromise(promiseId, duplicatePromise);
+                    return new Promise<TResult>(duplicatePromise, duplicatePromise.Id);
+#else
+                    // In RELEASE mode, we just return this for efficiency.
+                    return new Promise<TResult>(this, promiseId);
+#endif
+                }
+            }
+        } // class PromiseRefBase
+    } // class Internal
+}

--- a/Package/Core/Promises/Internal/PromiseRetainerInternal.cs.meta
+++ b/Package/Core/Promises/Internal/PromiseRetainerInternal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67e0086ac81d1c743ae6188101c3bbdb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Core/Promises/Manager.cs
+++ b/Package/Core/Promises/Manager.cs
@@ -17,7 +17,7 @@ namespace Proto.Promises
         public static class Manager
         {
             /// <summary>
-            /// Clears all currently pooled objects. Does not affect pending or preserved promises.
+            /// Clears all currently pooled objects. Does not affect pending or retained promises.
             /// </summary>
             public static void ClearObjectPool()
             {

--- a/Package/Core/Promises/Promise.cs
+++ b/Package/Core/Promises/Promise.cs
@@ -6,6 +6,7 @@
 #endif
 
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -55,7 +56,8 @@ namespace Proto.Promises
         /// <para/><see cref="Forget"/> must be called when you are finished with it.
         /// <para/>NOTE: You should not return a preserved <see cref="Promise"/> from a public API. Use <see cref="Duplicate"/> to get a <see cref="Promise"/> that is publicly safe.
         /// </summary>
-        [MethodImpl(Internal.InlineOption)]
+        /// <remarks>This method is obsolete. You should instead use <see cref="GetRetainer"/>.</remarks>
+        [Obsolete("Prefer Promise.GetRetainer()", false), EditorBrowsable(EditorBrowsableState.Never)]
         public Promise Preserve()
         {
             ValidateOperation(1);
@@ -148,7 +150,8 @@ namespace Proto.Promises
         /// <para/>Preserved promises are unsafe to return from public APIs. Use <see cref="Duplicate"/> to get a <see cref="Promise"/> that is publicly safe.
         /// <para/><see cref="Duplicate"/> is safe to call even if you are unsure if this is preserved.
         /// </summary>
-        [MethodImpl(Internal.InlineOption)]
+        /// <remarks>This method is obsolete. You should instead use <see cref="GetRetainer"/> with <see cref="Retainer.WaitAsync"/>.</remarks>
+        [Obsolete("Prefer Promise.Retainer.WaitAsync()", false), EditorBrowsable(EditorBrowsableState.Never)]
         public Promise Duplicate()
         {
             ValidateOperation(1);

--- a/Package/Core/Promises/PromiseStaticMerge.cs
+++ b/Package/Core/Promises/PromiseStaticMerge.cs
@@ -233,7 +233,9 @@ namespace Proto.Promises
             ValidateArgument(promise2, nameof(promise2), 1);
             if (promise2._ref == null)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 return promise1.Duplicate();
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             uint pendingCount = 1;

--- a/Package/Core/Promises/PromiseT.cs
+++ b/Package/Core/Promises/PromiseT.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -89,6 +90,8 @@ namespace Proto.Promises
         /// <para/><see cref="Forget"/> must be called when you are finished with it.
         /// <para/>NOTE: You should not return a preserved <see cref="Promise{T}"/> from a public API. Use <see cref="Duplicate"/> to get a <see cref="Promise{T}"/> that is publicly safe.
         /// </summary>
+        /// <remarks>This method is obsolete. You should instead use <see cref="GetRetainer"/>.</remarks>
+        [Obsolete("Prefer Promise<T>.GetRetainer()", false), EditorBrowsable(EditorBrowsableState.Never)]
         public Promise<T> Preserve()
         {
             ValidateOperation(1);
@@ -186,6 +189,8 @@ namespace Proto.Promises
         /// <para/>Preserved promises are unsafe to return from public APIs. Use <see cref="Duplicate"/> to get a <see cref="Promise{T}"/> that is publicly safe.
         /// <para/><see cref="Duplicate"/> is safe to call even if you are unsure if this is preserved.
         /// </summary>
+        /// <remarks>This method is obsolete. You should instead use <see cref="GetRetainer"/> with <see cref="Retainer.WaitAsync"/>.</remarks>
+        [Obsolete("Prefer Promise<T>.Retainer.WaitAsync()", false), EditorBrowsable(EditorBrowsableState.Never)]
         public Promise<T> Duplicate()
         {
             ValidateOperation(1);

--- a/Package/Core/Promises/Retainers.cs
+++ b/Package/Core/Promises/Retainers.cs
@@ -1,0 +1,141 @@
+﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+# endif
+
+using Proto.Promises.CompilerServices;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Proto.Promises
+{
+    partial struct Promise
+    {
+        /// <summary>
+        /// Retains this <see cref="Promise"/> so that it can be awaited multiple times.
+        /// </summary>
+        /// <returns>A <see cref="Retainer"/> that contains the retained <see cref="Promise"/>.</returns>
+        public Retainer GetRetainer()
+        {
+            ValidateOperation(1);
+            var promiseRef = _ref;
+            // TODO: call MaybeMarkAwaitedAndDispose and return a default Retainer if the promise is already complete, in RELEASE mode only.
+            return promiseRef == null
+                ? default
+                : new Retainer(Internal.PromiseRefBase.PromiseRetainer<Internal.VoidResult>.GetOrCreateAndHookup(promiseRef, _id));
+        }
+
+        /// <summary>
+        /// Retains a <see cref="Promise"/> so that it may be awaited multiple times.
+        /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        public readonly struct Retainer : IDisposable
+        {
+            private readonly Promise<Internal.VoidResult>.Retainer _impl;
+
+            [MethodImpl(Internal.InlineOption)]
+            internal Retainer(Internal.PromiseRefBase.PromiseRetainer<Internal.VoidResult> retainerRef)
+            {
+                _impl = new Promise<Internal.VoidResult>.Retainer(retainerRef, retainerRef.Id);
+            }
+
+            /// <summary>
+            /// Returns a <see cref="Promise"/> that adopts the state of the retained <see cref="Promise"/>.
+            /// </summary>
+            public Promise WaitAsync()
+                => _impl.WaitAsync();
+
+            /// <summary>
+            /// Asynchronous infrastructure support. This method permits instances of <see cref="Retainer"/> to be awaited.
+            /// </summary>
+            [MethodImpl(Internal.InlineOption), EditorBrowsable(EditorBrowsableState.Never)]
+            public PromiseAwaiterVoid GetAwaiter()
+                => WaitAsync().GetAwaiter();
+
+            /// <summary>
+            /// Releases the retained promise.
+            /// </summary>
+            public void Dispose()
+                => _impl.Dispose();
+        }
+    }
+
+    partial struct Promise<T>
+    {
+        /// <summary>
+        /// Retains this <see cref="Promise{T}"/> so that it can be awaited multiple times.
+        /// </summary>
+        /// <returns>A <see cref="Retainer"/> that contains the retained <see cref="Promise{T}"/>.</returns>
+        public Retainer GetRetainer()
+        {
+            ValidateOperation(1);
+            var promiseRef = _ref;
+            if (promiseRef == null)
+            {
+                return new Retainer(_result);
+            }
+
+            // TODO: call MaybeMarkAwaitedAndDispose and return a Retainer from its result if the promise is already complete, in RELEASE mode only.
+            var retainerRef = Internal.PromiseRefBase.PromiseRetainer<T>.GetOrCreateAndHookup(promiseRef, _id);
+            return new Retainer(retainerRef, retainerRef.Id);
+        }
+
+        /// <summary>
+        /// Retains a <see cref="Promise{T}"/> so that it may be awaited multiple times.
+        /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        public readonly struct Retainer : IDisposable
+        {
+            private readonly Internal.PromiseRefBase.PromiseRetainer<T> _ref;
+            private readonly T _result;
+            private readonly short _id;
+
+            [MethodImpl(Internal.InlineOption)]
+            internal Retainer(Internal.PromiseRefBase.PromiseRetainer<T> retainerRef, short retainerId)
+            {
+                _ref = retainerRef;
+                _result = default;
+                _id = retainerId;
+            }
+
+            [MethodImpl(Internal.InlineOption)]
+            internal Retainer(in T result)
+            {
+                _ref = default;
+                _result = result;
+                _id = 0;
+            }
+
+            /// <summary>
+            /// Returns a <see cref="Promise{T}"/> that adopts the state of the retained <see cref="Promise{T}"/>.
+            /// </summary>
+            public Promise<T> WaitAsync()
+            {
+                var promiseRef = _ref;
+                return promiseRef == null
+                    ? Promise.Resolved(_result)
+                    : promiseRef.WaitAsync(_id);
+            }
+
+            /// <summary>
+            /// Asynchronous infrastructure support. This method permits instances of <see cref="Retainer"/> to be awaited.
+            /// </summary>
+            [MethodImpl(Internal.InlineOption), EditorBrowsable(EditorBrowsableState.Never)]
+            public PromiseAwaiter<T> GetAwaiter()
+                => WaitAsync().GetAwaiter();
+
+            /// <summary>
+            /// Releases the retained promise.
+            /// </summary>
+            public void Dispose()
+                => _ref?.Dispose(_id);
+        }
+    }
+}

--- a/Package/Core/Promises/Retainers.cs.meta
+++ b/Package/Core/Promises/Retainers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 626aca6f91192574492ff31634e80720
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Core/Utilities/Internal/AsyncLazyInternal.cs
+++ b/Package/Core/Utilities/Internal/AsyncLazyInternal.cs
@@ -84,8 +84,8 @@ namespace Proto.Promises
         private sealed class LazyPromiseNoProgress : Internal.PromiseRefBase.LazyPromise<T>
         {
             private AsyncLazy<T> _owner;
-            // TODO: use PromiseRetainer instead.
-            internal PromiseMultiAwait<T> _preservedPromise;
+            // TODO: make LazyPromise implement multi await handling directly, instead of allocating a separate object.
+            internal PromiseRetainer<T> _promiseRetainer;
 
             [MethodImpl(Internal.InlineOption)]
             private static LazyPromiseNoProgress GetOrCreate()
@@ -114,7 +114,7 @@ namespace Proto.Promises
             internal static Promise<T> GetOrStartPromise(AsyncLazy<T> owner, LazyFieldsNoProgress lazyFields)
             {
                 LazyPromiseNoProgress lazyPromise;
-                PromiseMultiAwait<T> preservedPromise;
+                PromiseRetainer<T> promiseRetainer;
                 lock (lazyFields)
                 {
                     if (lazyFields.IsComplete)
@@ -124,16 +124,17 @@ namespace Proto.Promises
 
                     if (lazyFields.IsStarted)
                     {
-                        return GetDuplicate(lazyFields._lazyPromise.UnsafeAs<LazyPromiseNoProgress>()._preservedPromise);
+                        promiseRetainer = lazyFields._lazyPromise.UnsafeAs<LazyPromiseNoProgress>()._promiseRetainer;
+                        return promiseRetainer.WaitAsyncSkipValidation();
                     }
 
                     lazyPromise = GetOrCreate(owner);
                     lazyFields._lazyPromise = lazyPromise;
-                    // Same thing as Promise.Preserve(), but more direct.
-                    lazyPromise._preservedPromise = preservedPromise = PromiseMultiAwait<T>.GetOrCreateAndHookup(lazyPromise, lazyPromise.Id);
+                    // Same thing as Promise.GetRetainer(), but more direct.
+                    lazyPromise._promiseRetainer = promiseRetainer = PromiseRetainer<T>.GetOrCreateAndHookup(lazyPromise, lazyPromise.Id);
                     // Exit the lock before invoking the factory.
                 }
-                var promise = GetDuplicate(preservedPromise);
+                var promise = promiseRetainer.WaitAsyncSkipValidation();
                 lazyPromise.Start(lazyFields._factory);
                 return promise;
             }
@@ -151,18 +152,18 @@ namespace Proto.Promises
             protected override void OnComplete(Promise.State state)
             {
                 var lazyFields = _owner._lazyFields;
-                PromiseMultiAwait<T> preservedPromise;
+                PromiseRetainer<T> promiseRetainer;
                 if (state != Promises.Promise.State.Resolved)
                 {
                     lock (lazyFields)
                     {
                         // Reset the state so that the factory will be ran again the next time the Promise is accessed.
-                        preservedPromise = _preservedPromise;
-                        _preservedPromise = null;
+                        promiseRetainer = _promiseRetainer;
+                        _promiseRetainer = null;
                         lazyFields._lazyPromise = null;
                     }
 
-                    preservedPromise.Forget(preservedPromise.Id);
+                    promiseRetainer.Dispose(promiseRetainer.Id);
                     HandleNextInternal(state);
                     return;
                 }
@@ -174,12 +175,12 @@ namespace Proto.Promises
 
                 lock (lazyFields)
                 {
-                    preservedPromise = _preservedPromise;
-                    _preservedPromise = null;
+                    promiseRetainer = _promiseRetainer;
+                    _promiseRetainer = null;
                     lazyFields.UnsafeAs<LazyFieldsNoProgress>()._factory = null;
                 }
 
-                preservedPromise.Forget(preservedPromise.Id);
+                promiseRetainer.Dispose(promiseRetainer.Id);
                 HandleNextInternal(state);
             }
         } // class LazyPromiseNoProgress
@@ -190,8 +191,7 @@ namespace Proto.Promises
         private sealed class LazyWithProgressPromise : Internal.PromiseRefBase.LazyPromise<T>
         {
             private AsyncLazy<T> _owner;
-            // TODO: use PromiseRetainer instead.
-            internal PromiseMultiAwait<T> _preservedPromise;
+            internal PromiseRetainer<T> _promiseRetainer;
             internal Internal.ProgressMultiHandler _progressHandler;
 
             [MethodImpl(Internal.InlineOption)]
@@ -221,7 +221,7 @@ namespace Proto.Promises
             internal static Promise<T> GetOrStartPromise(AsyncLazy<T> owner, LazyFieldsWithProgress lazyFields, ProgressToken progressToken)
             {
                 LazyWithProgressPromise lazyPromise;
-                PromiseMultiAwait<T> preservedPromise;
+                PromiseRetainer<T> promiseRetainer;
                 lock (lazyFields)
                 {
                     if (lazyFields.IsComplete)
@@ -234,18 +234,19 @@ namespace Proto.Promises
                     {
                         var castedPromise = lazyFields._lazyPromise.UnsafeAs<LazyWithProgressPromise>();
                         castedPromise._progressHandler.Add(progressToken, castedPromise._progressHandler.Id);
-                        return GetDuplicate(castedPromise._preservedPromise);
+                        promiseRetainer = castedPromise._promiseRetainer;
+                        return promiseRetainer.WaitAsyncSkipValidation();
                     }
 
                     lazyPromise = GetOrCreate(owner);
                     lazyFields._lazyPromise = lazyPromise;
                     // Same thing as Progress.NewMultiHandler(), but more direct.
                     lazyPromise._progressHandler = Internal.ProgressMultiHandler.GetOrCreate();
-                    // Same thing as Promise.Preserve(), but more direct.
-                    lazyPromise._preservedPromise = preservedPromise = PromiseMultiAwait<T>.GetOrCreateAndHookup(lazyPromise, lazyPromise.Id);
+                    // Same thing as Promise.GetRetainer(), but more direct.
+                    lazyPromise._promiseRetainer = promiseRetainer = PromiseRetainer<T>.GetOrCreateAndHookup(lazyPromise, lazyPromise.Id);
                     // Exit the lock before invoking the factory.
                 }
-                var promise = GetDuplicate(preservedPromise);
+                var promise = promiseRetainer.WaitAsyncSkipValidation();
                 lazyPromise._progressHandler.Add(progressToken, lazyPromise._progressHandler.Id);
                 lazyPromise.Start(lazyFields._factory, new ProgressToken(lazyPromise._progressHandler, lazyPromise._progressHandler.Id, 0d, 1d));
                 return promise;
@@ -268,22 +269,22 @@ namespace Proto.Promises
             protected override void OnComplete(Promise.State state)
             {
                 var lazyFields = _owner._lazyFields;
-                PromiseMultiAwait<T> preservedPromise;
+                PromiseRetainer<T> promiseRetainer;
                 Internal.ProgressMultiHandler progressHandler;
                 if (state != Promises.Promise.State.Resolved)
                 {
                     lock (lazyFields)
                     {
                         // Reset the state so that the factory will be ran again the next time GetResultAsync is called.
-                        preservedPromise = _preservedPromise;
-                        _preservedPromise = null;
+                        promiseRetainer = _promiseRetainer;
+                        _promiseRetainer = null;
                         progressHandler = _progressHandler;
                         _progressHandler = null;
                         lazyFields._lazyPromise = null;
                     }
 
                     progressHandler.Dispose(progressHandler.Id);
-                    preservedPromise.Forget(preservedPromise.Id);
+                    promiseRetainer.Dispose(promiseRetainer.Id);
                     HandleNextInternal(state);
                     return;
                 }
@@ -295,8 +296,8 @@ namespace Proto.Promises
 
                 lock (lazyFields)
                 {
-                    preservedPromise = _preservedPromise;
-                    _preservedPromise = null;
+                    promiseRetainer = _promiseRetainer;
+                    _promiseRetainer = null;
                     progressHandler = _progressHandler;
                     _progressHandler = null;
                     lazyFields.UnsafeAs<LazyFieldsWithProgress>()._factory = null;
@@ -304,7 +305,7 @@ namespace Proto.Promises
 
                 progressHandler.Report(1d, progressHandler.Id);
                 progressHandler.Dispose(progressHandler.Id);
-                preservedPromise.Forget(preservedPromise.Id);
+                promiseRetainer.Dispose(promiseRetainer.Id);
                 HandleNextInternal(state);
             }
         } // class LazyWithProgressPromise
@@ -319,14 +320,6 @@ namespace Proto.Promises
 #endif
             internal abstract class LazyPromise<TResult> : PromiseWaitPromise<TResult>
             {
-                protected static Promise<TResult> GetDuplicate(PromiseMultiAwait<TResult> preservedPromise)
-                {
-                    // Same thing as Promise.Duplicate(), but more direct.
-                    var p = preservedPromise;
-                    var duplicate = p.GetDuplicateT(p.Id);
-                    return new Promise<TResult>(duplicate, duplicate.Id);
-                }
-
                 [MethodImpl(InlineOption)]
                 protected void Start(Func<Promise<TResult>> factory)
                 {

--- a/Package/Core/Utilities/Internal/AsyncLazyInternal.cs
+++ b/Package/Core/Utilities/Internal/AsyncLazyInternal.cs
@@ -84,6 +84,7 @@ namespace Proto.Promises
         private sealed class LazyPromiseNoProgress : Internal.PromiseRefBase.LazyPromise<T>
         {
             private AsyncLazy<T> _owner;
+            // TODO: use PromiseRetainer instead.
             internal PromiseMultiAwait<T> _preservedPromise;
 
             [MethodImpl(Internal.InlineOption)]
@@ -189,6 +190,7 @@ namespace Proto.Promises
         private sealed class LazyWithProgressPromise : Internal.PromiseRefBase.LazyPromise<T>
         {
             private AsyncLazy<T> _owner;
+            // TODO: use PromiseRetainer instead.
             internal PromiseMultiAwait<T> _preservedPromise;
             internal Internal.ProgressMultiHandler _progressHandler;
 

--- a/Package/Core/Utilities/Progress.cs
+++ b/Package/Core/Utilities/Progress.cs
@@ -264,7 +264,7 @@ namespace Proto.Promises
         /// Create a new progress handler that can report to multiple progress tokens.
         /// </summary>
         /// <remarks>
-        /// This can be useful when combined with <see cref="Promise.Preserve"/> for reporting progress to multiple consumers from a single async operation.
+        /// This can be useful when combined with <see cref="Promise.GetRetainer"/> for reporting progress to multiple consumers from a single async operation.
         /// </remarks>
         /// <returns>A new progress multi handler.</returns>
         public static MultiHandler NewMultiHandler()
@@ -402,7 +402,7 @@ namespace Proto.Promises
             /// Create a new progress handler that can report to multiple progress tokens.
             /// </summary>
             /// <remarks>
-            /// This can be useful when combined with <see cref="Promise.Preserve"/> for reporting progress to multiple consumers from a single async operation.
+            /// This can be useful when combined with <see cref="Promise.GetRetainer"/> for reporting progress to multiple consumers from a single async operation.
             /// </remarks>
             /// <returns>A new progress multi handler.</returns>
             [MethodImpl(Internal.InlineOption)]

--- a/Package/Tests/CoreTests/APIs/APlus_2_1_PromiseStates.cs
+++ b/Package/Tests/CoreTests/APIs/APlus_2_1_PromiseStates.cs
@@ -110,29 +110,28 @@ namespace ProtoPromiseTests.APIs
                 string RejectValue = "Rejected";
 
                 var deferred = Promise.NewDeferred();
-                var promise = deferred.Promise.Preserve();
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    bool voidResolved = false, voidRejected = false;
+                    promiseRetainer.WaitAsync()
+                        .Then(() => voidResolved = true, () => voidRejected = true)
+                        .Forget();
 
-                bool voidResolved = false, voidRejected = false;
-                promise
-                    .Then(() => voidResolved = true, () => voidRejected = true)
-                    .Forget();
+                    deferred.Resolve();
+                    Assert.IsTrue(voidResolved);
+                    Assert.IsFalse(voidRejected);
 
-                deferred.Resolve();
-                Assert.IsTrue(voidResolved);
-                Assert.IsFalse(voidRejected);
+                    Assert.IsFalse(deferred.TryResolve());
+                    Assert.Throws<InvalidOperationException>(() => deferred.Resolve());
+                    Assert.IsFalse(deferred.TryReject(RejectValue));
+                    Assert.Throws<InvalidOperationException>(() => deferred.Reject(RejectValue));
 
-                Assert.IsFalse(deferred.TryResolve());
-                Assert.Throws<InvalidOperationException>(() => deferred.Resolve());
-                Assert.IsFalse(deferred.TryReject(RejectValue));
-                Assert.Throws<InvalidOperationException>(() => deferred.Reject(RejectValue));
-
-                promise
-                    .Then(() => voidResolved = true, () => voidRejected = true)
-                    .Forget();
-                Assert.IsTrue(voidResolved);
-                Assert.IsFalse(voidRejected);
-
-                promise.Forget();
+                    promiseRetainer.WaitAsync()
+                        .Then(() => voidResolved = true, () => voidRejected = true)
+                        .Forget();
+                    Assert.IsTrue(voidResolved);
+                    Assert.IsFalse(voidRejected);
+                }
             }
 
             [Test]
@@ -141,28 +140,28 @@ namespace ProtoPromiseTests.APIs
                 string RejectValue = "Rejected";
 
                 var deferred = Promise.NewDeferred<int>();
-                var promise = deferred.Promise.Preserve();
-                bool intResolved = false, intRejected = false;
-                promise
-                    .Then(_ => intResolved = true, () => intRejected = true)
-                    .Forget();
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    bool intResolved = false, intRejected = false;
+                    promiseRetainer.WaitAsync()
+                        .Then(_ => intResolved = true, () => intRejected = true)
+                        .Forget();
 
-                deferred.Resolve(1);
-                Assert.IsTrue(intResolved);
-                Assert.IsFalse(intRejected);
+                    deferred.Resolve(1);
+                    Assert.IsTrue(intResolved);
+                    Assert.IsFalse(intRejected);
 
-                Assert.IsFalse(deferred.TryResolve(1));
-                Assert.Throws<InvalidOperationException>(() => deferred.Resolve(1));
-                Assert.IsFalse(deferred.TryReject(RejectValue));
-                Assert.Throws<InvalidOperationException>(() => deferred.Reject(RejectValue));
+                    Assert.IsFalse(deferred.TryResolve(1));
+                    Assert.Throws<InvalidOperationException>(() => deferred.Resolve(1));
+                    Assert.IsFalse(deferred.TryReject(RejectValue));
+                    Assert.Throws<InvalidOperationException>(() => deferred.Reject(RejectValue));
 
-                promise
-                    .Then(_ => intResolved = true, () => intRejected = true)
-                    .Forget();
-                Assert.IsTrue(intResolved);
-                Assert.IsFalse(intRejected);
-
-                promise.Forget();
+                    promiseRetainer.WaitAsync()
+                        .Then(_ => intResolved = true, () => intRejected = true)
+                        .Forget();
+                    Assert.IsTrue(intResolved);
+                    Assert.IsFalse(intRejected);
+                }
             }
 
             [Test]
@@ -216,29 +215,28 @@ namespace ProtoPromiseTests.APIs
                 string RejectValue = "Rejected";
 
                 var deferred = Promise.NewDeferred();
-                var promise = deferred.Promise.Preserve();
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    bool voidResolved = false, voidRejected = false;
+                    promiseRetainer.WaitAsync()
+                        .Then(() => voidResolved = true, () => voidRejected = true)
+                        .Forget();
 
-                bool voidResolved = false, voidRejected = false;
-                promise
-                    .Then(() => voidResolved = true, () => voidRejected = true)
-                    .Forget();
+                    deferred.Reject(RejectValue);
+                    Assert.IsFalse(voidResolved);
+                    Assert.IsTrue(voidRejected);
 
-                deferred.Reject(RejectValue);
-                Assert.IsFalse(voidResolved);
-                Assert.IsTrue(voidRejected);
+                    Assert.IsFalse(deferred.TryResolve());
+                    Assert.Throws<InvalidOperationException>(() => deferred.Resolve());
+                    Assert.IsFalse(deferred.TryReject(RejectValue));
+                    Assert.Throws<InvalidOperationException>(() => deferred.Reject(RejectValue));
 
-                Assert.IsFalse(deferred.TryResolve());
-                Assert.Throws<InvalidOperationException>(() => deferred.Resolve());
-                Assert.IsFalse(deferred.TryReject(RejectValue));
-                Assert.Throws<InvalidOperationException>(() => deferred.Reject(RejectValue));
-
-                promise
-                    .Then(() => voidResolved = true, () => voidRejected = true)
-                    .Forget();
-                Assert.IsFalse(voidResolved);
-                Assert.IsTrue(voidRejected);
-
-                promise.Forget();
+                    promiseRetainer.WaitAsync()
+                        .Then(() => voidResolved = true, () => voidRejected = true)
+                        .Forget();
+                    Assert.IsFalse(voidResolved);
+                    Assert.IsTrue(voidRejected);
+                }
             }
 
             [Test]
@@ -247,96 +245,94 @@ namespace ProtoPromiseTests.APIs
                 string RejectValue = "Rejected";
 
                 var deferred = Promise.NewDeferred<int>();
-                var promise = deferred.Promise.Preserve();
-                bool intResolved = false, intRejected = false;
-                promise
-                    .Then(_ => intResolved = true, () => intRejected = true)
-                    .Forget();
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    bool intResolved = false, intRejected = false;
+                    promiseRetainer.WaitAsync()
+                        .Then(_ => intResolved = true, () => intRejected = true)
+                        .Forget();
 
-                deferred.Reject(RejectValue);
-                Assert.IsFalse(intResolved);
-                Assert.IsTrue(intRejected);
+                    deferred.Reject(RejectValue);
+                    Assert.IsFalse(intResolved);
+                    Assert.IsTrue(intRejected);
 
-                Assert.IsFalse(deferred.TryResolve(1));
-                Assert.Throws<InvalidOperationException>(() => deferred.Resolve(1));
-                Assert.IsFalse(deferred.TryReject(RejectValue));
-                Assert.Throws<InvalidOperationException>(() => deferred.Reject(RejectValue));
+                    Assert.IsFalse(deferred.TryResolve(1));
+                    Assert.Throws<InvalidOperationException>(() => deferred.Resolve(1));
+                    Assert.IsFalse(deferred.TryReject(RejectValue));
+                    Assert.Throws<InvalidOperationException>(() => deferred.Reject(RejectValue));
 
-                promise
-                    .Then(_ => intResolved = true, () => intRejected = true)
-                    .Forget();
-                Assert.IsFalse(intResolved);
-                Assert.IsTrue(intRejected);
-
-                promise.Forget();
+                    promiseRetainer.WaitAsync()
+                        .Then(_ => intResolved = true, () => intRejected = true)
+                        .Forget();
+                    Assert.IsFalse(intResolved);
+                    Assert.IsTrue(intRejected);
+                }
             }
 
             [Test]
             public void _2_1_3_2_MustHaveAReasonWhichMustNotChange_void()
             {
                 var deferred = Promise.NewDeferred();
-                var promise = deferred.Promise.Preserve();
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    string rejection = null;
+                    string expected = "Fail Value";
+                    TestHelper.AddCallbacks<int, string, string>(promiseRetainer.WaitAsync(),
+                        onResolve: () => Assert.Fail("Promise was resolved when it should have been rejected."),
+                        onReject: failValue =>
+                        {
+                            Assert.AreEqual(expected, failValue);
+                            rejection = failValue;
+                        });
+                    deferred.Reject(expected);
 
-                string rejection = null;
-                string expected = "Fail Value";
-                TestHelper.AddCallbacks<int, string, string>(promise,
-                    onResolve: () => Assert.Fail("Promise was resolved when it should have been rejected."),
-                    onReject: failValue =>
-                    {
-                        Assert.AreEqual(expected, failValue);
-                        rejection = failValue;
-                    });
-                deferred.Reject(expected);
+                    Assert.AreEqual(expected, rejection);
 
-                Assert.AreEqual(expected, rejection);
+                    Assert.IsFalse(deferred.TryReject("Different Fail Value"));
+                    Assert.Throws<InvalidOperationException>(() => deferred.Reject("Different Fail Value"));
+                    TestHelper.AddCallbacks<int, string, string>(promiseRetainer.WaitAsync(),
+                        onResolve: () => Assert.Fail("Promise was resolved when it should have been rejected."),
+                        onReject: failValue =>
+                        {
+                            Assert.AreEqual(expected, failValue);
+                            rejection = failValue;
+                        });
 
-                Assert.IsFalse(deferred.TryReject("Different Fail Value"));
-                Assert.Throws<InvalidOperationException>(() => deferred.Reject("Different Fail Value"));
-                TestHelper.AddCallbacks<int, string, string>(promise,
-                    onResolve: () => Assert.Fail("Promise was resolved when it should have been rejected."),
-                    onReject: failValue =>
-                    {
-                        Assert.AreEqual(expected, failValue);
-                        rejection = failValue;
-                    });
-
-                Assert.AreEqual(expected, rejection);
-
-                promise.Forget();
+                    Assert.AreEqual(expected, rejection);
+                }
             }
 
             [Test]
             public void _2_1_3_2_MustHaveAReasonWhichMustNotChange_T()
             {
                 var deferred = Promise.NewDeferred<int>();
-                var promise = deferred.Promise.Preserve();
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    string rejection = null;
+                    string expected = "Fail Value";
+                    TestHelper.AddCallbacks<int, bool, string, string>(promiseRetainer.WaitAsync(),
+                        onResolve: v => Assert.Fail("Promise was resolved when it should have been rejected."),
+                        onReject: failValue =>
+                        {
+                            Assert.AreEqual(expected, failValue);
+                            rejection = failValue;
+                        });
+                    deferred.Reject(expected);
 
-                string rejection = null;
-                string expected = "Fail Value";
-                TestHelper.AddCallbacks<int, bool, string, string>(promise,
-                    onResolve: v => Assert.Fail("Promise was resolved when it should have been rejected."),
-                    onReject: failValue =>
-                    {
-                        Assert.AreEqual(expected, failValue);
-                        rejection = failValue;
-                    });
-                deferred.Reject(expected);
+                    Assert.AreEqual(expected, rejection);
 
-                Assert.AreEqual(expected, rejection);
+                    Assert.IsFalse(deferred.TryReject("Different Fail Value"));
+                    Assert.Throws<InvalidOperationException>(() => deferred.Reject("Different Fail Value"));
+                    TestHelper.AddCallbacks<int, bool, string, string>(promiseRetainer.WaitAsync(),
+                        onResolve: v => Assert.Fail("Promise was resolved when it should have been rejected."),
+                        onReject: failValue =>
+                        {
+                            Assert.AreEqual(expected, failValue);
+                            rejection = failValue;
+                        });
 
-                Assert.IsFalse(deferred.TryReject("Different Fail Value"));
-                Assert.Throws<InvalidOperationException>(() => deferred.Reject("Different Fail Value"));
-                TestHelper.AddCallbacks<int, bool, string, string>(promise,
-                    onResolve: v => Assert.Fail("Promise was resolved when it should have been rejected."),
-                    onReject: failValue =>
-                    {
-                        Assert.AreEqual(expected, failValue);
-                        rejection = failValue;
-                    });
-
-                Assert.AreEqual(expected, rejection);
-
-                promise.Forget();
+                    Assert.AreEqual(expected, rejection);
+                }
             }
         }
     }

--- a/Package/Tests/CoreTests/APIs/APlus_2_2_TheThenMethod.cs
+++ b/Package/Tests/CoreTests/APIs/APlus_2_2_TheThenMethod.cs
@@ -46,101 +46,38 @@ namespace ProtoPromiseTests.APIs
             public void _2_2_1_1_IfOnFulfilledIsNull_Throw_void()
             {
                 var deferred = Promise.NewDeferred();
-                var promise = deferred.Promise.Preserve();
+                var promise = deferred.Promise;
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Action));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<Promise>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<Promise<int>>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Action)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<Promise>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<Promise<int>>)));
 
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Action), () => { }));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Action), (string failValue) => { }));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Action), () => { });
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Action), (string failValue) => { });
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int>), () => default(int)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int>), (string failValue) => default(int)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int>), () => default(int));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int>), (string failValue) => default(int));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<Promise>), () => default(Promise)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<Promise>), (string failValue) => default(Promise)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<Promise>), () => default(Promise));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<Promise>), (string failValue) => default(Promise));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<Promise<int>>), () => default(Promise<int>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<Promise<int>>), (string failValue) => default(Promise<int>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<Promise<int>>), () => default(Promise<int>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<Promise<int>>), (string failValue) => default(Promise<int>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Action), () => default(Promise)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Action), (string failValue) => default(Promise)));
 
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int>), () => default(Promise<int>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int>), (string failValue) => default(Promise<int>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Action), () => default(Promise));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Action), (string failValue) => default(Promise));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<Promise>), () => { }));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<Promise>), (string failValue) => { }));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int>), () => default(Promise<int>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int>), (string failValue) => default(Promise<int>));
-                });
-
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<Promise>), () => { });
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<Promise>), (string failValue) => { });
-                });
-
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<Promise<int>>), () => default(int));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<Promise<int>>), (string failValue) => default(int));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<Promise<int>>), () => default(int)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<Promise<int>>), (string failValue) => default(int)));
 
                 deferred.Resolve();
-
                 promise.Forget();
             }
 
@@ -148,101 +85,38 @@ namespace ProtoPromiseTests.APIs
             public void _2_2_1_1_IfOnFulfilledIsNull_Throw_T()
             {
                 var deferred = Promise.NewDeferred<int>();
-                var promise = deferred.Promise.Preserve();
+                var promise = deferred.Promise;
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Action<int>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, int>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, Promise>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, Promise<int>>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Action<int>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, int>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, Promise>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, Promise<int>>)));
 
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Action<int>), () => { }));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Action<int>), (string failValue) => { }));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Action<int>), () => { });
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Action<int>), (string failValue) => { });
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, int>), () => default(int)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, int>), (string failValue) => default(int)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, int>), () => default(int));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, int>), (string failValue) => default(int));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, Promise>), () => default(Promise)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, Promise>), (string failValue) => default(Promise)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, Promise>), () => default(Promise));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, Promise>), (string failValue) => default(Promise));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, Promise<int>>), () => default(Promise<int>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, Promise<int>>), (string failValue) => default(Promise<int>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, Promise<int>>), () => default(Promise<int>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, Promise<int>>), (string failValue) => default(Promise<int>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Action<int>), () => default(Promise)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Action<int>), (string failValue) => default(Promise)));
 
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, int>), () => default(Promise<int>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, int>), (string failValue) => default(Promise<int>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Action<int>), () => default(Promise));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Action<int>), (string failValue) => default(Promise));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, Promise>), () => { }));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, Promise>), (string failValue) => { }));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, int>), () => default(Promise<int>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, int>), (string failValue) => default(Promise<int>));
-                });
-
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, Promise>), () => { });
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, Promise>), (string failValue) => { });
-                });
-
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, Promise<int>>), () => default(int));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(default(Func<int, Promise<int>>), (string failValue) => default(int));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, Promise<int>>), () => default(int)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(default(Func<int, Promise<int>>), (string failValue) => default(int)));
 
                 deferred.Resolve(0);
-
                 promise.Forget();
             }
 
@@ -250,102 +124,39 @@ namespace ProtoPromiseTests.APIs
             public void _2_2_1_2_IfOnRejectedIsNull_Throw_void()
             {
                 var deferred = Promise.NewDeferred();
-                var promise = deferred.Promise.Preserve();
+                var promise = deferred.Promise;
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Catch(default(Action));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Catch(default(Action<string>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(default(Action)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(default(Action<string>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Catch(default(Func<Promise>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Catch(default(Func<string, Promise>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(default(Func<Promise>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(default(Func<string, Promise>)));
 
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => { }, default(Action)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => { }, default(Action<string>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => { }, default(Action));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => { }, default(Action<string>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise), default(Func<Promise>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise), default(Func<string, Promise>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => default(Promise), default(Func<Promise>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => default(Promise), default(Func<string, Promise>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => "string", default(Func<string>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => "string", default(Func<Exception, string>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => "string", default(Func<string>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => "string", default(Func<Exception, string>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise<string>), default(Func<Promise<string>>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise<string>), default(Func<Exception, Promise<string>>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => default(Promise<string>), default(Func<Promise<string>>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => default(Promise<string>), default(Func<Exception, Promise<string>>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise), default(Action)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise), default(Action<string>)));
 
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => { }, default(Func<Promise>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => { }, default(Func<string, Promise>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => default(Promise), default(Action));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => default(Promise), default(Action<string>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise<string>), default(Func<string>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise<string>), default(Func<Exception, string>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => { }, default(Func<Promise>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => { }, default(Func<string, Promise>));
-                });
-
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => default(Promise<string>), default(Func<string>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => default(Promise<string>), default(Func<Exception, string>));
-                });
-
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => "string", default(Func<Promise<string>>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then(() => "string", default(Func<Exception, Promise<string>>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => "string", default(Func<Promise<string>>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => "string", default(Func<Exception, Promise<string>>)));
 
                 deferred.Resolve();
-
                 promise.Forget();
             }
 
@@ -353,102 +164,39 @@ namespace ProtoPromiseTests.APIs
             public void _2_2_1_2_IfOnRejectedIsNull_Throw_T()
             {
                 var deferred = Promise.NewDeferred<int>();
-                var promise = deferred.Promise.Preserve();
+                var promise = deferred.Promise;
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Catch(default(Func<int>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Catch(default(Func<string, int>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(default(Func<int>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(default(Func<string, int>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Catch(default(Func<Promise<int>>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Catch(default(Func<string, Promise<int>>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(default(Func<Promise<int>>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(default(Func<string, Promise<int>>)));
 
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => { }, default(Action)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => { }, default(Action<string>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => { }, default(Action));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => { }, default(Action<string>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise), default(Func<Promise>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise), default(Func<string, Promise>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => default(Promise), default(Func<Promise>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => default(Promise), default(Func<string, Promise>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => "string", default(Func<string>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => "string", default(Func<Exception, string>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => "string", default(Func<string>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => "string", default(Func<Exception, string>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise<string>), default(Func<Promise<string>>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise<string>), default(Func<Exception, Promise<string>>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => default(Promise<string>), default(Func<Promise<string>>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => default(Promise<string>), default(Func<Exception, Promise<string>>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise), default(Action)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise), default(Action<string>)));
 
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => { }, default(Func<Promise>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => { }, default(Func<string, Promise>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => default(Promise), default(Action));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => default(Promise), default(Action<string>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise<string>), default(Func<string>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise<string>), default(Func<Exception, string>)));
 
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => { }, default(Func<Promise>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => { }, default(Func<string, Promise>));
-                });
-
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => default(Promise<string>), default(Func<string>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => default(Promise<string>), default(Func<Exception, string>));
-                });
-
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => "string", default(Func<Promise<string>>));
-                });
-                Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-                {
-                    promise.Then((int x) => "string", default(Func<Exception, Promise<string>>));
-                });
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => "string", default(Func<Promise<string>>)));
+                Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => "string", default(Func<Exception, Promise<string>>)));
 
                 deferred.Resolve(0);
-
                 promise.Forget();
             }
         }
@@ -474,27 +222,26 @@ namespace ProtoPromiseTests.APIs
                 var promisedValue = 100;
                 var resolved = false;
                 var deferred = Promise.NewDeferred<int>();
-                var promise = deferred.Promise.Preserve();
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    TestHelper.AddResolveCallbacks<int, bool, string>(promiseRetainer.WaitAsync(),
+                        onResolve: v =>
+                        {
+                            Assert.AreEqual(promisedValue, v);
+                            resolved = true;
+                        }
+                    );
+                    TestHelper.AddCallbacks<int, bool, object, string>(promiseRetainer.WaitAsync(),
+                        onResolve: v =>
+                        {
+                            Assert.AreEqual(promisedValue, v);
+                            resolved = true;
+                        }
+                    );
+                    deferred.Resolve(promisedValue);
 
-                TestHelper.AddResolveCallbacks<int, bool, string>(promise,
-                    onResolve: v =>
-                    {
-                        Assert.AreEqual(promisedValue, v);
-                        resolved = true;
-                    }
-                );
-                TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                    onResolve: v =>
-                    {
-                        Assert.AreEqual(promisedValue, v);
-                        resolved = true;
-                    }
-                );
-                deferred.Resolve(promisedValue);
-
-                Assert.True(resolved);
-
-                promise.Forget();
+                    Assert.True(resolved);
+                }
             }
 
             [Test]
@@ -502,24 +249,23 @@ namespace ProtoPromiseTests.APIs
             {
                 var resolved = false;
                 var deferred = Promise.NewDeferred();
-                var promise = deferred.Promise.Preserve();
-
-                TestHelper.AddResolveCallbacks<bool, string>(promise,
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    TestHelper.AddResolveCallbacks<bool, string>(promiseRetainer.WaitAsync(),
                     () => resolved = true
                 );
-                TestHelper.AddCallbacks<bool, object, string>(promise,
-                    () => resolved = true,
-                    s => Assert.Fail("Promise was rejected when it should have been resolved."),
-                    () => Assert.Fail("Promise was rejected when it should have been resolved.")
-                );
+                    TestHelper.AddCallbacks<bool, object, string>(promiseRetainer.WaitAsync(),
+                        () => resolved = true,
+                        s => Assert.Fail("Promise was rejected when it should have been resolved."),
+                        () => Assert.Fail("Promise was rejected when it should have been resolved.")
+                    );
 
-                Assert.False(resolved);
+                    Assert.False(resolved);
 
-                deferred.Resolve();
+                    deferred.Resolve();
 
-                Assert.True(resolved);
-
-                promise.Forget();
+                    Assert.True(resolved);
+                }
             }
 
             [Test]
@@ -527,24 +273,23 @@ namespace ProtoPromiseTests.APIs
             {
                 var resolved = false;
                 var deferred = Promise.NewDeferred<int>();
-                var promise = deferred.Promise.Preserve();
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    TestHelper.AddResolveCallbacks<int, bool, string>(promiseRetainer.WaitAsync(),
+                        v => resolved = true
+                    );
+                    TestHelper.AddCallbacks<int, bool, object, string>(promiseRetainer.WaitAsync(),
+                        v => resolved = true,
+                        s => Assert.Fail("Promise was rejected when it should have been resolved."),
+                        () => Assert.Fail("Promise was rejected when it should have been resolved.")
+                    );
 
-                TestHelper.AddResolveCallbacks<int, bool, string>(promise,
-                    v => resolved = true
-                );
-                TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                    v => resolved = true,
-                    s => Assert.Fail("Promise was rejected when it should have been resolved."),
-                    () => Assert.Fail("Promise was rejected when it should have been resolved.")
-                );
+                    Assert.False(resolved);
 
-                Assert.False(resolved);
+                    deferred.Resolve(100);
 
-                deferred.Resolve(100);
-
-                Assert.True(resolved);
-
-                promise.Forget();
+                    Assert.True(resolved);
+                }
             }
 
             [Test]
@@ -552,28 +297,27 @@ namespace ProtoPromiseTests.APIs
             {
                 var resolveCount = 0;
                 var deferred = Promise.NewDeferred();
-                var promise = deferred.Promise.Preserve();
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    TestHelper.AddResolveCallbacks<bool, string>(promiseRetainer.WaitAsync(),
+                        () => ++resolveCount
+                    );
+                    TestHelper.AddCallbacks<bool, object, string>(promiseRetainer.WaitAsync(),
+                        () => ++resolveCount,
+                        s => Assert.Fail("Promise was rejected when it should have been resolved."),
+                        () => Assert.Fail("Promise was rejected when it should have been resolved.")
+                    );
+                    deferred.Resolve();
 
-                TestHelper.AddResolveCallbacks<bool, string>(promise,
-                    () => ++resolveCount
-                );
-                TestHelper.AddCallbacks<bool, object, string>(promise,
-                    () => ++resolveCount,
-                    s => Assert.Fail("Promise was rejected when it should have been resolved."),
-                    () => Assert.Fail("Promise was rejected when it should have been resolved.")
-                );
-                deferred.Resolve();
+                    Assert.IsFalse(deferred.TryResolve());
+                    Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve());
 
-                Assert.IsFalse(deferred.TryResolve());
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve());
-
-                Assert.AreEqual(
-                    (TestHelper.resolveVoidVoidCallbacks + TestHelper.resolveVoidConvertCallbacks +
-                    TestHelper.resolveVoidPromiseVoidCallbacks + TestHelper.resolveVoidPromiseConvertCallbacks) * 2,
-                    resolveCount
-                );
-
-                promise.Forget();
+                    Assert.AreEqual(
+                        (TestHelper.resolveVoidVoidCallbacks + TestHelper.resolveVoidConvertCallbacks +
+                        TestHelper.resolveVoidPromiseVoidCallbacks + TestHelper.resolveVoidPromiseConvertCallbacks) * 2,
+                        resolveCount
+                    );
+                }
             }
 
             [Test]
@@ -581,28 +325,27 @@ namespace ProtoPromiseTests.APIs
             {
                 var resolveCount = 0;
                 var deferred = Promise.NewDeferred<int>();
-                var promise = deferred.Promise.Preserve();
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    TestHelper.AddResolveCallbacks<int, bool, string>(promiseRetainer.WaitAsync(),
+                        x => ++resolveCount
+                    );
+                    TestHelper.AddCallbacks<int, bool, object, string>(promiseRetainer.WaitAsync(),
+                        x => ++resolveCount,
+                        s => Assert.Fail("Promise was rejected when it should have been resolved."),
+                        () => Assert.Fail("Promise was rejected when it should have been resolved.")
+                    );
+                    deferred.Resolve(1);
 
-                TestHelper.AddResolveCallbacks<int, bool, string>(promise,
-                    x => ++resolveCount
-                );
-                TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                    x => ++resolveCount,
-                    s => Assert.Fail("Promise was rejected when it should have been resolved."),
-                    () => Assert.Fail("Promise was rejected when it should have been resolved.")
-                );
-                deferred.Resolve(1);
+                    Assert.IsFalse(deferred.TryResolve(1));
+                    Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve(100));
 
-                Assert.IsFalse(deferred.TryResolve(1));
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve(100));
-
-                Assert.AreEqual(
-                    (TestHelper.resolveTVoidCallbacks + TestHelper.resolveTConvertCallbacks +
-                    TestHelper.resolveTPromiseVoidCallbacks + TestHelper.resolveTPromiseConvertCallbacks) * 2,
-                    resolveCount
-                );
-
-                promise.Forget();
+                    Assert.AreEqual(
+                        (TestHelper.resolveTVoidCallbacks + TestHelper.resolveTConvertCallbacks +
+                        TestHelper.resolveTPromiseVoidCallbacks + TestHelper.resolveTPromiseConvertCallbacks) * 2,
+                        resolveCount
+                    );
+                }
             }
         }
 
@@ -751,26 +494,25 @@ namespace ProtoPromiseTests.APIs
         {
             bool resolved = false;
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+            using (var promiseRetainer = deferred.Promise.GetRetainer())
+            {
+                TestHelper.AddResolveCallbacks<bool, string>(promiseRetainer.WaitAsync(),
+                    () => resolved = true,
+                    configureAwaitType: ConfigureAwaitType.Foreground,
+                    configureAwaitForceAsync: true
+                );
+                TestHelper.AddCallbacks<bool, object, string>(promiseRetainer.WaitAsync(),
+                    () => resolved = true,
+                    s => Assert.Fail("Promise was rejected when it should have been resolved."),
+                    configureAwaitType: ConfigureAwaitType.Foreground,
+                    configureAwaitForceAsync: true
+                );
+                deferred.Resolve();
+                Assert.False(resolved);
 
-            TestHelper.AddResolveCallbacks<bool, string>(promise,
-                () => resolved = true,
-                configureAwaitType: ConfigureAwaitType.Foreground,
-                configureAwaitForceAsync: true
-            );
-            TestHelper.AddCallbacks<bool, object, string>(promise,
-                () => resolved = true,
-                s => Assert.Fail("Promise was rejected when it should have been resolved."),
-                configureAwaitType: ConfigureAwaitType.Foreground,
-                configureAwaitForceAsync: true
-            );
-            deferred.Resolve();
-            Assert.False(resolved);
-
-            TestHelper.ExecuteForegroundCallbacks();
-            Assert.True(resolved);
-
-            promise.Forget();
+                TestHelper.ExecuteForegroundCallbacks();
+                Assert.True(resolved);
+            }
         }
 
         [Test]
@@ -778,26 +520,25 @@ namespace ProtoPromiseTests.APIs
         {
             bool resolved = false;
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
+            using (var promiseRetainer = deferred.Promise.GetRetainer())
+            {
+                TestHelper.AddResolveCallbacks<int, bool, string>(promiseRetainer.WaitAsync(),
+                    v => resolved = true,
+                    configureAwaitType: ConfigureAwaitType.Foreground,
+                    configureAwaitForceAsync: true
+                );
+                TestHelper.AddCallbacks<int, bool, object, string>(promiseRetainer.WaitAsync(),
+                    v => resolved = true,
+                    s => Assert.Fail("Promise was rejected when it should have been resolved."),
+                    configureAwaitType: ConfigureAwaitType.Foreground,
+                    configureAwaitForceAsync: true
+                );
+                deferred.Resolve(1);
+                Assert.False(resolved);
 
-            TestHelper.AddResolveCallbacks<int, bool, string>(promise,
-                v => resolved = true,
-                configureAwaitType: ConfigureAwaitType.Foreground,
-                configureAwaitForceAsync: true
-            );
-            TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                v => resolved = true,
-                s => Assert.Fail("Promise was rejected when it should have been resolved."),
-                configureAwaitType: ConfigureAwaitType.Foreground,
-                configureAwaitForceAsync: true
-            );
-            deferred.Resolve(1);
-            Assert.False(resolved);
-
-            TestHelper.ExecuteForegroundCallbacks();
-            Assert.True(resolved);
-
-            promise.Forget();
+                TestHelper.ExecuteForegroundCallbacks();
+                Assert.True(resolved);
+            }
         }
 
         [Test]
@@ -859,84 +600,80 @@ namespace ProtoPromiseTests.APIs
             public void _2_2_6_1_IfWhenPromiseIsFulfilled_AllRespectiveOnFulfilledCallbacksMustExecuteInTheOrderOfTheirOriginatingCallsToThen_void()
             {
                 var deferred = Promise.NewDeferred();
-                var promise = deferred.Promise.Preserve();
-
-                int counter = 0;
-                for (int i = 0; i < 10; ++i)
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
                 {
-                    int expected = i;
-                    promise
-                        .Then(() => Assert.AreEqual(expected, counter++))
-                        .Forget();
+                    int counter = 0;
+                    for (int i = 0; i < 10; ++i)
+                    {
+                        int expected = i;
+                        promiseRetainer.WaitAsync()
+                            .Then(() => Assert.AreEqual(expected, counter++))
+                            .Forget();
+                    }
+
+                    deferred.Resolve();
+                    Assert.AreEqual(10, counter);
                 }
-
-                deferred.Resolve();
-                promise.Forget();
-
-                Assert.AreEqual(10, counter);
             }
 
             [Test]
             public void _2_2_6_1_IfWhenPromiseIsFulfilled_AllRespectiveOnFulfilledCallbacksMustExecuteInTheOrderOfTheirOriginatingCallsToThen_T()
             {
                 var deferred = Promise.NewDeferred<int>();
-                var promise = deferred.Promise.Preserve();
-
-                int counter = 0;
-                for (int i = 0; i < 10; ++i)
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
                 {
-                    int expected = i;
-                    promise
-                        .Then(v => Assert.AreEqual(expected, counter++))
-                        .Forget();
+                    int counter = 0;
+                    for (int i = 0; i < 10; ++i)
+                    {
+                        int expected = i;
+                        promiseRetainer.WaitAsync()
+                            .Then(v => Assert.AreEqual(expected, counter++))
+                            .Forget();
+                    }
+
+                    deferred.Resolve(100);
+                    Assert.AreEqual(10, counter);
                 }
-
-                deferred.Resolve(100);
-                promise.Forget();
-
-                Assert.AreEqual(10, counter);
             }
 
             [Test]
             public void _2_2_6_2_IfWhenPromiseIsRejected_AllRespectiveOnRejectedCallbacksMustExecuteInTheOrderOfTheirOriginatingCallsToThenOrCatch_void()
             {
                 var deferred = Promise.NewDeferred();
-                var promise = deferred.Promise.Preserve();
-
-                int counter = 0;
-                for (int i = 0; i < 10; ++i)
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
                 {
-                    int expected = i;
-                    promise
+                    int counter = 0;
+                    for (int i = 0; i < 10; ++i)
+                    {
+                        int expected = i;
+                        promiseRetainer.WaitAsync()
                         .Catch(() => Assert.AreEqual(expected, counter++))
                         .Forget();
+                    }
+
+                    deferred.Reject("Fail value");
+                    Assert.AreEqual(10, counter);
                 }
-
-                deferred.Reject("Fail value");
-                promise.Forget();
-
-                Assert.AreEqual(10, counter);
             }
 
             [Test]
             public void _2_2_6_2_IfWhenPromiseIsRejected_AllRespectiveOnRejectedCallbacksMustExecuteInTheOrderOfTheirOriginatingCallsToThenOrCatch_T()
             {
                 var deferred = Promise.NewDeferred<int>();
-                var promise = deferred.Promise.Preserve();
-
-                int counter = 0;
-                for (int i = 0; i < 10; ++i)
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
                 {
-                    int expected = i;
-                    promise
+                    int counter = 0;
+                    for (int i = 0; i < 10; ++i)
+                    {
+                        int expected = i;
+                        promiseRetainer.WaitAsync()
                         .Catch(() => Assert.AreEqual(expected, counter++))
                         .Forget();
+                    }
+
+                    deferred.Reject("Fail value");
+                    Assert.AreEqual(10, counter);
                 }
-
-                deferred.Reject("Fail value");
-                promise.Forget();
-
-                Assert.AreEqual(10, counter);
             }
         }
 
@@ -960,85 +697,83 @@ namespace ProtoPromiseTests.APIs
             public void _2_2_7_2_IfOnFulfilledThrowsAnExceptionE_Promise2MustBeRejectedWithEAsTheReason_void()
             {
                 var deferred = Promise.NewDeferred();
-                var promise = deferred.Promise.Preserve();
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    int exceptionCount = 0;
+                    Exception expected = new Exception("Fail value");
 
-                int exceptionCount = 0;
-                Exception expected = new Exception("Fail value");
+                    Action<Promise> catchCallback = p =>
+                        p.Catch((Exception e) =>
+                        {
+                            Assert.AreEqual(expected, e);
+                            ++exceptionCount;
+                        }).Forget();
 
-                Action<Promise> catchCallback = p =>
-                    p.Catch((Exception e) =>
-                    {
-                        Assert.AreEqual(expected, e);
-                        ++exceptionCount;
-                    }).Forget();
+                    TestHelper.AddResolveCallbacks<bool, string>(promiseRetainer.WaitAsync(),
+                        onResolve: () => { throw expected; },
+                        onResolveCapture: _ => { throw expected; },
+                        onCallbackAdded: (ref Promise p) => catchCallback(p),
+                        onCallbackAddedConvert: (ref Promise<bool> p) => catchCallback(p)
+                    );
+                    TestHelper.AddCallbacks<bool, object, string>(promiseRetainer.WaitAsync(),
+                        onReject: s => Assert.Fail("Promise was rejected when it should have been resolved."),
+                        onUnknownRejection: () => Assert.Fail("Promise was rejected when it should have been resolved."),
+                        onResolve: () => { throw expected; },
+                        onResolveCapture: _ => { throw expected; },
+                        onCallbackAdded: (ref Promise p) => catchCallback(p),
+                        onCallbackAddedConvert: (ref Promise<bool> p) => catchCallback(p)
+                    );
 
-                TestHelper.AddResolveCallbacks<bool, string>(promise,
-                    onResolve: () => { throw expected; },
-                    onResolveCapture: _ => { throw expected; },
-                    onCallbackAdded: (ref Promise p) => catchCallback(p),
-                    onCallbackAddedConvert: (ref Promise<bool> p) => catchCallback(p)
-                );
-                TestHelper.AddCallbacks<bool, object, string>(promise,
-                    onReject: s => Assert.Fail("Promise was rejected when it should have been resolved."),
-                    onUnknownRejection: () => Assert.Fail("Promise was rejected when it should have been resolved."),
-                    onResolve: () => { throw expected; },
-                    onResolveCapture: _ => { throw expected; },
-                    onCallbackAdded: (ref Promise p) => catchCallback(p),
-                    onCallbackAddedConvert: (ref Promise<bool> p) => catchCallback(p)
-                );
+                    deferred.Resolve();
 
-                deferred.Resolve();
-
-                Assert.AreEqual(
-                    (TestHelper.resolveVoidVoidCallbacks + TestHelper.resolveVoidConvertCallbacks +
-                    TestHelper.resolveVoidPromiseVoidCallbacks + TestHelper.resolveVoidPromiseConvertCallbacks) * 2,
-                    exceptionCount
-                );
-
-                promise.Forget();
+                    Assert.AreEqual(
+                        (TestHelper.resolveVoidVoidCallbacks + TestHelper.resolveVoidConvertCallbacks +
+                        TestHelper.resolveVoidPromiseVoidCallbacks + TestHelper.resolveVoidPromiseConvertCallbacks) * 2,
+                        exceptionCount
+                    );
+                }
             }
 
             [Test]
             public void _2_2_7_2_IfOnFulfilledThrowsAnExceptionE_Promise2MustBeRejectedWithEAsTheReason_T()
             {
                 var deferred = Promise.NewDeferred<int>();
-                var promise = deferred.Promise.Preserve();
+                using (var promiseRetainer = deferred.Promise.GetRetainer())
+                {
+                    int exceptionCount = 0;
+                    Exception expected = new Exception("Fail value");
 
-                int exceptionCount = 0;
-                Exception expected = new Exception("Fail value");
+                    Action<Promise> catchCallback = p =>
+                        p.Catch((Exception e) =>
+                        {
+                            Assert.AreEqual(expected, e);
+                            ++exceptionCount;
+                        }).Forget();
 
-                Action<Promise> catchCallback = p =>
-                    p.Catch((Exception e) =>
-                    {
-                        Assert.AreEqual(expected, e);
-                        ++exceptionCount;
-                    }).Forget();
+                    TestHelper.AddResolveCallbacks<int, bool, string>(promiseRetainer.WaitAsync(),
+                        onResolve: v => { throw expected; },
+                        onResolveCapture: _ => { throw expected; },
+                        onCallbackAdded: (ref Promise p) => catchCallback(p),
+                        onCallbackAddedConvert: (ref Promise<bool> p) => catchCallback(p)
+                    );
+                    TestHelper.AddCallbacks<int, bool, object, string>(promiseRetainer.WaitAsync(),
+                        onReject: s => Assert.Fail("Promise was rejected when it should have been resolved."),
+                        onUnknownRejection: () => Assert.Fail("Promise was rejected when it should have been resolved."),
+                        onResolve: v => { throw expected; },
+                        onResolveCapture: _ => { throw expected; },
+                        onCallbackAdded: (ref Promise p) => catchCallback(p),
+                        onCallbackAddedConvert: (ref Promise<bool> p) => catchCallback(p),
+                        onCallbackAddedT: (ref Promise<int> p) => catchCallback(p)
+                    );
 
-                TestHelper.AddResolveCallbacks<int, bool, string>(promise,
-                    onResolve: v => { throw expected; },
-                    onResolveCapture: _ => { throw expected; },
-                    onCallbackAdded: (ref Promise p) => catchCallback(p),
-                    onCallbackAddedConvert: (ref Promise<bool> p) => catchCallback(p)
-                );
-                TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                    onReject: s => Assert.Fail("Promise was rejected when it should have been resolved."),
-                    onUnknownRejection: () => Assert.Fail("Promise was rejected when it should have been resolved."),
-                    onResolve: v => { throw expected; },
-                    onResolveCapture: _ => { throw expected; },
-                    onCallbackAdded: (ref Promise p) => catchCallback(p),
-                    onCallbackAddedConvert: (ref Promise<bool> p) => catchCallback(p),
-                    onCallbackAddedT: (ref Promise<int> p) => catchCallback(p)
-                );
+                    deferred.Resolve(100);
 
-                deferred.Resolve(100);
-
-                Assert.AreEqual(
-                    (TestHelper.resolveTVoidCallbacks + TestHelper.resolveTConvertCallbacks +
-                    TestHelper.resolveTPromiseVoidCallbacks + TestHelper.resolveTPromiseConvertCallbacks) * 2,
-                    exceptionCount
-                );
-
-                promise.Forget();
+                    Assert.AreEqual(
+                        (TestHelper.resolveTVoidCallbacks + TestHelper.resolveTConvertCallbacks +
+                        TestHelper.resolveTPromiseVoidCallbacks + TestHelper.resolveTPromiseConvertCallbacks) * 2,
+                        exceptionCount
+                    );
+                }
             }
 
             [Test]
@@ -1117,26 +852,25 @@ namespace ProtoPromiseTests.APIs
 
                 var deferred = Promise.NewDeferred();
                 var promise1 = deferred.Promise;
-                var promise2 = promise1
+                using (var promiseRetainer2 = promise1
                     .Catch(() => { Assert.Fail("Promise was rejected when it should have been resolved."); return; })
-                    .Preserve();
+                    .GetRetainer())
+                {
+                    TestHelper.AddResolveCallbacks<bool, string>(promiseRetainer2.WaitAsync(),
+                        () => ++counter
+                    );
+                    TestHelper.AddCallbacks<bool, object, string>(promiseRetainer2.WaitAsync(),
+                        () => ++counter,
+                        s => Assert.Fail("Promise was rejected when it should have been resolved.")
+                    );
 
-                TestHelper.AddResolveCallbacks<bool, string>(promise2,
-                    () => ++counter
-                );
-                TestHelper.AddCallbacks<bool, object, string>(promise2,
-                    () => ++counter,
-                    s => Assert.Fail("Promise was rejected when it should have been resolved.")
-                );
+                    deferred.Resolve();
 
-                deferred.Resolve();
-
-                Assert.AreEqual(
-                    TestHelper.resolveVoidCallbacks * 2,
-                    counter
-                );
-
-                promise2.Forget();
+                    Assert.AreEqual(
+                        TestHelper.resolveVoidCallbacks * 2,
+                        counter
+                    );
+                }
             }
 
             [Test]
@@ -1146,26 +880,25 @@ namespace ProtoPromiseTests.APIs
 
                 var deferred = Promise.NewDeferred();
                 var promise1 = deferred.Promise;
-                var promise2 = promise1
+                using (var promiseRetainer2 = promise1
                     .Catch(() => { Assert.Fail("Promise was rejected when it should have been resolved."); return Promise.Resolved(); })
-                    .Preserve();
+                    .GetRetainer())
+                {
+                    TestHelper.AddResolveCallbacks<bool, string>(promiseRetainer2.WaitAsync(),
+                        () => ++counter
+                    );
+                    TestHelper.AddCallbacks<bool, object, string>(promiseRetainer2.WaitAsync(),
+                        () => ++counter,
+                        s => Assert.Fail("Promise was rejected when it should have been resolved.")
+                    );
 
-                TestHelper.AddResolveCallbacks<bool, string>(promise2,
-                    () => ++counter
-                );
-                TestHelper.AddCallbacks<bool, object, string>(promise2,
-                    () => ++counter,
-                    s => Assert.Fail("Promise was rejected when it should have been resolved.")
-                );
+                    deferred.Resolve();
 
-                deferred.Resolve();
-
-                Assert.AreEqual(
-                    TestHelper.resolveVoidCallbacks * 2,
-                    counter
-                );
-
-                promise2.Forget();
+                    Assert.AreEqual(
+                        TestHelper.resolveVoidCallbacks * 2,
+                        counter
+                    );
+                }
             }
 
             [Test]
@@ -1176,26 +909,25 @@ namespace ProtoPromiseTests.APIs
 
                 var deferred = Promise.NewDeferred<int>();
                 var promise1 = deferred.Promise;
-                var promise2 = promise1
+                using (var promiseRetainer2 = promise1
                     .Catch(() => { Assert.Fail("Promise was rejected when it should have been resolved."); return 50; })
-                    .Preserve();
+                    .GetRetainer())
+                {
+                    TestHelper.AddResolveCallbacks<int, bool, string>(promiseRetainer2.WaitAsync(),
+                        v => { Assert.AreEqual(expected, v); ++counter; }
+                    );
+                    TestHelper.AddCallbacks<int, bool, object, string>(promiseRetainer2.WaitAsync(),
+                        v => { Assert.AreEqual(expected, v); ++counter; },
+                        s => Assert.Fail("Promise was rejected when it should have been resolved.")
+                    );
 
-                TestHelper.AddResolveCallbacks<int, bool, string>(promise2,
-                    v => { Assert.AreEqual(expected, v); ++counter; }
-                );
-                TestHelper.AddCallbacks<int, bool, object, string>(promise2,
-                    v => { Assert.AreEqual(expected, v); ++counter; },
-                    s => Assert.Fail("Promise was rejected when it should have been resolved.")
-                );
+                    deferred.Resolve(expected);
 
-                deferred.Resolve(expected);
-
-                Assert.AreEqual(
-                    TestHelper.resolveTCallbacks * 2,
-                    counter
-                );
-
-                promise2.Forget();
+                    Assert.AreEqual(
+                        TestHelper.resolveTCallbacks * 2,
+                        counter
+                    );
+                }
             }
 
             [Test]
@@ -1206,26 +938,25 @@ namespace ProtoPromiseTests.APIs
 
                 var deferred = Promise.NewDeferred<int>();
                 var promise1 = deferred.Promise;
-                var promise2 = promise1
+                using (var promiseRetainer2 = promise1
                     .Catch(() => { Assert.Fail("Promise was rejected when it should have been resolved."); return Promise.Resolved(50); })
-                    .Preserve();
+                    .GetRetainer())
+                {
+                    TestHelper.AddResolveCallbacks<int, bool, string>(promiseRetainer2.WaitAsync(),
+                        v => { Assert.AreEqual(expected, v); ++counter; }
+                    );
+                    TestHelper.AddCallbacks<int, bool, object, string>(promiseRetainer2.WaitAsync(),
+                        v => { Assert.AreEqual(expected, v); ++counter; },
+                        s => Assert.Fail("Promise was rejected when it should have been resolved.")
+                    );
 
-                TestHelper.AddResolveCallbacks<int, bool, string>(promise2,
-                    v => { Assert.AreEqual(expected, v); ++counter; }
-                );
-                TestHelper.AddCallbacks<int, bool, object, string>(promise2,
-                    v => { Assert.AreEqual(expected, v); ++counter; },
-                    s => Assert.Fail("Promise was rejected when it should have been resolved.")
-                );
+                    deferred.Resolve(expected);
 
-                deferred.Resolve(expected);
-
-                Assert.AreEqual(
-                    TestHelper.resolveTCallbacks * 2,
-                    counter
-                );
-
-                promise2.Forget();
+                    Assert.AreEqual(
+                        TestHelper.resolveTCallbacks * 2,
+                        counter
+                    );
+                }
             }
 
             [Test]

--- a/Package/Tests/CoreTests/APIs/AllSettledTests.cs
+++ b/Package/Tests/CoreTests/APIs/AllSettledTests.cs
@@ -336,39 +336,39 @@ namespace ProtoPromiseTests.APIs
             string reason = "reject";
 
             var deferred = Promise.NewDeferred();
-            var promise1 = deferred.Promise.Preserve();
-            var promise2 = Promise.Rejected(reason).Preserve();
-
-            Promise.AllSettled(promise1, promise2)
-                .Finally(() => ++invokeCount)
-                .Then(results =>
+            using (var promiseRetainer1 = deferred.Promise.GetRetainer())
+            {
+                using (var promiseRetainer2 = Promise.Rejected(reason).GetRetainer())
                 {
-                    Assert.AreEqual(2, results.Count);
-                    Assert.AreEqual(Promise.State.Resolved, results[0].State);
-                    Assert.AreEqual(Promise.State.Rejected, results[1].State);
-                    Assert.AreEqual(reason, results[1].Reason);
-                })
-                .Forget();
+                    Promise.AllSettled(promiseRetainer1.WaitAsync(), promiseRetainer2.WaitAsync())
+                        .Finally(() => ++invokeCount)
+                        .Then(results =>
+                        {
+                            Assert.AreEqual(2, results.Count);
+                            Assert.AreEqual(Promise.State.Resolved, results[0].State);
+                            Assert.AreEqual(Promise.State.Rejected, results[1].State);
+                            Assert.AreEqual(reason, results[1].Reason);
+                        })
+                        .Forget();
 
-            Promise.AllSettled(promise2, promise1)
-                .Finally(() => ++invokeCount)
-                .Then(results =>
-                {
-                    Assert.AreEqual(2, results.Count);
-                    Assert.AreEqual(Promise.State.Rejected, results[0].State);
-                    Assert.AreEqual(Promise.State.Resolved, results[1].State);
-                    Assert.AreEqual(reason, results[0].Reason);
-                })
-                .Forget();
+                    Promise.AllSettled(promiseRetainer2.WaitAsync(), promiseRetainer1.WaitAsync())
+                        .Finally(() => ++invokeCount)
+                        .Then(results =>
+                        {
+                            Assert.AreEqual(2, results.Count);
+                            Assert.AreEqual(Promise.State.Rejected, results[0].State);
+                            Assert.AreEqual(Promise.State.Resolved, results[1].State);
+                            Assert.AreEqual(reason, results[0].Reason);
+                        })
+                        .Forget();
 
-            Assert.AreEqual(0, invokeCount);
+                    Assert.AreEqual(0, invokeCount);
 
-            deferred.Resolve();
+                    deferred.Resolve();
 
-            Assert.AreEqual(2, invokeCount);
-
-            promise1.Forget();
-            promise2.Forget();
+                    Assert.AreEqual(2, invokeCount);
+                }
+            }
         }
 
         [Test]
@@ -378,41 +378,41 @@ namespace ProtoPromiseTests.APIs
             string reason = "reject";
 
             var deferred = Promise.NewDeferred<int>();
-            var promise1 = deferred.Promise.Preserve();
-            var promise2 = Promise<int>.Rejected(reason).Preserve();
-
-            Promise<int>.AllSettled(promise1, promise2)
-                .Finally(() => ++invokeCount)
-                .Then(results =>
+            using (var promiseRetainer1 = deferred.Promise.GetRetainer())
+            {
+                using (var promiseRetainer2 = Promise<int>.Rejected(reason).GetRetainer())
                 {
-                    Assert.AreEqual(2, results.Count);
-                    Assert.AreEqual(Promise.State.Resolved, results[0].State);
-                    Assert.AreEqual(Promise.State.Rejected, results[1].State);
-                    Assert.AreEqual(1, results[0].Value);
-                    Assert.AreEqual(reason, results[1].Reason);
-                })
-                .Forget();
+                    Promise<int>.AllSettled(promiseRetainer1.WaitAsync(), promiseRetainer2.WaitAsync())
+                        .Finally(() => ++invokeCount)
+                        .Then(results =>
+                        {
+                            Assert.AreEqual(2, results.Count);
+                            Assert.AreEqual(Promise.State.Resolved, results[0].State);
+                            Assert.AreEqual(Promise.State.Rejected, results[1].State);
+                            Assert.AreEqual(1, results[0].Value);
+                            Assert.AreEqual(reason, results[1].Reason);
+                        })
+                        .Forget();
 
-            Promise<int>.AllSettled(promise2, promise1)
-                .Finally(() => ++invokeCount)
-                .Then(results =>
-                {
-                    Assert.AreEqual(2, results.Count);
-                    Assert.AreEqual(Promise.State.Rejected, results[0].State);
-                    Assert.AreEqual(Promise.State.Resolved, results[1].State);
-                    Assert.AreEqual(1, results[1].Value);
-                    Assert.AreEqual(reason, results[0].Reason);
-                })
-                .Forget();
+                    Promise<int>.AllSettled(promiseRetainer2.WaitAsync(), promiseRetainer1.WaitAsync())
+                        .Finally(() => ++invokeCount)
+                        .Then(results =>
+                        {
+                            Assert.AreEqual(2, results.Count);
+                            Assert.AreEqual(Promise.State.Rejected, results[0].State);
+                            Assert.AreEqual(Promise.State.Resolved, results[1].State);
+                            Assert.AreEqual(1, results[1].Value);
+                            Assert.AreEqual(reason, results[0].Reason);
+                        })
+                        .Forget();
 
-            Assert.AreEqual(0, invokeCount);
+                    Assert.AreEqual(0, invokeCount);
 
-            deferred.Resolve(1);
+                    deferred.Resolve(1);
 
-            Assert.AreEqual(2, invokeCount);
-
-            promise1.Forget();
-            promise2.Forget();
+                    Assert.AreEqual(2, invokeCount);
+                }
+            }
         }
 
         [Test]
@@ -619,37 +619,37 @@ namespace ProtoPromiseTests.APIs
             int invokeCount = 0;
 
             var deferred = Promise.NewDeferred();
-            var promise1 = deferred.Promise.Preserve();
-            var promise2 = Promise.Canceled().Preserve();
-
-            Promise.AllSettled(promise1, promise2)
-                .Then(results =>
+            using (var promiseRetainer1 = deferred.Promise.GetRetainer())
+            {
+                using (var promiseRetainer2 = Promise.Canceled().GetRetainer())
                 {
-                    ++invokeCount;
-                    Assert.AreEqual(2, results.Count);
-                    Assert.AreEqual(Promise.State.Resolved, results[0].State);
-                    Assert.AreEqual(Promise.State.Canceled, results[1].State);
-                })
-                .Forget();
+                    Promise.AllSettled(promiseRetainer1.WaitAsync(), promiseRetainer2.WaitAsync())
+                        .Then(results =>
+                        {
+                            ++invokeCount;
+                            Assert.AreEqual(2, results.Count);
+                            Assert.AreEqual(Promise.State.Resolved, results[0].State);
+                            Assert.AreEqual(Promise.State.Canceled, results[1].State);
+                        })
+                        .Forget();
 
-            Promise.AllSettled(promise2, promise1)
-                .Then(results =>
-                {
-                    ++invokeCount;
-                    Assert.AreEqual(2, results.Count);
-                    Assert.AreEqual(Promise.State.Canceled, results[0].State);
-                    Assert.AreEqual(Promise.State.Resolved, results[1].State);
-                })
-                .Forget();
+                    Promise.AllSettled(promiseRetainer2.WaitAsync(), promiseRetainer1.WaitAsync())
+                        .Then(results =>
+                        {
+                            ++invokeCount;
+                            Assert.AreEqual(2, results.Count);
+                            Assert.AreEqual(Promise.State.Canceled, results[0].State);
+                            Assert.AreEqual(Promise.State.Resolved, results[1].State);
+                        })
+                        .Forget();
 
-            Assert.AreEqual(0, invokeCount);
+                    Assert.AreEqual(0, invokeCount);
 
-            deferred.Resolve();
+                    deferred.Resolve();
 
-            Assert.AreEqual(2, invokeCount);
-
-            promise1.Forget();
-            promise2.Forget();
+                    Assert.AreEqual(2, invokeCount);
+                }
+            }
         }
 
         [Test]
@@ -658,39 +658,39 @@ namespace ProtoPromiseTests.APIs
             int invokeCount = 0;
 
             var deferred = Promise.NewDeferred<int>();
-            var promise1 = deferred.Promise.Preserve();
-            var promise2 = Promise<int>.Canceled().Preserve();
-
-            Promise<int>.AllSettled(promise1, promise2)
-                .Then(results =>
+            using (var promiseRetainer1 = deferred.Promise.GetRetainer())
+            {
+                using (var promiseRetainer2 = Promise<int>.Canceled().GetRetainer())
                 {
-                    ++invokeCount;
-                    Assert.AreEqual(2, results.Count);
-                    Assert.AreEqual(Promise.State.Resolved, results[0].State);
-                    Assert.AreEqual(Promise.State.Canceled, results[1].State);
-                    Assert.AreEqual(1, results[0].Value);
-                })
-                .Forget();
+                    Promise<int>.AllSettled(promiseRetainer1.WaitAsync(), promiseRetainer2.WaitAsync())
+                        .Then(results =>
+                        {
+                            ++invokeCount;
+                            Assert.AreEqual(2, results.Count);
+                            Assert.AreEqual(Promise.State.Resolved, results[0].State);
+                            Assert.AreEqual(Promise.State.Canceled, results[1].State);
+                            Assert.AreEqual(1, results[0].Value);
+                        })
+                        .Forget();
 
-            Promise<int>.AllSettled(promise2, promise1)
-                .Then(results =>
-                {
-                    ++invokeCount;
-                    Assert.AreEqual(2, results.Count);
-                    Assert.AreEqual(Promise.State.Canceled, results[0].State);
-                    Assert.AreEqual(Promise.State.Resolved, results[1].State);
-                    Assert.AreEqual(1, results[1].Value);
-                })
-                .Forget();
+                    Promise<int>.AllSettled(promiseRetainer2.WaitAsync(), promiseRetainer1.WaitAsync())
+                        .Then(results =>
+                        {
+                            ++invokeCount;
+                            Assert.AreEqual(2, results.Count);
+                            Assert.AreEqual(Promise.State.Canceled, results[0].State);
+                            Assert.AreEqual(Promise.State.Resolved, results[1].State);
+                            Assert.AreEqual(1, results[1].Value);
+                        })
+                        .Forget();
 
-            Assert.AreEqual(0, invokeCount);
+                    Assert.AreEqual(0, invokeCount);
 
-            deferred.Resolve(1);
+                    deferred.Resolve(1);
 
-            Assert.AreEqual(2, invokeCount);
-
-            promise1.Forget();
-            promise2.Forget();
+                    Assert.AreEqual(2, invokeCount);
+                }
+            }
         }
     }
 }

--- a/Package/Tests/CoreTests/APIs/CaptureTests.cs
+++ b/Package/Tests/CoreTests/APIs/CaptureTests.cs
@@ -31,12 +31,10 @@ namespace ProtoPromiseTests.APIs
         public void IfOnCanceledIsNullThrow_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+            var promise = deferred.Promise;
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.CatchCancelation(100, default(Action<int>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.CatchCancelation(100, default(Action<int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.CatchCancelation(100, default(Func<int, Promise>)));
 
             deferred.Resolve();
             promise.Forget();
@@ -46,12 +44,10 @@ namespace ProtoPromiseTests.APIs
         public void IfOnCanceledIsNullThrow_T()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
+            var promise = deferred.Promise;
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.CatchCancelation(100, default(Action<int>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.CatchCancelation(100, default(Action<int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.CatchCancelation(100, default(Func<int, Promise>)));
 
             deferred.Resolve(1);
             promise.Forget();
@@ -61,15 +57,12 @@ namespace ProtoPromiseTests.APIs
         public void IfOnFinallyIsNullThrow_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+            var promise = deferred.Promise;
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Finally(100, default(Action<int>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Finally(100, default(Action<int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Finally(100, default(Func<int, Promise>)));
 
             deferred.Resolve();
-
             promise.Forget();
         }
 
@@ -77,15 +70,12 @@ namespace ProtoPromiseTests.APIs
         public void IfOnFinallyIsNullThrow_T()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
+            var promise = deferred.Promise;
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Finally(100, default(Action<int>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Finally(100, default(Action<int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Finally(100, default(Func<int, Promise>)));
 
             deferred.Resolve(1);
-
             promise.Forget();
         }
 
@@ -93,27 +83,14 @@ namespace ProtoPromiseTests.APIs
         public void IfOnContinueIsNullThrow_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+            var promise = deferred.Promise;
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(100, default(Action<int, Promise.ResultContainer>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(100, default(Func<int, Promise.ResultContainer, bool>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(100, default(Func<int, Promise.ResultContainer, Promise>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(100, default(Func<int, Promise.ResultContainer, Promise<bool>>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(100, default(Action<int, Promise.ResultContainer>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(100, default(Func<int, Promise.ResultContainer, bool>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(100, default(Func<int, Promise.ResultContainer, Promise>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(100, default(Func<int, Promise.ResultContainer, Promise<bool>>)));
 
             deferred.Resolve();
-
             promise.Forget();
         }
 
@@ -121,27 +98,14 @@ namespace ProtoPromiseTests.APIs
         public void IfOnContinueIsNullThrow_T()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
+            var promise = deferred.Promise;
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(100, default(Action<int, Promise<int>.ResultContainer>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(100, default(Func<int, Promise<int>.ResultContainer, bool>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(100, default(Func<int, Promise<int>.ResultContainer, Promise>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(100, default(Func<int, Promise<int>.ResultContainer, Promise<bool>>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(100, default(Action<int, Promise<int>.ResultContainer>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(100, default(Func<int, Promise<int>.ResultContainer, bool>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(100, default(Func<int, Promise<int>.ResultContainer, Promise>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(100, default(Func<int, Promise<int>.ResultContainer, Promise<bool>>)));
 
             deferred.Resolve(1);
-
             promise.Forget();
         }
 
@@ -149,98 +113,36 @@ namespace ProtoPromiseTests.APIs
         public void IfOnFulfilledIsNullThrow_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+            var promise = deferred.Promise;
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Action<int>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, bool>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, Promise>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, Promise<bool>>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Action<int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, bool>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, Promise>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, Promise<bool>>)));
 
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Action<int>), () => { }));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Action<int>), (string failValue) => { }));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Action<int>), () => { });
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Action<int>), (string failValue) => { });
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, bool>), () => default(bool)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, bool>), (string failValue) => default(bool)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, bool>), () => default(bool));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, bool>), (string failValue) => default(bool));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, Promise>), () => default(Promise)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, Promise>), (string failValue) => default(Promise)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, Promise>), () => default(Promise));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, Promise>), (string failValue) => default(Promise));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, Promise<bool>>), () => default(Promise<bool>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, Promise<bool>>), (string failValue) => default(Promise<bool>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, Promise<bool>>), () => default(Promise<bool>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, Promise<bool>>), (string failValue) => default(Promise<bool>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Action<int>), () => default(Promise)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Action<int>), (string failValue) => default(Promise)));
 
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, bool>), () => default(Promise<bool>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, bool>), (string failValue) => default(Promise<bool>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Action<int>), () => default(Promise));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Action<int>), (string failValue) => default(Promise));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, Promise>), () => { }));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, Promise>), (string failValue) => { }));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, bool>), () => default(Promise<bool>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, bool>), (string failValue) => default(Promise<bool>));
-            });
-
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, Promise>), () => { });
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, Promise>), (string failValue) => { });
-            });
-
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, Promise<bool>>), () => default(bool));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(100, default(Func<int, Promise<bool>>), (string failValue) => default(bool));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, Promise<bool>>), () => default(bool)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(100, default(Func<int, Promise<bool>>), (string failValue) => default(bool)));
 
             deferred.Resolve();
             promise.Forget();
@@ -250,98 +152,36 @@ namespace ProtoPromiseTests.APIs
         public void IfOnFulfilledIsNullThrow_T()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
+            var promise = deferred.Promise;
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Action<bool, int>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, int>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, Promise>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, Promise<int>>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Action<bool, int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, Promise>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, Promise<int>>)));
 
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Action<bool, int>), () => { }));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Action<bool, int>), (string failValue) => { }));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Action<bool, int>), () => { });
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Action<bool, int>), (string failValue) => { });
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, int>), () => default(int)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, int>), (string failValue) => default(int)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, int>), () => default(int));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, int>), (string failValue) => default(int));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, Promise>), () => default(Promise)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, Promise>), (string failValue) => default(Promise)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, Promise>), () => default(Promise));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, Promise>), (string failValue) => default(Promise));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, Promise<int>>), () => default(Promise<int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, Promise<int>>), (string failValue) => default(Promise<int>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, Promise<int>>), () => default(Promise<int>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, Promise<int>>), (string failValue) => default(Promise<int>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Action<bool, int>), () => default(Promise)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Action<bool, int>), (string failValue) => default(Promise)));
 
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, int>), () => default(Promise<int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, int>), (string failValue) => default(Promise<int>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Action<bool, int>), () => default(Promise));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Action<bool, int>), (string failValue) => default(Promise));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, Promise>), () => { }));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, Promise>), (string failValue) => { }));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, int>), () => default(Promise<int>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, int>), (string failValue) => default(Promise<int>));
-            });
-
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, Promise>), () => { });
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, Promise>), (string failValue) => { });
-            });
-
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, Promise<int>>), () => default(int));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(true, default(Func<bool, int, Promise<int>>), (string failValue) => default(int));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, Promise<int>>), () => default(int)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(true, default(Func<bool, int, Promise<int>>), (string failValue) => default(int)));
 
             deferred.Resolve(1);
             promise.Forget();
@@ -351,99 +191,37 @@ namespace ProtoPromiseTests.APIs
         public void IfOnRejectedIsNullThrow_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+            var promise = deferred.Promise;
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Catch(100, default(Action<int>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Catch(100, default(Action<int, string>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(100, default(Action<int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(100, default(Action<int, string>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Catch(100, default(Func<int, Promise>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Catch(100, default(Func<int, string, Promise>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(100, default(Func<int, Promise>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(100, default(Func<int, string, Promise>)));
 
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => { }, 100, default(Action<int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => { }, 100, default(Action<int, string>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => { }, 100, default(Action<int>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => { }, 100, default(Action<int, string>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise), 100, default(Func<int, Promise>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise), 100, default(Func<int, string, Promise>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => default(Promise), 100, default(Func<int, Promise>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => default(Promise), 100, default(Func<int, string, Promise>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => "string", 100, default(Func<int, string>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => "string", 100, default(Func<int, Exception, string>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => "string", 100, default(Func<int, string>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => "string", 100, default(Func<int, Exception, string>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise<string>), 100, default(Func<int, Promise<string>>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise<string>), 100, default(Func<int, Exception, Promise<string>>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => default(Promise<string>), 100, default(Func<int, Promise<string>>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => default(Promise<string>), 100, default(Func<int, Exception, Promise<string>>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise), 100, default(Action<int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise), 100, default(Action<int, string>)));
 
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => { }, 100, default(Func<int, Promise>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => { }, 100, default(Func<int, string, Promise>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => default(Promise), 100, default(Action<int>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => default(Promise), 100, default(Action<int, string>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise<string>), 100, default(Func<int, string>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => default(Promise<string>), 100, default(Func<int, Exception, string>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => { }, 100, default(Func<int, Promise>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => { }, 100, default(Func<int, string, Promise>));
-            });
-
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => default(Promise<string>), 100, default(Func<int, string>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => default(Promise<string>), 100, default(Func<int, Exception, string>));
-            });
-
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => "string", 100, default(Func<int, Promise<string>>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then(() => "string", 100, default(Func<int, Exception, Promise<string>>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => "string", 100, default(Func<int, Promise<string>>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then(() => "string", 100, default(Func<int, Exception, Promise<string>>)));
 
             deferred.Resolve();
             promise.Forget();
@@ -453,99 +231,37 @@ namespace ProtoPromiseTests.APIs
         public void IfOnRejectedIsNullThrow_T()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
+            var promise = deferred.Promise;
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Catch(true, default(Func<bool, int>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Catch(true, default(Func<bool, string, int>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(true, default(Func<bool, int>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(true, default(Func<bool, string, int>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Catch(true, default(Func<bool, Promise<int>>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Catch(true, default(Func<bool, string, Promise<int>>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(true, default(Func<bool, Promise<int>>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Catch(true, default(Func<bool, string, Promise<int>>)));
 
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => { }, true, default(Action<bool>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => { }, true, default(Action<bool, string>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => { }, true, default(Action<bool>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => { }, true, default(Action<bool, string>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise), true, default(Func<bool, Promise>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise), true, default(Func<bool, string, Promise>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => default(Promise), true, default(Func<bool, Promise>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => default(Promise), true, default(Func<bool, string, Promise>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => "string", true, default(Func<bool, string>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => "string", true, default(Func<bool, Exception, string>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => "string", true, default(Func<bool, string>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => "string", true, default(Func<bool, Exception, string>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise<string>), true, default(Func<bool, Promise<string>>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise<string>), true, default(Func<bool, Exception, Promise<string>>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => default(Promise<string>), true, default(Func<bool, Promise<string>>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => default(Promise<string>), true, default(Func<bool, Exception, Promise<string>>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise), true, default(Action<bool>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise), true, default(Action<bool, string>)));
 
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => { }, true, default(Func<bool, Promise>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => { }, true, default(Func<bool, string, Promise>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => default(Promise), true, default(Action<bool>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => default(Promise), true, default(Action<bool, string>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise<string>), true, default(Func<bool, string>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => default(Promise<string>), true, default(Func<bool, Exception, string>)));
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => { }, true, default(Func<bool, Promise>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => { }, true, default(Func<bool, string, Promise>));
-            });
-
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => default(Promise<string>), true, default(Func<bool, string>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => default(Promise<string>), true, default(Func<bool, Exception, string>));
-            });
-
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => "string", true, default(Func<bool, Promise<string>>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.Then((int x) => "string", true, default(Func<bool, Exception, Promise<string>>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => "string", true, default(Func<bool, Promise<string>>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.Then((int x) => "string", true, default(Func<bool, Exception, Promise<string>>)));
 
             deferred.Resolve(1);
             promise.Forget();
@@ -906,12 +622,10 @@ namespace ProtoPromiseTests.APIs
         public void OnContinueWillBeInvokedWithCapturedValue_resolved_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
-
             string expected = "expected";
             bool invoked = false;
 
-            TestHelper.AddContinueCallbacks<int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, string>(deferred.Promise,
                 captureValue: expected,
                 onContinueCapture: (cv, r) =>
                 {
@@ -923,8 +637,6 @@ namespace ProtoPromiseTests.APIs
             deferred.Resolve();
 
             Assert.IsTrue(invoked);
-
-            promise.Forget();
         }
 
         [Test]
@@ -934,9 +646,7 @@ namespace ProtoPromiseTests.APIs
             bool invoked = false;
 
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
-
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, int, string>(deferred.Promise,
                 captureValue: expected,
                 onContinueCapture: (cv, r) =>
                 {
@@ -948,8 +658,6 @@ namespace ProtoPromiseTests.APIs
             deferred.Resolve(50);
 
             Assert.IsTrue(invoked);
-
-            promise.Forget();
         }
 
         [Test]
@@ -959,9 +667,7 @@ namespace ProtoPromiseTests.APIs
             bool invoked = false;
 
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
-
-            TestHelper.AddContinueCallbacks<int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, string>(deferred.Promise,
                 captureValue: expected,
                 onContinueCapture: (cv, r) =>
                 {
@@ -973,8 +679,6 @@ namespace ProtoPromiseTests.APIs
             deferred.Reject("Reject");
 
             Assert.IsTrue(invoked);
-
-            promise.Forget();
         }
 
         [Test]
@@ -984,9 +688,7 @@ namespace ProtoPromiseTests.APIs
             bool invoked = false;
 
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
-
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, int, string>(deferred.Promise,
                 captureValue: expected,
                 onContinueCapture: (cv, r) =>
                 {
@@ -998,8 +700,6 @@ namespace ProtoPromiseTests.APIs
             deferred.Reject("Reject");
 
             Assert.IsTrue(invoked);
-
-            promise.Forget();
         }
 
         [Test]
@@ -1009,11 +709,9 @@ namespace ProtoPromiseTests.APIs
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred();
             cancelationSource.Token.Register(deferred);
-            var promise = deferred.Promise.Preserve();
-
             bool invoked = false;
 
-            TestHelper.AddContinueCallbacks<int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, string>(deferred.Promise,
                 captureValue: expected,
                 onContinueCapture: (cv, r) =>
                 {
@@ -1026,7 +724,6 @@ namespace ProtoPromiseTests.APIs
             Assert.IsTrue(invoked);
 
             cancelationSource.Dispose();
-            promise.Forget();
         }
 
         [Test]
@@ -1035,12 +732,10 @@ namespace ProtoPromiseTests.APIs
             CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>();
             cancelationSource.Token.Register(deferred);
-            var promise = deferred.Promise.Preserve();
-
             string expected = "expected";
             bool invoked = false;
 
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, int, string>(deferred.Promise,
                 captureValue: expected,
                 onContinueCapture: (cv, r) =>
                 {
@@ -1053,85 +748,80 @@ namespace ProtoPromiseTests.APIs
             Assert.IsTrue(invoked);
 
             cancelationSource.Dispose();
-            promise.Forget();
         }
 
         [Test]
         public void OnResolvedWillBeInvokedWithCapturedValue_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+            using (var promiseRetainer = deferred.Promise.GetRetainer())
+            {
+                string expected = "expected";
+                bool invoked = false;
 
-            string expected = "expected";
-            bool invoked = false;
+                TestHelper.AddResolveCallbacks<int, string>(promiseRetainer.WaitAsync(),
+                    captureValue: expected,
+                    onResolveCapture: cv =>
+                    {
+                        Assert.AreEqual(expected, cv);
+                        invoked = true;
+                    }
+                );
+                TestHelper.AddCallbacks<int, object, string>(promiseRetainer.WaitAsync(),
+                    captureValue: expected,
+                    onResolveCapture: cv =>
+                    {
+                        Assert.AreEqual(expected, cv);
+                        invoked = true;
+                    }
+                );
 
-            TestHelper.AddResolveCallbacks<int, string>(promise,
-                captureValue: expected,
-                onResolveCapture: cv =>
-                {
-                    Assert.AreEqual(expected, cv);
-                    invoked = true;
-                }
-            );
-            TestHelper.AddCallbacks<int, object, string>(promise,
-                captureValue: expected,
-                onResolveCapture: cv =>
-                {
-                    Assert.AreEqual(expected, cv);
-                    invoked = true;
-                }
-            );
+                deferred.Resolve();
 
-            deferred.Resolve();
-
-            Assert.IsTrue(invoked);
-
-            promise.Forget();
+                Assert.IsTrue(invoked);
+            }
         }
 
         [Test]
         public void OnResolvedWillBeInvokedWithCapturedValue_T()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
+            using (var promiseRetainer = deferred.Promise.GetRetainer())
+            {
+                string expected = "expected";
+                bool invoked = false;
 
-            string expected = "expected";
-            bool invoked = false;
+                TestHelper.AddResolveCallbacks<int, bool, string>(promiseRetainer.WaitAsync(),
+                    captureValue: expected,
+                    onResolveCapture: cv =>
+                    {
+                        Assert.AreEqual(expected, cv);
+                        invoked = true;
+                    }
+                );
+                TestHelper.AddCallbacks<int, bool, object, string>(promiseRetainer.WaitAsync(),
+                    captureValue: expected,
+                    onResolveCapture: cv =>
+                    {
+                        Assert.AreEqual(expected, cv);
+                        invoked = true;
+                    }
+                );
 
-            TestHelper.AddResolveCallbacks<int, bool, string>(promise,
-                captureValue: expected,
-                onResolveCapture: cv =>
-                {
-                    Assert.AreEqual(expected, cv);
-                    invoked = true;
-                }
-            );
-            TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                captureValue: expected,
-                onResolveCapture: cv =>
-                {
-                    Assert.AreEqual(expected, cv);
-                    invoked = true;
-                }
-            );
+                deferred.Resolve(50);
 
-            deferred.Resolve(50);
-
-            Assert.IsTrue(invoked);
-
-            promise.Forget();
+                Assert.IsTrue(invoked);
+            }
         }
 
         [Test]
         public void OnRejectedWillBeInvokedWithCapturedValue_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
-
             string expected = "expected";
             bool invoked = false;
 
-            TestHelper.AddCallbacks<int, object, string>(promise,
+            TestHelper.AddCallbacks<int, object, string>(deferred.Promise,
                 captureValue: expected,
                 onRejectCapture: cv =>
                 {
@@ -1148,20 +838,16 @@ namespace ProtoPromiseTests.APIs
             deferred.Reject("Reject");
 
             Assert.IsTrue(invoked);
-
-            promise.Forget();
         }
 
         [Test]
         public void OnRejectedWillBeInvokedWithCapturedValue_T()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
-
             string expected = "expected";
             bool invoked = false;
 
-            TestHelper.AddCallbacks<int, bool, object, string>(promise,
+            TestHelper.AddCallbacks<int, bool, object, string>(deferred.Promise,
                 captureValue: expected,
                 onResolveCapture: cv =>
                 {
@@ -1178,8 +864,6 @@ namespace ProtoPromiseTests.APIs
             deferred.Reject("Reject");
 
             Assert.IsTrue(invoked);
-
-            promise.Forget();
         }
     }
 }

--- a/Package/Tests/CoreTests/APIs/ContinuewithTests.cs
+++ b/Package/Tests/CoreTests/APIs/ContinuewithTests.cs
@@ -29,24 +29,12 @@ namespace ProtoPromiseTests.APIs
         public void IfOnContinueIsNullThrow_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+            var promise = deferred.Promise;
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(default(Action<Promise.ResultContainer>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(default(Func<Promise.ResultContainer, bool>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(default(Func<Promise.ResultContainer, Promise>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(default(Func<Promise.ResultContainer, Promise<bool>>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(default(Action<Promise.ResultContainer>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(default(Func<Promise.ResultContainer, bool>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(default(Func<Promise.ResultContainer, Promise>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(default(Func<Promise.ResultContainer, Promise<bool>>)));
 
             deferred.Resolve();
             promise.Forget();
@@ -56,24 +44,12 @@ namespace ProtoPromiseTests.APIs
         public void IfOnContinueIsNullThrow_T()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
+            var promise = deferred.Promise;
 
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(default(Action<Promise<int>.ResultContainer>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(default(Func<Promise<int>.ResultContainer, bool>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(default(Func<Promise<int>.ResultContainer, Promise>));
-            });
-            Assert.Throws<Proto.Promises.ArgumentNullException>(() =>
-            {
-                promise.ContinueWith(default(Func<Promise<int>.ResultContainer, Promise<bool>>));
-            });
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(default(Action<Promise<int>.ResultContainer>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(default(Func<Promise<int>.ResultContainer, bool>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(default(Func<Promise<int>.ResultContainer, Promise>)));
+            Assert.Throws<Proto.Promises.ArgumentNullException>(() => promise.ContinueWith(default(Func<Promise<int>.ResultContainer, Promise<bool>>)));
 
             deferred.Resolve(1);
             promise.Forget();
@@ -84,64 +60,54 @@ namespace ProtoPromiseTests.APIs
         public void OnContinueIsInvokedWhenPromiseIsResolved_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
 
             int finallyCount = 0;
 
-            TestHelper.AddContinueCallbacks<int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, string>(deferred.Promise,
                 onContinue: r => ++finallyCount
             );
 
             deferred.Resolve();
 
             Assert.AreEqual(TestHelper.continueVoidCallbacks * 2, finallyCount);
-
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueIsInvokedWhenPromiseIsResolved_T()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
 
             int finallyCount = 0;
 
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, int, string>(deferred.Promise,
                 onContinue: r => ++finallyCount
             );
 
             deferred.Resolve(50);
 
             Assert.AreEqual(TestHelper.continueTCallbacks * 2, finallyCount);
-
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueStateWhenPromiseIsResolved()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
 
-            TestHelper.AddContinueCallbacks<int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, string>(deferred.Promise,
                 onContinue: r => Assert.AreEqual(r.State, Promise.State.Resolved)
             );
 
             deferred.Resolve();
-
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueResultWhenPromiseIsResolved()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
 
             int expected = 50;
 
-            TestHelper.AddContinueCallbacks<int, bool, string>(promise,
+            TestHelper.AddContinueCallbacks<int, bool, string>(deferred.Promise,
                 onContinue: r =>
                 {
                     Assert.AreEqual(r.State, Promise.State.Resolved);
@@ -150,55 +116,46 @@ namespace ProtoPromiseTests.APIs
             );
 
             deferred.Resolve(expected);
-
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueIsInvokedWhenPromiseIsRejected_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
 
             int finallyCount = 0;
 
-            TestHelper.AddContinueCallbacks<int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, string>(deferred.Promise,
                 onContinue: r => ++finallyCount
             );
 
             deferred.Reject("Reject");
             Assert.AreEqual(TestHelper.continueVoidCallbacks * 2, finallyCount);
-
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueIsInvokedWhenPromiseIsRejected_T()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
 
             int finallyCount = 0;
 
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, int, string>(deferred.Promise,
                 onContinue: r => ++finallyCount
             );
 
             deferred.Reject("Reject");
             Assert.AreEqual(TestHelper.continueTCallbacks * 2, finallyCount);
-
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueRejectReasonWhenPromiseIsRejected_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
 
             string rejection = "Reject";
 
-            TestHelper.AddContinueCallbacks<int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, string>(deferred.Promise,
                 onContinue: r =>
                 {
                     Assert.AreEqual(r.State, Promise.State.Rejected);
@@ -207,19 +164,16 @@ namespace ProtoPromiseTests.APIs
             );
 
             deferred.Reject(rejection);
-
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueRejectReasonWhenPromiseIsRejected_T()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
 
             string rejection = "Reject";
 
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, int, string>(deferred.Promise,
                 onContinue: r =>
                 {
                     Assert.AreEqual(r.State, Promise.State.Rejected);
@@ -228,20 +182,17 @@ namespace ProtoPromiseTests.APIs
             );
 
             deferred.Reject(rejection);
-
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueRethrowRejectReasonWhenPromiseIsRejected_void()
         {
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
 
             int rejections = 0;
             string rejection = "Reject";
 
-            TestHelper.AddContinueCallbacks<int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, string>(deferred.Promise,
                 onContinue: r => r.RethrowIfRejected(),
                 onCallbackAdded: (ref Promise p) => p.Catch((object e) => { Assert.AreEqual(rejection, e); ++rejections; }).Forget(),
                 onCallbackAddedConvert: (ref Promise<int> p) => p.Catch((object e) => { Assert.AreEqual(rejection, e); ++rejections; }).Forget()
@@ -253,20 +204,17 @@ namespace ProtoPromiseTests.APIs
                 TestHelper.continueVoidCallbacks * 2,
                 rejections
             );
-
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueRethrowRejectReasonWhenPromiseIsRejected_T()
         {
             var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
 
             int rejections = 0;
             string rejection = "Reject";
 
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, int, string>(deferred.Promise,
                 onContinue: r => r.RethrowIfRejected(),
                 onCallbackAdded: (ref Promise p) => p.Catch((object e) => { Assert.AreEqual(rejection, e); ++rejections; }).Forget(),
                 onCallbackAddedConvert: (ref Promise<int> p) => p.Catch((object e) => { Assert.AreEqual(rejection, e); ++rejections; }).Forget()
@@ -278,144 +226,106 @@ namespace ProtoPromiseTests.APIs
                 TestHelper.continueTCallbacks * 2,
                 rejections
             );
-
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueIsInvokedWhenPromiseIsCanceled_void()
         {
-            CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred();
-            cancelationSource.Token.Register(deferred);
-            var promise = deferred.Promise.Preserve();
 
             int finallyCount = 0;
 
-            TestHelper.AddContinueCallbacks<int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, string>(deferred.Promise,
                 onContinue: r => ++finallyCount
             );
 
-            cancelationSource.Cancel();
+            deferred.Cancel();
             Assert.AreEqual(TestHelper.continueVoidCallbacks * 2, finallyCount);
-
-            cancelationSource.Dispose();
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueIsInvokedWhenPromiseIsCanceled_T()
         {
-            CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>();
-            cancelationSource.Token.Register(deferred);
-            var promise = deferred.Promise.Preserve();
 
             int finallyCount = 0;
 
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, int, string>(deferred.Promise,
                 onContinue: r => ++finallyCount
             );
 
-            cancelationSource.Cancel();
+            deferred.Cancel();
             Assert.AreEqual(TestHelper.continueTCallbacks * 2, finallyCount);
-
-            cancelationSource.Dispose();
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueCancelStateWhenPromiseIsCanceled_void()
         {
-            CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred();
-            cancelationSource.Token.Register(deferred);
-            var promise = deferred.Promise.Preserve();
 
-            TestHelper.AddContinueCallbacks<int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, string>(deferred.Promise,
                 onContinue: r =>
                 {
                     Assert.AreEqual(r.State, Promise.State.Canceled);
                 }
             );
 
-            cancelationSource.Cancel();
-
-            cancelationSource.Dispose();
-            promise.Forget();
+            deferred.Cancel();
         }
 
         [Test]
         public void OnContinueCancelStateWhenPromiseIsCanceled_T()
         {
-            CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>();
-            cancelationSource.Token.Register(deferred);
-            var promise = deferred.Promise.Preserve();
 
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, int, string>(deferred.Promise,
                 onContinue: r =>
                 {
                     Assert.AreEqual(r.State, Promise.State.Canceled);
                 }
             );
 
-            cancelationSource.Cancel();
-
-            cancelationSource.Dispose();
-            promise.Forget();
+            deferred.Cancel();
         }
 
         [Test]
         public void OnContinueRethrowCancelWhenPromiseIsCanceled_void()
         {
-            CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred();
-            cancelationSource.Token.Register(deferred);
-            var promise = deferred.Promise.Preserve();
 
             int cancelCount = 0;
 
-            TestHelper.AddContinueCallbacks<int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, string>(deferred.Promise,
                 onContinue: r => r.RethrowIfCanceled(),
                 onCancel: () => { ++cancelCount; }
             );
 
-            cancelationSource.Cancel();
+            deferred.Cancel();
 
             Assert.AreEqual(
                 TestHelper.continueVoidCallbacks * 2,
                 cancelCount
             );
-
-            cancelationSource.Dispose();
-            promise.Forget();
         }
 
         [Test]
         public void OnContinueRethrowCancelReasonWhenPromiseIsCanceled_T()
         {
-            CancelationSource cancelationSource = CancelationSource.New();
             var deferred = Promise.NewDeferred<int>();
-            cancelationSource.Token.Register(deferred);
-            var promise = deferred.Promise.Preserve();
 
             int cancelCount = 0;
 
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
+            TestHelper.AddContinueCallbacks<int, int, string>(deferred.Promise,
                 onContinue: r => r.RethrowIfCanceled(),
                 onCancel: () => { ++cancelCount; }
             );
 
-            cancelationSource.Cancel();
+            deferred.Cancel();
 
             Assert.AreEqual(
                 TestHelper.continueTCallbacks * 2,
                 cancelCount
             );
-
-            cancelationSource.Dispose();
-            promise.Forget();
         }
     }
 }

--- a/Package/Tests/CoreTests/APIs/MiscellaneousTests.cs
+++ b/Package/Tests/CoreTests/APIs/MiscellaneousTests.cs
@@ -1476,5 +1476,51 @@ namespace ProtoPromiseTests.APIs
 
             Promise.Manager.ClearObjectPool();
         }
+
+        [Test]
+        public void PromiseRetainer_CanAddCallbacksToWaitAsyncPromiseAfterDisposed_void()
+        {
+            var deferred = Promise.NewDeferred();
+            var promiseRetainer = deferred.Promise.GetRetainer();
+            var promises = new Queue<Promise>();
+            var actions = TestHelper.ResolveActionsVoid()
+                .Concat(TestHelper.ThenActionsVoid())
+                .Concat(TestHelper.CatchActionsVoid())
+                .Concat(TestHelper.ContinueWithActionsVoid());
+            foreach (var action in actions)
+            {
+                promises.Enqueue(promiseRetainer.WaitAsync());
+            }
+            promiseRetainer.Dispose();
+            foreach (var action in actions)
+            {
+                action.Invoke(promises.Dequeue());
+            }
+
+            deferred.Resolve();
+        }
+
+        [Test]
+        public void PromiseRetainer_CanAddCallbacksToWaitAsyncPromiseAfterDisposed_T()
+        {
+            var deferred = Promise.NewDeferred<int>();
+            var promiseRetainer = deferred.Promise.GetRetainer();
+            var promises = new Queue<Promise<int>>();
+            var actions = TestHelper.ResolveActions<int>()
+                .Concat(TestHelper.ThenActions<int>())
+                .Concat(TestHelper.CatchActions<int>())
+                .Concat(TestHelper.ContinueWithActions<int>());
+            foreach (var action in actions)
+            {
+                promises.Enqueue(promiseRetainer.WaitAsync());
+            }
+            promiseRetainer.Dispose();
+            foreach (var action in actions)
+            {
+                action.Invoke(promises.Dequeue());
+            }
+
+            deferred.Resolve(1);
+        }
     }
 }

--- a/Package/Tests/CoreTests/APIs/MiscellaneousTests.cs
+++ b/Package/Tests/CoreTests/APIs/MiscellaneousTests.cs
@@ -60,9 +60,12 @@ namespace ProtoPromiseTests.APIs
 #if PROMISE_DEBUG
             Assert.Throws<InvalidOperationException>(() => promise.GetAwaiter());
 #endif
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Throws<InvalidOperationException>(() => promise.Preserve());
-            Assert.Throws<InvalidOperationException>(() => promise.Forget());
             Assert.Throws<InvalidOperationException>(() => promise.Duplicate());
+#pragma warning restore CS0618 // Type or member is obsolete
+            Assert.Throws<InvalidOperationException>(() => promise.GetRetainer());
+            Assert.Throws<InvalidOperationException>(() => promise.Forget());
 
             Assert.Throws<InvalidOperationException>(() => promise.CatchCancelation(() => { }));
             Assert.Throws<InvalidOperationException>(() => promise.CatchCancelation(1, cv => { }));
@@ -187,9 +190,12 @@ namespace ProtoPromiseTests.APIs
 #if PROMISE_DEBUG
             Assert.Throws<InvalidOperationException>(() => promise.GetAwaiter());
 #endif
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Throws<InvalidOperationException>(() => promise.Preserve());
-            Assert.Throws<InvalidOperationException>(() => promise.Forget());
             Assert.Throws<InvalidOperationException>(() => promise.Duplicate());
+#pragma warning restore CS0618 // Type or member is obsolete
+            Assert.Throws<InvalidOperationException>(() => promise.GetRetainer());
+            Assert.Throws<InvalidOperationException>(() => promise.Forget());
 
             Assert.Throws<InvalidOperationException>(() => promise.CatchCancelation(() => { }));
             Assert.Throws<InvalidOperationException>(() => promise.CatchCancelation(1, cv => { }));
@@ -302,390 +308,380 @@ namespace ProtoPromiseTests.APIs
         [Test]
         public void ThrowingRejectExceptionInOnResolvedRejectsThePromiseWithTheGivenValue_void()
         {
-            var promise = Promise.Resolved().Preserve();
-
-            int rejectCount = 0;
-            string expected = "Reject!";
-
-            TestAction<Promise> onCallbackAdded = (ref Promise p) =>
-                p.Catch((string e) =>
-                {
-                    Assert.AreEqual(expected, e);
-                    ++rejectCount;
-                }).Forget();
-            TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
+            using (var promiseRetainer = Promise.Resolved().GetRetainer())
             {
-                p.Catch((string e) =>
+                int rejectCount = 0;
+                string expected = "Reject!";
+
+                TestAction<Promise> onCallbackAdded = (ref Promise p) =>
+                    p.Catch((string e) =>
+                    {
+                        Assert.AreEqual(expected, e);
+                        ++rejectCount;
+                    }).Forget();
+                TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
                 {
-                    Assert.AreEqual(expected, e);
-                    ++rejectCount;
-                }).Forget();
-            };
+                    p.Catch((string e) =>
+                    {
+                        Assert.AreEqual(expected, e);
+                        ++rejectCount;
+                    }).Forget();
+                };
 
-            TestHelper.AddResolveCallbacks<int, string>(promise,
-                onResolve: () => { throw Promise.RejectException(expected); },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-            TestHelper.AddCallbacks<int, object, string>(promise,
-                onResolve: () => { throw Promise.RejectException(expected); },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-            TestHelper.AddContinueCallbacks<int, string>(promise,
-                onContinue: _ => { throw Promise.RejectException(expected); },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
+                TestHelper.AddResolveCallbacks<int, string>(promiseRetainer.WaitAsync(),
+                    onResolve: () => { throw Promise.RejectException(expected); },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
+                TestHelper.AddCallbacks<int, object, string>(promiseRetainer.WaitAsync(),
+                    onResolve: () => { throw Promise.RejectException(expected); },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
+                TestHelper.AddContinueCallbacks<int, string>(promiseRetainer.WaitAsync(),
+                    onContinue: _ => { throw Promise.RejectException(expected); },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
 
-            Assert.AreEqual(
-                (TestHelper.resolveVoidCallbacks + TestHelper.continueVoidCallbacks) * 2,
-                rejectCount
-            );
-
-            promise.Forget();
+                Assert.AreEqual(
+                    (TestHelper.resolveVoidCallbacks + TestHelper.continueVoidCallbacks) * 2,
+                    rejectCount
+                );
+            }
         }
 
         [Test]
         public void ThrowingRejectExceptionInOnResolvedRejectsThePromiseWithTheGivenValue_T()
         {
-            var promise = Promise.Resolved(100).Preserve();
+            using (var promiseRetainer = Promise.Resolved(100).GetRetainer())
+            {
+                int rejectCount = 0;
+                string expected = "Reject!";
 
-            int rejectCount = 0;
-            string expected = "Reject!";
+                TestAction<Promise> onCallbackAdded = (ref Promise p) =>
+                    p.Catch((string e) =>
+                    {
+                        Assert.AreEqual(expected, e);
+                        ++rejectCount;
+                    }).Forget();
+                TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
+                    p.Catch((string e) =>
+                    {
+                        Assert.AreEqual(expected, e);
+                        ++rejectCount;
+                    }).Forget();
 
-            TestAction<Promise> onCallbackAdded = (ref Promise p) =>
-                p.Catch((string e) =>
-                {
-                    Assert.AreEqual(expected, e);
-                    ++rejectCount;
-                }).Forget();
-            TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
-                p.Catch((string e) =>
-                {
-                    Assert.AreEqual(expected, e);
-                    ++rejectCount;
-                }).Forget();
+                TestHelper.AddResolveCallbacks<int, int, string>(promiseRetainer.WaitAsync(),
+                    onResolve: v => { throw Promise.RejectException(expected); },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
+                TestHelper.AddCallbacks<int, int, object, string>(promiseRetainer.WaitAsync(),
+                    onResolve: v => { throw Promise.RejectException(expected); },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
+                TestHelper.AddContinueCallbacks<int, int, string>(promiseRetainer.WaitAsync(),
+                    onContinue: _ => { throw Promise.RejectException(expected); },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
 
-            TestHelper.AddResolveCallbacks<int, int, string>(promise,
-                onResolve: v => { throw Promise.RejectException(expected); },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-            TestHelper.AddCallbacks<int, int, object, string>(promise,
-                onResolve: v => { throw Promise.RejectException(expected); },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
-                onContinue: _ => { throw Promise.RejectException(expected); },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-
-            Assert.AreEqual(
-                (TestHelper.resolveTCallbacks + TestHelper.continueTCallbacks) * 2,
-                rejectCount
-            );
-
-            promise.Forget();
+                Assert.AreEqual(
+                    (TestHelper.resolveTCallbacks + TestHelper.continueTCallbacks) * 2,
+                    rejectCount
+                );
+            }
         }
 
         [Test]
         public void ThrowingRejectExceptionInOnRejectedRejectsThePromiseWithTheGivenValue_void()
         {
-            var promise = Promise.Rejected("A different reject value.").Preserve();
+            using (var promiseRetainer = Promise.Rejected("A different reject value.").GetRetainer())
+            {
+                int rejectCount = 0;
+                string expected = "Reject!";
 
-            int rejectCount = 0;
-            string expected = "Reject!";
+                TestAction<Promise> onCallbackAdded = (ref Promise p) =>
+                    p.Catch((string e) =>
+                    {
+                        Assert.AreEqual(expected, e);
+                        ++rejectCount;
+                    }).Forget();
+                TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
+                    p.Catch((string e) =>
+                    {
+                        Assert.AreEqual(expected, e);
+                        ++rejectCount;
+                    }).Forget();
 
-            TestAction<Promise> onCallbackAdded = (ref Promise p) =>
-                p.Catch((string e) =>
-                {
-                    Assert.AreEqual(expected, e);
-                    ++rejectCount;
-                }).Forget();
-            TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
-                p.Catch((string e) =>
-                {
-                    Assert.AreEqual(expected, e);
-                    ++rejectCount;
-                }).Forget();
+                TestHelper.AddCallbacks<int, object, string>(promiseRetainer.WaitAsync(),
+                    onReject: v => { throw Promise.RejectException(expected); },
+                    onUnknownRejection: () => { throw Promise.RejectException(expected); },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
+                TestHelper.AddContinueCallbacks<int, string>(promiseRetainer.WaitAsync(),
+                    onContinue: _ => { throw Promise.RejectException(expected); },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
 
-            TestHelper.AddCallbacks<int, object, string>(promise,
-                onReject: v => { throw Promise.RejectException(expected); },
-                onUnknownRejection: () => { throw Promise.RejectException(expected); },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-            TestHelper.AddContinueCallbacks<int, string>(promise,
-                onContinue: _ => { throw Promise.RejectException(expected); },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-
-            Assert.AreEqual(
-                (TestHelper.rejectVoidCallbacks + TestHelper.continueVoidCallbacks) * 2,
-                rejectCount
-            );
-
-            promise.Forget();
+                Assert.AreEqual(
+                    (TestHelper.rejectVoidCallbacks + TestHelper.continueVoidCallbacks) * 2,
+                    rejectCount
+                );
+            }
         }
 
         [Test]
         public void ThrowingRejectExceptionInOnRejectedRejectsThePromiseWithTheGivenValue_T()
         {
-            var promise = Promise<int>.Rejected("A different reject value.").Preserve();
+            using (var promiseRetainer = Promise<int>.Rejected("A different reject value.").GetRetainer())
+            {
+                int rejectCount = 0;
+                string expected = "Reject!";
 
-            int rejectCount = 0;
-            string expected = "Reject!";
+                TestAction<Promise> onCallbackAdded = (ref Promise p) =>
+                    p.Catch((string e) =>
+                    {
+                        Assert.AreEqual(expected, e);
+                        ++rejectCount;
+                    }).Forget();
+                TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
+                    p.Catch((string e) =>
+                    {
+                        Assert.AreEqual(expected, e);
+                        ++rejectCount;
+                    }).Forget();
 
-            TestAction<Promise> onCallbackAdded = (ref Promise p) =>
-                p.Catch((string e) =>
-                {
-                    Assert.AreEqual(expected, e);
-                    ++rejectCount;
-                }).Forget();
-            TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
-                p.Catch((string e) =>
-                {
-                    Assert.AreEqual(expected, e);
-                    ++rejectCount;
-                }).Forget();
+                TestHelper.AddCallbacks<int, int, object, string>(promiseRetainer.WaitAsync(),
+                    onReject: v => { throw Promise.RejectException(expected); },
+                    onUnknownRejection: () => { throw Promise.RejectException(expected); },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert,
+                    onCallbackAddedT: onCallbackAddedConvert
+                );
+                TestHelper.AddContinueCallbacks<int, int, string>(promiseRetainer.WaitAsync(),
+                    onContinue: _ => { throw Promise.RejectException(expected); },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
 
-            TestHelper.AddCallbacks<int, int, object, string>(promise,
-                onReject: v => { throw Promise.RejectException(expected); },
-                onUnknownRejection: () => { throw Promise.RejectException(expected); },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert,
-                onCallbackAddedT: onCallbackAddedConvert
-            );
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
-                onContinue: _ => { throw Promise.RejectException(expected); },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-
-            Assert.AreEqual(
-                (TestHelper.rejectTCallbacks + TestHelper.continueTCallbacks) * 2,
-                rejectCount
-            );
-
-            promise.Forget();
+                Assert.AreEqual(
+                    (TestHelper.rejectTCallbacks + TestHelper.continueTCallbacks) * 2,
+                    rejectCount
+                );
+            }
         }
 
         [Test]
         public void ThrowingCancelExceptionInOnResolvedCancelsThePromiseWithTheGivenValue_void()
         {
-            var promise = Promise.Resolved().Preserve();
-
-            int cancelCount = 0;
-
-            System.Action onCancel = () =>
+            using (var promiseRetainer = Promise.Resolved().GetRetainer())
             {
-                ++cancelCount;
-            };
+                int cancelCount = 0;
 
-            TestHelper.AddResolveCallbacks<int, string>(promise,
-                onResolve: () => { throw Promise.CancelException(); },
-                onCancel: onCancel
-            );
-            TestHelper.AddCallbacks<int, object, string>(promise,
-                onResolve: () => { throw Promise.CancelException(); },
-                onCancel: onCancel
-            );
-            TestHelper.AddContinueCallbacks<int, string>(promise,
-                onContinue: _ => { throw Promise.CancelException(); },
-                onCancel: onCancel
-            );
+                System.Action onCancel = () =>
+                {
+                    ++cancelCount;
+                };
 
-            Assert.AreEqual(
-                (TestHelper.resolveVoidCallbacks + TestHelper.continueVoidCallbacks) * 2,
-                cancelCount
-            );
+                TestHelper.AddResolveCallbacks<int, string>(promiseRetainer.WaitAsync(),
+                    onResolve: () => { throw Promise.CancelException(); },
+                    onCancel: onCancel
+                );
+                TestHelper.AddCallbacks<int, object, string>(promiseRetainer.WaitAsync(),
+                    onResolve: () => { throw Promise.CancelException(); },
+                    onCancel: onCancel
+                );
+                TestHelper.AddContinueCallbacks<int, string>(promiseRetainer.WaitAsync(),
+                    onContinue: _ => { throw Promise.CancelException(); },
+                    onCancel: onCancel
+                );
 
-            promise.Forget();
+                Assert.AreEqual(
+                    (TestHelper.resolveVoidCallbacks + TestHelper.continueVoidCallbacks) * 2,
+                    cancelCount
+                );
+            }
         }
 
         [Test]
         public void ThrowingCancelExceptionInOnResolvedCancelsThePromiseWithTheGivenValue_T()
         {
-            var promise = Promise.Resolved(100).Preserve();
-
-            int cancelCount = 0;
-
-            System.Action onCancel = () =>
+            using (var promiseRetainer = Promise.Resolved(100).GetRetainer())
             {
-                ++cancelCount;
-            };
+                int cancelCount = 0;
 
-            TestHelper.AddResolveCallbacks<int, bool, string>(promise,
-                onResolve: v => { throw Promise.CancelException(); },
-                onCancel: onCancel
-            );
-            TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                onResolve: v => { throw Promise.CancelException(); },
-                onCancel: onCancel
-            );
-            TestHelper.AddContinueCallbacks<int, bool, string>(promise,
-                onContinue: _ => { throw Promise.CancelException(); },
-                onCancel: onCancel
-            );
+                System.Action onCancel = () =>
+                {
+                    ++cancelCount;
+                };
 
-            Assert.AreEqual(
-                (TestHelper.resolveTCallbacks + TestHelper.continueTCallbacks) * 2,
-                cancelCount
-            );
+                TestHelper.AddResolveCallbacks<int, bool, string>(promiseRetainer.WaitAsync(),
+                    onResolve: v => { throw Promise.CancelException(); },
+                    onCancel: onCancel
+                );
+                TestHelper.AddCallbacks<int, bool, object, string>(promiseRetainer.WaitAsync(),
+                    onResolve: v => { throw Promise.CancelException(); },
+                    onCancel: onCancel
+                );
+                TestHelper.AddContinueCallbacks<int, bool, string>(promiseRetainer.WaitAsync(),
+                    onContinue: _ => { throw Promise.CancelException(); },
+                    onCancel: onCancel
+                );
 
-            promise.Forget();
+                Assert.AreEqual(
+                    (TestHelper.resolveTCallbacks + TestHelper.continueTCallbacks) * 2,
+                    cancelCount
+                );
+            }
         }
 
         [Test]
         public void ThrowingCancelExceptionInOnRejectedCancelsThePromiseWithTheGivenValue_void()
         {
-            var promise = Promise.Rejected("Rejected").Preserve();
-
-            int cancelCount = 0;
-
-            System.Action onCancel = () =>
+            using (var promiseRetainer = Promise.Rejected("Rejected").GetRetainer())
             {
-                ++cancelCount;
-            };
+                int cancelCount = 0;
 
-            TestHelper.AddCallbacks<int, object, string>(promise,
-                onReject: v => { throw Promise.CancelException(); },
-                onUnknownRejection: () => { throw Promise.CancelException(); },
-                onCancel: onCancel
-            );
-            TestHelper.AddContinueCallbacks<int, string>(promise,
-                onContinue: _ => { throw Promise.CancelException(); },
-                onCancel: onCancel
-            );
+                System.Action onCancel = () =>
+                {
+                    ++cancelCount;
+                };
 
-            Assert.AreEqual(
-                (TestHelper.rejectVoidCallbacks + TestHelper.continueVoidCallbacks) * 2,
-                cancelCount
-            );
+                TestHelper.AddCallbacks<int, object, string>(promiseRetainer.WaitAsync(),
+                    onReject: v => { throw Promise.CancelException(); },
+                    onUnknownRejection: () => { throw Promise.CancelException(); },
+                    onCancel: onCancel
+                );
+                TestHelper.AddContinueCallbacks<int, string>(promiseRetainer.WaitAsync(),
+                    onContinue: _ => { throw Promise.CancelException(); },
+                    onCancel: onCancel
+                );
 
-            promise.Forget();
+                Assert.AreEqual(
+                    (TestHelper.rejectVoidCallbacks + TestHelper.continueVoidCallbacks) * 2,
+                    cancelCount
+                );
+            }
         }
 
         [Test]
         public void ThrowingCancelExceptionInOnRejectedCancelsThePromiseWithTheGivenValue_T()
         {
-            var promise = Promise<int>.Rejected("Rejected").Preserve();
-
-            int cancelCount = 0;
-
-            System.Action onCancel = () =>
+            using (var promiseRetainer = Promise<int>.Rejected("Rejected").GetRetainer())
             {
-                ++cancelCount;
-            };
+                int cancelCount = 0;
 
-            TestHelper.AddCallbacks<int, bool, object, string>(promise,
-                onReject: v => { throw Promise.CancelException(); },
-                onUnknownRejection: () => { throw Promise.CancelException(); },
-                onCancel: onCancel
-            );
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
-                onContinue: _ => { throw Promise.CancelException(); },
-                onCancel: onCancel
-            );
+                System.Action onCancel = () =>
+                {
+                    ++cancelCount;
+                };
 
-            Assert.AreEqual(
-                (TestHelper.rejectTCallbacks + TestHelper.continueTCallbacks) * 2,
-                cancelCount
-            );
+                TestHelper.AddCallbacks<int, bool, object, string>(promiseRetainer.WaitAsync(),
+                    onReject: v => { throw Promise.CancelException(); },
+                    onUnknownRejection: () => { throw Promise.CancelException(); },
+                    onCancel: onCancel
+                );
+                TestHelper.AddContinueCallbacks<int, int, string>(promiseRetainer.WaitAsync(),
+                    onContinue: _ => { throw Promise.CancelException(); },
+                    onCancel: onCancel
+                );
 
-            promise.Forget();
+                Assert.AreEqual(
+                    (TestHelper.rejectTCallbacks + TestHelper.continueTCallbacks) * 2,
+                    cancelCount
+                );
+            }
         }
 
         [Test]
         public void ThrowingRethrowInOnResolvedRejectsThePromiseWithInvalidOperationException_void()
         {
-            var promise = Promise.Resolved().Preserve();
+            using (var promiseRetainer = Promise.Resolved().GetRetainer())
+            {
+                int errorCount = 0;
 
-            int errorCount = 0;
+                TestAction<Promise> onCallbackAdded = (ref Promise p) =>
+                    p.Catch((object e) =>
+                    {
+                        Assert.IsInstanceOf(typeof(InvalidOperationException), e);
+                        ++errorCount;
+                    }).Forget();
+                TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
+                    p.Catch((object e) =>
+                    {
+                        Assert.IsInstanceOf(typeof(InvalidOperationException), e);
+                        ++errorCount;
+                    }).Forget();
 
-            TestAction<Promise> onCallbackAdded = (ref Promise p) =>
-                p.Catch((object e) =>
-                {
-                    Assert.IsInstanceOf(typeof(InvalidOperationException), e);
-                    ++errorCount;
-                }).Forget();
-            TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
-                p.Catch((object e) =>
-                {
-                    Assert.IsInstanceOf(typeof(InvalidOperationException), e);
-                    ++errorCount;
-                }).Forget();
+                TestHelper.AddResolveCallbacks<int, string>(promiseRetainer.WaitAsync(),
+                    onResolve: () => { throw Promise.Rethrow; },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
+                TestHelper.AddCallbacks<int, object, string>(promiseRetainer.WaitAsync(),
+                    onResolve: () => { throw Promise.Rethrow; },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
+                TestHelper.AddContinueCallbacks<int, string>(promiseRetainer.WaitAsync(),
+                    onContinue: _ => { throw Promise.Rethrow; },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
 
-            TestHelper.AddResolveCallbacks<int, string>(promise,
-                onResolve: () => { throw Promise.Rethrow; },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-            TestHelper.AddCallbacks<int, object, string>(promise,
-                onResolve: () => { throw Promise.Rethrow; },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-            TestHelper.AddContinueCallbacks<int, string>(promise,
-                onContinue: _ => { throw Promise.Rethrow; },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-
-            Assert.AreEqual(
-                (TestHelper.resolveVoidCallbacks + TestHelper.continueVoidCallbacks) * 2,
-                errorCount
-            );
-
-            promise.Forget();
+                Assert.AreEqual(
+                    (TestHelper.resolveVoidCallbacks + TestHelper.continueVoidCallbacks) * 2,
+                    errorCount
+                );
+            }
         }
 
         [Test]
         public void ThrowingRethrowInOnResolvedRejectsThePromiseWithInvalidOperationException_T()
         {
-            var promise = Promise.Resolved(100).Preserve();
+            using (var promiseRetainer = Promise.Resolved(100).GetRetainer())
+            {
+                int errorCount = 0;
 
-            int errorCount = 0;
+                TestAction<Promise> onCallbackAdded = (ref Promise p) =>
+                    p.Catch((object e) =>
+                    {
+                        Assert.IsInstanceOf(typeof(InvalidOperationException), e);
+                        ++errorCount;
+                    }).Forget();
+                TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
+                    p.Catch((object e) =>
+                    {
+                        Assert.IsInstanceOf(typeof(InvalidOperationException), e);
+                        ++errorCount;
+                    }).Forget();
 
-            TestAction<Promise> onCallbackAdded = (ref Promise p) =>
-                p.Catch((object e) =>
-                {
-                    Assert.IsInstanceOf(typeof(InvalidOperationException), e);
-                    ++errorCount;
-                }).Forget();
-            TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
-                p.Catch((object e) =>
-                {
-                    Assert.IsInstanceOf(typeof(InvalidOperationException), e);
-                    ++errorCount;
-                }).Forget();
+                TestHelper.AddResolveCallbacks<int, int, string>(promiseRetainer.WaitAsync(),
+                    onResolve: v => { throw Promise.Rethrow; },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
+                TestHelper.AddCallbacks<int, int, object, string>(promiseRetainer.WaitAsync(),
+                    onResolve: v => { throw Promise.Rethrow; },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
+                TestHelper.AddContinueCallbacks<int, int, string>(promiseRetainer.WaitAsync(),
+                    onContinue: _ => { throw Promise.Rethrow; },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
 
-            TestHelper.AddResolveCallbacks<int, int, string>(promise,
-                onResolve: v => { throw Promise.Rethrow; },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-            TestHelper.AddCallbacks<int, int, object, string>(promise,
-                onResolve: v => { throw Promise.Rethrow; },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-            TestHelper.AddContinueCallbacks<int, int, string>(promise,
-                onContinue: _ => { throw Promise.Rethrow; },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
-
-            Assert.AreEqual(
-                (TestHelper.resolveTCallbacks + TestHelper.continueTCallbacks) * 2,
-                errorCount
-            );
-
-            promise.Forget();
+                Assert.AreEqual(
+                    (TestHelper.resolveTCallbacks + TestHelper.continueTCallbacks) * 2,
+                    errorCount
+                );
+            }
         }
 
         [Test]
@@ -694,39 +690,38 @@ namespace ProtoPromiseTests.APIs
         {
             string expected = "Reject!";
 
-            var promise = TestHelper.BuildPromise(CompleteType.Reject, alreadyComplete, expected, out var tryCompleter)
-                .Preserve();
+            using (var promiseRetainer = TestHelper.BuildPromise(CompleteType.Reject, alreadyComplete, expected, out var tryCompleter)
+                .GetRetainer())
+            {
+                int rejectCount = 0;
 
-            int rejectCount = 0;
+                TestAction<Promise> onCallbackAdded = (ref Promise p) =>
+                    p.Catch((string e) =>
+                    {
+                        Assert.AreEqual(expected, e);
+                        ++rejectCount;
+                    }).Forget();
+                TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
+                    p.Catch((string e) =>
+                    {
+                        Assert.AreEqual(expected, e);
+                        ++rejectCount;
+                    }).Forget();
 
-            TestAction<Promise> onCallbackAdded = (ref Promise p) =>
-                p.Catch((string e) =>
-                {
-                    Assert.AreEqual(expected, e);
-                    ++rejectCount;
-                }).Forget();
-            TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
-                p.Catch((string e) =>
-                {
-                    Assert.AreEqual(expected, e);
-                    ++rejectCount;
-                }).Forget();
+                TestHelper.AddCallbacks<int, object, string>(promiseRetainer.WaitAsync(),
+                    onReject: _ => { throw Promise.Rethrow; },
+                    onUnknownRejection: () => { throw Promise.Rethrow; },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert
+                );
 
-            TestHelper.AddCallbacks<int, object, string>(promise,
-                onReject: _ => { throw Promise.Rethrow; },
-                onUnknownRejection: () => { throw Promise.Rethrow; },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert
-            );
+                tryCompleter();
 
-            tryCompleter();
-
-            Assert.AreEqual(
-                TestHelper.rejectVoidCallbacks * 2,
-                rejectCount
-            );
-
-            promise.Forget();
+                Assert.AreEqual(
+                    TestHelper.rejectVoidCallbacks * 2,
+                    rejectCount
+                );
+            }
         }
 
         [Test]
@@ -735,40 +730,39 @@ namespace ProtoPromiseTests.APIs
         {
             string expected = "Reject!";
 
-            var promise = TestHelper.BuildPromise(CompleteType.Reject, alreadyComplete, 0, expected, out var tryCompleter)
-                .Preserve();
+            using (var promiseRetainer = TestHelper.BuildPromise(CompleteType.Reject, alreadyComplete, 0, expected, out var tryCompleter)
+                .GetRetainer())
+            {
+                int rejectCount = 0;
 
-            int rejectCount = 0;
+                TestAction<Promise> onCallbackAdded = (ref Promise p) =>
+                    p.Catch((string e) =>
+                    {
+                        Assert.AreEqual(expected, e);
+                        ++rejectCount;
+                    }).Forget();
+                TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
+                    p.Catch((string e) =>
+                    {
+                        Assert.AreEqual(expected, e);
+                        ++rejectCount;
+                    }).Forget();
 
-            TestAction<Promise> onCallbackAdded = (ref Promise p) =>
-                p.Catch((string e) =>
-                {
-                    Assert.AreEqual(expected, e);
-                    ++rejectCount;
-                }).Forget();
-            TestAction<Promise<int>> onCallbackAddedConvert = (ref Promise<int> p) =>
-                p.Catch((string e) =>
-                {
-                    Assert.AreEqual(expected, e);
-                    ++rejectCount;
-                }).Forget();
+                TestHelper.AddCallbacks<int, int, object, string>(promiseRetainer.WaitAsync(),
+                    onReject: _ => { throw Promise.Rethrow; },
+                    onUnknownRejection: () => { throw Promise.Rethrow; },
+                    onCallbackAdded: onCallbackAdded,
+                    onCallbackAddedConvert: onCallbackAddedConvert,
+                    onCallbackAddedT: onCallbackAddedConvert
+                );
 
-            TestHelper.AddCallbacks<int, int, object, string>(promise,
-                onReject: _ => { throw Promise.Rethrow; },
-                onUnknownRejection: () => { throw Promise.Rethrow; },
-                onCallbackAdded: onCallbackAdded,
-                onCallbackAddedConvert: onCallbackAddedConvert,
-                onCallbackAddedT: onCallbackAddedConvert
-            );
+                tryCompleter();
 
-            tryCompleter();
-
-            Assert.AreEqual(
-                TestHelper.rejectTCallbacks * 2,
-                rejectCount
-            );
-
-            promise.Forget();
+                Assert.AreEqual(
+                    TestHelper.rejectTCallbacks * 2,
+                    rejectCount
+                );
+            }
         }
 
         [Test]
@@ -1459,7 +1453,9 @@ namespace ProtoPromiseTests.APIs
         public void ClearObjectPool_NoErrors()
         {
             var deferred = Promise.NewDeferred();
+#pragma warning disable CS0618 // Type or member is obsolete
             var promise = deferred.Promise.Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             promise
                 .Then(() => { })
@@ -1467,6 +1463,16 @@ namespace ProtoPromiseTests.APIs
 
             deferred.Resolve();
             promise.Forget();
+
+            deferred = Promise.NewDeferred();
+            using (var promiseRetainer = deferred.Promise.GetRetainer())
+            {
+                promiseRetainer.WaitAsync()
+                    .Then(() => { })
+                    .Forget();
+            }
+
+            deferred.Resolve();
 
             Promise.Manager.ClearObjectPool();
         }

--- a/Package/Tests/CoreTests/APIs/ParallelForTests.cs
+++ b/Package/Tests/CoreTests/APIs/ParallelForTests.cs
@@ -95,23 +95,23 @@ namespace ProtoPromiseTests.APIs
 
             int activeWorkers = 0;
             var block = Promise.NewDeferred();
-            var blockPromise = block.Promise.Preserve();
-
-            Promise t = Promise.ParallelForEach(IterateUntilSet(box), (item, cancelationToken) =>
+            using (var blockPromiseRetainer = block.Promise.GetRetainer())
             {
-                Interlocked.Increment(ref activeWorkers);
-                return blockPromise;
-            }, maxDegreeOfParallelism: dop);
+                Promise t = Promise.ParallelForEach(IterateUntilSet(box), (item, cancelationToken) =>
+                {
+                    Interlocked.Increment(ref activeWorkers);
+                    return blockPromiseRetainer.WaitAsync();
+                }, maxDegreeOfParallelism: dop);
 
-            Thread.Sleep(20); // give the loop some time to run
+                Thread.Sleep(20); // give the loop some time to run
 
-            box.Value = true;
-            block.Resolve();
-            int maxWorkers = dop == -1 ? Environment.ProcessorCount : dop;
-            t.WaitWithTimeout(TimeSpan.FromSeconds(maxWorkers));
+                box.Value = true;
+                block.Resolve();
+                int maxWorkers = dop == -1 ? Environment.ProcessorCount : dop;
+                t.WaitWithTimeout(TimeSpan.FromSeconds(maxWorkers));
 
-            blockPromise.Forget();
-            Assert.LessOrEqual(activeWorkers, maxWorkers);
+                Assert.LessOrEqual(activeWorkers, maxWorkers);
+            }
         }
 
         private static IEnumerable<int> InfiniteZero()
@@ -315,39 +315,40 @@ namespace ProtoPromiseTests.APIs
         public void Exceptions_HavePriorityOverCancelation_Sync()
         {
             var deferred = Promise.NewDeferred();
-            var promisePreserved = deferred.Promise.Preserve();
-            var cts = CancelationSource.New();
-
-            Exception expected = new Exception();
-            Exception actual = null;
-
-            Promise.ParallelForEach(Infinite(), (item, cancelationToken) =>
+            using (var promiseRetainer = deferred.Promise.GetRetainer())
             {
-                if (item == 0)
-                {
-                    return promisePreserved
-                        .Then(() =>
-                        {
-                            cts.Cancel();
-                            throw expected;
-                        });
-                }
-                else
-                {
-                    deferred.TryResolve();
-                    return Promise.Resolved();
-                }
-            }, cts.Token, maxDegreeOfParallelism: 2)
-                .Catch((Exception e) => actual = e)
-                .WaitWithTimeout(TimeSpan.FromSeconds(2));
+                var cts = CancelationSource.New();
 
-            promisePreserved.Forget();
-            cts.Dispose();
+                Exception expected = new Exception();
+                Exception actual = null;
 
-            Assert.IsInstanceOf<AggregateException>(actual);
-            var aggregate = (AggregateException) actual;
-            Assert.AreEqual(1, aggregate.InnerExceptions.Count);
-            Assert.AreEqual(expected, aggregate.InnerException);
+                Promise.ParallelForEach(Infinite(), (item, cancelationToken) =>
+                {
+                    if (item == 0)
+                    {
+                        return promiseRetainer.WaitAsync()
+                            .Then(() =>
+                            {
+                                cts.Cancel();
+                                throw expected;
+                            });
+                    }
+                    else
+                    {
+                        deferred.TryResolve();
+                        return Promise.Resolved();
+                    }
+                }, cts.Token, maxDegreeOfParallelism: 2)
+                    .Catch((Exception e) => actual = e)
+                    .WaitWithTimeout(TimeSpan.FromSeconds(2));
+
+                cts.Dispose();
+
+                Assert.IsInstanceOf<AggregateException>(actual);
+                var aggregate = (AggregateException) actual;
+                Assert.AreEqual(1, aggregate.InnerExceptions.Count);
+                Assert.AreEqual(expected, aggregate.InnerException);
+            }
         }
 
         [Test]
@@ -687,41 +688,42 @@ namespace ProtoPromiseTests.APIs
                 : TestHelper._backgroundContext;
 
             var deferred = Promise.NewDeferred();
-            var blockPromise = deferred.Promise.Preserve();
-            int readyCount = 0;
-
-            var parallelPromise = Promise.ParallelFor(0, 3, (index, cancelationToken) =>
+            using (var blockPromiseRetainer = deferred.Promise.GetRetainer())
             {
-                cancelationToken.Register(() => throw new Exception("Error in cancelation!"));
-                Interlocked.Increment(ref readyCount);
-                if (index == 2)
+                int readyCount = 0;
+
+                var parallelPromise = Promise.ParallelFor(0, 3, (index, cancelationToken) =>
                 {
-                    // Wait until all iterations are ready, otherwise the token could be canceled before a worker registered, causing it to throw synchronously.
-                    TestHelper.SpinUntil(() => readyCount == 3, TimeSpan.FromSeconds(2));
-                    throw new System.InvalidOperationException("Error in loop body!");
+                    cancelationToken.Register(() => throw new Exception("Error in cancelation!"));
+                    Interlocked.Increment(ref readyCount);
+                    if (index == 2)
+                    {
+                        // Wait until all iterations are ready, otherwise the token could be canceled before a worker registered, causing it to throw synchronously.
+                        TestHelper.SpinUntil(() => readyCount == 3, TimeSpan.FromSeconds(2));
+                        throw new System.InvalidOperationException("Error in loop body!");
+                    }
+                    return blockPromiseRetainer.WaitAsync();
+                }, context);
+
+                TestHelper.SpinUntilWhileExecutingForegroundContext(() => readyCount == 3, TimeSpan.FromSeconds(3));
+
+                bool didThrow = false;
+                try
+                {
+                    deferred.Resolve();
+                    parallelPromise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(Environment.ProcessorCount));
                 }
-                return blockPromise;
-            }, context);
+                catch (AggregateException e)
+                {
+                    didThrow = true;
+                    Assert.AreEqual(2, e.InnerExceptions.Count);
+                    Assert.IsInstanceOf<System.InvalidOperationException>(e.InnerExceptions[0]);
+                    Assert.IsInstanceOf<AggregateException>(e.InnerExceptions[1]);
+                    Assert.AreEqual(3, ((AggregateException) e.InnerExceptions[1]).InnerExceptions.Count);
+                }
 
-            TestHelper.SpinUntilWhileExecutingForegroundContext(() => readyCount == 3, TimeSpan.FromSeconds(3));
-
-            bool didThrow = false;
-            try
-            {
-                deferred.Resolve();
-                parallelPromise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(Environment.ProcessorCount));
+                Assert.True(didThrow);
             }
-            catch (AggregateException e)
-            {
-                didThrow = true;
-                Assert.AreEqual(2, e.InnerExceptions.Count);
-                Assert.IsInstanceOf<System.InvalidOperationException>(e.InnerExceptions[0]);
-                Assert.IsInstanceOf<AggregateException>(e.InnerExceptions[1]);
-                Assert.AreEqual(3, ((AggregateException) e.InnerExceptions[1]).InnerExceptions.Count);
-            }
-
-            Assert.True(didThrow);
-            blockPromise.Forget();
         }
 
         [Test]
@@ -733,41 +735,42 @@ namespace ProtoPromiseTests.APIs
                 : TestHelper._backgroundContext;
 
             var deferred = Promise.NewDeferred();
-            var blockPromise = deferred.Promise.Preserve();
-            int readyCount = 0;
-
-            var parallelPromise = Promise.ParallelForEach(Enumerable.Range(0, 3), (index, cancelationToken) =>
+            using (var blockPromiseRetainer = deferred.Promise.GetRetainer())
             {
-                cancelationToken.Register(() => throw new Exception("Error in cancelation!"));
-                Interlocked.Increment(ref readyCount);
-                if (index == 2)
+                int readyCount = 0;
+
+                var parallelPromise = Promise.ParallelForEach(Enumerable.Range(0, 3), (index, cancelationToken) =>
                 {
-                    // Wait until all iterations are ready, otherwise the token could be canceled before a worker registered, causing it to throw synchronously.
-                    TestHelper.SpinUntil(() => readyCount == 3, TimeSpan.FromSeconds(2));
-                    throw new System.InvalidOperationException("Error in loop body!");
+                    cancelationToken.Register(() => throw new Exception("Error in cancelation!"));
+                    Interlocked.Increment(ref readyCount);
+                    if (index == 2)
+                    {
+                        // Wait until all iterations are ready, otherwise the token could be canceled before a worker registered, causing it to throw synchronously.
+                        TestHelper.SpinUntil(() => readyCount == 3, TimeSpan.FromSeconds(2));
+                        throw new System.InvalidOperationException("Error in loop body!");
+                    }
+                    return blockPromiseRetainer.WaitAsync();
+                }, context);
+
+                TestHelper.SpinUntilWhileExecutingForegroundContext(() => readyCount == 3, TimeSpan.FromSeconds(3));
+
+                bool didThrow = false;
+                try
+                {
+                    deferred.Resolve();
+                    parallelPromise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(Environment.ProcessorCount));
                 }
-                return blockPromise;
-            }, context);
+                catch (AggregateException e)
+                {
+                    didThrow = true;
+                    Assert.AreEqual(2, e.InnerExceptions.Count);
+                    Assert.IsInstanceOf<System.InvalidOperationException>(e.InnerExceptions[0]);
+                    Assert.IsInstanceOf<AggregateException>(e.InnerExceptions[1]);
+                    Assert.AreEqual(3, ((AggregateException) e.InnerExceptions[1]).InnerExceptions.Count);
+                }
 
-            TestHelper.SpinUntilWhileExecutingForegroundContext(() => readyCount == 3, TimeSpan.FromSeconds(3));
-
-            bool didThrow = false;
-            try
-            {
-                deferred.Resolve();
-                parallelPromise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(Environment.ProcessorCount));
+                Assert.True(didThrow);
             }
-            catch (AggregateException e)
-            {
-                didThrow = true;
-                Assert.AreEqual(2, e.InnerExceptions.Count);
-                Assert.IsInstanceOf<System.InvalidOperationException>(e.InnerExceptions[0]);
-                Assert.IsInstanceOf<AggregateException>(e.InnerExceptions[1]);
-                Assert.AreEqual(3, ((AggregateException) e.InnerExceptions[1]).InnerExceptions.Count);
-            }
-
-            Assert.True(didThrow);
-            blockPromise.Forget();
         }
     }
 #endif // !UNITY_WEBGL

--- a/Package/Tests/CoreTests/APIs/UncaughtRejectionTests.cs
+++ b/Package/Tests/CoreTests/APIs/UncaughtRejectionTests.cs
@@ -1003,7 +1003,9 @@ namespace ProtoPromiseTests.APIs
 #endif
 
                     // Run it again with a freshly preserved promise, because the preserved testabled promise will have had its rejection suppressed by the other promises.
+#pragma warning disable CS0618 // Type or member is obsolete
                     var secondPreservedPromise = promiseRetainer.WaitAsync().Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
                     Assert.IsFalse(secondPreservedPromise.TryWait(System.TimeSpan.FromMilliseconds(timeout)));
                     secondPreservedPromise.Forget();
                 }
@@ -1055,7 +1057,9 @@ namespace ProtoPromiseTests.APIs
 #endif
 
                     // Run it again with a freshly preserved promise, because the preserved testabled promise will have had its rejection suppressed by the other promises.
+#pragma warning disable CS0618 // Type or member is obsolete
                     var secondPreservedPromise = promiseRetainer.WaitAsync().Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
                     Assert.IsFalse(secondPreservedPromise.TryWaitForResult(System.TimeSpan.FromMilliseconds(timeout), out _));
                     secondPreservedPromise.Forget();
                 }

--- a/Package/Tests/CoreTests/APIs/WaitAsyncTests.cs
+++ b/Package/Tests/CoreTests/APIs/WaitAsyncTests.cs
@@ -183,198 +183,195 @@ namespace ProtoPromiseTests.APIs
                 : configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? CancelationToken.Canceled()
                 : configureAwaitCancelationSource2.Token;
 
-            Promise firstPromise = TestHelper.BuildPromise(firstCompleteType, isFirstAlreadyComplete, rejectValue, out var tryCompleter1);
-            Promise<int> secondPromise = TestHelper.BuildPromise(secondCompleteType, isSecondAlreadyComplete, 1, rejectValue, out var tryCompleter2);
-
-            firstPromise = firstPromise.Preserve();
-            secondPromise = secondPromise.Preserve();
-
-            int firstInvokeCounter = 0;
-            int secondInvokeCounter = 0;
-
-            int expectedFirstInvokes = 0;
-            int expectedSecondInvokes = 0;
-
-            Action onFirstCallback = () =>
+            using (var firstPromiseRetainer = TestHelper.BuildPromise(firstCompleteType, isFirstAlreadyComplete, rejectValue, out var tryCompleter1).GetRetainer())
             {
-                TestHelper.AssertCallbackContext(firstWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? firstWaitType : firstReportType, foregroundThread);
-                Interlocked.Increment(ref firstInvokeCounter);
-            };
-            Action onSecondCallback = () =>
-            {
-                // We can't assert the context due to thread race conditions, just make sure the callback is invoked.
-                Interlocked.Increment(ref secondInvokeCounter);
-            };
+                using (var secondPromiseRetainer = TestHelper.BuildPromise(secondCompleteType, isSecondAlreadyComplete, 1, rejectValue, out var tryCompleter2).GetRetainer())
+                {
+                    int firstInvokeCounter = 0;
+                    int secondInvokeCounter = 0;
 
-            Func<Promise, Promise> HookupSecondVoid = promise =>
-            {
-                ++expectedSecondInvokes;
-                return promise.ContinueWith(_ => onSecondCallback());
-            };
+                    int expectedFirstInvokes = 0;
+                    int expectedSecondInvokes = 0;
 
-            Func<Promise<int>, Promise<int>> HookupSecondT = promise =>
-            {
-                ++expectedSecondInvokes;
-                return promise.ContinueWith(_ => { onSecondCallback(); return 2; });
-            };
-
-            bool isFirstCancelExpected = configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled
-                || (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst && (!isFirstAlreadyComplete || firstWaitType != SynchronizationType.Synchronous));
-
-            if (firstCompleteType == CompleteType.Resolve)
-            {
-                TestHelper.AddResolveCallbacksWithCancelation<int, string>(firstPromise,
-                    onResolve: () => onFirstCallback(),
-                    promiseToPromise: p => secondPromise.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
-                    promiseToPromiseConvert: p => secondPromise.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
-                    onCallbackAdded: (ref Promise promise) =>
+                    Action onFirstCallback = () =>
                     {
-                        ++expectedFirstInvokes;
-                        promise.Forget();
-                    },
-                    onCallbackAddedConvert: (ref Promise<int> promise) =>
-                    {
-                        ++expectedFirstInvokes;
-                        promise.Forget();
-                    },
-                    onAdoptCallbackAdded: (ref Promise promise) =>
-                    {
-                        promise = HookupSecondVoid(promise);
-                    },
-                    onAdoptCallbackAddedConvert: (ref Promise<int> promise) =>
-                    {
-                        promise = HookupSecondT(promise);
-                    },
-                    onCancel: () =>
-                    {
-                        if (isFirstCancelExpected)
-                        {
-                            // Don't assert the context due to a race condition between the cancelation propagating on another thread before the CatchCancelation is hooked up.
-                            Interlocked.Increment(ref firstInvokeCounter);
-                        }
-                    },
-                    configureAwaitType: (ConfigureAwaitType) firstWaitType,
-                    waitAsyncCancelationToken: configureAwaitCancelationToken1,
-                    configureAwaitForceAsync: true
-                );
-            }
-            TestHelper.AddCallbacksWithCancelation<int, object, string>(firstPromise,
-                onResolve: () => onFirstCallback(),
-                onReject: r => onFirstCallback(),
-                onUnknownRejection: () => onFirstCallback(),
-                promiseToPromise: p => secondPromise.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
-                promiseToPromiseConvert: p => secondPromise.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
-                onDirectCallbackAdded: (ref Promise promise) =>
-                {
-                    ++expectedFirstInvokes;
-                    promise = promise.Catch(() => { });
-                },
-                onDirectCallbackAddedConvert: (ref Promise<int> promise) =>
-                {
-                    ++expectedFirstInvokes;
-                    promise = promise.Catch(() => 2);
-                },
-                onDirectCallbackAddedCatch: (ref Promise promise) =>
-                {
-                    if (firstCompleteType != CompleteType.Resolve)
-                    {
-                        ++expectedFirstInvokes;
-                    }
-                    // Don't expect cancelation invoke if it will continue on background, as that introduces a race condition.
-                    else if (isFirstCancelExpected && firstWaitType != TestHelper.backgroundType)
-                    {
-                        ++expectedFirstInvokes;
-                    }
-                },
-                onAdoptCallbackAdded: (ref Promise promise, AdoptLocation adoptLocation) =>
-                {
-                    ++expectedFirstInvokes;
-                    if (adoptLocation == AdoptLocation.Both || (CompleteType) adoptLocation == firstCompleteType)
-                    {
-                        promise = HookupSecondVoid(promise);
-                    }
-                },
-                onAdoptCallbackAddedConvert: (ref Promise<int> promise, AdoptLocation adoptLocation) =>
-                {
-                    ++expectedFirstInvokes;
-                    if (adoptLocation == AdoptLocation.Both || (CompleteType) adoptLocation == firstCompleteType)
-                    {
-                        promise = HookupSecondT(promise);
-                    }
-                },
-                onAdoptCallbackAddedCatch: (ref Promise promise) =>
-                {
-                    if (firstCompleteType != CompleteType.Resolve)
-                    {
-                        ++expectedFirstInvokes;
-                    }
-                    // Don't expect cancelation invoke if it will continue on background, as that introduces a race condition.
-                    else if (isFirstCancelExpected && firstWaitType != TestHelper.backgroundType)
-                    {
-                        ++expectedFirstInvokes;
-                    }
-                    if (firstCompleteType == CompleteType.Reject)
-                    {
-                        promise = HookupSecondVoid(promise);
-                    }
-                },
-                onCancel: () =>
-                {
-                    if (isFirstCancelExpected)
-                    {
-                        // Don't assert the context due to a race condition between the cancelation propagating on another thread before the CatchCancelation is hooked up.
+                        TestHelper.AssertCallbackContext(firstWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? firstWaitType : firstReportType, foregroundThread);
                         Interlocked.Increment(ref firstInvokeCounter);
-                    }
-                },
-                configureAwaitType: (ConfigureAwaitType) firstWaitType,
-                waitAsyncCancelationToken: configureAwaitCancelationToken1,
-                configureAwaitForceAsync: true
-            );
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                () =>
-                {
-                    if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst)
+                    };
+                    Action onSecondCallback = () =>
                     {
-                        configureAwaitCancelationSource1.Cancel();
-                    }
-                    tryCompleter1();
-                },
-                firstReportType == SynchronizationType.Foreground);
+                        // We can't assert the context due to thread race conditions, just make sure the callback is invoked.
+                        Interlocked.Increment(ref secondInvokeCounter);
+                    };
 
-            TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
-            if (firstWaitType != (SynchronizationType) SynchronizationOption.Background)
-            {
-                Assert.AreEqual(expectedFirstInvokes, firstInvokeCounter);
-            }
-            else
-            {
-                // We check >= instead of == because of race conditions
-                Assert.GreaterOrEqual(firstInvokeCounter, expectedFirstInvokes);
-            }
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                () =>
-                {
-                    if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelSecond)
+                    Func<Promise, Promise> HookupSecondVoid = promise =>
                     {
-                        configureAwaitCancelationSource2.Cancel();
+                        ++expectedSecondInvokes;
+                        return promise.ContinueWith(_ => onSecondCallback());
+                    };
+
+                    Func<Promise<int>, Promise<int>> HookupSecondT = promise =>
+                    {
+                        ++expectedSecondInvokes;
+                        return promise.ContinueWith(_ => { onSecondCallback(); return 2; });
+                    };
+
+                    bool isFirstCancelExpected = configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled
+                        || (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst && (!isFirstAlreadyComplete || firstWaitType != SynchronizationType.Synchronous));
+
+                    if (firstCompleteType == CompleteType.Resolve)
+                    {
+                        TestHelper.AddResolveCallbacksWithCancelation<int, string>(firstPromiseRetainer.WaitAsync(),
+                            onResolve: () => onFirstCallback(),
+                            promiseToPromise: p => secondPromiseRetainer.WaitAsync().ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
+                            promiseToPromiseConvert: p => secondPromiseRetainer.WaitAsync().ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
+                            onCallbackAdded: (ref Promise promise) =>
+                            {
+                                ++expectedFirstInvokes;
+                                promise.Forget();
+                            },
+                            onCallbackAddedConvert: (ref Promise<int> promise) =>
+                            {
+                                ++expectedFirstInvokes;
+                                promise.Forget();
+                            },
+                            onAdoptCallbackAdded: (ref Promise promise) =>
+                            {
+                                promise = HookupSecondVoid(promise);
+                            },
+                            onAdoptCallbackAddedConvert: (ref Promise<int> promise) =>
+                            {
+                                promise = HookupSecondT(promise);
+                            },
+                            onCancel: () =>
+                            {
+                                if (isFirstCancelExpected)
+                                {
+                                    // Don't assert the context due to a race condition between the cancelation propagating on another thread before the CatchCancelation is hooked up.
+                                    Interlocked.Increment(ref firstInvokeCounter);
+                                }
+                            },
+                            configureAwaitType: (ConfigureAwaitType) firstWaitType,
+                            waitAsyncCancelationToken: configureAwaitCancelationToken1,
+                            configureAwaitForceAsync: true
+                        );
                     }
-                    tryCompleter2();
-                },
-                secondReportType == SynchronizationType.Foreground);
-            TestHelper.ExecuteForegroundCallbacks();
+                    TestHelper.AddCallbacksWithCancelation<int, object, string>(firstPromiseRetainer.WaitAsync(),
+                        onResolve: () => onFirstCallback(),
+                        onReject: r => onFirstCallback(),
+                        onUnknownRejection: () => onFirstCallback(),
+                        promiseToPromise: p => secondPromiseRetainer.WaitAsync().ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
+                        promiseToPromiseConvert: p => secondPromiseRetainer.WaitAsync().ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
+                        onDirectCallbackAdded: (ref Promise promise) =>
+                        {
+                            ++expectedFirstInvokes;
+                            promise = promise.Catch(() => { });
+                        },
+                        onDirectCallbackAddedConvert: (ref Promise<int> promise) =>
+                        {
+                            ++expectedFirstInvokes;
+                            promise = promise.Catch(() => 2);
+                        },
+                        onDirectCallbackAddedCatch: (ref Promise promise) =>
+                        {
+                            if (firstCompleteType != CompleteType.Resolve)
+                            {
+                                ++expectedFirstInvokes;
+                            }
+                            // Don't expect cancelation invoke if it will continue on background, as that introduces a race condition.
+                            else if (isFirstCancelExpected && firstWaitType != TestHelper.backgroundType)
+                            {
+                                ++expectedFirstInvokes;
+                            }
+                        },
+                        onAdoptCallbackAdded: (ref Promise promise, AdoptLocation adoptLocation) =>
+                        {
+                            ++expectedFirstInvokes;
+                            if (adoptLocation == AdoptLocation.Both || (CompleteType) adoptLocation == firstCompleteType)
+                            {
+                                promise = HookupSecondVoid(promise);
+                            }
+                        },
+                        onAdoptCallbackAddedConvert: (ref Promise<int> promise, AdoptLocation adoptLocation) =>
+                        {
+                            ++expectedFirstInvokes;
+                            if (adoptLocation == AdoptLocation.Both || (CompleteType) adoptLocation == firstCompleteType)
+                            {
+                                promise = HookupSecondT(promise);
+                            }
+                        },
+                        onAdoptCallbackAddedCatch: (ref Promise promise) =>
+                        {
+                            if (firstCompleteType != CompleteType.Resolve)
+                            {
+                                ++expectedFirstInvokes;
+                            }
+                            // Don't expect cancelation invoke if it will continue on background, as that introduces a race condition.
+                            else if (isFirstCancelExpected && firstWaitType != TestHelper.backgroundType)
+                            {
+                                ++expectedFirstInvokes;
+                            }
+                            if (firstCompleteType == CompleteType.Reject)
+                            {
+                                promise = HookupSecondVoid(promise);
+                            }
+                        },
+                        onCancel: () =>
+                        {
+                            if (isFirstCancelExpected)
+                            {
+                                // Don't assert the context due to a race condition between the cancelation propagating on another thread before the CatchCancelation is hooked up.
+                                Interlocked.Increment(ref firstInvokeCounter);
+                            }
+                        },
+                        configureAwaitType: (ConfigureAwaitType) firstWaitType,
+                        waitAsyncCancelationToken: configureAwaitCancelationToken1,
+                        configureAwaitForceAsync: true
+                    );
 
-            // We must execute foreground context on every spin to account for the race condition between firstInvokeCounter being incremented and the configured promise returning in the callback.
-            TestHelper.SpinUntilWhileExecutingForegroundContext(() => secondInvokeCounter == expectedSecondInvokes, timeout,
-                $"expectedSecondInvokes: {expectedSecondInvokes}, secondInvokeCounter: {secondInvokeCounter}");
+                    threadHelper.ExecuteSynchronousOrOnThread(
+                        () =>
+                        {
+                            if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst)
+                            {
+                                configureAwaitCancelationSource1.Cancel();
+                            }
+                            tryCompleter1();
+                        },
+                        firstReportType == SynchronizationType.Foreground);
 
-            // Fix a race condition that causes forget to be called before ConfigureAwait.
-            TestHelper._backgroundContext.WaitForAllThreadsToComplete();
-            TestHelper.ExecuteForegroundCallbacks();
+                    TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                    if (firstWaitType != (SynchronizationType) SynchronizationOption.Background)
+                    {
+                        Assert.AreEqual(expectedFirstInvokes, firstInvokeCounter);
+                    }
+                    else
+                    {
+                        // We check >= instead of == because of race conditions
+                        Assert.GreaterOrEqual(firstInvokeCounter, expectedFirstInvokes);
+                    }
 
-            firstPromise.Forget();
-            secondPromise.Forget();
+                    threadHelper.ExecuteSynchronousOrOnThread(
+                        () =>
+                        {
+                            if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelSecond)
+                            {
+                                configureAwaitCancelationSource2.Cancel();
+                            }
+                            tryCompleter2();
+                        },
+                        secondReportType == SynchronizationType.Foreground);
+                    TestHelper.ExecuteForegroundCallbacks();
+
+                    // We must execute foreground context on every spin to account for the race condition between firstInvokeCounter being incremented and the configured promise returning in the callback.
+                    TestHelper.SpinUntilWhileExecutingForegroundContext(() => secondInvokeCounter == expectedSecondInvokes, timeout,
+                        $"expectedSecondInvokes: {expectedSecondInvokes}, secondInvokeCounter: {secondInvokeCounter}");
+
+                    // Fix a race condition that causes forget to be called before ConfigureAwait.
+                    TestHelper._backgroundContext.WaitForAllThreadsToComplete();
+                    TestHelper.ExecuteForegroundCallbacks();
+                }
+            }
             configureAwaitCancelationSource1.TryDispose();
             configureAwaitCancelationSource2.TryDispose();
         }
@@ -403,198 +400,195 @@ namespace ProtoPromiseTests.APIs
                 : configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? CancelationToken.Canceled()
                 : configureAwaitCancelationSource2.Token;
 
-            Promise<int> firstPromise = TestHelper.BuildPromise(firstCompleteType, isFirstAlreadyComplete, 1, rejectValue, out var tryCompleter1);
-            Promise<int> secondPromise = TestHelper.BuildPromise(secondCompleteType, isSecondAlreadyComplete, 1, rejectValue, out var tryCompleter2);
-
-            firstPromise = firstPromise.Preserve();
-            secondPromise = secondPromise.Preserve();
-
-            int firstInvokeCounter = 0;
-            int secondInvokeCounter = 0;
-
-            int expectedFirstInvokes = 0;
-            int expectedSecondInvokes = 0;
-
-            Action onFirstCallback = () =>
+            using (var firstPromiseRetainer = TestHelper.BuildPromise(firstCompleteType, isFirstAlreadyComplete, 1, rejectValue, out var tryCompleter1).GetRetainer())
             {
-                TestHelper.AssertCallbackContext(firstWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? firstWaitType : firstReportType, foregroundThread);
-                Interlocked.Increment(ref firstInvokeCounter);
-            };
-            Action onSecondCallback = () =>
-            {
-                // We can't assert the context due to thread race conditions, just make sure the callback is invoked.
-                Interlocked.Increment(ref secondInvokeCounter);
-            };
+                using (var secondPromiseRetainer = TestHelper.BuildPromise(secondCompleteType, isSecondAlreadyComplete, 1, rejectValue, out var tryCompleter2).GetRetainer())
+                {
+                    int firstInvokeCounter = 0;
+                    int secondInvokeCounter = 0;
 
-            Func<Promise, Promise> HookupSecondVoid = promise =>
-            {
-                ++expectedSecondInvokes;
-                return promise.ContinueWith(_ => onSecondCallback());
-            };
+                    int expectedFirstInvokes = 0;
+                    int expectedSecondInvokes = 0;
 
-            Func<Promise<int>, Promise<int>> HookupSecondT = promise =>
-            {
-                ++expectedSecondInvokes;
-                return promise.ContinueWith(_ => { onSecondCallback(); return 2; });
-            };
-
-            bool isFirstCancelExpected = configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled
-                || (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst && (!isFirstAlreadyComplete || firstWaitType != SynchronizationType.Synchronous));
-
-            if (firstCompleteType == CompleteType.Resolve)
-            {
-                TestHelper.AddResolveCallbacksWithCancelation<int, int, string>(firstPromise,
-                    onResolve: v => onFirstCallback(),
-                    promiseToPromise: p => secondPromise.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
-                    promiseToPromiseConvert: p => secondPromise.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
-                    onCallbackAdded: (ref Promise promise) =>
+                    Action onFirstCallback = () =>
                     {
-                        ++expectedFirstInvokes;
-                        promise.Forget();
-                    },
-                    onCallbackAddedConvert: (ref Promise<int> promise) =>
-                    {
-                        ++expectedFirstInvokes;
-                        promise.Forget();
-                    },
-                    onAdoptCallbackAdded: (ref Promise promise) =>
-                    {
-                        promise = HookupSecondVoid(promise);
-                    },
-                    onAdoptCallbackAddedConvert: (ref Promise<int> promise) =>
-                    {
-                        promise = HookupSecondT(promise);
-                    },
-                    onCancel: () =>
-                    {
-                        if (isFirstCancelExpected)
-                        {
-                            // Don't assert the context due to a race condition between the cancelation propagating on another thread before the CatchCancelation is hooked up.
-                            Interlocked.Increment(ref firstInvokeCounter);
-                        }
-                    },
-                    configureAwaitType: (ConfigureAwaitType) firstWaitType,
-                    waitAsyncCancelationToken: configureAwaitCancelationToken1,
-                    configureAwaitForceAsync: true
-                );
-            }
-            TestHelper.AddCallbacksWithCancelation<int, int, object, string>(firstPromise,
-                onResolve: v => onFirstCallback(),
-                onReject: r => onFirstCallback(),
-                onUnknownRejection: () => onFirstCallback(),
-                promiseToPromise: p => secondPromise.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
-                promiseToPromiseConvert: p => secondPromise.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
-                onDirectCallbackAdded: (ref Promise promise) =>
-                {
-                    ++expectedFirstInvokes;
-                    promise = promise.Catch(() => { });
-                },
-                onDirectCallbackAddedConvert: (ref Promise<int> promise) =>
-                {
-                    ++expectedFirstInvokes;
-                    promise = promise.Catch(() => 2);
-                },
-                onDirectCallbackAddedT: (ref Promise<int> promise) =>
-                {
-                    if (firstCompleteType != CompleteType.Resolve)
-                    {
-                        ++expectedFirstInvokes;
-                    }
-                    // Don't expect cancelation invoke if it will continue on background, as that introduces a race condition.
-                    else if (isFirstCancelExpected && firstWaitType != TestHelper.backgroundType)
-                    {
-                        ++expectedFirstInvokes;
-                    }
-                },
-                onAdoptCallbackAdded: (ref Promise promise, AdoptLocation adoptLocation) =>
-                {
-                    ++expectedFirstInvokes;
-                    if (adoptLocation == AdoptLocation.Both || (CompleteType) adoptLocation == firstCompleteType)
-                    {
-                        promise = HookupSecondVoid(promise);
-                    }
-                },
-                onAdoptCallbackAddedConvert: (ref Promise<int> promise, AdoptLocation adoptLocation) =>
-                {
-                    ++expectedFirstInvokes;
-                    if (adoptLocation == AdoptLocation.Both || (CompleteType) adoptLocation == firstCompleteType)
-                    {
-                        promise = HookupSecondT(promise);
-                    }
-                },
-                onAdoptCallbackAddedT: (ref Promise<int> promise) =>
-                {
-                    if (firstCompleteType != CompleteType.Resolve)
-                    {
-                        ++expectedFirstInvokes;
-                    }
-                    // Don't expect cancelation invoke if it will continue on background, as that introduces a race condition.
-                    else if (isFirstCancelExpected && firstWaitType != TestHelper.backgroundType)
-                    {
-                        ++expectedFirstInvokes;
-                    }
-                    if (firstCompleteType == CompleteType.Reject)
-                    {
-                        promise = HookupSecondT(promise);
-                    }
-                },
-                onCancel: () =>
-                {
-                    if (isFirstCancelExpected)
-                    {
-                        // Don't assert the context due to a race condition between the cancelation propagating on another thread before the CatchCancelation is hooked up.
+                        TestHelper.AssertCallbackContext(firstWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? firstWaitType : firstReportType, foregroundThread);
                         Interlocked.Increment(ref firstInvokeCounter);
-                    }
-                },
-                configureAwaitType: (ConfigureAwaitType) firstWaitType,
-                waitAsyncCancelationToken: configureAwaitCancelationToken1,
-                configureAwaitForceAsync: true
-            );
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                () =>
-                {
-                    if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst)
+                    };
+                    Action onSecondCallback = () =>
                     {
-                        configureAwaitCancelationSource1.Cancel();
-                    }
-                    tryCompleter1();
-                },
-                firstReportType == SynchronizationType.Foreground);
+                        // We can't assert the context due to thread race conditions, just make sure the callback is invoked.
+                        Interlocked.Increment(ref secondInvokeCounter);
+                    };
 
-            TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
-            if (firstWaitType != (SynchronizationType) SynchronizationOption.Background)
-            {
-                Assert.AreEqual(expectedFirstInvokes, firstInvokeCounter);
-            }
-            else
-            {
-                // We check >= instead of == because of race conditions
-                Assert.GreaterOrEqual(firstInvokeCounter, expectedFirstInvokes);
-            }
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                () =>
-                {
-                    if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelSecond)
+                    Func<Promise, Promise> HookupSecondVoid = promise =>
                     {
-                        configureAwaitCancelationSource2.Cancel();
+                        ++expectedSecondInvokes;
+                        return promise.ContinueWith(_ => onSecondCallback());
+                    };
+
+                    Func<Promise<int>, Promise<int>> HookupSecondT = promise =>
+                    {
+                        ++expectedSecondInvokes;
+                        return promise.ContinueWith(_ => { onSecondCallback(); return 2; });
+                    };
+
+                    bool isFirstCancelExpected = configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled
+                        || (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst && (!isFirstAlreadyComplete || firstWaitType != SynchronizationType.Synchronous));
+
+                    if (firstCompleteType == CompleteType.Resolve)
+                    {
+                        TestHelper.AddResolveCallbacksWithCancelation<int, int, string>(firstPromiseRetainer.WaitAsync(),
+                            onResolve: v => onFirstCallback(),
+                            promiseToPromise: p => secondPromiseRetainer.WaitAsync().ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
+                            promiseToPromiseConvert: p => secondPromiseRetainer.WaitAsync().ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
+                            onCallbackAdded: (ref Promise promise) =>
+                            {
+                                ++expectedFirstInvokes;
+                                promise.Forget();
+                            },
+                            onCallbackAddedConvert: (ref Promise<int> promise) =>
+                            {
+                                ++expectedFirstInvokes;
+                                promise.Forget();
+                            },
+                            onAdoptCallbackAdded: (ref Promise promise) =>
+                            {
+                                promise = HookupSecondVoid(promise);
+                            },
+                            onAdoptCallbackAddedConvert: (ref Promise<int> promise) =>
+                            {
+                                promise = HookupSecondT(promise);
+                            },
+                            onCancel: () =>
+                            {
+                                if (isFirstCancelExpected)
+                                {
+                                    // Don't assert the context due to a race condition between the cancelation propagating on another thread before the CatchCancelation is hooked up.
+                                    Interlocked.Increment(ref firstInvokeCounter);
+                                }
+                            },
+                            configureAwaitType: (ConfigureAwaitType) firstWaitType,
+                            waitAsyncCancelationToken: configureAwaitCancelationToken1,
+                            configureAwaitForceAsync: true
+                        );
                     }
-                    tryCompleter2();
-                },
-                secondReportType == SynchronizationType.Foreground);
-            TestHelper.ExecuteForegroundCallbacks();
+                    TestHelper.AddCallbacksWithCancelation<int, int, object, string>(firstPromiseRetainer.WaitAsync(),
+                        onResolve: v => onFirstCallback(),
+                        onReject: r => onFirstCallback(),
+                        onUnknownRejection: () => onFirstCallback(),
+                        promiseToPromise: p => secondPromiseRetainer.WaitAsync().ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
+                        promiseToPromiseConvert: p => secondPromiseRetainer.WaitAsync().ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
+                        onDirectCallbackAdded: (ref Promise promise) =>
+                        {
+                            ++expectedFirstInvokes;
+                            promise = promise.Catch(() => { });
+                        },
+                        onDirectCallbackAddedConvert: (ref Promise<int> promise) =>
+                        {
+                            ++expectedFirstInvokes;
+                            promise = promise.Catch(() => 2);
+                        },
+                        onDirectCallbackAddedT: (ref Promise<int> promise) =>
+                        {
+                            if (firstCompleteType != CompleteType.Resolve)
+                            {
+                                ++expectedFirstInvokes;
+                            }
+                            // Don't expect cancelation invoke if it will continue on background, as that introduces a race condition.
+                            else if (isFirstCancelExpected && firstWaitType != TestHelper.backgroundType)
+                            {
+                                ++expectedFirstInvokes;
+                            }
+                        },
+                        onAdoptCallbackAdded: (ref Promise promise, AdoptLocation adoptLocation) =>
+                        {
+                            ++expectedFirstInvokes;
+                            if (adoptLocation == AdoptLocation.Both || (CompleteType) adoptLocation == firstCompleteType)
+                            {
+                                promise = HookupSecondVoid(promise);
+                            }
+                        },
+                        onAdoptCallbackAddedConvert: (ref Promise<int> promise, AdoptLocation adoptLocation) =>
+                        {
+                            ++expectedFirstInvokes;
+                            if (adoptLocation == AdoptLocation.Both || (CompleteType) adoptLocation == firstCompleteType)
+                            {
+                                promise = HookupSecondT(promise);
+                            }
+                        },
+                        onAdoptCallbackAddedT: (ref Promise<int> promise) =>
+                        {
+                            if (firstCompleteType != CompleteType.Resolve)
+                            {
+                                ++expectedFirstInvokes;
+                            }
+                            // Don't expect cancelation invoke if it will continue on background, as that introduces a race condition.
+                            else if (isFirstCancelExpected && firstWaitType != TestHelper.backgroundType)
+                            {
+                                ++expectedFirstInvokes;
+                            }
+                            if (firstCompleteType == CompleteType.Reject)
+                            {
+                                promise = HookupSecondT(promise);
+                            }
+                        },
+                        onCancel: () =>
+                        {
+                            if (isFirstCancelExpected)
+                            {
+                                // Don't assert the context due to a race condition between the cancelation propagating on another thread before the CatchCancelation is hooked up.
+                                Interlocked.Increment(ref firstInvokeCounter);
+                            }
+                        },
+                        configureAwaitType: (ConfigureAwaitType) firstWaitType,
+                        waitAsyncCancelationToken: configureAwaitCancelationToken1,
+                        configureAwaitForceAsync: true
+                    );
 
-            // We must execute foreground context on every spin to account for the race condition between firstInvokeCounter being incremented and the configured promise returning in the callback.
-            TestHelper.SpinUntilWhileExecutingForegroundContext(() => secondInvokeCounter == expectedSecondInvokes, timeout,
-                $"expectedSecondInvokes: {expectedSecondInvokes}, secondInvokeCounter: {secondInvokeCounter}");
+                    threadHelper.ExecuteSynchronousOrOnThread(
+                        () =>
+                        {
+                            if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst)
+                            {
+                                configureAwaitCancelationSource1.Cancel();
+                            }
+                            tryCompleter1();
+                        },
+                        firstReportType == SynchronizationType.Foreground);
 
-            // Fix a race condition that causes forget to be called before ConfigureAwait.
-            TestHelper._backgroundContext.WaitForAllThreadsToComplete();
-            TestHelper.ExecuteForegroundCallbacks();
+                    TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                    if (firstWaitType != (SynchronizationType) SynchronizationOption.Background)
+                    {
+                        Assert.AreEqual(expectedFirstInvokes, firstInvokeCounter);
+                    }
+                    else
+                    {
+                        // We check >= instead of == because of race conditions
+                        Assert.GreaterOrEqual(firstInvokeCounter, expectedFirstInvokes);
+                    }
 
-            firstPromise.Forget();
-            secondPromise.Forget();
+                    threadHelper.ExecuteSynchronousOrOnThread(
+                        () =>
+                        {
+                            if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelSecond)
+                            {
+                                configureAwaitCancelationSource2.Cancel();
+                            }
+                            tryCompleter2();
+                        },
+                        secondReportType == SynchronizationType.Foreground);
+                    TestHelper.ExecuteForegroundCallbacks();
+
+                    // We must execute foreground context on every spin to account for the race condition between firstInvokeCounter being incremented and the configured promise returning in the callback.
+                    TestHelper.SpinUntilWhileExecutingForegroundContext(() => secondInvokeCounter == expectedSecondInvokes, timeout,
+                        $"expectedSecondInvokes: {expectedSecondInvokes}, secondInvokeCounter: {secondInvokeCounter}");
+
+                    // Fix a race condition that causes forget to be called before ConfigureAwait.
+                    TestHelper._backgroundContext.WaitForAllThreadsToComplete();
+                    TestHelper.ExecuteForegroundCallbacks();
+                }
+            }
             configureAwaitCancelationSource1.TryDispose();
             configureAwaitCancelationSource2.TryDispose();
         }
@@ -623,90 +617,85 @@ namespace ProtoPromiseTests.APIs
                 : configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? CancelationToken.Canceled()
                 : configureAwaitCancelationSource2.Token;
 
-            Promise firstPromise = TestHelper.BuildPromise(firstCompleteType, isFirstAlreadyComplete, rejectValue, out var tryCompleter1);
-            Promise<int> secondPromise = TestHelper.BuildPromise(secondCompleteType, isSecondAlreadyComplete, 1, rejectValue, out var tryCompleter2);
-
-            firstPromise = firstPromise.Preserve();
-            secondPromise = secondPromise.Preserve();
-
-            int firstInvokeCounter = 0;
-            int secondInvokeCounter = 0;
-
-            int expectedFirstInvokes = 0;
-            int expectedSecondInvokes = 0;
-
-            Action onFirstCallback = () =>
+            using (var promiseRetainer = TestHelper.BuildPromise(secondCompleteType, isSecondAlreadyComplete, 1, rejectValue, out var tryCompleter2)
+                .GetRetainer())
             {
-                TestHelper.AssertCallbackContext(firstWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? firstWaitType : firstReportType, foregroundThread);
-                Interlocked.Increment(ref firstInvokeCounter);
-            };
-            Action onSecondCallback = () =>
-            {
-                // We can't assert the context due to thread race conditions, just make sure the callback is invoked.
-                Interlocked.Increment(ref secondInvokeCounter);
-            };
+                int firstInvokeCounter = 0;
+                int secondInvokeCounter = 0;
 
-            TestHelper.AddContinueCallbacksWithCancelation<int, string>(firstPromise,
-                onContinue: _ => onFirstCallback(),
-                promiseToPromise: p => secondPromise.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
-                promiseToPromiseConvert: p => secondPromise.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
-                onCallbackAdded: (ref Promise promise) =>
-                {
-                    ++expectedFirstInvokes;
-                    promise.Forget();
-                },
-                onCallbackAddedConvert: (ref Promise<int> promise) =>
-                {
-                    ++expectedFirstInvokes;
-                    promise.Forget();
-                },
-                onAdoptCallbackAdded: (ref Promise promise) =>
-                {
-                    ++expectedSecondInvokes;
-                    promise = promise.ContinueWith(_ => onSecondCallback());
-                },
-                onAdoptCallbackAddedConvert: (ref Promise<int> promise) =>
-                {
-                    ++expectedSecondInvokes;
-                    promise = promise.ContinueWith(_ => { onSecondCallback(); return 2; });
-                },
-                configureAwaitType: (ConfigureAwaitType) firstWaitType,
-                waitAsyncCancelationToken: configureAwaitCancelationToken1,
-                configureAwaitForceAsync: true
-            );
+                int expectedFirstInvokes = 0;
+                int expectedSecondInvokes = 0;
 
-            threadHelper.ExecuteSynchronousOrOnThread(
-                () =>
+                Action onFirstCallback = () =>
                 {
-                    if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst)
+                    TestHelper.AssertCallbackContext(firstWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? firstWaitType : firstReportType, foregroundThread);
+                    Interlocked.Increment(ref firstInvokeCounter);
+                };
+                Action onSecondCallback = () =>
+                {
+                    // We can't assert the context due to thread race conditions, just make sure the callback is invoked.
+                    Interlocked.Increment(ref secondInvokeCounter);
+                };
+
+                TestHelper.AddContinueCallbacksWithCancelation<int, string>(TestHelper.BuildPromise(firstCompleteType, isFirstAlreadyComplete, rejectValue, out var tryCompleter1),
+                    onContinue: _ => onFirstCallback(),
+                    promiseToPromise: p => promiseRetainer.WaitAsync().ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
+                    promiseToPromiseConvert: p => promiseRetainer.WaitAsync().ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
+                    onCallbackAdded: (ref Promise promise) =>
                     {
-                        configureAwaitCancelationSource1.Cancel();
-                    }
-                    tryCompleter1();
-                },
-                firstReportType == SynchronizationType.Foreground);
-
-            TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
-            Assert.AreEqual(expectedFirstInvokes, firstInvokeCounter);
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                () =>
-                {
-                    if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelSecond)
+                        ++expectedFirstInvokes;
+                        promise.Forget();
+                    },
+                    onCallbackAddedConvert: (ref Promise<int> promise) =>
                     {
-                        configureAwaitCancelationSource2.Cancel();
-                    }
-                    tryCompleter2();
-                },
-                secondReportType == SynchronizationType.Foreground);
-            TestHelper.ExecuteForegroundCallbacks();
+                        ++expectedFirstInvokes;
+                        promise.Forget();
+                    },
+                    onAdoptCallbackAdded: (ref Promise promise) =>
+                    {
+                        ++expectedSecondInvokes;
+                        promise = promise.ContinueWith(_ => onSecondCallback());
+                    },
+                    onAdoptCallbackAddedConvert: (ref Promise<int> promise) =>
+                    {
+                        ++expectedSecondInvokes;
+                        promise = promise.ContinueWith(_ => { onSecondCallback(); return 2; });
+                    },
+                    configureAwaitType: (ConfigureAwaitType) firstWaitType,
+                    waitAsyncCancelationToken: configureAwaitCancelationToken1,
+                    configureAwaitForceAsync: true
+                );
 
-            // We must execute foreground context on every spin to account for the race condition between firstInvokeCounter being incremented and the configured promise returning in the callback.
-            TestHelper.SpinUntilWhileExecutingForegroundContext(() => secondInvokeCounter == expectedSecondInvokes, timeout,
-                $"expectedSecondInvokes: {expectedSecondInvokes}, secondInvokeCounter: {secondInvokeCounter}");
+                threadHelper.ExecuteSynchronousOrOnThread(
+                    () =>
+                    {
+                        if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst)
+                        {
+                            configureAwaitCancelationSource1.Cancel();
+                        }
+                        tryCompleter1();
+                    },
+                    firstReportType == SynchronizationType.Foreground);
 
-            firstPromise.Forget();
-            secondPromise.Forget();
+                TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                Assert.AreEqual(expectedFirstInvokes, firstInvokeCounter);
+
+                threadHelper.ExecuteSynchronousOrOnThread(
+                    () =>
+                    {
+                        if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelSecond)
+                        {
+                            configureAwaitCancelationSource2.Cancel();
+                        }
+                        tryCompleter2();
+                    },
+                    secondReportType == SynchronizationType.Foreground);
+                TestHelper.ExecuteForegroundCallbacks();
+
+                // We must execute foreground context on every spin to account for the race condition between firstInvokeCounter being incremented and the configured promise returning in the callback.
+                TestHelper.SpinUntilWhileExecutingForegroundContext(() => secondInvokeCounter == expectedSecondInvokes, timeout,
+                    $"expectedSecondInvokes: {expectedSecondInvokes}, secondInvokeCounter: {secondInvokeCounter}");
+            }
             configureAwaitCancelationSource1.TryDispose();
             configureAwaitCancelationSource2.TryDispose();
         }
@@ -735,90 +724,85 @@ namespace ProtoPromiseTests.APIs
                 : configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? CancelationToken.Canceled()
                 : configureAwaitCancelationSource2.Token;
 
-            Promise<int> firstPromise = TestHelper.BuildPromise(firstCompleteType, isFirstAlreadyComplete, 1, rejectValue, out var tryCompleter1);
-            Promise<int> secondPromise = TestHelper.BuildPromise(secondCompleteType, isSecondAlreadyComplete, 1, rejectValue, out var tryCompleter2);
-
-            firstPromise = firstPromise.Preserve();
-            secondPromise = secondPromise.Preserve();
-
-            int firstInvokeCounter = 0;
-            int secondInvokeCounter = 0;
-
-            int expectedFirstInvokes = 0;
-            int expectedSecondInvokes = 0;
-
-            Action onFirstCallback = () =>
+            using (var promiseRetainer = TestHelper.BuildPromise(secondCompleteType, isSecondAlreadyComplete, 1, rejectValue, out var tryCompleter2)
+                .GetRetainer())
             {
-                TestHelper.AssertCallbackContext(firstWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? firstWaitType : firstReportType, foregroundThread);
-                Interlocked.Increment(ref firstInvokeCounter);
-            };
-            Action onSecondCallback = () =>
-            {
-                // We can't assert the context due to thread race conditions, just make sure the callback is invoked.
-                Interlocked.Increment(ref secondInvokeCounter);
-            };
+                int firstInvokeCounter = 0;
+                int secondInvokeCounter = 0;
 
-            TestHelper.AddContinueCallbacksWithCancelation<int, int, string>(firstPromise,
-                onContinue: _ => onFirstCallback(),
-                promiseToPromise: p => secondPromise.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
-                promiseToPromiseConvert: p => secondPromise.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
-                onCallbackAdded: (ref Promise promise) =>
-                {
-                    ++expectedFirstInvokes;
-                    promise.Forget();
-                },
-                onCallbackAddedConvert: (ref Promise<int> promise) =>
-                {
-                    ++expectedFirstInvokes;
-                    promise.Forget();
-                },
-                onAdoptCallbackAdded: (ref Promise promise) =>
-                {
-                    ++expectedSecondInvokes;
-                    promise = promise.ContinueWith(_ => onSecondCallback());
-                },
-                onAdoptCallbackAddedConvert: (ref Promise<int> promise) =>
-                {
-                    ++expectedSecondInvokes;
-                    promise = promise.ContinueWith(_ => { onSecondCallback(); return 2; });
-                },
-                configureAwaitType: (ConfigureAwaitType) firstWaitType,
-                waitAsyncCancelationToken: configureAwaitCancelationToken1,
-                configureAwaitForceAsync: true
-            );
+                int expectedFirstInvokes = 0;
+                int expectedSecondInvokes = 0;
 
-            threadHelper.ExecuteSynchronousOrOnThread(
-                () =>
+                Action onFirstCallback = () =>
                 {
-                    if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst)
+                    TestHelper.AssertCallbackContext(firstWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? firstWaitType : firstReportType, foregroundThread);
+                    Interlocked.Increment(ref firstInvokeCounter);
+                };
+                Action onSecondCallback = () =>
+                {
+                    // We can't assert the context due to thread race conditions, just make sure the callback is invoked.
+                    Interlocked.Increment(ref secondInvokeCounter);
+                };
+
+                TestHelper.AddContinueCallbacksWithCancelation<int, int, string>(TestHelper.BuildPromise(firstCompleteType, isFirstAlreadyComplete, 1, rejectValue, out var tryCompleter1),
+                    onContinue: _ => onFirstCallback(),
+                    promiseToPromise: p => promiseRetainer.WaitAsync().ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
+                    promiseToPromiseConvert: p => promiseRetainer.WaitAsync().ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2),
+                    onCallbackAdded: (ref Promise promise) =>
                     {
-                        configureAwaitCancelationSource1.Cancel();
-                    }
-                    tryCompleter1();
-                },
-                firstReportType == SynchronizationType.Foreground);
-
-            TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
-            Assert.AreEqual(expectedFirstInvokes, firstInvokeCounter);
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                () =>
-                {
-                    if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelSecond)
+                        ++expectedFirstInvokes;
+                        promise.Forget();
+                    },
+                    onCallbackAddedConvert: (ref Promise<int> promise) =>
                     {
-                        configureAwaitCancelationSource2.Cancel();
-                    }
-                    tryCompleter2();
-                },
-                secondReportType == SynchronizationType.Foreground);
-            TestHelper.ExecuteForegroundCallbacks();
+                        ++expectedFirstInvokes;
+                        promise.Forget();
+                    },
+                    onAdoptCallbackAdded: (ref Promise promise) =>
+                    {
+                        ++expectedSecondInvokes;
+                        promise = promise.ContinueWith(_ => onSecondCallback());
+                    },
+                    onAdoptCallbackAddedConvert: (ref Promise<int> promise) =>
+                    {
+                        ++expectedSecondInvokes;
+                        promise = promise.ContinueWith(_ => { onSecondCallback(); return 2; });
+                    },
+                    configureAwaitType: (ConfigureAwaitType) firstWaitType,
+                    waitAsyncCancelationToken: configureAwaitCancelationToken1,
+                    configureAwaitForceAsync: true
+                );
 
-            // We must execute foreground context on every spin to account for the race condition between firstInvokeCounter being incremented and the configured promise returning in the callback.
-            TestHelper.SpinUntilWhileExecutingForegroundContext(() => secondInvokeCounter == expectedSecondInvokes, timeout,
-                $"expectedSecondInvokes: {expectedSecondInvokes}, secondInvokeCounter: {secondInvokeCounter}");
+                threadHelper.ExecuteSynchronousOrOnThread(
+                    () =>
+                    {
+                        if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst)
+                        {
+                            configureAwaitCancelationSource1.Cancel();
+                        }
+                        tryCompleter1();
+                    },
+                    firstReportType == SynchronizationType.Foreground);
 
-            firstPromise.Forget();
-            secondPromise.Forget();
+                TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                Assert.AreEqual(expectedFirstInvokes, firstInvokeCounter);
+
+                threadHelper.ExecuteSynchronousOrOnThread(
+                    () =>
+                    {
+                        if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelSecond)
+                        {
+                            configureAwaitCancelationSource2.Cancel();
+                        }
+                        tryCompleter2();
+                    },
+                    secondReportType == SynchronizationType.Foreground);
+                TestHelper.ExecuteForegroundCallbacks();
+
+                // We must execute foreground context on every spin to account for the race condition between firstInvokeCounter being incremented and the configured promise returning in the callback.
+                TestHelper.SpinUntilWhileExecutingForegroundContext(() => secondInvokeCounter == expectedSecondInvokes, timeout,
+                    $"expectedSecondInvokes: {expectedSecondInvokes}, secondInvokeCounter: {secondInvokeCounter}");
+            }
             configureAwaitCancelationSource1.TryDispose();
             configureAwaitCancelationSource2.TryDispose();
         }
@@ -833,44 +817,42 @@ namespace ProtoPromiseTests.APIs
             var foregroundThread = Thread.CurrentThread;
             var threadHelper = new ThreadHelper();
 
-            Promise promise = TestHelper.BuildPromise(completeType, isAlreadyComplete, rejectValue, out var tryCompleter);
-
-            promise = promise.Preserve();
-
-            int invokeCounter = 0;
-            int expectedInvokes = 0;
-
-            foreach (var p in TestHelper.GetTestablePromises(promise))
+            using (var promiseRetainer = TestHelper.BuildPromise(completeType, isAlreadyComplete, rejectValue, out var tryCompleter)
+                .GetRetainer())
             {
-                ++expectedInvokes;
-                p.ConfigureAwait((ConfigureAwaitType) waitType)
-                    .CatchCancelation(() =>
-                    {
-                        TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
-                        Interlocked.Increment(ref invokeCounter);
-                    })
-                    .Forget();
+                int invokeCounter = 0;
+                int expectedInvokes = 0;
+
+                foreach (var p in TestHelper.GetTestablePromises(promiseRetainer))
+                {
+                    ++expectedInvokes;
+                    p.ConfigureAwait((ConfigureAwaitType) waitType)
+                        .CatchCancelation(() =>
+                        {
+                            TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                            Interlocked.Increment(ref invokeCounter);
+                        })
+                        .Forget();
+                }
+                foreach (var p in TestHelper.GetTestablePromises(promiseRetainer))
+                {
+                    ++expectedInvokes;
+                    p.ConfigureAwait((ConfigureAwaitType) waitType)
+                        .CatchCancelation(1, cv =>
+                        {
+                            TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                            Interlocked.Increment(ref invokeCounter);
+                        })
+                        .Forget();
+                }
+
+                threadHelper.ExecuteSynchronousOrOnThread(
+                    tryCompleter,
+                    reportType == SynchronizationType.Foreground);
+
+                TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                Assert.AreEqual(expectedInvokes, invokeCounter);
             }
-            foreach (var p in TestHelper.GetTestablePromises(promise))
-            {
-                ++expectedInvokes;
-                p.ConfigureAwait((ConfigureAwaitType) waitType)
-                    .CatchCancelation(1, cv =>
-                    {
-                        TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
-                        Interlocked.Increment(ref invokeCounter);
-                    })
-                    .Forget();
-            }
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                tryCompleter,
-                reportType == SynchronizationType.Foreground);
-
-            TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
-            Assert.AreEqual(expectedInvokes, invokeCounter);
-
-            promise.Forget();
         }
 
         [Test, TestCaseSource(nameof(GetArgs_Cancel))]
@@ -883,44 +865,42 @@ namespace ProtoPromiseTests.APIs
             var foregroundThread = Thread.CurrentThread;
             var threadHelper = new ThreadHelper();
 
-            Promise<int> promise = TestHelper.BuildPromise(completeType, isAlreadyComplete, 1, rejectValue, out var tryCompleter);
-
-            promise = promise.Preserve();
-
-            int invokeCounter = 0;
-            int expectedInvokes = 0;
-
-            foreach (var p in TestHelper.GetTestablePromises(promise))
+            using (var promiseRetainer = TestHelper.BuildPromise(completeType, isAlreadyComplete, 1, rejectValue, out var tryCompleter)
+                .GetRetainer())
             {
-                ++expectedInvokes;
-                p.ConfigureAwait((ConfigureAwaitType) waitType)
-                    .CatchCancelation(() =>
-                    {
-                        TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
-                        Interlocked.Increment(ref invokeCounter);
-                    })
-                    .Forget();
+                int invokeCounter = 0;
+                int expectedInvokes = 0;
+
+                foreach (var p in TestHelper.GetTestablePromises(promiseRetainer))
+                {
+                    ++expectedInvokes;
+                    p.ConfigureAwait((ConfigureAwaitType) waitType)
+                        .CatchCancelation(() =>
+                        {
+                            TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                            Interlocked.Increment(ref invokeCounter);
+                        })
+                        .Forget();
+                }
+                foreach (var p in TestHelper.GetTestablePromises(promiseRetainer))
+                {
+                    ++expectedInvokes;
+                    p.ConfigureAwait((ConfigureAwaitType) waitType)
+                        .CatchCancelation(1, cv =>
+                        {
+                            TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                            Interlocked.Increment(ref invokeCounter);
+                        })
+                        .Forget();
+                }
+
+                threadHelper.ExecuteSynchronousOrOnThread(
+                    tryCompleter,
+                    reportType == SynchronizationType.Foreground);
+
+                TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                Assert.AreEqual(expectedInvokes, invokeCounter);
             }
-            foreach (var p in TestHelper.GetTestablePromises(promise))
-            {
-                ++expectedInvokes;
-                p.ConfigureAwait((ConfigureAwaitType) waitType)
-                    .CatchCancelation(1, cv =>
-                    {
-                        TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
-                        Interlocked.Increment(ref invokeCounter);
-                    })
-                    .Forget();
-            }
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                tryCompleter,
-                reportType == SynchronizationType.Foreground);
-
-            TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
-            Assert.AreEqual(expectedInvokes, invokeCounter);
-
-            promise.Forget();
         }
 
         [Test, TestCaseSource(nameof(GetArgs_Finally))]
@@ -933,46 +913,44 @@ namespace ProtoPromiseTests.APIs
             var foregroundThread = Thread.CurrentThread;
             var threadHelper = new ThreadHelper();
 
-            Promise promise = TestHelper.BuildPromise(completeType, isAlreadyComplete, rejectValue, out var tryCompleter);
-
-            promise = promise.Preserve();
-
-            int invokeCounter = 0;
-            int expectedInvokes = 0;
-
-            foreach (var p in TestHelper.GetTestablePromises(promise))
+            using (var promiseRetainer = TestHelper.BuildPromise(completeType, isAlreadyComplete, rejectValue, out var tryCompleter)
+                .GetRetainer())
             {
-                ++expectedInvokes;
-                p.ConfigureAwait((ConfigureAwaitType) waitType)
-                    .Finally(() =>
-                    {
-                        TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
-                        Interlocked.Increment(ref invokeCounter);
-                    })
-                    .Catch(() => { })
-                    .Forget();
+                int invokeCounter = 0;
+                int expectedInvokes = 0;
+
+                foreach (var p in TestHelper.GetTestablePromises(promiseRetainer))
+                {
+                    ++expectedInvokes;
+                    p.ConfigureAwait((ConfigureAwaitType) waitType)
+                        .Finally(() =>
+                        {
+                            TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                            Interlocked.Increment(ref invokeCounter);
+                        })
+                        .Catch(() => { })
+                        .Forget();
+                }
+                foreach (var p in TestHelper.GetTestablePromises(promiseRetainer))
+                {
+                    ++expectedInvokes;
+                    p.ConfigureAwait((ConfigureAwaitType) waitType)
+                        .Finally(1, cv =>
+                        {
+                            TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                            Interlocked.Increment(ref invokeCounter);
+                        })
+                        .Catch(() => { })
+                        .Forget();
+                }
+
+                threadHelper.ExecuteSynchronousOrOnThread(
+                    tryCompleter,
+                    reportType == SynchronizationType.Foreground);
+
+                TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                Assert.AreEqual(expectedInvokes, invokeCounter);
             }
-            foreach (var p in TestHelper.GetTestablePromises(promise))
-            {
-                ++expectedInvokes;
-                p.ConfigureAwait((ConfigureAwaitType) waitType)
-                    .Finally(1, cv =>
-                    {
-                        TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
-                        Interlocked.Increment(ref invokeCounter);
-                    })
-                    .Catch(() => { })
-                    .Forget();
-            }
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                tryCompleter,
-                reportType == SynchronizationType.Foreground);
-
-            TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
-            Assert.AreEqual(expectedInvokes, invokeCounter);
-
-            promise.Forget();
         }
 
         [Test, TestCaseSource(nameof(GetArgs_Finally))]
@@ -985,46 +963,44 @@ namespace ProtoPromiseTests.APIs
             var foregroundThread = Thread.CurrentThread;
             var threadHelper = new ThreadHelper();
 
-            Promise<int> promise = TestHelper.BuildPromise(completeType, isAlreadyComplete, 1, rejectValue, out var tryCompleter);
-
-            promise = promise.Preserve();
-
-            int invokeCounter = 0;
-            int expectedInvokes = 0;
-
-            foreach (var p in TestHelper.GetTestablePromises(promise))
+            using (var promiseRetainer = TestHelper.BuildPromise(completeType, isAlreadyComplete, 1, rejectValue, out var tryCompleter)
+                .GetRetainer())
             {
-                ++expectedInvokes;
-                p.ConfigureAwait((ConfigureAwaitType) waitType)
-                    .Finally(() =>
-                    {
-                        TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
-                        Interlocked.Increment(ref invokeCounter);
-                    })
-                    .Catch(() => { })
-                    .Forget();
+                int invokeCounter = 0;
+                int expectedInvokes = 0;
+
+                foreach (var p in TestHelper.GetTestablePromises(promiseRetainer))
+                {
+                    ++expectedInvokes;
+                    p.ConfigureAwait((ConfigureAwaitType) waitType)
+                        .Finally(() =>
+                        {
+                            TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                            Interlocked.Increment(ref invokeCounter);
+                        })
+                        .Catch(() => { })
+                        .Forget();
+                }
+                foreach (var p in TestHelper.GetTestablePromises(promiseRetainer))
+                {
+                    ++expectedInvokes;
+                    p.ConfigureAwait((ConfigureAwaitType) waitType)
+                        .Finally(1, cv =>
+                        {
+                            TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
+                            Interlocked.Increment(ref invokeCounter);
+                        })
+                        .Catch(() => { })
+                        .Forget();
+                }
+
+                threadHelper.ExecuteSynchronousOrOnThread(
+                    tryCompleter,
+                    reportType == SynchronizationType.Foreground);
+
+                TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                Assert.AreEqual(expectedInvokes, invokeCounter);
             }
-            foreach (var p in TestHelper.GetTestablePromises(promise))
-            {
-                ++expectedInvokes;
-                p.ConfigureAwait((ConfigureAwaitType) waitType)
-                    .Finally(1, cv =>
-                    {
-                        TestHelper.AssertCallbackContext(waitType, reportType, foregroundThread);
-                        Interlocked.Increment(ref invokeCounter);
-                    })
-                    .Catch(() => { })
-                    .Forget();
-            }
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                tryCompleter,
-                reportType == SynchronizationType.Foreground);
-
-            TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
-            Assert.AreEqual(expectedInvokes, invokeCounter);
-
-            promise.Forget();
         }
 
         [Test]
@@ -1155,91 +1131,89 @@ namespace ProtoPromiseTests.APIs
                 : configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? CancelationToken.Canceled()
                 : configureAwaitCancelationSource2.Token;
 
-            Promise firstPromise = TestHelper.BuildPromise(firstCompleteType, isFirstAlreadyComplete, rejectValue, out var tryCompleter1);
-            Promise secondPromise = TestHelper.BuildPromise(secondCompleteType, isSecondAlreadyComplete, rejectValue, out var tryCompleter2);
-
-            firstPromise = firstPromise.Preserve();
-            secondPromise = secondPromise.Preserve();
-
-            int firstInvokeCounter = 0;
-            int secondInvokeCounter = 0;
-
-            int expectedInvokes = 0;
-            bool hasRaceCondition = firstWaitType == (SynchronizationType) SynchronizationOption.Background && secondWaitType == SynchronizationType.Synchronous && !isSecondAlreadyComplete;
-
-            foreach (var p1 in TestHelper.GetTestablePromises(firstPromise))
+            using (var firstPromiseRetainer = TestHelper.BuildPromise(firstCompleteType, isFirstAlreadyComplete, rejectValue, out var tryCompleter1).GetRetainer())
             {
-                ++expectedInvokes;
-                RunAsync(p1, secondPromise).Forget();
-            }
-            foreach (var p2 in TestHelper.GetTestablePromises(secondPromise))
-            {
-                ++expectedInvokes;
-                RunAsync(firstPromise, p2).Forget();
-            }
+                using (var secondPromiseRetainer = TestHelper.BuildPromise(secondCompleteType, isSecondAlreadyComplete, rejectValue, out var tryCompleter2).GetRetainer())
+                {
+                    int firstInvokeCounter = 0;
+                    int secondInvokeCounter = 0;
 
-            async Promise RunAsync(Promise p1, Promise p2)
-            {
-                try
-                {
-                    await p1.ConfigureAwait((ConfigureAwaitType) firstWaitType, true, configureAwaitCancelationToken1);
-                }
-                catch { }
-                finally
-                {
-                    TestHelper.AssertCallbackContext(firstWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? firstWaitType : firstReportType, foregroundThread);
-                    Interlocked.Increment(ref firstInvokeCounter);
-                }
+                    int expectedInvokes = 0;
+                    bool hasRaceCondition = firstWaitType == (SynchronizationType) SynchronizationOption.Background && secondWaitType == SynchronizationType.Synchronous && !isSecondAlreadyComplete;
 
-                try
-                {
-                    await p2.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2);
-                }
-                catch { }
-                finally
-                {
-                    // If there's a race condition, p2 could be completed on a separate thread before it's awaited, causing the assert to fail.
-                    // This only matters for SynchronizationOption.Synchronous, for which the caller does not care on what context it executes.
-                    if (!hasRaceCondition)
+                    foreach (var p1 in TestHelper.GetTestablePromises(firstPromiseRetainer))
                     {
-                        TestHelper.AssertCallbackContext(secondWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? secondWaitType : secondReportType, foregroundThread);
+                        ++expectedInvokes;
+                        RunAsync(p1, secondPromiseRetainer.WaitAsync()).Forget();
                     }
-                    Interlocked.Increment(ref secondInvokeCounter);
+                    // We don't include preserved promise for the second promise, because it becomes forgotten before it's awaited in the async function.
+                    foreach (var p2 in TestHelper.GetTestablePromises(secondPromiseRetainer, includePreserved: false))
+                    {
+                        ++expectedInvokes;
+                        RunAsync(firstPromiseRetainer.WaitAsync(), p2).Forget();
+                    }
+
+                    async Promise RunAsync(Promise p1, Promise p2)
+                    {
+                        try
+                        {
+                            await p1.ConfigureAwait((ConfigureAwaitType) firstWaitType, true, configureAwaitCancelationToken1);
+                        }
+                        catch { }
+                        finally
+                        {
+                            TestHelper.AssertCallbackContext(firstWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? firstWaitType : firstReportType, foregroundThread);
+                            Interlocked.Increment(ref firstInvokeCounter);
+                        }
+
+                        try
+                        {
+                            await p2.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2);
+                        }
+                        catch { }
+                        finally
+                        {
+                            // If there's a race condition, p2 could be completed on a separate thread before it's awaited, causing the assert to fail.
+                            // This only matters for SynchronizationOption.Synchronous, for which the caller does not care on what context it executes.
+                            if (!hasRaceCondition)
+                            {
+                                TestHelper.AssertCallbackContext(secondWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? secondWaitType : secondReportType, foregroundThread);
+                            }
+                            Interlocked.Increment(ref secondInvokeCounter);
+                        }
+                    }
+
+                    threadHelper.ExecuteSynchronousOrOnThread(
+                        () =>
+                        {
+                            if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst)
+                            {
+                                configureAwaitCancelationSource1.Cancel();
+                            }
+                            tryCompleter1();
+                        },
+                        firstReportType == SynchronizationType.Foreground);
+
+                    TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                    Assert.AreEqual(expectedInvokes, firstInvokeCounter);
+
+                    threadHelper.ExecuteSynchronousOrOnThread(
+                        () =>
+                        {
+                            if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelSecond)
+                            {
+                                configureAwaitCancelationSource2.Cancel();
+                            }
+                            tryCompleter2();
+                        },
+                        secondReportType == SynchronizationType.Foreground);
+                    TestHelper.ExecuteForegroundCallbacks();
+
+                    // We must execute foreground context on every spin to account for the race condition between firstInvokeCounter being incremented and the configured promise being awaited.
+                    TestHelper.SpinUntilWhileExecutingForegroundContext(() => secondInvokeCounter == expectedInvokes, timeout,
+                        $"expectedInvokes: {expectedInvokes}, secondInvokeCounter: {secondInvokeCounter}");
                 }
             }
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                () =>
-                {
-                    if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst)
-                    {
-                        configureAwaitCancelationSource1.Cancel();
-                    }
-                    tryCompleter1();
-                },
-                firstReportType == SynchronizationType.Foreground);
-
-            TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
-            Assert.AreEqual(expectedInvokes, firstInvokeCounter);
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                () =>
-                {
-                    if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelSecond)
-                    {
-                        configureAwaitCancelationSource2.Cancel();
-                    }
-                    tryCompleter2();
-                },
-                secondReportType == SynchronizationType.Foreground);
-            TestHelper.ExecuteForegroundCallbacks();
-
-            // We must execute foreground context on every spin to account for the race condition between firstInvokeCounter being incremented and the configured promise being awaited.
-            TestHelper.SpinUntilWhileExecutingForegroundContext(() => secondInvokeCounter == expectedInvokes, timeout,
-                $"expectedInvokes: {expectedInvokes}, secondInvokeCounter: {secondInvokeCounter}");
-
-            firstPromise.Forget();
-            secondPromise.Forget();
             configureAwaitCancelationSource1.TryDispose();
             configureAwaitCancelationSource2.TryDispose();
         }
@@ -1268,91 +1242,89 @@ namespace ProtoPromiseTests.APIs
                 : configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? CancelationToken.Canceled()
                 : configureAwaitCancelationSource2.Token;
 
-            Promise<int> firstPromise = TestHelper.BuildPromise(firstCompleteType, isFirstAlreadyComplete, 1, rejectValue, out var tryCompleter1);
-            Promise<int> secondPromise = TestHelper.BuildPromise(secondCompleteType, isSecondAlreadyComplete, 1, rejectValue, out var tryCompleter2);
-
-            firstPromise = firstPromise.Preserve();
-            secondPromise = secondPromise.Preserve();
-
-            int firstInvokeCounter = 0;
-            int secondInvokeCounter = 0;
-
-            int expectedInvokes = 0;
-            bool hasRaceCondition = firstWaitType == (SynchronizationType) SynchronizationOption.Background && secondWaitType == SynchronizationType.Synchronous && !isSecondAlreadyComplete;
-
-            foreach (var p1 in TestHelper.GetTestablePromises(firstPromise))
+            using (var firstPromiseRetainer = TestHelper.BuildPromise(firstCompleteType, isFirstAlreadyComplete, 1, rejectValue, out var tryCompleter1).GetRetainer())
             {
-                ++expectedInvokes;
-                RunAsync(p1, secondPromise).Forget();
-            }
-            foreach (var p2 in TestHelper.GetTestablePromises(secondPromise))
-            {
-                ++expectedInvokes;
-                RunAsync(firstPromise, p2).Forget();
-            }
+                using (var secondPromiseRetainer = TestHelper.BuildPromise(secondCompleteType, isSecondAlreadyComplete, 1, rejectValue, out var tryCompleter2).GetRetainer())
+                {
+                    int firstInvokeCounter = 0;
+                    int secondInvokeCounter = 0;
 
-            async Promise RunAsync(Promise<int> p1, Promise<int> p2)
-            {
-                try
-                {
-                    _ = await p1.ConfigureAwait((ConfigureAwaitType) firstWaitType, true, configureAwaitCancelationToken1);
-                }
-                catch { }
-                finally
-                {
-                    TestHelper.AssertCallbackContext(firstWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? firstWaitType : firstReportType, foregroundThread);
-                    Interlocked.Increment(ref firstInvokeCounter);
-                }
+                    int expectedInvokes = 0;
+                    bool hasRaceCondition = firstWaitType == (SynchronizationType) SynchronizationOption.Background && secondWaitType == SynchronizationType.Synchronous && !isSecondAlreadyComplete;
 
-                try
-                {
-                    _ = await p2.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2);
-                }
-                catch { }
-                finally
-                {
-                    // If there's a race condition, p2 could be completed on a separate thread before it's awaited, causing the assert to fail.
-                    // This only matters for SynchronizationOption.Synchronous, for which the caller does not care on what context it executes.
-                    if (!hasRaceCondition)
+                    foreach (var p1 in TestHelper.GetTestablePromises(firstPromiseRetainer))
                     {
-                        TestHelper.AssertCallbackContext(secondWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? secondWaitType : secondReportType, foregroundThread);
+                        ++expectedInvokes;
+                        RunAsync(p1, secondPromiseRetainer.WaitAsync()).Forget();
                     }
-                    Interlocked.Increment(ref secondInvokeCounter);
+                    // We don't include preserved promise for the second promise, because it becomes forgotten before it's awaited in the async function.
+                    foreach (var p2 in TestHelper.GetTestablePromises(secondPromiseRetainer, includePreserved: false))
+                    {
+                        ++expectedInvokes;
+                        RunAsync(firstPromiseRetainer.WaitAsync(), p2).Forget();
+                    }
+
+                    async Promise RunAsync(Promise<int> p1, Promise<int> p2)
+                    {
+                        try
+                        {
+                            _ = await p1.ConfigureAwait((ConfigureAwaitType) firstWaitType, true, configureAwaitCancelationToken1);
+                        }
+                        catch { }
+                        finally
+                        {
+                            TestHelper.AssertCallbackContext(firstWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? firstWaitType : firstReportType, foregroundThread);
+                            Interlocked.Increment(ref firstInvokeCounter);
+                        }
+
+                        try
+                        {
+                            _ = await p2.ConfigureAwait((ConfigureAwaitType) secondWaitType, false, configureAwaitCancelationToken2);
+                        }
+                        catch { }
+                        finally
+                        {
+                            // If there's a race condition, p2 could be completed on a separate thread before it's awaited, causing the assert to fail.
+                            // This only matters for SynchronizationOption.Synchronous, for which the caller does not care on what context it executes.
+                            if (!hasRaceCondition)
+                            {
+                                TestHelper.AssertCallbackContext(secondWaitType, configureAwaitCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? secondWaitType : secondReportType, foregroundThread);
+                            }
+                            Interlocked.Increment(ref secondInvokeCounter);
+                        }
+                    }
+
+                    threadHelper.ExecuteSynchronousOrOnThread(
+                        () =>
+                        {
+                            if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst)
+                            {
+                                configureAwaitCancelationSource1.Cancel();
+                            }
+                            tryCompleter1();
+                        },
+                        firstReportType == SynchronizationType.Foreground);
+
+                    TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
+                    Assert.AreEqual(expectedInvokes, firstInvokeCounter);
+
+                    threadHelper.ExecuteSynchronousOrOnThread(
+                        () =>
+                        {
+                            if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelSecond)
+                            {
+                                configureAwaitCancelationSource2.Cancel();
+                            }
+                            tryCompleter2();
+                        },
+                        secondReportType == SynchronizationType.Foreground);
+                    TestHelper.ExecuteForegroundCallbacks();
+
+                    // We must execute foreground context on every spin to account for the race condition between firstInvokeCounter being incremented and the configured promise being awaited.
+                    TestHelper.SpinUntilWhileExecutingForegroundContext(() => secondInvokeCounter == expectedInvokes, timeout,
+                        $"expectedInvokes: {expectedInvokes}, secondInvokeCounter: {secondInvokeCounter}");
                 }
             }
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                () =>
-                {
-                    if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelFirst)
-                    {
-                        configureAwaitCancelationSource1.Cancel();
-                    }
-                    tryCompleter1();
-                },
-                firstReportType == SynchronizationType.Foreground);
-
-            TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
-            Assert.AreEqual(expectedInvokes, firstInvokeCounter);
-
-            threadHelper.ExecuteSynchronousOrOnThread(
-                () =>
-                {
-                    if (configureAwaitCancelType == ConfigureAwaitCancelType.CancelSecond)
-                    {
-                        configureAwaitCancelationSource2.Cancel();
-                    }
-                    tryCompleter2();
-                },
-                secondReportType == SynchronizationType.Foreground);
-            TestHelper.ExecuteForegroundCallbacks();
-
-            // We must execute foreground context on every spin to account for the race condition between firstInvokeCounter being incremented and the configured promise being awaited.
-            TestHelper.SpinUntilWhileExecutingForegroundContext(() => secondInvokeCounter == expectedInvokes, timeout,
-                $"expectedInvokes: {expectedInvokes}, secondInvokeCounter: {secondInvokeCounter}");
-
-            firstPromise.Forget();
-            secondPromise.Forget();
             configureAwaitCancelationSource1.TryDispose();
             configureAwaitCancelationSource2.TryDispose();
         }
@@ -1482,63 +1454,61 @@ namespace ProtoPromiseTests.APIs
                 : waitAsyncCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? CancelationToken.Canceled()
                 : waitAsyncCancelationSource.Token;
 
-            Promise promise = TestHelper.BuildPromise(completeType, isAlreadyComplete, rejectValue, out var tryCompleter);
-
-            promise = promise.Preserve();
-
-            int invokeCounter = 0;
-            int expectedInvokes = 0;
-            bool cancelationExpected = waitAsyncCancelType == ConfigureAwaitCancelType.AlreadyCanceled || (waitAsyncCancelType == ConfigureAwaitCancelType.CancelFirst && !isAlreadyComplete);
-            var expectedCompleteState = cancelationExpected ? Promise.State.Canceled : (Promise.State) completeType;
-
-            foreach (var p in TestHelper.GetTestablePromises(promise))
+            using (var promiseRetainer = TestHelper.BuildPromise(completeType, isAlreadyComplete, rejectValue, out var tryCompleter)
+                .GetRetainer())
             {
-                ++expectedInvokes;
-                p.WaitAsync(waitAsyncCancelationToken)
-                    .ContinueWith(container =>
+                int invokeCounter = 0;
+                int expectedInvokes = 0;
+                bool cancelationExpected = waitAsyncCancelType == ConfigureAwaitCancelType.AlreadyCanceled || (waitAsyncCancelType == ConfigureAwaitCancelType.CancelFirst && !isAlreadyComplete);
+                var expectedCompleteState = cancelationExpected ? Promise.State.Canceled : (Promise.State) completeType;
+
+                foreach (var p in TestHelper.GetTestablePromises(promiseRetainer))
+                {
+                    ++expectedInvokes;
+                    p.WaitAsync(waitAsyncCancelationToken)
+                        .ContinueWith(container =>
+                        {
+                            Assert.AreEqual(expectedCompleteState, container.State);
+                            Interlocked.Increment(ref invokeCounter);
+                        })
+                        .Forget();
+                }
+
+                foreach (var p in TestHelper.GetTestablePromises(promiseRetainer))
+                {
+                    ++expectedInvokes;
+                    RunAsync(p).Forget();
+                }
+
+                async Promise RunAsync(Promise p)
+                {
+                    var actualCompleteState = Promise.State.Pending;
+                    try
                     {
-                        Assert.AreEqual(expectedCompleteState, container.State);
-                        Interlocked.Increment(ref invokeCounter);
-                    })
-                    .Forget();
-            }
+                        await p.WaitAsync(waitAsyncCancelationToken);
+                        actualCompleteState = Promise.State.Resolved;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        actualCompleteState = Promise.State.Canceled;
+                    }
+                    catch (Exception)
+                    {
+                        actualCompleteState = Promise.State.Rejected;
+                    }
 
-            foreach (var p in TestHelper.GetTestablePromises(promise))
-            {
-                ++expectedInvokes;
-                RunAsync(p).Forget();
-            }
-
-            async Promise RunAsync(Promise p)
-            {
-                var actualCompleteState = Promise.State.Pending;
-                try
-                {
-                    await p.WaitAsync(waitAsyncCancelationToken);
-                    actualCompleteState = Promise.State.Resolved;
-                }
-                catch (OperationCanceledException)
-                {
-                    actualCompleteState = Promise.State.Canceled;
-                }
-                catch (Exception)
-                {
-                    actualCompleteState = Promise.State.Rejected;
+                    Assert.AreEqual(expectedCompleteState, actualCompleteState);
+                    Interlocked.Increment(ref invokeCounter);
                 }
 
-                Assert.AreEqual(expectedCompleteState, actualCompleteState);
-                Interlocked.Increment(ref invokeCounter);
+                if (waitAsyncCancelType == ConfigureAwaitCancelType.CancelFirst)
+                {
+                    waitAsyncCancelationSource.Cancel();
+                }
+                tryCompleter();
+
+                Assert.AreEqual(expectedInvokes, invokeCounter);
             }
-
-            if (waitAsyncCancelType == ConfigureAwaitCancelType.CancelFirst)
-            {
-                waitAsyncCancelationSource.Cancel();
-            }
-            tryCompleter();
-
-            Assert.AreEqual(expectedInvokes, invokeCounter);
-
-            promise.Forget();
             waitAsyncCancelationSource.TryDispose();
         }
 
@@ -1555,63 +1525,61 @@ namespace ProtoPromiseTests.APIs
                 : waitAsyncCancelType == ConfigureAwaitCancelType.AlreadyCanceled ? CancelationToken.Canceled()
                 : waitAsyncCancelationSource.Token;
 
-            Promise<int> promise = TestHelper.BuildPromise(completeType, isAlreadyComplete, 1, rejectValue, out var tryCompleter);
-
-            promise = promise.Preserve();
-
-            int invokeCounter = 0;
-            int expectedInvokes = 0;
-            bool cancelationExpected = waitAsyncCancelType == ConfigureAwaitCancelType.AlreadyCanceled || (waitAsyncCancelType == ConfigureAwaitCancelType.CancelFirst && !isAlreadyComplete);
-            var expectedCompleteState = cancelationExpected ? Promise.State.Canceled : (Promise.State) completeType;
-
-            foreach (var p in TestHelper.GetTestablePromises(promise))
+            using (var promiseRetainer = TestHelper.BuildPromise(completeType, isAlreadyComplete, 1, rejectValue, out var tryCompleter)
+                .GetRetainer())
             {
-                ++expectedInvokes;
-                p.WaitAsync(waitAsyncCancelationToken)
-                    .ContinueWith(container =>
+                int invokeCounter = 0;
+                int expectedInvokes = 0;
+                bool cancelationExpected = waitAsyncCancelType == ConfigureAwaitCancelType.AlreadyCanceled || (waitAsyncCancelType == ConfigureAwaitCancelType.CancelFirst && !isAlreadyComplete);
+                var expectedCompleteState = cancelationExpected ? Promise.State.Canceled : (Promise.State) completeType;
+
+                foreach (var p in TestHelper.GetTestablePromises(promiseRetainer))
+                {
+                    ++expectedInvokes;
+                    p.WaitAsync(waitAsyncCancelationToken)
+                        .ContinueWith(container =>
+                        {
+                            Assert.AreEqual(expectedCompleteState, container.State);
+                            Interlocked.Increment(ref invokeCounter);
+                        })
+                        .Forget();
+                }
+
+                foreach (var p in TestHelper.GetTestablePromises(promiseRetainer))
+                {
+                    ++expectedInvokes;
+                    RunAsync(p).Forget();
+                }
+
+                async Promise RunAsync(Promise<int> p)
+                {
+                    var actualCompleteState = Promise.State.Pending;
+                    try
                     {
-                        Assert.AreEqual(expectedCompleteState, container.State);
-                        Interlocked.Increment(ref invokeCounter);
-                    })
-                    .Forget();
-            }
+                        _ = await p.WaitAsync(waitAsyncCancelationToken);
+                        actualCompleteState = Promise.State.Resolved;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        actualCompleteState = Promise.State.Canceled;
+                    }
+                    catch (Exception)
+                    {
+                        actualCompleteState = Promise.State.Rejected;
+                    }
 
-            foreach (var p in TestHelper.GetTestablePromises(promise))
-            {
-                ++expectedInvokes;
-                RunAsync(p).Forget();
-            }
-
-            async Promise RunAsync(Promise<int> p)
-            {
-                var actualCompleteState = Promise.State.Pending;
-                try
-                {
-                    _ = await p.WaitAsync(waitAsyncCancelationToken);
-                    actualCompleteState = Promise.State.Resolved;
-                }
-                catch (OperationCanceledException)
-                {
-                    actualCompleteState = Promise.State.Canceled;
-                }
-                catch (Exception)
-                {
-                    actualCompleteState = Promise.State.Rejected;
+                    Assert.AreEqual(expectedCompleteState, actualCompleteState);
+                    Interlocked.Increment(ref invokeCounter);
                 }
 
-                Assert.AreEqual(expectedCompleteState, actualCompleteState);
-                Interlocked.Increment(ref invokeCounter);
+                if (waitAsyncCancelType == ConfigureAwaitCancelType.CancelFirst)
+                {
+                    waitAsyncCancelationSource.Cancel();
+                }
+                tryCompleter();
+
+                Assert.AreEqual(expectedInvokes, invokeCounter);
             }
-
-            if (waitAsyncCancelType == ConfigureAwaitCancelType.CancelFirst)
-            {
-                waitAsyncCancelationSource.Cancel();
-            }
-            tryCompleter();
-
-            Assert.AreEqual(expectedInvokes, invokeCounter);
-
-            promise.Forget();
             waitAsyncCancelationSource.TryDispose();
         }
     }

--- a/Package/Tests/CoreTests/Concurrency/AwaitConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/AwaitConcurrencyTests.cs
@@ -35,7 +35,7 @@ namespace ProtoPromiseTests.Concurrency
         {
             int invokedCount = 0;
             var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+            var promiseRetainer = deferred.Promise.GetRetainer();
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(
@@ -47,7 +47,7 @@ namespace ProtoPromiseTests.Concurrency
                     {
                         try
                         {
-                            await promise;
+                            await promiseRetainer;
                             Interlocked.Increment(ref invokedCount);
                         }
                         catch (UnhandledException)
@@ -62,7 +62,7 @@ namespace ProtoPromiseTests.Concurrency
                 }
             );
 
-            promise.Forget();
+            promiseRetainer.Dispose();
             TestHelper.GetTryCompleterVoid(completeType, rejectValue).Invoke(deferred);
             Assert.AreEqual(ThreadHelper.multiExecutionCount, invokedCount);
         }
@@ -72,11 +72,11 @@ namespace ProtoPromiseTests.Concurrency
             [Values] CompleteType completeType)
         {
             int invokedCount = 0;
-            var promise = completeType == CompleteType.Resolve
-                ? Promise.Resolved().Preserve()
+            var promiseRetainer = completeType == CompleteType.Resolve
+                ? Promise.Resolved().GetRetainer()
                 : completeType == CompleteType.Reject
-                ? Promise.Rejected(rejectValue).Preserve()
-                : Promise.Canceled().Preserve();
+                ? Promise.Rejected(rejectValue).GetRetainer()
+                : Promise.Canceled().GetRetainer();
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(
@@ -88,7 +88,7 @@ namespace ProtoPromiseTests.Concurrency
                     {
                         try
                         {
-                            await promise;
+                            await promiseRetainer;
                             Interlocked.Increment(ref invokedCount);
                         }
                         catch (UnhandledException)
@@ -103,7 +103,7 @@ namespace ProtoPromiseTests.Concurrency
                 }
             );
 
-            promise.Forget();
+            promiseRetainer.Dispose();
             Assert.AreEqual(ThreadHelper.multiExecutionCount, invokedCount);
         }
 
@@ -113,7 +113,7 @@ namespace ProtoPromiseTests.Concurrency
         {
             int invokedCount = 0;
             var deferred = Promise<int>.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+            var promiseRetainer = deferred.Promise.GetRetainer();
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(
@@ -125,7 +125,7 @@ namespace ProtoPromiseTests.Concurrency
                     {
                         try
                         {
-                            await promise;
+                            await promiseRetainer;
                             Interlocked.Increment(ref invokedCount);
                         }
                         catch (UnhandledException)
@@ -140,7 +140,7 @@ namespace ProtoPromiseTests.Concurrency
                 }
             );
 
-            promise.Forget();
+            promiseRetainer.Dispose();
             TestHelper.GetTryCompleterT(completeType, 1, rejectValue).Invoke(deferred);
             Assert.AreEqual(ThreadHelper.multiExecutionCount, invokedCount);
         }
@@ -150,11 +150,11 @@ namespace ProtoPromiseTests.Concurrency
             [Values] CompleteType completeType)
         {
             int invokedCount = 0;
-            var promise = completeType == CompleteType.Resolve
-                ? Promise<int>.Resolved(1).Preserve()
+            var promiseRetainer = completeType == CompleteType.Resolve
+                ? Promise<int>.Resolved(1).GetRetainer()
                 : completeType == CompleteType.Reject
-                ? Promise<int>.Rejected(rejectValue).Preserve()
-                : Promise<int>.Canceled().Preserve();
+                ? Promise<int>.Rejected(rejectValue).GetRetainer()
+                : Promise<int>.Canceled().GetRetainer();
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(
@@ -166,7 +166,7 @@ namespace ProtoPromiseTests.Concurrency
                     {
                         try
                         {
-                            await promise;
+                            await promiseRetainer;
                             Interlocked.Increment(ref invokedCount);
                         }
                         catch (UnhandledException)
@@ -181,7 +181,7 @@ namespace ProtoPromiseTests.Concurrency
                 }
             );
 
-            promise.Forget();
+            promiseRetainer.Dispose();
             Assert.AreEqual(ThreadHelper.multiExecutionCount, invokedCount);
         }
 

--- a/Package/Tests/CoreTests/Concurrency/PromiseConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/PromiseConcurrencyTests.cs
@@ -33,10 +33,70 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
+        public void PromiseRetainerWithReferenceBacking_DisposeMayOnlyBeCalledOnce_void()
+        {
+            var deferred = Promise.NewDeferred();
+            var promiseRetainer = deferred.Promise.GetRetainer();
+
+            int successCount = 0, invalidCount = 0;
+
+            var threadHelper = new ThreadHelper();
+            threadHelper.ExecuteMultiActionParallel(
+                () =>
+                {
+                    try
+                    {
+                        promiseRetainer.Dispose();
+                        Interlocked.Increment(ref successCount);
+                    }
+                    catch
+                    {
+                        Interlocked.Increment(ref invalidCount);
+                    }
+                }
+            );
+
+            deferred.Resolve();
+            Assert.AreEqual(1, successCount);
+            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, invalidCount);
+        }
+
+        [Test]
+        public void PromiseRetainerWithReferenceBacking_DisposeMayOnlyBeCalledOnce_T()
+        {
+            var deferred = Promise.NewDeferred<int>();
+            var promiseRetainer = deferred.Promise.GetRetainer();
+
+            int successCount = 0, invalidCount = 0;
+
+            var threadHelper = new ThreadHelper();
+            threadHelper.ExecuteMultiActionParallel(
+                () =>
+                {
+                    try
+                    {
+                        promiseRetainer.Dispose();
+                        Interlocked.Increment(ref successCount);
+                    }
+                    catch
+                    {
+                        Interlocked.Increment(ref invalidCount);
+                    }
+                }
+            );
+
+            deferred.Resolve(1);
+            Assert.AreEqual(1, successCount);
+            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, invalidCount);
+        }
+
+        [Test]
         public void PreservedPromiseWithReferenceBacking_ForgetMayOnlyBeCalledOnce_void()
         {
             var deferred = Promise.NewDeferred();
+#pragma warning disable CS0618 // Type or member is obsolete
             var promise = deferred.Promise.Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             int successCount = 0, invalidCount = 0;
 
@@ -65,7 +125,9 @@ namespace ProtoPromiseTests.Concurrency
         public void PreservedPromiseWithReferenceBacking_ForgetMayOnlyBeCalledOnce_T()
         {
             var deferred = Promise.NewDeferred<int>();
+#pragma warning disable CS0618 // Type or member is obsolete
             var promise = deferred.Promise.Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             int successCount = 0, invalidCount = 0;
 
@@ -93,6 +155,7 @@ namespace ProtoPromiseTests.Concurrency
         [Test]
         public void PreservedPromiseWithReferenceBacking_DuplicateCalledConcurrentlyAlwaysReturnsUnique_void()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var deferred = Promise.NewDeferred();
             var promise = deferred.Promise.Preserve();
 
@@ -116,11 +179,13 @@ namespace ProtoPromiseTests.Concurrency
             {
                 Assert.Fail("Duplicate returned at least one of the same promise instance. Duplicate should always return a unique instance from a reference-backed promise.");
             }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Test]
         public void PreservedPromiseWithReferenceBacking_DuplicateCalledConcurrentlyAlwaysReturnsUnique_T()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var deferred = Promise.NewDeferred<int>();
             var promise = deferred.Promise.Preserve();
 
@@ -144,11 +209,13 @@ namespace ProtoPromiseTests.Concurrency
             {
                 Assert.Fail("Duplicate returned at least one of the same promise instance. Duplicate should always return a unique instance from a reference-backed promise.");
             }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Test]
         public void PreservedPromiseWithReferenceBacking_PreserveCalledConcurrentlyAlwaysReturnsUnique_void()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var deferred = Promise.NewDeferred();
             var promise = deferred.Promise.Preserve();
 
@@ -172,11 +239,13 @@ namespace ProtoPromiseTests.Concurrency
             {
                 Assert.Fail("Duplicate returned at least one of the same promise instance. Duplicate should always return a unique instance from a reference-backed promise.");
             }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Test]
         public void PreservedPromiseWithReferenceBacking_PreserveCalledConcurrentlyAlwaysReturnsUnique_T()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var deferred = Promise.NewDeferred<int>();
             var promise = deferred.Promise.Preserve();
 
@@ -200,6 +269,7 @@ namespace ProtoPromiseTests.Concurrency
             {
                 Assert.Fail("Duplicate returned at least one of the same promise instance. Duplicate should always return a unique instance from a reference-backed promise.");
             }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Test]
@@ -323,106 +393,22 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
-        public void PreservedPromiseThenMayBeCalledConcurrently_PendingThenResolved_void()
+        public void PreservedPromise_ThenMayBeCalledConcurrently_void(
+            [Values(CompleteType.Resolve, CompleteType.Reject)] CompleteType completeType,
+            [Values] bool isAlreadyComplete)
         {
             int invokedCount = 0;
-            var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+#pragma warning disable CS0618 // Type or member is obsolete
+            var promise = TestHelper.BuildPromise(CompleteType.Cancel, isAlreadyComplete, "Rejected", out var tryCompleter).Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
 
-            var resolveActions = TestHelper.ResolveActionsVoid(() => Interlocked.Increment(ref invokedCount));
-            var thenActions = TestHelper.ThenActionsVoid(() => Interlocked.Increment(ref invokedCount), null);
+            var actions = TestHelper.ThenActionsVoid(null, () => Interlocked.Increment(ref invokedCount))
+                .Concat(completeType == CompleteType.Resolve
+                    ? TestHelper.ResolveActionsVoid(() => Interlocked.Increment(ref invokedCount))
+                    : TestHelper.CatchActionsVoid(() => Interlocked.Increment(ref invokedCount))
+                );
             var threadHelper = new ThreadHelper();
-            foreach (var action in resolveActions.Concat(thenActions))
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            deferred.Resolve();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.resolveVoidCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseThenMayBeCalledConcurrently_Resolved_void()
-        {
-            int invokedCount = 0;
-            var promise = Promise.Resolved().Preserve();
-
-            var resolveActions = TestHelper.ResolveActionsVoid(() => Interlocked.Increment(ref invokedCount));
-            var thenActions = TestHelper.ThenActionsVoid(() => Interlocked.Increment(ref invokedCount), null);
-            var threadHelper = new ThreadHelper();
-            foreach (var action in resolveActions.Concat(thenActions))
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.resolveVoidCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseThenMayBeCalledConcurrently_PendingThenResolved_T()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
-
-            var resolveActions = TestHelper.ResolveActions<int>(v => Interlocked.Increment(ref invokedCount));
-            var thenActions = TestHelper.ThenActions<int>(v => Interlocked.Increment(ref invokedCount), null);
-            var threadHelper = new ThreadHelper();
-            foreach (var action in resolveActions.Concat(thenActions))
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            deferred.Resolve(1);
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.resolveTCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseThenMayBeCalledConcurrently_Resolved_T()
-        {
-            int invokedCount = 0;
-            var promise = Promise.Resolved(1).Preserve();
-
-            var resolveActions = TestHelper.ResolveActions<int>(v => Interlocked.Increment(ref invokedCount));
-            var thenActions = TestHelper.ThenActions<int>(v => Interlocked.Increment(ref invokedCount), null);
-            var threadHelper = new ThreadHelper();
-            foreach (var action in resolveActions.Concat(thenActions))
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.resolveTCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseThenMayBeCalledConcurrently_PendingThenRejected_void()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
-
-            var catchActions = TestHelper.CatchActionsVoid(() => Interlocked.Increment(ref invokedCount));
-            var thenActions = TestHelper.ThenActionsVoid(null, () => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in catchActions.Concat(thenActions))
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            deferred.Reject("Reject");
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.rejectVoidCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseThenMayBeCalledConcurrently_Rejected_void()
-        {
-            int invokedCount = 0;
-            var promise = Promise.Rejected("Reject").Preserve();
-
-            var catchActions = TestHelper.CatchActionsVoid(() => Interlocked.Increment(ref invokedCount));
-            var thenActions = TestHelper.ThenActionsVoid(null, () => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in catchActions.Concat(thenActions))
+            foreach (var action in actions)
             {
                 threadHelper.ExecuteMultiActionParallel(() => action(promise));
             }
@@ -431,103 +417,73 @@ namespace ProtoPromiseTests.Concurrency
         }
 
         [Test]
-        public void PreservedPromiseThenMayBeCalledConcurrently_PendingThenRejected_T()
+        public void PreservedPromise_ThenMayBeCalledConcurrently_T(
+            [Values(CompleteType.Resolve, CompleteType.Reject)] CompleteType completeType,
+            [Values] bool isAlreadyComplete)
         {
             int invokedCount = 0;
-            var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
+#pragma warning disable CS0618 // Type or member is obsolete
+            var promise = TestHelper.BuildPromise(CompleteType.Cancel, isAlreadyComplete, 42, "Rejected", out var tryCompleter).Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
 
-            var catchActions = TestHelper.CatchActions<int>(() => Interlocked.Increment(ref invokedCount));
-            var thenActions = TestHelper.ThenActions<int>(null, () => Interlocked.Increment(ref invokedCount));
+            var actions = TestHelper.ThenActions<int>(null, () => Interlocked.Increment(ref invokedCount))
+                .Concat(completeType == CompleteType.Resolve
+                    ? TestHelper.ResolveActions<int>(v => Interlocked.Increment(ref invokedCount))
+                    : TestHelper.CatchActions<int>(() => Interlocked.Increment(ref invokedCount))
+                );
             var threadHelper = new ThreadHelper();
-            foreach (var action in catchActions.Concat(thenActions))
+            foreach (var action in actions)
             {
                 threadHelper.ExecuteMultiActionParallel(() => action(promise));
             }
             promise.Forget();
-            deferred.Reject("Reject");
+            tryCompleter();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.rejectTCallbacks / TestHelper.callbacksMultiplier, invokedCount);
         }
 
         [Test]
-        public void PreservedPromiseThenMayBeCalledConcurrently_Rejected_T()
+        public void PreservedPromise_CatchCancelationMayBeCalledConcurrently_void(
+            [Values] bool isAlreadyComplete)
         {
             int invokedCount = 0;
-            var promise = Promise<int>.Rejected("Reject").Preserve();
-
-            var catchActions = TestHelper.CatchActions<int>(() => Interlocked.Increment(ref invokedCount));
-            var thenActions = TestHelper.ThenActions<int>(null, () => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in catchActions.Concat(thenActions))
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.rejectTCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PromiseCatchCancelationnMayBeCalledConcurrently_PendingThenCanceled_void()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+#pragma warning disable CS0618 // Type or member is obsolete
+            var promise = TestHelper.BuildPromise(CompleteType.Cancel, isAlreadyComplete, "Rejected", out var tryCompleter).Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(() => Interlocked.Increment(ref invokedCount)).Forget());
             threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
             promise.Forget();
-            deferred.Cancel();
+            tryCompleter();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
         }
 
         [Test]
-        public void PromiseCatchCancelationnMayBeCalledConcurrently_Canceled_void()
+        public void PreservedPromise_CatchCancelationMayBeCalledConcurrently_T(
+            [Values] bool isAlreadyComplete)
         {
             int invokedCount = 0;
-            var promise = Promise.Canceled().Preserve();
+#pragma warning disable CS0618 // Type or member is obsolete
+            var promise = TestHelper.BuildPromise(CompleteType.Cancel, isAlreadyComplete, "Rejected", out var tryCompleter).Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(() => Interlocked.Increment(ref invokedCount)).Forget());
             threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
             promise.Forget();
+            tryCompleter();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
         }
 
         [Test]
-        public void PromiseCatchCancelationnMayBeCalledConcurrently_PendingThenCanceled_T()
+        public void PreservedPromise_ContinueWithMayBeCalledConcurrently_void(
+            [Values] CompleteType completeType,
+            [Values] bool isAlreadyComplete)
         {
             int invokedCount = 0;
-            var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(() => Interlocked.Increment(ref invokedCount)).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
-            promise.Forget();
-            deferred.Cancel();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-        }
-
-        [Test]
-        public void PromiseCatchCancelationnMayBeCalledConcurrently_Canceled_T()
-        {
-            int invokedCount = 0;
-            var promise = Promise<int>.Canceled().Preserve();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(() => Interlocked.Increment(ref invokedCount)).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.CatchCancelation(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseContinueWithMayBeCalledConcurrently_PendingThenResolved_void()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+#pragma warning disable CS0618 // Type or member is obsolete
+            var promise = TestHelper.BuildPromise(completeType, isAlreadyComplete, "Rejected", out var tryCompleter).Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var continueActions = TestHelper.ContinueWithActionsVoid(() => Interlocked.Increment(ref invokedCount));
             var threadHelper = new ThreadHelper();
@@ -536,32 +492,19 @@ namespace ProtoPromiseTests.Concurrency
                 threadHelper.ExecuteMultiActionParallel(() => action(promise));
             }
             promise.Forget();
-            deferred.Resolve();
+            tryCompleter();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueVoidCallbacks / TestHelper.callbacksMultiplier, invokedCount);
         }
 
         [Test]
-        public void PreservedPromiseContinueWithMayBeCalledConcurrently_Resolved_void()
+        public void PreservedPromise_ContinueWithMayBeCalledConcurrently_T(
+            [Values] CompleteType completeType,
+            [Values] bool isAlreadyComplete)
         {
             int invokedCount = 0;
-            var promise = Promise.Resolved().Preserve();
-
-            var continueActions = TestHelper.ContinueWithActionsVoid(() => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in continueActions)
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueVoidCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseContinueWithMayBeCalledConcurrently_PendingThenResolved_T()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
+#pragma warning disable CS0618 // Type or member is obsolete
+            var promise = TestHelper.BuildPromise(completeType, isAlreadyComplete, 42, "Rejected", out var tryCompleter).Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var continueActions = TestHelper.ContinueWithActions<int>(() => Interlocked.Increment(ref invokedCount));
             var threadHelper = new ThreadHelper();
@@ -570,327 +513,100 @@ namespace ProtoPromiseTests.Concurrency
                 threadHelper.ExecuteMultiActionParallel(() => action(promise));
             }
             promise.Forget();
-            deferred.Resolve(1);
+            tryCompleter();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueTCallbacks / TestHelper.callbacksMultiplier, invokedCount);
         }
 
         [Test]
-        public void PreservedPromiseContinueWithMayBeCalledConcurrently_Resolved_T()
+        public void PreservedPromise_FinallyMayBeCalledConcurrently_void(
+            [Values] CompleteType completeType,
+            [Values] bool isAlreadyComplete)
         {
             int invokedCount = 0;
-            var promise = Promise.Resolved(1).Preserve();
-
-            var continueActions = TestHelper.ContinueWithActions<int>(() => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in continueActions)
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueTCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseContinueWithMayBeCalledConcurrently_PendingThenRejected_void()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
-
-            var continueActions = TestHelper.ContinueWithActionsVoid(() => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in continueActions)
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            deferred.Reject("Reject");
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueVoidCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseContinueWithMayBeCalledConcurrently_Rejected_void()
-        {
-            int invokedCount = 0;
-            var promise = Promise.Rejected("Reject").Preserve();
-
-            var continueActions = TestHelper.ContinueWithActionsVoid(() => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in continueActions)
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueVoidCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseContinueWithMayBeCalledConcurrently_PendingThenRejected_T()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
-
-            var continueActions = TestHelper.ContinueWithActions<int>(() => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in continueActions)
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            deferred.Reject("Reject");
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueTCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseContinueWithMayBeCalledConcurrently_Rejected_T()
-        {
-            int invokedCount = 0;
-            var promise = Promise<int>.Rejected("Reject").Preserve();
-
-            var continueActions = TestHelper.ContinueWithActions<int>(() => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in continueActions)
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueTCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseContinueWithMayBeCalledConcurrently_PendingThenCanceled_void()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
-
-            var continueActions = TestHelper.ContinueWithActionsVoid(() => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in continueActions)
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            deferred.Cancel();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueVoidCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseContinueWithMayBeCalledConcurrently_Canceled_void()
-        {
-            int invokedCount = 0;
-            var promise = Promise.Canceled().Preserve();
-
-            var continueActions = TestHelper.ContinueWithActionsVoid(() => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in continueActions)
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueVoidCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseContinueWithMayBeCalledConcurrently_PendingThenCanceled_T()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
-
-            var continueActions = TestHelper.ContinueWithActions<int>(() => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in continueActions)
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            deferred.Cancel();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueTCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PreservedPromiseContinueWithMayBeCalledConcurrently_Canceled_T()
-        {
-            int invokedCount = 0;
-            var promise = Promise<int>.Canceled().Preserve();
-
-            var continueActions = TestHelper.ContinueWithActions<int>(() => Interlocked.Increment(ref invokedCount));
-            var threadHelper = new ThreadHelper();
-            foreach (var action in continueActions)
-            {
-                threadHelper.ExecuteMultiActionParallel(() => action(promise));
-            }
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * TestHelper.continueTCallbacks / TestHelper.callbacksMultiplier, invokedCount);
-        }
-
-        [Test]
-        public void PromiseFinallyMayBeCalledConcurrently_PendingThenResolved_void()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
+#pragma warning disable CS0618 // Type or member is obsolete
+            var promise = TestHelper.BuildPromise(completeType, isAlreadyComplete, "Rejected", out var tryCompleter).Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Forget());
             threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
             promise.Forget();
-            deferred.Resolve();
+            tryCompleter();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
         }
 
         [Test]
-        public void PromiseFinallyMayBeCalledConcurrently_Resolved_void()
+        public void PreservedPromise_FinallyMayBeCalledConcurrently_T(
+            [Values] CompleteType completeType,
+            [Values] bool isAlreadyComplete)
         {
             int invokedCount = 0;
-            var promise = Promise.Resolved().Preserve();
+#pragma warning disable CS0618 // Type or member is obsolete
+            var promise = TestHelper.BuildPromise(completeType, isAlreadyComplete, 42, "Rejected", out var tryCompleter).Preserve();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Forget());
             threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
             promise.Forget();
+            tryCompleter();
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
         }
 
         [Test]
-        public void PromiseFinallyMayBeCalledConcurrently_PendingThenResolved_T()
+        public void PromiseRetainer_WaitAsyncMayBeCalledConcurrently_void(
+            [Values] CompleteType completeType,
+            [Values] bool isAlreadyComplete)
         {
+            var expectedRejection = "Rejected";
             int invokedCount = 0;
-            var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
-            promise.Forget();
-            deferred.Resolve(1);
+            using (var promiseRetainer = TestHelper.BuildPromise(completeType, isAlreadyComplete, expectedRejection, out var tryCompleter)
+                .GetRetainer())
+            {
+                new ThreadHelper().ExecuteMultiActionParallel(() =>
+                    promiseRetainer.WaitAsync()
+                        .ContinueWith(resultContainer =>
+                        {
+                            Interlocked.Increment(ref invokedCount);
+                            Assert.AreEqual((Promise.State) completeType, resultContainer.State);
+                            if (completeType == CompleteType.Reject)
+                            {
+                                Assert.AreEqual(expectedRejection, resultContainer.Reason);
+                            }
+                        })
+                        .Forget()
+                    );
+                tryCompleter();
+            }
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
         }
 
         [Test]
-        public void PromiseFinallyMayBeCalledConcurrently_Resolved_T()
+        public void PromiseRetainer_WaitAsyncMayBeCalledConcurrently_T(
+            [Values] CompleteType completeType,
+            [Values] bool isAlreadyComplete)
         {
+            var expectedRejection = "Rejected";
+            var expectedResult = 42;
             int invokedCount = 0;
-            var promise = Promise.Resolved(1).Preserve();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-        }
-
-        [Test]
-        public void PromiseFinallyMayBeCalledConcurrently_PendingThenRejected_void()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Catch(() => { }).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Catch(() => { }).Forget());
-            promise.Forget();
-            deferred.Reject("Reject");
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-        }
-
-        [Test]
-        public void PromiseFinallyMayBeCalledConcurrently_Rejected_void()
-        {
-            int invokedCount = 0;
-            var promise = Promise.Rejected("Reject").Preserve();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Catch(() => { }).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Catch(() => { }).Forget());
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-        }
-
-        [Test]
-        public void PromiseFinallyMayBeCalledConcurrently_PendingThenRejected_T()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Catch(() => { }).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Catch(() => { }).Forget());
-            promise.Forget();
-            deferred.Reject("Reject");
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-        }
-
-        [Test]
-        public void PromiseFinallyMayBeCalledConcurrently_Rejected_T()
-        {
-            int invokedCount = 0;
-            var promise = Promise<int>.Rejected("Reject").Preserve();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Catch(() => { }).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Catch(() => { }).Forget());
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-        }
-
-        [Test]
-        public void PromiseFinallyMayBeCalledConcurrently_PendingThenCanceled_void()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred();
-            var promise = deferred.Promise.Preserve();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
-            promise.Forget();
-            deferred.Cancel();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-        }
-
-        [Test]
-        public void PromiseFinallyMayBeCalledConcurrently_Canceled_void()
-        {
-            int invokedCount = 0;
-            var promise = Promise.Canceled().Preserve();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
-            promise.Forget();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-        }
-
-        [Test]
-        public void PromiseFinallyMayBeCalledConcurrently_PendingThenCanceled_T()
-        {
-            int invokedCount = 0;
-            var deferred = Promise.NewDeferred<int>();
-            var promise = deferred.Promise.Preserve();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
-            promise.Forget();
-            deferred.Cancel();
-            Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
-        }
-
-        [Test]
-        public void PromiseFinallyMayBeCalledConcurrently_Canceled_T()
-        {
-            int invokedCount = 0;
-            var promise = Promise<int>.Canceled().Preserve();
-
-            var threadHelper = new ThreadHelper();
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(() => Interlocked.Increment(ref invokedCount)).Forget());
-            threadHelper.ExecuteMultiActionParallel(() => promise.Finally(1, cv => Interlocked.Increment(ref invokedCount)).Forget());
-            promise.Forget();
+            using (var promiseRetainer = TestHelper.BuildPromise(completeType, isAlreadyComplete, expectedResult, expectedRejection, out var tryCompleter)
+                .GetRetainer())
+            {
+                new ThreadHelper().ExecuteMultiActionParallel(() =>
+                    promiseRetainer.WaitAsync()
+                        .ContinueWith(resultContainer =>
+                        {
+                            Interlocked.Increment(ref invokedCount);
+                            Assert.AreEqual((Promise.State) completeType, resultContainer.State);
+                            if (completeType == CompleteType.Reject)
+                            {
+                                Assert.AreEqual(expectedRejection, resultContainer.Reason);
+                            }
+                        })
+                        .Forget()
+                    );
+                tryCompleter();
+            }
             Assert.AreEqual(ThreadHelper.multiExecutionCount * 2, invokedCount);
         }
     }

--- a/Package/Tests/CoreTests/Concurrency/PromiseNonPreservedConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/PromiseNonPreservedConcurrencyTests.cs
@@ -94,7 +94,9 @@ namespace ProtoPromiseTests.Concurrency
                 {
                     try
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         promise.Duplicate().Forget();
+#pragma warning restore CS0618 // Type or member is obsolete
                         Interlocked.Increment(ref successCount);
                     }
                     catch (Proto.Promises.InvalidOperationException)
@@ -123,7 +125,9 @@ namespace ProtoPromiseTests.Concurrency
                 {
                     try
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         promise.Duplicate().Forget();
+#pragma warning restore CS0618 // Type or member is obsolete
                         Interlocked.Increment(ref successCount);
                     }
                     catch (Proto.Promises.InvalidOperationException)
@@ -152,7 +156,9 @@ namespace ProtoPromiseTests.Concurrency
                 {
                     try
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         promise.Preserve().Forget();
+#pragma warning restore CS0618 // Type or member is obsolete
                         Interlocked.Increment(ref successCount);
                     }
                     catch (Proto.Promises.InvalidOperationException)
@@ -181,8 +187,72 @@ namespace ProtoPromiseTests.Concurrency
                 {
                     try
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         promise.Preserve().Forget();
+#pragma warning restore CS0618 // Type or member is obsolete
                         Interlocked.Increment(ref successCount);
+                    }
+                    catch (Proto.Promises.InvalidOperationException)
+                    {
+                        Interlocked.Increment(ref invalidCount);
+                    }
+                }
+            );
+
+            deferred.Resolve(1);
+            Assert.AreEqual(1, successCount);
+            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, invalidCount);
+        }
+
+        [Test]
+        public void PromiseWithReferenceBacking_GetRetainerMayOnlyBeCalledOnce_void()
+        {
+            var deferred = Promise.NewDeferred();
+            var promise = deferred.Promise;
+
+            int successCount = 0, invalidCount = 0;
+
+            var threadHelper = new ThreadHelper();
+            threadHelper.ExecuteMultiActionParallel(
+                () =>
+                {
+                    try
+                    {
+                        using (promise.GetRetainer())
+                        {
+                            Interlocked.Increment(ref successCount);
+                        }
+                    }
+                    catch (Proto.Promises.InvalidOperationException)
+                    {
+                        Interlocked.Increment(ref invalidCount);
+                    }
+                }
+            );
+
+            deferred.Resolve();
+            Assert.AreEqual(1, successCount);
+            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, invalidCount);
+        }
+
+        [Test]
+        public void PromiseWithReferenceBacking_GetRetainerMayOnlyBeCalledOnce_T()
+        {
+            var deferred = Promise.NewDeferred<int>();
+            var promise = deferred.Promise;
+
+            int successCount = 0, invalidCount = 0;
+
+            var threadHelper = new ThreadHelper();
+            threadHelper.ExecuteMultiActionParallel(
+                () =>
+                {
+                    try
+                    {
+                        using (promise.GetRetainer())
+                        {
+                            Interlocked.Increment(ref successCount);
+                        }
                     }
                     catch (Proto.Promises.InvalidOperationException)
                     {

--- a/Package/Tests/Helpers/TestHelper.cs
+++ b/Package/Tests/Helpers/TestHelper.cs
@@ -579,7 +579,7 @@ namespace ProtoPromiseTests
         // The distance between 1 and the largest value smaller than 1.
         public static readonly float progressEpsilon = 1f - 0.99999994f;
 
-        public const int callbacksMultiplier = 4;
+        public const int callbacksMultiplier = 5;
 
         public const int resolveVoidCallbacks = 72 * callbacksMultiplier;
         public const int resolveTCallbacks = 72 * callbacksMultiplier;
@@ -629,13 +629,19 @@ namespace ProtoPromiseTests
 
         public const int onCancelCallbacks = 4 * callbacksMultiplier;
 
-        public static IEnumerable<Promise> GetTestablePromises(Promise preservedPromise)
+        public static IEnumerable<Promise> GetTestablePromises(Promise.Retainer promiseRetainer, bool includePreserved = true)
         {
             // This helps to test several different kinds of promises to make sure they all work with the same API.
-            yield return preservedPromise;
-            yield return preservedPromise.Duplicate();
+            if (includePreserved)
+            {
+                var preservedPromise = promiseRetainer.WaitAsync().Preserve();
+                yield return preservedPromise;
+                yield return preservedPromise.Duplicate();
+                preservedPromise.Forget();
+            }
+            yield return promiseRetainer.WaitAsync();
             var deferred = Promise.NewDeferred();
-            preservedPromise
+            promiseRetainer.WaitAsync()
                 .ContinueWith(deferred, (d, result) =>
                 {
                     if (result.State == Promise.State.Resolved)
@@ -653,16 +659,22 @@ namespace ProtoPromiseTests
                 })
                 .Forget();
             yield return deferred.Promise;
-            yield return Await(preservedPromise);
+            yield return Await(promiseRetainer.WaitAsync());
         }
 
-        public static IEnumerable<Promise<T>> GetTestablePromises<T>(Promise<T> preservedPromise)
+        public static IEnumerable<Promise<T>> GetTestablePromises<T>(Promise<T>.Retainer promiseRetainer, bool includePreserved = true)
         {
             // This helps to test several different kinds of promises to make sure they all work with the same API.
-            yield return preservedPromise;
-            yield return preservedPromise.Duplicate();
+            if (includePreserved)
+            {
+                var preservedPromise = promiseRetainer.WaitAsync().Preserve();
+                yield return preservedPromise;
+                yield return preservedPromise.Duplicate();
+                preservedPromise.Forget();
+            }
+            yield return promiseRetainer.WaitAsync();
             var deferred = Promise.NewDeferred<T>();
-            preservedPromise
+            promiseRetainer.WaitAsync()
                 .ContinueWith(deferred, (d, result) =>
                 {
                     if (result.State == Promise.State.Resolved)
@@ -680,7 +692,7 @@ namespace ProtoPromiseTests
                 })
                 .Forget();
             yield return deferred.Promise;
-            yield return Await(preservedPromise);
+            yield return Await(promiseRetainer.WaitAsync());
         }
 
         private static async Promise Await(Promise promise)
@@ -702,36 +714,36 @@ namespace ProtoPromiseTests
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            AddResolveCallbacksWithCancelation(
-                promise,
-                onResolve, convertValue,
-                onResolveCapture, captureValue,
-                promiseToPromise, promiseToPromiseConvert,
-                onCallbackAdded, onCallbackAddedConvert,
-                default(CancelationToken), default(CancelationToken),
-                onCancel,
-                onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
-                configureAwaitType, configureAwaitForceAsync
-            );
+                AddResolveCallbacksWithCancelation(
+                    retainer.WaitAsync(),
+                    onResolve, convertValue,
+                    onResolveCapture, captureValue,
+                    promiseToPromise, promiseToPromiseConvert,
+                    onCallbackAdded, onCallbackAddedConvert,
+                    default(CancelationToken), default(CancelationToken),
+                    onCancel,
+                    onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
+                    configureAwaitType, configureAwaitForceAsync
+                );
 
-            CancelationSource cancelationSource = CancelationSource.New();
-            AddResolveCallbacksWithCancelation(
-                promise,
-                onResolve, convertValue,
-                onResolveCapture, captureValue,
-                promiseToPromise, promiseToPromiseConvert,
-                onCallbackAdded, onCallbackAddedConvert,
-                cancelationSource.Token, cancelationSource.Token,
-                onCancel,
-                onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
-                configureAwaitType, configureAwaitForceAsync
-            );
-            cancelationSource.Dispose();
-
-            promise.Forget();
+                CancelationSource cancelationSource = CancelationSource.New();
+                AddResolveCallbacksWithCancelation(
+                    retainer.WaitAsync(),
+                    onResolve, convertValue,
+                    onResolveCapture, captureValue,
+                    promiseToPromise, promiseToPromiseConvert,
+                    onCallbackAdded, onCallbackAddedConvert,
+                    cancelationSource.Token, cancelationSource.Token,
+                    onCancel,
+                    onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
+                    configureAwaitType, configureAwaitForceAsync
+                );
+                cancelationSource.Dispose();
+            }
         }
 
         public static void AddResolveCallbacksWithCancelation<TConvert, TCapture>(Promise promise,
@@ -744,109 +756,109 @@ namespace ProtoPromiseTests
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            // Add empty delegates so no need for null check.
-            onResolve += () => { };
-            onResolveCapture += _ => { };
-            if (promiseToPromise == null)
-            {
-                promiseToPromise = _ => Promise.Resolved();
-            }
-            if (promiseToPromiseConvert == null)
-            {
-                promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
-            }
-            if (onCallbackAdded == null)
-            {
-                onCallbackAdded = (ref Promise p) => p.Forget();
-            }
-            if (onCallbackAddedConvert == null)
-            {
-                onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
-            }
-            if (onAdoptCallbackAdded == null)
-            {
-                onAdoptCallbackAdded = (ref Promise p) => { };
-            }
-            if (onAdoptCallbackAddedConvert == null)
-            {
-                onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
-            }
-            onCancel += () => { };
+                // Add empty delegates so no need for null check.
+                onResolve += () => { };
+                onResolveCapture += _ => { };
+                if (promiseToPromise == null)
+                {
+                    promiseToPromise = _ => Promise.Resolved();
+                }
+                if (promiseToPromiseConvert == null)
+                {
+                    promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
+                }
+                if (onCallbackAdded == null)
+                {
+                    onCallbackAdded = (ref Promise p) => p.Forget();
+                }
+                if (onCallbackAddedConvert == null)
+                {
+                    onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
+                }
+                if (onAdoptCallbackAdded == null)
+                {
+                    onAdoptCallbackAdded = (ref Promise p) => { };
+                }
+                if (onAdoptCallbackAddedConvert == null)
+                {
+                    onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
+                }
+                onCancel += () => { };
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p1 = default(Promise);
-                p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onCallbackAdded(ref p1);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p2 = default(Promise<TConvert>);
-                p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onCallbackAddedConvert(ref p2);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p3 = default(Promise);
-                p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromise(p3); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p3);
-                onCallbackAdded(ref p3);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p4 = default(Promise<TConvert>);
-                p4 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromiseConvert(p4); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p4);
-                onCallbackAddedConvert(ref p4);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p1 = default(Promise);
+                    p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onCallbackAdded(ref p1);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p2 = default(Promise<TConvert>);
+                    p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onCallbackAddedConvert(ref p2);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p3 = default(Promise);
+                    p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromise(p3); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p3);
+                    onCallbackAdded(ref p3);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p4 = default(Promise<TConvert>);
+                    p4 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromiseConvert(p4); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p4);
+                    onCallbackAddedConvert(ref p4);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p5 = default(Promise);
-                p5 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onCallbackAdded(ref p5);
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p5 = default(Promise);
+                    p5 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onCallbackAdded(ref p5);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p6 = default(Promise<TConvert>);
+                    p6 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onCallbackAddedConvert(ref p6);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p7 = default(Promise);
+                    p7 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p7); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p7);
+                    onCallbackAdded(ref p7);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p8 = default(Promise<TConvert>);
+                    p8 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p8); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p8);
+                    onCallbackAddedConvert(ref p8);
+                }
             }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p6 = default(Promise<TConvert>);
-                p6 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onCallbackAddedConvert(ref p6);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p7 = default(Promise);
-                p7 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p7); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p7);
-                onCallbackAdded(ref p7);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p8 = default(Promise<TConvert>);
-                p8 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p8); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p8);
-                onCallbackAddedConvert(ref p8);
-            }
-
-            promise.Forget();
         }
 
         public static void AddResolveCallbacks<T, TConvert, TCapture>(Promise<T> promise,
@@ -858,11 +870,12 @@ namespace ProtoPromiseTests
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            AddResolveCallbacksWithCancelation(
-                promise,
+                AddResolveCallbacksWithCancelation(
+                retainer.WaitAsync(),
                 onResolve, convertValue,
                 onResolveCapture, captureValue,
                 promiseToPromise, promiseToPromiseConvert,
@@ -873,21 +886,20 @@ namespace ProtoPromiseTests
                 configureAwaitType, configureAwaitForceAsync
             );
 
-            CancelationSource cancelationSource = CancelationSource.New();
-            AddResolveCallbacksWithCancelation(
-                promise,
-                onResolve, convertValue,
-                onResolveCapture, captureValue,
-                promiseToPromise, promiseToPromiseConvert,
-                onCallbackAdded, onCallbackAddedConvert,
-                cancelationSource.Token, cancelationSource.Token,
-                onCancel,
-                onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
-                configureAwaitType, configureAwaitForceAsync
-            );
-            cancelationSource.Dispose();
-
-            promise.Forget();
+                CancelationSource cancelationSource = CancelationSource.New();
+                AddResolveCallbacksWithCancelation(
+                    retainer.WaitAsync(),
+                    onResolve, convertValue,
+                    onResolveCapture, captureValue,
+                    promiseToPromise, promiseToPromiseConvert,
+                    onCallbackAdded, onCallbackAddedConvert,
+                    cancelationSource.Token, cancelationSource.Token,
+                    onCancel,
+                    onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
+                    configureAwaitType, configureAwaitForceAsync
+                );
+                cancelationSource.Dispose();
+            }
         }
 
         public static void AddResolveCallbacksWithCancelation<T, TConvert, TCapture>(Promise<T> promise,
@@ -900,109 +912,109 @@ namespace ProtoPromiseTests
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            // Add empty delegates so no need for null check.
-            onResolve += _ => { };
-            onResolveCapture += _ => { };
-            if (promiseToPromise == null)
-            {
-                promiseToPromise = _ => Promise.Resolved();
-            }
-            if (promiseToPromiseConvert == null)
-            {
-                promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
-            }
-            if (onCallbackAdded == null)
-            {
-                onCallbackAdded = (ref Promise p) => p.Forget();
-            }
-            if (onCallbackAddedConvert == null)
-            {
-                onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
-            }
-            if (onAdoptCallbackAdded == null)
-            {
-                onAdoptCallbackAdded = (ref Promise p) => { };
-            }
-            if (onAdoptCallbackAddedConvert == null)
-            {
-                onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
-            }
-            onCancel += () => { };
+                // Add empty delegates so no need for null check.
+                onResolve += _ => { };
+                onResolveCapture += _ => { };
+                if (promiseToPromise == null)
+                {
+                    promiseToPromise = _ => Promise.Resolved();
+                }
+                if (promiseToPromiseConvert == null)
+                {
+                    promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
+                }
+                if (onCallbackAdded == null)
+                {
+                    onCallbackAdded = (ref Promise p) => p.Forget();
+                }
+                if (onCallbackAddedConvert == null)
+                {
+                    onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
+                }
+                if (onAdoptCallbackAdded == null)
+                {
+                    onAdoptCallbackAdded = (ref Promise p) => { };
+                }
+                if (onAdoptCallbackAddedConvert == null)
+                {
+                    onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
+                }
+                onCancel += () => { };
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p1 = default(Promise);
-                p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onCallbackAdded(ref p1);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p2 = default(Promise<TConvert>);
-                p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onCallbackAddedConvert(ref p2);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p3 = default(Promise);
-                p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromise(p3); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p3);
-                onCallbackAdded(ref p3);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p4 = default(Promise<TConvert>);
-                p4 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromiseConvert(p4); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p4);
-                onCallbackAddedConvert(ref p4);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p1 = default(Promise);
+                    p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onCallbackAdded(ref p1);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p2 = default(Promise<TConvert>);
+                    p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onCallbackAddedConvert(ref p2);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p3 = default(Promise);
+                    p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromise(p3); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p3);
+                    onCallbackAdded(ref p3);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p4 = default(Promise<TConvert>);
+                    p4 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromiseConvert(p4); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p4);
+                    onCallbackAddedConvert(ref p4);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p5 = default(Promise);
-                p5 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onCallbackAdded(ref p5);
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p5 = default(Promise);
+                    p5 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onCallbackAdded(ref p5);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p6 = default(Promise<TConvert>);
+                    p6 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onCallbackAddedConvert(ref p6);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p7 = default(Promise);
+                    p7 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p7); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p7);
+                    onCallbackAdded(ref p7);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p8 = default(Promise<TConvert>);
+                    p8 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p8); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p8);
+                    onCallbackAddedConvert(ref p8);
+                }
             }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p6 = default(Promise<TConvert>);
-                p6 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onCallbackAddedConvert(ref p6);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p7 = default(Promise);
-                p7 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p7); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p7);
-                onCallbackAdded(ref p7);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p8 = default(Promise<TConvert>);
-                p8 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p8); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p8);
-                onCallbackAddedConvert(ref p8);
-            }
-
-            promise.Forget();
         }
 
         public static void AddCallbacks<TConvert, TReject, TCapture>(Promise promise,
@@ -1015,11 +1027,12 @@ namespace ProtoPromiseTests
             TestAction<Promise, AdoptLocation> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>, AdoptLocation> onAdoptCallbackAddedConvert = null, TestAction<Promise> onAdoptCallbackAddedCatch = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            AddCallbacksWithCancelation(
-                promise,
+                AddCallbacksWithCancelation(
+                retainer.WaitAsync(),
                 onResolve, onReject, onUnknownRejection, convertValue,
                 onResolveCapture, onRejectCapture, onUnknownRejectionCapture, captureValue,
                 promiseToPromise, promiseToPromiseConvert,
@@ -1031,22 +1044,21 @@ namespace ProtoPromiseTests
                 configureAwaitType, configureAwaitForceAsync
             );
 
-            CancelationSource cancelationSource = CancelationSource.New();
-            AddCallbacksWithCancelation(
-                promise,
-                onResolve, onReject, onUnknownRejection, convertValue,
-                onResolveCapture, onRejectCapture, onUnknownRejectionCapture, captureValue,
-                promiseToPromise, promiseToPromiseConvert,
-                onCallbackAdded, onCallbackAddedConvert,
-                cancelationSource.Token, cancelationSource.Token,
-                onCancel,
-                onDirectCallbackAdded, onDirectCallbackAddedConvert, onDirectCallbackAddedCatch,
-                onAdoptCallbackAdded, onAdoptCallbackAddedConvert, onAdoptCallbackAddedCatch,
-                configureAwaitType, configureAwaitForceAsync
-            );
-            cancelationSource.Dispose();
-
-            promise.Forget();
+                CancelationSource cancelationSource = CancelationSource.New();
+                AddCallbacksWithCancelation(
+                    retainer.WaitAsync(),
+                    onResolve, onReject, onUnknownRejection, convertValue,
+                    onResolveCapture, onRejectCapture, onUnknownRejectionCapture, captureValue,
+                    promiseToPromise, promiseToPromiseConvert,
+                    onCallbackAdded, onCallbackAddedConvert,
+                    cancelationSource.Token, cancelationSource.Token,
+                    onCancel,
+                    onDirectCallbackAdded, onDirectCallbackAddedConvert, onDirectCallbackAddedCatch,
+                    onAdoptCallbackAdded, onAdoptCallbackAddedConvert, onAdoptCallbackAddedCatch,
+                    configureAwaitType, configureAwaitForceAsync
+                );
+                cancelationSource.Dispose();
+            }
         }
 
         public static void AddCallbacksWithCancelation<TConvert, TReject, TCapture>(Promise promise,
@@ -1060,730 +1072,730 @@ namespace ProtoPromiseTests
             TestAction<Promise, AdoptLocation> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>, AdoptLocation> onAdoptCallbackAddedConvert = null, TestAction<Promise> onAdoptCallbackAddedCatch = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            // Add empty delegates so no need for null check.
-            onResolve += () => { };
-            onReject += s => { };
-            onUnknownRejection += () => { };
-            onResolveCapture += _ => { };
-            onRejectCapture += _ => { };
-            onUnknownRejectionCapture += _ => { };
-            if (promiseToPromise == null)
-            {
-                promiseToPromise = _ => Promise.Resolved();
-            }
-            if (promiseToPromiseConvert == null)
-            {
-                promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
-            }
-            if (onCallbackAdded == null)
-            {
-                onCallbackAdded = (ref Promise p) => p.Forget();
-            }
-            if (onCallbackAddedConvert == null)
-            {
-                onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
-            }
-            if (onDirectCallbackAdded == null)
-            {
-                onDirectCallbackAdded = (ref Promise p) => { };
-            }
-            if (onDirectCallbackAddedConvert == null)
-            {
-                onDirectCallbackAddedConvert = (ref Promise<TConvert> p) => { };
-            }
-            if (onDirectCallbackAddedCatch == null)
-            {
-                onDirectCallbackAddedCatch = (ref Promise p) => { };
-            }
-            if (onAdoptCallbackAdded == null)
-            {
-                onAdoptCallbackAdded = (ref Promise p, AdoptLocation _) => { };
-            }
-            if (onAdoptCallbackAddedConvert == null)
-            {
-                onAdoptCallbackAddedConvert = (ref Promise<TConvert> p, AdoptLocation _) => { };
-            }
-            if (onAdoptCallbackAddedCatch == null)
-            {
-                onAdoptCallbackAddedCatch = (ref Promise p) => { };
-            }
-            onCancel += () => { };
+                // Add empty delegates so no need for null check.
+                onResolve += () => { };
+                onReject += s => { };
+                onUnknownRejection += () => { };
+                onResolveCapture += _ => { };
+                onRejectCapture += _ => { };
+                onUnknownRejectionCapture += _ => { };
+                if (promiseToPromise == null)
+                {
+                    promiseToPromise = _ => Promise.Resolved();
+                }
+                if (promiseToPromiseConvert == null)
+                {
+                    promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
+                }
+                if (onCallbackAdded == null)
+                {
+                    onCallbackAdded = (ref Promise p) => p.Forget();
+                }
+                if (onCallbackAddedConvert == null)
+                {
+                    onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
+                }
+                if (onDirectCallbackAdded == null)
+                {
+                    onDirectCallbackAdded = (ref Promise p) => { };
+                }
+                if (onDirectCallbackAddedConvert == null)
+                {
+                    onDirectCallbackAddedConvert = (ref Promise<TConvert> p) => { };
+                }
+                if (onDirectCallbackAddedCatch == null)
+                {
+                    onDirectCallbackAddedCatch = (ref Promise p) => { };
+                }
+                if (onAdoptCallbackAdded == null)
+                {
+                    onAdoptCallbackAdded = (ref Promise p, AdoptLocation _) => { };
+                }
+                if (onAdoptCallbackAddedConvert == null)
+                {
+                    onAdoptCallbackAddedConvert = (ref Promise<TConvert> p, AdoptLocation _) => { };
+                }
+                if (onAdoptCallbackAddedCatch == null)
+                {
+                    onAdoptCallbackAddedCatch = (ref Promise p) => { };
+                }
+                onCancel += () => { };
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p1 = default(Promise);
-                p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); }, () => { onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p1);
-                onCallbackAdded(ref p1);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p2 = default(Promise);
-                p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p2);
-                onCallbackAdded(ref p2);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p3 = default(Promise);
-                p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); }, () => { onUnknownRejection(); return promiseToPromise(p3); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p3, AdoptLocation.Reject);
-                onCallbackAdded(ref p3);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p4 = default(Promise);
-                p4 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p4); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p4, AdoptLocation.Reject);
-                onCallbackAdded(ref p4);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p1 = default(Promise);
+                    p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); }, () => { onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p1);
+                    onCallbackAdded(ref p1);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p2 = default(Promise);
+                    p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p2);
+                    onCallbackAdded(ref p2);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p3 = default(Promise);
+                    p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); }, () => { onUnknownRejection(); return promiseToPromise(p3); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p3, AdoptLocation.Reject);
+                    onCallbackAdded(ref p3);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p4 = default(Promise);
+                    p4 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p4); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p4, AdoptLocation.Reject);
+                    onCallbackAdded(ref p4);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p5 = default(Promise<TConvert>);
-                p5 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return convertValue; }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p5);
-                onCallbackAddedConvert(ref p5);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p6 = default(Promise<TConvert>);
-                p6 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return convertValue; }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p6);
-                onCallbackAddedConvert(ref p6);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p7 = default(Promise<TConvert>);
-                p7 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return convertValue; }, () => { onUnknownRejection(); return promiseToPromiseConvert(p7); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p7, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p7);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p8 = default(Promise<TConvert>);
-                p8 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return convertValue; }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p8); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p8, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p8);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p5 = default(Promise<TConvert>);
+                    p5 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return convertValue; }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p5);
+                    onCallbackAddedConvert(ref p5);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p6 = default(Promise<TConvert>);
+                    p6 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return convertValue; }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p6);
+                    onCallbackAddedConvert(ref p6);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p7 = default(Promise<TConvert>);
+                    p7 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return convertValue; }, () => { onUnknownRejection(); return promiseToPromiseConvert(p7); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p7, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p7);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p8 = default(Promise<TConvert>);
+                    p8 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return convertValue; }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p8); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p8, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p8);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p9 = default(Promise);
-                p9 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromise(p9); }, () => { onUnknownRejection(); return promiseToPromise(p9); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p9, AdoptLocation.Both);
-                onCallbackAdded(ref p9);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p10 = default(Promise);
-                p10 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromise(p10); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p10); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p10, AdoptLocation.Both);
-                onCallbackAdded(ref p10);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p11 = default(Promise);
-                p11 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromise(p11); }, () => { onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p11, AdoptLocation.Resolve);
-                onCallbackAdded(ref p11);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p12 = default(Promise);
-                p12 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromise(p12); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p12, AdoptLocation.Resolve);
-                onCallbackAdded(ref p12);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p9 = default(Promise);
+                    p9 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromise(p9); }, () => { onUnknownRejection(); return promiseToPromise(p9); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p9, AdoptLocation.Both);
+                    onCallbackAdded(ref p9);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p10 = default(Promise);
+                    p10 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromise(p10); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p10); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p10, AdoptLocation.Both);
+                    onCallbackAdded(ref p10);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p11 = default(Promise);
+                    p11 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromise(p11); }, () => { onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p11, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p11);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p12 = default(Promise);
+                    p12 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromise(p12); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p12, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p12);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p13 = default(Promise<TConvert>);
-                p13 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromiseConvert(p13); }, () => { onUnknownRejection(); return promiseToPromiseConvert(p13); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p13, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p13);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p14 = default(Promise<TConvert>);
-                p14 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromiseConvert(p14); }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p14); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p14, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p14);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p15 = default(Promise<TConvert>);
-                p15 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromiseConvert(p15); }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p15, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p15);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p16 = default(Promise<TConvert>);
-                p16 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromiseConvert(p16); }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p16, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p16);
-            }
-
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p17 = default(Promise);
-                p17 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch(() => { onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAddedCatch(ref p17);
-                onCallbackAdded(ref p17);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p18 = default(Promise);
-                p18 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch((TReject failValue) => { onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAddedCatch(ref p18);
-                onCallbackAdded(ref p18);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p19 = default(Promise);
-                p19 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch(() => { onUnknownRejection(); return promiseToPromise(p19); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAddedCatch(ref p19);
-                onCallbackAdded(ref p19);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p20 = default(Promise);
-                p20 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch((TReject failValue) => { onReject(failValue); return promiseToPromise(p20); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAddedCatch(ref p20);
-                onCallbackAdded(ref p20);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p13 = default(Promise<TConvert>);
+                    p13 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromiseConvert(p13); }, () => { onUnknownRejection(); return promiseToPromiseConvert(p13); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p13, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p13);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p14 = default(Promise<TConvert>);
+                    p14 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromiseConvert(p14); }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p14); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p14, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p14);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p15 = default(Promise<TConvert>);
+                    p15 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromiseConvert(p15); }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p15, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p15);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p16 = default(Promise<TConvert>);
+                    p16 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromiseConvert(p16); }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p16, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p16);
+                }
 
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p21 = default(Promise);
-                p21 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p21);
-                onCallbackAdded(ref p21);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p22 = default(Promise);
-                p22 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p22);
-                onCallbackAdded(ref p22);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p23 = default(Promise);
-                p23 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p23); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p23, AdoptLocation.Reject);
-                onCallbackAdded(ref p23);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p24 = default(Promise);
-                p24 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p24); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p24, AdoptLocation.Reject);
-                onCallbackAdded(ref p24);
-            }
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p25 = default(Promise<TConvert>);
-                p25 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p25);
-                onCallbackAddedConvert(ref p25);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p26 = default(Promise<TConvert>);
-                p26 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p26);
-                onCallbackAddedConvert(ref p26);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p27 = default(Promise<TConvert>);
-                p27 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p27); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p27, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p27);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p28 = default(Promise<TConvert>);
-                p28 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p28); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p28, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p28);
-            }
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p29 = default(Promise);
-                p29 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p29); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p29); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p29, AdoptLocation.Both);
-                onCallbackAdded(ref p29);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p30 = default(Promise);
-                p30 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p30); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p30); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p30, AdoptLocation.Both);
-                onCallbackAdded(ref p30);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p31 = default(Promise);
-                p31 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p31); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p31, AdoptLocation.Resolve);
-                onCallbackAdded(ref p31);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p32 = default(Promise);
-                p32 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p32); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p32, AdoptLocation.Resolve);
-                onCallbackAdded(ref p32);
-            }
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p33 = default(Promise<TConvert>);
-                p33 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p33); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p33); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p33, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p33);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p34 = default(Promise<TConvert>);
-                p34 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p34); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p34); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p34, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p34);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p35 = default(Promise<TConvert>);
-                p35 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p35); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p35, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p35);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p36 = default(Promise<TConvert>);
-                p36 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p36); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p36, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p36);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p17 = default(Promise);
+                    p17 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch(() => { onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAddedCatch(ref p17);
+                    onCallbackAdded(ref p17);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p18 = default(Promise);
+                    p18 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch((TReject failValue) => { onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAddedCatch(ref p18);
+                    onCallbackAdded(ref p18);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p19 = default(Promise);
+                    p19 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch(() => { onUnknownRejection(); return promiseToPromise(p19); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAddedCatch(ref p19);
+                    onCallbackAdded(ref p19);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p20 = default(Promise);
+                    p20 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch((TReject failValue) => { onReject(failValue); return promiseToPromise(p20); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAddedCatch(ref p20);
+                    onCallbackAdded(ref p20);
+                }
 
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p37 = default(Promise);
-                p37 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch(captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAddedCatch(ref p37);
-                onCallbackAdded(ref p37);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p38 = default(Promise);
-                p38 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch(captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAddedCatch(ref p38);
-                onCallbackAdded(ref p38);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p39 = default(Promise);
-                p39 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch(captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p39); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAddedCatch(ref p39);
-                onCallbackAdded(ref p39);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p40 = default(Promise);
-                p40 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch(captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p40); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAddedCatch(ref p40);
-                onCallbackAdded(ref p40);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p21 = default(Promise);
+                    p21 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p21);
+                    onCallbackAdded(ref p21);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p22 = default(Promise);
+                    p22 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p22);
+                    onCallbackAdded(ref p22);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p23 = default(Promise);
+                    p23 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p23); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p23, AdoptLocation.Reject);
+                    onCallbackAdded(ref p23);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p24 = default(Promise);
+                    p24 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p24); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p24, AdoptLocation.Reject);
+                    onCallbackAdded(ref p24);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p25 = default(Promise<TConvert>);
+                    p25 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p25);
+                    onCallbackAddedConvert(ref p25);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p26 = default(Promise<TConvert>);
+                    p26 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p26);
+                    onCallbackAddedConvert(ref p26);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p27 = default(Promise<TConvert>);
+                    p27 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p27); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p27, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p27);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p28 = default(Promise<TConvert>);
+                    p28 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p28); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p28, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p28);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p29 = default(Promise);
+                    p29 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p29); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p29); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p29, AdoptLocation.Both);
+                    onCallbackAdded(ref p29);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p30 = default(Promise);
+                    p30 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p30); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p30); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p30, AdoptLocation.Both);
+                    onCallbackAdded(ref p30);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p31 = default(Promise);
+                    p31 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p31); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p31, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p31);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p32 = default(Promise);
+                    p32 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p32); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p32, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p32);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p33 = default(Promise<TConvert>);
+                    p33 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p33); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p33); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p33, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p33);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p34 = default(Promise<TConvert>);
+                    p34 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p34); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p34); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p34, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p34);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p35 = default(Promise<TConvert>);
+                    p35 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p35); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p35, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p35);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p36 = default(Promise<TConvert>);
+                    p36 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p36); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p36, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p36);
+                }
 
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p41 = default(Promise);
-                p41 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, () => { onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p41);
-                onCallbackAdded(ref p41);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p42 = default(Promise);
-                p42 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p42);
-                onCallbackAdded(ref p42);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p43 = default(Promise);
-                p43 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, () => { onUnknownRejection(); return promiseToPromise(p43); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p43, AdoptLocation.Reject);
-                onCallbackAdded(ref p43);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p44 = default(Promise);
-                p44 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p44); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p44, AdoptLocation.Reject);
-                onCallbackAdded(ref p44);
-            }
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p45 = default(Promise<TConvert>);
-                p45 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p45);
-                onCallbackAddedConvert(ref p45);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p46 = default(Promise<TConvert>);
-                p46 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p46);
-                onCallbackAddedConvert(ref p46);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p47 = default(Promise<TConvert>);
-                p47 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, () => { onUnknownRejection(); return promiseToPromiseConvert(p47); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p47, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p47);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p48 = default(Promise<TConvert>);
-                p48 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p48); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p48, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p48);
-            }
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p49 = default(Promise);
-                p49 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p49); }, () => { onUnknownRejection(); return promiseToPromise(p49); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p49, AdoptLocation.Both);
-                onCallbackAdded(ref p49);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p50 = default(Promise);
-                p50 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p50); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p50); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p50, AdoptLocation.Both);
-                onCallbackAdded(ref p50);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p51 = default(Promise);
-                p51 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p51); }, () => { onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p51, AdoptLocation.Resolve);
-                onCallbackAdded(ref p51);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p52 = default(Promise);
-                p52 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p52); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p52, AdoptLocation.Resolve);
-                onCallbackAdded(ref p52);
-            }
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p53 = default(Promise<TConvert>);
-                p53 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p53); }, () => { onUnknownRejection(); return promiseToPromiseConvert(p53); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p53, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p53);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p54 = default(Promise<TConvert>);
-                p54 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p54); }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p54); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p54, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p54);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p55 = default(Promise<TConvert>);
-                p55 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p55); }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p55, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p55);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p56 = default(Promise<TConvert>);
-                p56 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p56); }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p56, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p56);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p37 = default(Promise);
+                    p37 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch(captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAddedCatch(ref p37);
+                    onCallbackAdded(ref p37);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p38 = default(Promise);
+                    p38 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch(captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAddedCatch(ref p38);
+                    onCallbackAdded(ref p38);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p39 = default(Promise);
+                    p39 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch(captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p39); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAddedCatch(ref p39);
+                    onCallbackAdded(ref p39);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p40 = default(Promise);
+                    p40 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch(captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p40); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAddedCatch(ref p40);
+                    onCallbackAdded(ref p40);
+                }
 
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p57 = default(Promise);
-                p57 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p57);
-                onCallbackAdded(ref p57);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p58 = default(Promise);
-                p58 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p58);
-                onCallbackAdded(ref p58);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p59 = default(Promise);
-                p59 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p59); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p59, AdoptLocation.Reject);
-                onCallbackAdded(ref p59);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p60 = default(Promise);
-                p60 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p60); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p60, AdoptLocation.Reject);
-                onCallbackAdded(ref p60);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p41 = default(Promise);
+                    p41 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, () => { onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p41);
+                    onCallbackAdded(ref p41);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p42 = default(Promise);
+                    p42 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p42);
+                    onCallbackAdded(ref p42);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p43 = default(Promise);
+                    p43 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, () => { onUnknownRejection(); return promiseToPromise(p43); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p43, AdoptLocation.Reject);
+                    onCallbackAdded(ref p43);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p44 = default(Promise);
+                    p44 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p44); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p44, AdoptLocation.Reject);
+                    onCallbackAdded(ref p44);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p61 = default(Promise<TConvert>);
-                p61 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p61);
-                onCallbackAddedConvert(ref p61);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p62 = default(Promise<TConvert>);
-                p62 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p62);
-                onCallbackAddedConvert(ref p62);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p63 = default(Promise<TConvert>);
-                p63 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p63); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p63, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p63);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p64 = default(Promise<TConvert>);
-                p64 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p64); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p64, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p64);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p45 = default(Promise<TConvert>);
+                    p45 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p45);
+                    onCallbackAddedConvert(ref p45);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p46 = default(Promise<TConvert>);
+                    p46 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p46);
+                    onCallbackAddedConvert(ref p46);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p47 = default(Promise<TConvert>);
+                    p47 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, () => { onUnknownRejection(); return promiseToPromiseConvert(p47); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p47, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p47);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p48 = default(Promise<TConvert>);
+                    p48 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return convertValue; }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p48); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p48, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p48);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p65 = default(Promise);
-                p65 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromise(p65); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p65); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p65, AdoptLocation.Both);
-                onCallbackAdded(ref p65);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p66 = default(Promise);
-                p66 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromise(p66); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p66); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p66, AdoptLocation.Both);
-                onCallbackAdded(ref p66);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p67 = default(Promise);
-                p67 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromise(p67); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p67, AdoptLocation.Resolve);
-                onCallbackAdded(ref p67);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p68 = default(Promise);
-                p68 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromise(p68); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p68, AdoptLocation.Resolve);
-                onCallbackAdded(ref p68);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p49 = default(Promise);
+                    p49 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p49); }, () => { onUnknownRejection(); return promiseToPromise(p49); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p49, AdoptLocation.Both);
+                    onCallbackAdded(ref p49);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p50 = default(Promise);
+                    p50 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p50); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p50); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p50, AdoptLocation.Both);
+                    onCallbackAdded(ref p50);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p51 = default(Promise);
+                    p51 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p51); }, () => { onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p51, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p51);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p52 = default(Promise);
+                    p52 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromise(p52); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p52, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p52);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p69 = default(Promise<TConvert>);
-                p69 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromiseConvert(p69); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p69); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p69, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p69);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p70 = default(Promise<TConvert>);
-                p70 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromiseConvert(p70); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p70); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p70, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p70);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p71 = default(Promise<TConvert>);
-                p71 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromiseConvert(p71); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p71, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p71);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p72 = default(Promise<TConvert>);
-                p72 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(() => { onResolve(); return promiseToPromiseConvert(p72); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p72, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p72);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p53 = default(Promise<TConvert>);
+                    p53 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p53); }, () => { onUnknownRejection(); return promiseToPromiseConvert(p53); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p53, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p53);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p54 = default(Promise<TConvert>);
+                    p54 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p54); }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p54); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p54, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p54);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p55 = default(Promise<TConvert>);
+                    p55 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p55); }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p55, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p55);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p56 = default(Promise<TConvert>);
+                    p56 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, cv => { onResolveCapture(cv); onResolve(); return promiseToPromiseConvert(p56); }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p56, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p56);
+                }
 
-            promise.Forget();
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p57 = default(Promise);
+                    p57 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p57);
+                    onCallbackAdded(ref p57);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p58 = default(Promise);
+                    p58 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p58);
+                    onCallbackAdded(ref p58);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p59 = default(Promise);
+                    p59 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p59); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p59, AdoptLocation.Reject);
+                    onCallbackAdded(ref p59);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p60 = default(Promise);
+                    p60 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p60); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p60, AdoptLocation.Reject);
+                    onCallbackAdded(ref p60);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p61 = default(Promise<TConvert>);
+                    p61 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p61);
+                    onCallbackAddedConvert(ref p61);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p62 = default(Promise<TConvert>);
+                    p62 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p62);
+                    onCallbackAddedConvert(ref p62);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p63 = default(Promise<TConvert>);
+                    p63 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p63); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p63, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p63);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p64 = default(Promise<TConvert>);
+                    p64 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p64); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p64, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p64);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p65 = default(Promise);
+                    p65 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromise(p65); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p65); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p65, AdoptLocation.Both);
+                    onCallbackAdded(ref p65);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p66 = default(Promise);
+                    p66 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromise(p66); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p66); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p66, AdoptLocation.Both);
+                    onCallbackAdded(ref p66);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p67 = default(Promise);
+                    p67 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromise(p67); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p67, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p67);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p68 = default(Promise);
+                    p68 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromise(p68); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p68, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p68);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p69 = default(Promise<TConvert>);
+                    p69 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromiseConvert(p69); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p69); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p69, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p69);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p70 = default(Promise<TConvert>);
+                    p70 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromiseConvert(p70); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p70); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p70, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p70);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p71 = default(Promise<TConvert>);
+                    p71 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromiseConvert(p71); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p71, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p71);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p72 = default(Promise<TConvert>);
+                    p72 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(() => { onResolve(); return promiseToPromiseConvert(p72); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p72, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p72);
+                }
+            }
         }
 
         public static void AddCallbacks<T, TConvert, TReject, TCapture>(Promise<T> promise,
@@ -1796,38 +1808,38 @@ namespace ProtoPromiseTests
             TestAction<Promise, AdoptLocation> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>, AdoptLocation> onAdoptCallbackAddedConvert = null, TestAction<Promise<T>> onAdoptCallbackAddedT = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            AddCallbacksWithCancelation(
-                promise,
-                onResolve, onReject, onUnknownRejection, convertValue, TValue,
-                onResolveCapture, onRejectCapture, onUnknownRejectionCapture, captureValue,
-                promiseToPromise, promiseToPromiseConvert, promiseToPromiseT,
-                onCallbackAdded, onCallbackAddedConvert, onCallbackAddedT,
-                default(CancelationToken), default(CancelationToken),
-                onCancel,
-                onDirectCallbackAdded, onDirectCallbackAddedConvert, onDirectCallbackAddedT,
-                onAdoptCallbackAdded, onAdoptCallbackAddedConvert, onAdoptCallbackAddedT,
-                configureAwaitType, configureAwaitForceAsync
-            );
+                AddCallbacksWithCancelation(
+                    retainer.WaitAsync(),
+                    onResolve, onReject, onUnknownRejection, convertValue, TValue,
+                    onResolveCapture, onRejectCapture, onUnknownRejectionCapture, captureValue,
+                    promiseToPromise, promiseToPromiseConvert, promiseToPromiseT,
+                    onCallbackAdded, onCallbackAddedConvert, onCallbackAddedT,
+                    default(CancelationToken), default(CancelationToken),
+                    onCancel,
+                    onDirectCallbackAdded, onDirectCallbackAddedConvert, onDirectCallbackAddedT,
+                    onAdoptCallbackAdded, onAdoptCallbackAddedConvert, onAdoptCallbackAddedT,
+                    configureAwaitType, configureAwaitForceAsync
+                );
 
-            CancelationSource cancelationSource = CancelationSource.New();
-            AddCallbacksWithCancelation(
-                promise,
-                onResolve, onReject, onUnknownRejection, convertValue, TValue,
-                onResolveCapture, onRejectCapture, onUnknownRejectionCapture, captureValue,
-                promiseToPromise, promiseToPromiseConvert, promiseToPromiseT,
-                onCallbackAdded, onCallbackAddedConvert, onCallbackAddedT,
-                cancelationSource.Token, cancelationSource.Token,
-                onCancel,
-                onDirectCallbackAdded, onDirectCallbackAddedConvert, onDirectCallbackAddedT,
-                onAdoptCallbackAdded, onAdoptCallbackAddedConvert, onAdoptCallbackAddedT,
-                configureAwaitType, configureAwaitForceAsync
-            );
-            cancelationSource.Dispose();
-
-            promise.Forget();
+                CancelationSource cancelationSource = CancelationSource.New();
+                AddCallbacksWithCancelation(
+                    retainer.WaitAsync(),
+                    onResolve, onReject, onUnknownRejection, convertValue, TValue,
+                    onResolveCapture, onRejectCapture, onUnknownRejectionCapture, captureValue,
+                    promiseToPromise, promiseToPromiseConvert, promiseToPromiseT,
+                    onCallbackAdded, onCallbackAddedConvert, onCallbackAddedT,
+                    cancelationSource.Token, cancelationSource.Token,
+                    onCancel,
+                    onDirectCallbackAdded, onDirectCallbackAddedConvert, onDirectCallbackAddedT,
+                    onAdoptCallbackAdded, onAdoptCallbackAddedConvert, onAdoptCallbackAddedT,
+                    configureAwaitType, configureAwaitForceAsync
+                );
+                cancelationSource.Dispose();
+            }
         }
 
         public static void AddCallbacksWithCancelation<T, TConvert, TReject, TCapture>(Promise<T> promise,
@@ -1841,739 +1853,739 @@ namespace ProtoPromiseTests
             TestAction<Promise, AdoptLocation> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>, AdoptLocation> onAdoptCallbackAddedConvert = null, TestAction<Promise<T>> onAdoptCallbackAddedT = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            // Add empty delegates so no need for null check.
-            onResolve += x => { };
-            onReject += s => { };
-            onUnknownRejection += () => { };
-            onResolveCapture += _ => { };
-            onRejectCapture += _ => { };
-            onUnknownRejectionCapture += _ => { };
-            if (promiseToPromiseT == null)
-            {
-                promiseToPromiseT = _ => Promise.Resolved(TValue);
-            }
-            if (promiseToPromise == null)
-            {
-                promiseToPromise = _ => Promise.Resolved();
-            }
-            if (promiseToPromiseConvert == null)
-            {
-                promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
-            }
-            if (onCallbackAdded == null)
-            {
-                onCallbackAdded = (ref Promise p) => p.Forget();
-            }
-            if (onCallbackAddedConvert == null)
-            {
-                onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
-            }
-            if (onCallbackAddedT == null)
-            {
-                onCallbackAddedT = (ref Promise<T> p) => p.Forget();
-            }
-            if (onDirectCallbackAdded == null)
-            {
-                onDirectCallbackAdded = (ref Promise p) => { };
-            }
-            if (onDirectCallbackAddedConvert == null)
-            {
-                onDirectCallbackAddedConvert = (ref Promise<TConvert> p) => { };
-            }
-            if (onDirectCallbackAddedT == null)
-            {
-                onDirectCallbackAddedT = (ref Promise<T> p) => { };
-            }
-            if (onAdoptCallbackAdded == null)
-            {
-                onAdoptCallbackAdded = (ref Promise p, AdoptLocation _) => { };
-            }
-            if (onAdoptCallbackAddedConvert == null)
-            {
-                onAdoptCallbackAddedConvert = (ref Promise<TConvert> p, AdoptLocation _) => { };
-            }
-            if (onAdoptCallbackAddedT == null)
-            {
-                onAdoptCallbackAddedT = (ref Promise<T> p) => { };
-            }
-            onCancel += () => { };
+                // Add empty delegates so no need for null check.
+                onResolve += x => { };
+                onReject += s => { };
+                onUnknownRejection += () => { };
+                onResolveCapture += _ => { };
+                onRejectCapture += _ => { };
+                onUnknownRejectionCapture += _ => { };
+                if (promiseToPromiseT == null)
+                {
+                    promiseToPromiseT = _ => Promise.Resolved(TValue);
+                }
+                if (promiseToPromise == null)
+                {
+                    promiseToPromise = _ => Promise.Resolved();
+                }
+                if (promiseToPromiseConvert == null)
+                {
+                    promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
+                }
+                if (onCallbackAdded == null)
+                {
+                    onCallbackAdded = (ref Promise p) => p.Forget();
+                }
+                if (onCallbackAddedConvert == null)
+                {
+                    onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
+                }
+                if (onCallbackAddedT == null)
+                {
+                    onCallbackAddedT = (ref Promise<T> p) => p.Forget();
+                }
+                if (onDirectCallbackAdded == null)
+                {
+                    onDirectCallbackAdded = (ref Promise p) => { };
+                }
+                if (onDirectCallbackAddedConvert == null)
+                {
+                    onDirectCallbackAddedConvert = (ref Promise<TConvert> p) => { };
+                }
+                if (onDirectCallbackAddedT == null)
+                {
+                    onDirectCallbackAddedT = (ref Promise<T> p) => { };
+                }
+                if (onAdoptCallbackAdded == null)
+                {
+                    onAdoptCallbackAdded = (ref Promise p, AdoptLocation _) => { };
+                }
+                if (onAdoptCallbackAddedConvert == null)
+                {
+                    onAdoptCallbackAddedConvert = (ref Promise<TConvert> p, AdoptLocation _) => { };
+                }
+                if (onAdoptCallbackAddedT == null)
+                {
+                    onAdoptCallbackAddedT = (ref Promise<T> p) => { };
+                }
+                onCancel += () => { };
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p1 = default(Promise);
-                p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); }, () => { onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p1);
-                onCallbackAdded(ref p1);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p2 = default(Promise);
-                p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p2);
-                onCallbackAdded(ref p2);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p3 = default(Promise);
-                p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); }, () => { onUnknownRejection(); return promiseToPromise(p3); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p3, AdoptLocation.Reject);
-                onCallbackAdded(ref p3);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p4 = default(Promise);
-                p4 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p4); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p4, AdoptLocation.Reject);
-                onCallbackAdded(ref p4);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p1 = default(Promise);
+                    p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); }, () => { onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p1);
+                    onCallbackAdded(ref p1);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p2 = default(Promise);
+                    p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p2);
+                    onCallbackAdded(ref p2);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p3 = default(Promise);
+                    p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); }, () => { onUnknownRejection(); return promiseToPromise(p3); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p3, AdoptLocation.Reject);
+                    onCallbackAdded(ref p3);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p4 = default(Promise);
+                    p4 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p4); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p4, AdoptLocation.Reject);
+                    onCallbackAdded(ref p4);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p5 = default(Promise<TConvert>);
-                p5 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return convertValue; }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p5);
-                onCallbackAddedConvert(ref p5);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p6 = default(Promise<TConvert>);
-                p6 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return convertValue; }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p6);
-                onCallbackAddedConvert(ref p6);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p7 = default(Promise<TConvert>);
-                p7 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return convertValue; }, () => { onUnknownRejection(); return promiseToPromiseConvert(p7); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p7, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p7);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p8 = default(Promise<TConvert>);
-                p8 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return convertValue; }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p8); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p8, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p8);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p5 = default(Promise<TConvert>);
+                    p5 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return convertValue; }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p5);
+                    onCallbackAddedConvert(ref p5);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p6 = default(Promise<TConvert>);
+                    p6 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return convertValue; }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p6);
+                    onCallbackAddedConvert(ref p6);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p7 = default(Promise<TConvert>);
+                    p7 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return convertValue; }, () => { onUnknownRejection(); return promiseToPromiseConvert(p7); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p7, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p7);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p8 = default(Promise<TConvert>);
+                    p8 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return convertValue; }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p8); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p8, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p8);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p9 = default(Promise);
-                p9 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromise(p9); }, () => { onUnknownRejection(); return promiseToPromise(p9); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p9, AdoptLocation.Both);
-                onCallbackAdded(ref p9);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p10 = default(Promise);
-                p10 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromise(p10); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p10); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p10, AdoptLocation.Both);
-                onCallbackAdded(ref p10);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p11 = default(Promise);
-                p11 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromise(p11); }, () => { onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p11, AdoptLocation.Resolve);
-                onCallbackAdded(ref p11);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p12 = default(Promise);
-                p12 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromise(p12); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p12, AdoptLocation.Resolve);
-                onCallbackAdded(ref p12);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p9 = default(Promise);
+                    p9 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromise(p9); }, () => { onUnknownRejection(); return promiseToPromise(p9); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p9, AdoptLocation.Both);
+                    onCallbackAdded(ref p9);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p10 = default(Promise);
+                    p10 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromise(p10); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p10); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p10, AdoptLocation.Both);
+                    onCallbackAdded(ref p10);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p11 = default(Promise);
+                    p11 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromise(p11); }, () => { onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p11, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p11);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p12 = default(Promise);
+                    p12 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromise(p12); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p12, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p12);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p13 = default(Promise<TConvert>);
-                p13 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromiseConvert(p13); }, () => { onUnknownRejection(); return promiseToPromiseConvert(p13); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p13, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p13);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p14 = default(Promise<TConvert>);
-                p14 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromiseConvert(p14); }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p14); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p14, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p14);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p15 = default(Promise<TConvert>);
-                p15 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromiseConvert(p15); }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p15, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p15);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p16 = default(Promise<TConvert>);
-                p16 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromiseConvert(p16); }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p16, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p16);
-            }
-
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<T> p17 = default(Promise<T>);
-                p17 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch(() => { onUnknownRejection(); return TValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return TValue; });
-                onDirectCallbackAddedT(ref p17);
-                onCallbackAddedT(ref p17);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<T> p18 = default(Promise<T>);
-                p18 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch((TReject failValue) => { onReject(failValue); return TValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return TValue; });
-                onDirectCallbackAddedT(ref p18);
-                onCallbackAddedT(ref p18);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<T> p19 = default(Promise<T>);
-                p19 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch(() => { onUnknownRejection(); return promiseToPromiseT(p19); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return TValue; });
-                onAdoptCallbackAddedT(ref p19);
-                onCallbackAddedT(ref p19);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<T> p20 = default(Promise<T>);
-                p20 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch((TReject failValue) => { onReject(failValue); return promiseToPromiseT(p20); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return TValue; });
-                onAdoptCallbackAddedT(ref p20);
-                onCallbackAddedT(ref p20);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p13 = default(Promise<TConvert>);
+                    p13 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromiseConvert(p13); }, () => { onUnknownRejection(); return promiseToPromiseConvert(p13); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p13, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p13);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p14 = default(Promise<TConvert>);
+                    p14 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromiseConvert(p14); }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p14); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p14, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p14);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p15 = default(Promise<TConvert>);
+                    p15 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromiseConvert(p15); }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p15, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p15);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p16 = default(Promise<TConvert>);
+                    p16 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromiseConvert(p16); }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p16, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p16);
+                }
 
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p21 = default(Promise);
-                p21 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p21);
-                onCallbackAdded(ref p21);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p22 = default(Promise);
-                p22 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p22);
-                onCallbackAdded(ref p22);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p23 = default(Promise);
-                p23 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p23); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p23, AdoptLocation.Reject);
-                onCallbackAdded(ref p23);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p24 = default(Promise);
-                p24 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p24); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p24, AdoptLocation.Reject);
-                onCallbackAdded(ref p24);
-            }
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p25 = default(Promise<TConvert>);
-                p25 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p25);
-                onCallbackAddedConvert(ref p25);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p26 = default(Promise<TConvert>);
-                p26 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p26);
-                onCallbackAddedConvert(ref p26);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p27 = default(Promise<TConvert>);
-                p27 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p27); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p27, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p27);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p28 = default(Promise<TConvert>);
-                p28 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p28); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p28, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p28);
-            }
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p29 = default(Promise);
-                p29 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p29); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p29); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p29, AdoptLocation.Both);
-                onCallbackAdded(ref p29);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p30 = default(Promise);
-                p30 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p30); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p30); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p30, AdoptLocation.Both);
-                onCallbackAdded(ref p30);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p31 = default(Promise);
-                p31 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p31); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p31, AdoptLocation.Resolve);
-                onCallbackAdded(ref p31);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p32 = default(Promise);
-                p32 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p32); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p32, AdoptLocation.Resolve);
-                onCallbackAdded(ref p32);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<T> p17 = default(Promise<T>);
+                    p17 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch(() => { onUnknownRejection(); return TValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return TValue; });
+                    onDirectCallbackAddedT(ref p17);
+                    onCallbackAddedT(ref p17);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<T> p18 = default(Promise<T>);
+                    p18 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch((TReject failValue) => { onReject(failValue); return TValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return TValue; });
+                    onDirectCallbackAddedT(ref p18);
+                    onCallbackAddedT(ref p18);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<T> p19 = default(Promise<T>);
+                    p19 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch(() => { onUnknownRejection(); return promiseToPromiseT(p19); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return TValue; });
+                    onAdoptCallbackAddedT(ref p19);
+                    onCallbackAddedT(ref p19);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<T> p20 = default(Promise<T>);
+                    p20 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch((TReject failValue) => { onReject(failValue); return promiseToPromiseT(p20); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return TValue; });
+                    onAdoptCallbackAddedT(ref p20);
+                    onCallbackAddedT(ref p20);
+                }
 
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p33 = default(Promise<TConvert>);
-                p33 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p33); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p33); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p33, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p33);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p34 = default(Promise<TConvert>);
-                p34 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p34); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p34); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p34, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p34);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p35 = default(Promise<TConvert>);
-                p35 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p35); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p35, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p35);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p36 = default(Promise<TConvert>);
-                p36 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p36); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p36, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p36);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p21 = default(Promise);
+                    p21 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p21);
+                    onCallbackAdded(ref p21);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p22 = default(Promise);
+                    p22 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p22);
+                    onCallbackAdded(ref p22);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p23 = default(Promise);
+                    p23 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p23); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p23, AdoptLocation.Reject);
+                    onCallbackAdded(ref p23);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p24 = default(Promise);
+                    p24 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p24); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p24, AdoptLocation.Reject);
+                    onCallbackAdded(ref p24);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p25 = default(Promise<TConvert>);
+                    p25 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p25);
+                    onCallbackAddedConvert(ref p25);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p26 = default(Promise<TConvert>);
+                    p26 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p26);
+                    onCallbackAddedConvert(ref p26);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p27 = default(Promise<TConvert>);
+                    p27 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p27); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p27, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p27);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p28 = default(Promise<TConvert>);
+                    p28 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p28); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p28, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p28);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p29 = default(Promise);
+                    p29 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p29); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p29); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p29, AdoptLocation.Both);
+                    onCallbackAdded(ref p29);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p30 = default(Promise);
+                    p30 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p30); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p30); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p30, AdoptLocation.Both);
+                    onCallbackAdded(ref p30);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p31 = default(Promise);
+                    p31 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p31); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p31, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p31);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p32 = default(Promise);
+                    p32 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p32); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p32, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p32);
+                }
 
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<T> p37 = default(Promise<T>);
-                p37 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch(captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return TValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return TValue; });
-                onDirectCallbackAddedT(ref p37);
-                onCallbackAddedT(ref p37);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<T> p38 = default(Promise<T>);
-                p38 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch(captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return TValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return TValue; });
-                onDirectCallbackAddedT(ref p38);
-                onCallbackAddedT(ref p38);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<T> p39 = default(Promise<T>);
-                p39 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch(captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseT(p39); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return TValue; });
-                onAdoptCallbackAddedT(ref p39);
-                onCallbackAddedT(ref p39);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<T> p40 = default(Promise<T>);
-                p40 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Catch(captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseT(p40); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return TValue; });
-                onAdoptCallbackAddedT(ref p40);
-                onCallbackAddedT(ref p40);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p33 = default(Promise<TConvert>);
+                    p33 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p33); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p33); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p33, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p33);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p34 = default(Promise<TConvert>);
+                    p34 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p34); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p34); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p34, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p34);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p35 = default(Promise<TConvert>);
+                    p35 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p35); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p35, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p35);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p36 = default(Promise<TConvert>);
+                    p36 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p36); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p36, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p36);
+                }
 
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p41 = default(Promise);
-                p41 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, () => { onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p41);
-                onCallbackAdded(ref p41);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p42 = default(Promise);
-                p42 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p42);
-                onCallbackAdded(ref p42);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p43 = default(Promise);
-                p43 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, () => { onUnknownRejection(); return promiseToPromise(p43); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p43, AdoptLocation.Reject);
-                onCallbackAdded(ref p43);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p44 = default(Promise);
-                p44 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p44); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p44, AdoptLocation.Reject);
-                onCallbackAdded(ref p44);
-            }
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p45 = default(Promise<TConvert>);
-                p45 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p45);
-                onCallbackAddedConvert(ref p45);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p46 = default(Promise<TConvert>);
-                p46 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p46);
-                onCallbackAddedConvert(ref p46);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p47 = default(Promise<TConvert>);
-                p47 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, () => { onUnknownRejection(); return promiseToPromiseConvert(p47); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p47, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p47);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p48 = default(Promise<TConvert>);
-                p48 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p48); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p48, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p48);
-            }
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p49 = default(Promise);
-                p49 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p49); }, () => { onUnknownRejection(); return promiseToPromise(p49); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p49, AdoptLocation.Both);
-                onCallbackAdded(ref p49);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p50 = default(Promise);
-                p50 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p50); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p50); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p50, AdoptLocation.Both);
-                onCallbackAdded(ref p50);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p51 = default(Promise);
-                p51 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p51); }, () => { onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p51, AdoptLocation.Resolve);
-                onCallbackAdded(ref p51);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p52 = default(Promise);
-                p52 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p52); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p52, AdoptLocation.Resolve);
-                onCallbackAdded(ref p52);
-            }
-
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p53 = default(Promise<TConvert>);
-                p53 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p53); }, () => { onUnknownRejection(); return promiseToPromiseConvert(p53); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p53, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p53);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p54 = default(Promise<TConvert>);
-                p54 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p54); }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p54); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p54, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p54);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p55 = default(Promise<TConvert>);
-                p55 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p55); }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p55, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p55);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p56 = default(Promise<TConvert>);
-                p56 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p56); }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p56, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p56);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<T> p37 = default(Promise<T>);
+                    p37 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch(captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return TValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return TValue; });
+                    onDirectCallbackAddedT(ref p37);
+                    onCallbackAddedT(ref p37);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<T> p38 = default(Promise<T>);
+                    p38 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch(captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return TValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return TValue; });
+                    onDirectCallbackAddedT(ref p38);
+                    onCallbackAddedT(ref p38);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<T> p39 = default(Promise<T>);
+                    p39 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch(captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseT(p39); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return TValue; });
+                    onAdoptCallbackAddedT(ref p39);
+                    onCallbackAddedT(ref p39);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<T> p40 = default(Promise<T>);
+                    p40 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Catch(captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseT(p40); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return TValue; });
+                    onAdoptCallbackAddedT(ref p40);
+                    onCallbackAddedT(ref p40);
+                }
 
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p57 = default(Promise);
-                p57 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p57);
-                onCallbackAdded(ref p57);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p58 = default(Promise);
-                p58 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onDirectCallbackAdded(ref p58);
-                onCallbackAdded(ref p58);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p59 = default(Promise);
-                p59 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p59); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p59, AdoptLocation.Reject);
-                onCallbackAdded(ref p59);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p60 = default(Promise);
-                p60 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p60); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p60, AdoptLocation.Reject);
-                onCallbackAdded(ref p60);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p41 = default(Promise);
+                    p41 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, () => { onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p41);
+                    onCallbackAdded(ref p41);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p42 = default(Promise);
+                    p42 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p42);
+                    onCallbackAdded(ref p42);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p43 = default(Promise);
+                    p43 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, () => { onUnknownRejection(); return promiseToPromise(p43); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p43, AdoptLocation.Reject);
+                    onCallbackAdded(ref p43);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p44 = default(Promise);
+                    p44 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p44); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p44, AdoptLocation.Reject);
+                    onCallbackAdded(ref p44);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p61 = default(Promise<TConvert>);
-                p61 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p61);
-                onCallbackAddedConvert(ref p61);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p62 = default(Promise<TConvert>);
-                p62 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onDirectCallbackAddedConvert(ref p62);
-                onCallbackAddedConvert(ref p62);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p63 = default(Promise<TConvert>);
-                p63 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p63); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p63, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p63);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p64 = default(Promise<TConvert>);
-                p64 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p64); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p64, AdoptLocation.Reject);
-                onCallbackAddedConvert(ref p64);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p45 = default(Promise<TConvert>);
+                    p45 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p45);
+                    onCallbackAddedConvert(ref p45);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p46 = default(Promise<TConvert>);
+                    p46 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p46);
+                    onCallbackAddedConvert(ref p46);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p47 = default(Promise<TConvert>);
+                    p47 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, () => { onUnknownRejection(); return promiseToPromiseConvert(p47); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p47, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p47);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p48 = default(Promise<TConvert>);
+                    p48 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return convertValue; }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p48); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p48, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p48);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p65 = default(Promise);
-                p65 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromise(p65); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p65); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p65, AdoptLocation.Both);
-                onCallbackAdded(ref p65);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p66 = default(Promise);
-                p66 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromise(p66); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p66); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p66, AdoptLocation.Both);
-                onCallbackAdded(ref p66);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p67 = default(Promise);
-                p67 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromise(p67); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p67, AdoptLocation.Resolve);
-                onCallbackAdded(ref p67);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p68 = default(Promise);
-                p68 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromise(p68); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p68, AdoptLocation.Resolve);
-                onCallbackAdded(ref p68);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p49 = default(Promise);
+                    p49 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p49); }, () => { onUnknownRejection(); return promiseToPromise(p49); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p49, AdoptLocation.Both);
+                    onCallbackAdded(ref p49);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p50 = default(Promise);
+                    p50 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p50); }, (TReject failValue) => { onReject(failValue); return promiseToPromise(p50); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p50, AdoptLocation.Both);
+                    onCallbackAdded(ref p50);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p51 = default(Promise);
+                    p51 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p51); }, () => { onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p51, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p51);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p52 = default(Promise);
+                    p52 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromise(p52); }, (TReject failValue) => { onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p52, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p52);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p69 = default(Promise<TConvert>);
-                p69 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromiseConvert(p69); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p69); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p69, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p69);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p70 = default(Promise<TConvert>);
-                p70 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromiseConvert(p70); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p70); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p70, AdoptLocation.Both);
-                onCallbackAddedConvert(ref p70);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p71 = default(Promise<TConvert>);
-                p71 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromiseConvert(p71); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p71, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p71);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p72 = default(Promise<TConvert>);
-                p72 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .Then(x => { onResolve(x); return promiseToPromiseConvert(p72); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p72, AdoptLocation.Resolve);
-                onCallbackAddedConvert(ref p72);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p53 = default(Promise<TConvert>);
+                    p53 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p53); }, () => { onUnknownRejection(); return promiseToPromiseConvert(p53); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p53, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p53);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p54 = default(Promise<TConvert>);
+                    p54 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p54); }, (TReject failValue) => { onReject(failValue); return promiseToPromiseConvert(p54); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p54, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p54);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p55 = default(Promise<TConvert>);
+                    p55 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p55); }, () => { onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p55, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p55);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p56 = default(Promise<TConvert>);
+                    p56 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(captureValue, (cv, x) => { onResolveCapture(cv); onResolve(x); return promiseToPromiseConvert(p56); }, (TReject failValue) => { onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p56, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p56);
+                }
 
-            promise.Forget();
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p57 = default(Promise);
+                    p57 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p57);
+                    onCallbackAdded(ref p57);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p58 = default(Promise);
+                    p58 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onDirectCallbackAdded(ref p58);
+                    onCallbackAdded(ref p58);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p59 = default(Promise);
+                    p59 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p59); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p59, AdoptLocation.Reject);
+                    onCallbackAdded(ref p59);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p60 = default(Promise);
+                    p60 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p60); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p60, AdoptLocation.Reject);
+                    onCallbackAdded(ref p60);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p61 = default(Promise<TConvert>);
+                    p61 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p61);
+                    onCallbackAddedConvert(ref p61);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p62 = default(Promise<TConvert>);
+                    p62 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onDirectCallbackAddedConvert(ref p62);
+                    onCallbackAddedConvert(ref p62);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p63 = default(Promise<TConvert>);
+                    p63 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return convertValue; }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p63); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p63, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p63);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p64 = default(Promise<TConvert>);
+                    p64 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return convertValue; }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p64); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p64, AdoptLocation.Reject);
+                    onCallbackAddedConvert(ref p64);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p65 = default(Promise);
+                    p65 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromise(p65); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromise(p65); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p65, AdoptLocation.Both);
+                    onCallbackAdded(ref p65);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p66 = default(Promise);
+                    p66 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromise(p66); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromise(p66); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p66, AdoptLocation.Both);
+                    onCallbackAdded(ref p66);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p67 = default(Promise);
+                    p67 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromise(p67); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p67, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p67);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p68 = default(Promise);
+                    p68 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromise(p68); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p68, AdoptLocation.Resolve);
+                    onCallbackAdded(ref p68);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p69 = default(Promise<TConvert>);
+                    p69 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromiseConvert(p69); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return promiseToPromiseConvert(p69); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p69, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p69);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p70 = default(Promise<TConvert>);
+                    p70 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromiseConvert(p70); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return promiseToPromiseConvert(p70); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p70, AdoptLocation.Both);
+                    onCallbackAddedConvert(ref p70);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p71 = default(Promise<TConvert>);
+                    p71 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromiseConvert(p71); }, captureValue, cv => { onUnknownRejectionCapture(cv); onUnknownRejection(); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p71, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p71);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p72 = default(Promise<TConvert>);
+                    p72 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .Then(x => { onResolve(x); return promiseToPromiseConvert(p72); }, captureValue, (TCapture cv, TReject failValue) => { onRejectCapture(cv); onReject(failValue); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p72, AdoptLocation.Resolve);
+                    onCallbackAddedConvert(ref p72);
+                }
+            }
         }
 
         public static void AddContinueCallbacks<TConvert, TCapture>(Promise promise,
@@ -2585,11 +2597,12 @@ namespace ProtoPromiseTests
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            AddContinueCallbacksWithCancelation(
-                promise,
+                AddContinueCallbacksWithCancelation(
+                retainer.WaitAsync(),
                 onContinue, convertValue,
                 onContinueCapture, captureValue,
                 promiseToPromise, promiseToPromiseConvert,
@@ -2600,21 +2613,20 @@ namespace ProtoPromiseTests
                 configureAwaitType, configureAwaitForceAsync
             );
 
-            CancelationSource cancelationSource = CancelationSource.New();
-            AddContinueCallbacksWithCancelation(
-                promise,
-                onContinue, convertValue,
-                onContinueCapture, captureValue,
-                promiseToPromise, promiseToPromiseConvert,
-                onCallbackAdded, onCallbackAddedConvert,
-                cancelationSource.Token, cancelationSource.Token,
-                onCancel,
-                onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
-                configureAwaitType, configureAwaitForceAsync
-            );
-            cancelationSource.Dispose();
-
-            promise.Forget();
+                CancelationSource cancelationSource = CancelationSource.New();
+                AddContinueCallbacksWithCancelation(
+                    retainer.WaitAsync(),
+                    onContinue, convertValue,
+                    onContinueCapture, captureValue,
+                    promiseToPromise, promiseToPromiseConvert,
+                    onCallbackAdded, onCallbackAddedConvert,
+                    cancelationSource.Token, cancelationSource.Token,
+                    onCancel,
+                    onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
+                    configureAwaitType, configureAwaitForceAsync
+                );
+                cancelationSource.Dispose();
+            }
         }
 
         public static void AddContinueCallbacksWithCancelation<TConvert, TCapture>(Promise promise,
@@ -2627,109 +2639,109 @@ namespace ProtoPromiseTests
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            // Add empty delegate so no need for null check.
-            onContinue += _ => { };
-            onContinueCapture += (_, __) => { };
-            if (promiseToPromise == null)
-            {
-                promiseToPromise = _ => Promise.Resolved();
-            }
-            if (promiseToPromiseConvert == null)
-            {
-                promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
-            }
-            if (onCallbackAdded == null)
-            {
-                onCallbackAdded = (ref Promise p) => p.Forget();
-            }
-            if (onCallbackAddedConvert == null)
-            {
-                onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
-            }
-            if (onAdoptCallbackAdded == null)
-            {
-                onAdoptCallbackAdded = (ref Promise p) => { };
-            }
-            if (onAdoptCallbackAddedConvert == null)
-            {
-                onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
-            }
-            onCancel += () => { };
+                // Add empty delegate so no need for null check.
+                onContinue += _ => { };
+                onContinueCapture += (_, __) => { };
+                if (promiseToPromise == null)
+                {
+                    promiseToPromise = _ => Promise.Resolved();
+                }
+                if (promiseToPromiseConvert == null)
+                {
+                    promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
+                }
+                if (onCallbackAdded == null)
+                {
+                    onCallbackAdded = (ref Promise p) => p.Forget();
+                }
+                if (onCallbackAddedConvert == null)
+                {
+                    onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
+                }
+                if (onAdoptCallbackAdded == null)
+                {
+                    onAdoptCallbackAdded = (ref Promise p) => { };
+                }
+                if (onAdoptCallbackAddedConvert == null)
+                {
+                    onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
+                }
+                onCancel += () => { };
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p1 = default(Promise);
-                p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(r => { onContinue(r); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onCallbackAdded(ref p1);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p2 = default(Promise<TConvert>);
-                p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(r => { onContinue(r); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onCallbackAddedConvert(ref p2);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p3 = default(Promise);
-                p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(r => { onContinue(r); return promiseToPromise(p3); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p3);
-                onCallbackAdded(ref p3);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p4 = default(Promise<TConvert>);
-                p4 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(r => { onContinue(r); return promiseToPromiseConvert(p4); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p4);
-                onCallbackAddedConvert(ref p4);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p1 = default(Promise);
+                    p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(r => { onContinue(r); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onCallbackAdded(ref p1);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p2 = default(Promise<TConvert>);
+                    p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(r => { onContinue(r); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onCallbackAddedConvert(ref p2);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p3 = default(Promise);
+                    p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(r => { onContinue(r); return promiseToPromise(p3); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p3);
+                    onCallbackAdded(ref p3);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p4 = default(Promise<TConvert>);
+                    p4 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(r => { onContinue(r); return promiseToPromiseConvert(p4); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p4);
+                    onCallbackAddedConvert(ref p4);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p5 = default(Promise);
-                p5 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onCallbackAdded(ref p5);
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p5 = default(Promise);
+                    p5 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onCallbackAdded(ref p5);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p6 = default(Promise<TConvert>);
+                    p6 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onCallbackAddedConvert(ref p6);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p7 = default(Promise);
+                    p7 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return promiseToPromise(p7); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p7);
+                    onCallbackAdded(ref p7);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p8 = default(Promise<TConvert>);
+                    p8 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return promiseToPromiseConvert(p8); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p8);
+                    onCallbackAddedConvert(ref p8);
+                }
             }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p6 = default(Promise<TConvert>);
-                p6 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onCallbackAddedConvert(ref p6);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p7 = default(Promise);
-                p7 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return promiseToPromise(p7); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p7);
-                onCallbackAdded(ref p7);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p8 = default(Promise<TConvert>);
-                p8 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return promiseToPromiseConvert(p8); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p8);
-                onCallbackAddedConvert(ref p8);
-            }
-
-            promise.Forget();
         }
 
         public static void AddContinueCallbacks<T, TConvert, TCapture>(Promise<T> promise,
@@ -2741,36 +2753,36 @@ namespace ProtoPromiseTests
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            AddContinueCallbacksWithCancelation(
-                promise,
-                onContinue, convertValue,
-                onContinueCapture, captureValue,
-                promiseToPromise, promiseToPromiseConvert,
-                onCallbackAdded, onCallbackAddedConvert,
-                default(CancelationToken), default(CancelationToken),
-                onCancel,
-                onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
-                configureAwaitType, configureAwaitForceAsync
-            );
+                AddContinueCallbacksWithCancelation(
+                    retainer.WaitAsync(),
+                    onContinue, convertValue,
+                    onContinueCapture, captureValue,
+                    promiseToPromise, promiseToPromiseConvert,
+                    onCallbackAdded, onCallbackAddedConvert,
+                    default(CancelationToken), default(CancelationToken),
+                    onCancel,
+                    onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
+                    configureAwaitType, configureAwaitForceAsync
+                );
 
-            CancelationSource cancelationSource = CancelationSource.New();
-            AddContinueCallbacksWithCancelation(
-                promise,
-                onContinue, convertValue,
-                onContinueCapture, captureValue,
-                promiseToPromise, promiseToPromiseConvert,
-                onCallbackAdded, onCallbackAddedConvert,
-                cancelationSource.Token, cancelationSource.Token,
-                onCancel,
-                onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
-                configureAwaitType, configureAwaitForceAsync
-            );
-            cancelationSource.Dispose();
-
-            promise.Forget();
+                CancelationSource cancelationSource = CancelationSource.New();
+                AddContinueCallbacksWithCancelation(
+                    retainer.WaitAsync(),
+                    onContinue, convertValue,
+                    onContinueCapture, captureValue,
+                    promiseToPromise, promiseToPromiseConvert,
+                    onCallbackAdded, onCallbackAddedConvert,
+                    cancelationSource.Token, cancelationSource.Token,
+                    onCancel,
+                    onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
+                    configureAwaitType, configureAwaitForceAsync
+                );
+                cancelationSource.Dispose();
+            }
         }
 
         public static void AddContinueCallbacksWithCancelation<T, TConvert, TCapture>(Promise<T> promise,
@@ -2783,109 +2795,109 @@ namespace ProtoPromiseTests
             TestAction<Promise> onAdoptCallbackAdded = null, TestAction<Promise<TConvert>> onAdoptCallbackAddedConvert = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            // Add empty delegate so no need for null check.
-            onContinue += _ => { };
-            onContinueCapture += (_, __) => { };
-            if (promiseToPromise == null)
-            {
-                promiseToPromise = _ => Promise.Resolved();
-            }
-            if (promiseToPromiseConvert == null)
-            {
-                promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
-            }
-            if (onCallbackAdded == null)
-            {
-                onCallbackAdded = (ref Promise p) => p.Forget();
-            }
-            if (onCallbackAddedConvert == null)
-            {
-                onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
-            }
-            if (onAdoptCallbackAdded == null)
-            {
-                onAdoptCallbackAdded = (ref Promise p) => { };
-            }
-            if (onAdoptCallbackAddedConvert == null)
-            {
-                onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
-            }
-            onCancel += () => { };
+                // Add empty delegate so no need for null check.
+                onContinue += _ => { };
+                onContinueCapture += (_, __) => { };
+                if (promiseToPromise == null)
+                {
+                    promiseToPromise = _ => Promise.Resolved();
+                }
+                if (promiseToPromiseConvert == null)
+                {
+                    promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
+                }
+                if (onCallbackAdded == null)
+                {
+                    onCallbackAdded = (ref Promise p) => p.Forget();
+                }
+                if (onCallbackAddedConvert == null)
+                {
+                    onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
+                }
+                if (onAdoptCallbackAdded == null)
+                {
+                    onAdoptCallbackAdded = (ref Promise p) => { };
+                }
+                if (onAdoptCallbackAddedConvert == null)
+                {
+                    onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
+                }
+                onCancel += () => { };
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p1 = default(Promise);
-                p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(r => { onContinue(r); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onCallbackAdded(ref p1);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p2 = default(Promise<TConvert>);
-                p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(r => { onContinue(r); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onCallbackAddedConvert(ref p2);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p3 = default(Promise);
-                p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(r => { onContinue(r); return promiseToPromise(p3); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p3);
-                onCallbackAdded(ref p3);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p4 = default(Promise<TConvert>);
-                p4 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(r => { onContinue(r); return promiseToPromiseConvert(p4); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p4);
-                onCallbackAddedConvert(ref p4);
-            }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p1 = default(Promise);
+                    p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(r => { onContinue(r); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onCallbackAdded(ref p1);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p2 = default(Promise<TConvert>);
+                    p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(r => { onContinue(r); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onCallbackAddedConvert(ref p2);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p3 = default(Promise);
+                    p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(r => { onContinue(r); return promiseToPromise(p3); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p3);
+                    onCallbackAdded(ref p3);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p4 = default(Promise<TConvert>);
+                    p4 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(r => { onContinue(r); return promiseToPromiseConvert(p4); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p4);
+                    onCallbackAddedConvert(ref p4);
+                }
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p5 = default(Promise);
-                p5 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onCallbackAdded(ref p5);
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p5 = default(Promise);
+                    p5 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onCallbackAdded(ref p5);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p6 = default(Promise<TConvert>);
+                    p6 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return convertValue; }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onCallbackAddedConvert(ref p6);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p7 = default(Promise);
+                    p7 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return promiseToPromise(p7); }, cancelationToken)
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p7);
+                    onCallbackAdded(ref p7);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p8 = default(Promise<TConvert>);
+                    p8 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return promiseToPromiseConvert(p8); }, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p8);
+                    onCallbackAddedConvert(ref p8);
+                }
             }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p6 = default(Promise<TConvert>);
-                p6 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return convertValue; }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onCallbackAddedConvert(ref p6);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p7 = default(Promise);
-                p7 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return promiseToPromise(p7); }, cancelationToken)
-                    .CatchCancelation(onCancel);
-                onAdoptCallbackAdded(ref p7);
-                onCallbackAdded(ref p7);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<TConvert> p8 = default(Promise<TConvert>);
-                p8 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return promiseToPromiseConvert(p8); }, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); return convertValue; });
-                onAdoptCallbackAddedConvert(ref p8);
-                onCallbackAddedConvert(ref p8);
-            }
-
-            promise.Forget();
         }
 
         public static void AddCancelCallbacks<TCapture>(Promise promise,
@@ -2896,38 +2908,38 @@ namespace ProtoPromiseTests
             TestAction<Promise> onAdoptCallbackAdded = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            AddCancelCallbacks(
-                promise,
-                default(CancelationToken),
-                onCancel, onCancelCapture,
-                captureValue,
-                promiseToPromise,
-                onCallbackAdded,
-                onAdoptCallbackAdded,
-                default(CancelationToken),
-                configureAwaitType,
-                configureAwaitForceAsync
-            );
+                AddCancelCallbacks(
+                    retainer.WaitAsync(),
+                    default(CancelationToken),
+                    onCancel, onCancelCapture,
+                    captureValue,
+                    promiseToPromise,
+                    onCallbackAdded,
+                    onAdoptCallbackAdded,
+                    default(CancelationToken),
+                    configureAwaitType,
+                    configureAwaitForceAsync
+                );
 
-            CancelationSource cancelationSource = CancelationSource.New();
-            AddCancelCallbacks(
-                promise,
-                cancelationSource.Token,
-                onCancel, onCancelCapture,
-                captureValue,
-                promiseToPromise,
-                onCallbackAdded,
-                onAdoptCallbackAdded,
-                cancelationSource.Token,
-                configureAwaitType,
-                configureAwaitForceAsync
-            );
-            cancelationSource.Dispose();
-
-            promise.Forget();
+                CancelationSource cancelationSource = CancelationSource.New();
+                AddCancelCallbacks(
+                    retainer.WaitAsync(),
+                    cancelationSource.Token,
+                    onCancel, onCancelCapture,
+                    captureValue,
+                    promiseToPromise,
+                    onCallbackAdded,
+                    onAdoptCallbackAdded,
+                    cancelationSource.Token,
+                    configureAwaitType,
+                    configureAwaitForceAsync
+                );
+                cancelationSource.Dispose();
+            }
         }
 
         public static void AddCancelCallbacks<TCapture>(Promise promise,
@@ -2940,57 +2952,57 @@ namespace ProtoPromiseTests
             CancelationToken waitAsyncCancelationToken = default(CancelationToken),
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            // Add empty delegate so no need for null check.
-            if (promiseToPromise == null)
-            {
-                promiseToPromise = _ => Promise.Resolved();
-            }
-            if (onCallbackAdded == null)
-            {
-                onCallbackAdded = (ref Promise p) => p.Forget();
-            }
-            if (onAdoptCallbackAdded == null)
-            {
-                onAdoptCallbackAdded = (ref Promise p) => { };
-            }
-            onCancel += () => { };
-            onCancelCapture += cv => { };
+                // Add empty delegate so no need for null check.
+                if (promiseToPromise == null)
+                {
+                    promiseToPromise = _ => Promise.Resolved();
+                }
+                if (onCallbackAdded == null)
+                {
+                    onCallbackAdded = (ref Promise p) => p.Forget();
+                }
+                if (onAdoptCallbackAdded == null)
+                {
+                    onAdoptCallbackAdded = (ref Promise p) => { };
+                }
+                onCancel += () => { };
+                onCancelCapture += cv => { };
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p1 = default(Promise);
-                p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, cancelationToken)
-                    .CatchCancelation(() => { onCancel(); }, cancelationToken);
-                onCallbackAdded(ref p1);
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p1 = default(Promise);
+                    p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, cancelationToken)
+                        .CatchCancelation(() => { onCancel(); }, cancelationToken);
+                    onCallbackAdded(ref p1);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p2 = default(Promise);
+                    p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .CatchCancelation(captureValue, cv => { onCancelCapture(cv); }, cancelationToken);
+                    onCallbackAdded(ref p2);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p3 = default(Promise);
+                    p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .CatchCancelation(() => { onCancel(); return promiseToPromise(p3); }, cancelationToken);
+                    onAdoptCallbackAdded(ref p3);
+                    onCallbackAdded(ref p3);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p3 = default(Promise);
+                    p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .CatchCancelation(captureValue, cv => { onCancelCapture(cv); return promiseToPromise(p3); }, cancelationToken);
+                    onAdoptCallbackAdded(ref p3);
+                    onCallbackAdded(ref p3);
+                }
             }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p2 = default(Promise);
-                p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .CatchCancelation(captureValue, cv => { onCancelCapture(cv); }, cancelationToken);
-                onCallbackAdded(ref p2);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p3 = default(Promise);
-                p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .CatchCancelation(() => { onCancel(); return promiseToPromise(p3); }, cancelationToken);
-                onAdoptCallbackAdded(ref p3);
-                onCallbackAdded(ref p3);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise p3 = default(Promise);
-                p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .CatchCancelation(captureValue, cv => { onCancelCapture(cv); return promiseToPromise(p3); }, cancelationToken);
-                onAdoptCallbackAdded(ref p3);
-                onCallbackAdded(ref p3);
-            }
-
-            promise.Forget();
         }
 
         public static void AddCancelCallbacks<T, TCapture>(Promise<T> promise, T TValue = default(T),
@@ -3001,38 +3013,38 @@ namespace ProtoPromiseTests
             TestAction<Promise<T>> onAdoptCallbackAdded = null,
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            AddCancelCallbacks(
-                promise,
-                default(CancelationToken), TValue,
-                onCancel, onCancelCapture,
-                captureValue,
-                promiseToPromise,
-                onCallbackAdded,
-                onAdoptCallbackAdded,
-                default(CancelationToken),
-                configureAwaitType,
-                configureAwaitForceAsync
-            );
+                AddCancelCallbacks(
+                    retainer.WaitAsync(),
+                    default(CancelationToken), TValue,
+                    onCancel, onCancelCapture,
+                    captureValue,
+                    promiseToPromise,
+                    onCallbackAdded,
+                    onAdoptCallbackAdded,
+                    default(CancelationToken),
+                    configureAwaitType,
+                    configureAwaitForceAsync
+                );
 
-            CancelationSource cancelationSource = CancelationSource.New();
-            AddCancelCallbacks(
-                promise,
-                cancelationSource.Token, TValue,
-                onCancel, onCancelCapture,
-                captureValue,
-                promiseToPromise,
-                onCallbackAdded,
-                onAdoptCallbackAdded,
-                cancelationSource.Token,
-                configureAwaitType,
-                configureAwaitForceAsync
-            );
-            cancelationSource.Dispose();
-
-            promise.Forget();
+                CancelationSource cancelationSource = CancelationSource.New();
+                AddCancelCallbacks(
+                    retainer.WaitAsync(),
+                    cancelationSource.Token, TValue,
+                    onCancel, onCancelCapture,
+                    captureValue,
+                    promiseToPromise,
+                    onCallbackAdded,
+                    onAdoptCallbackAdded,
+                    cancelationSource.Token,
+                    configureAwaitType,
+                    configureAwaitForceAsync
+                );
+                cancelationSource.Dispose();
+            }
         }
 
         public static void AddCancelCallbacks<T, TCapture>(Promise<T> promise,
@@ -3045,57 +3057,57 @@ namespace ProtoPromiseTests
             CancelationToken waitAsyncCancelationToken = default(CancelationToken),
             ConfigureAwaitType configureAwaitType = ConfigureAwaitType.None, bool configureAwaitForceAsync = false)
         {
-            promise = promise.Preserve();
-            promise.Catch(() => { }).Forget(); // Suppress any rejections from the preserved promise.
+            using (var retainer = promise.GetRetainer())
+            {
+                retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-            // Add empty delegate so no need for null check.
-            if (promiseToPromise == null)
-            {
-                promiseToPromise = _ => Promise.Resolved(TValue);
-            }
-            if (onCallbackAdded == null)
-            {
-                onCallbackAdded = (ref Promise<T> p) => p.Forget();
-            }
-            if (onAdoptCallbackAdded == null)
-            {
-                onAdoptCallbackAdded = (ref Promise<T> p) => { };
-            }
-            onCancel += () => { };
-            onCancelCapture += cv => { };
+                // Add empty delegate so no need for null check.
+                if (promiseToPromise == null)
+                {
+                    promiseToPromise = _ => Promise.Resolved(TValue);
+                }
+                if (onCallbackAdded == null)
+                {
+                    onCallbackAdded = (ref Promise<T> p) => p.Forget();
+                }
+                if (onAdoptCallbackAdded == null)
+                {
+                    onAdoptCallbackAdded = (ref Promise<T> p) => { };
+                }
+                onCancel += () => { };
+                onCancelCapture += cv => { };
 
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<T> p1 = default(Promise<T>);
-                p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .CatchCancelation(() => { onCancel(); return TValue; }, cancelationToken);
-                onCallbackAdded(ref p1);
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<T> p1 = default(Promise<T>);
+                    p1 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .CatchCancelation(() => { onCancel(); return TValue; }, cancelationToken);
+                    onCallbackAdded(ref p1);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<T> p2 = default(Promise<T>);
+                    p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .CatchCancelation(captureValue, cv => { onCancelCapture(cv); return TValue; }, cancelationToken);
+                    onCallbackAdded(ref p2);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<T> p3 = default(Promise<T>);
+                    p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .CatchCancelation(() => { onCancel(); return promiseToPromise(p3); }, cancelationToken);
+                    onAdoptCallbackAdded(ref p3);
+                    onCallbackAdded(ref p3);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<T> p3 = default(Promise<T>);
+                    p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
+                        .CatchCancelation(captureValue, cv => { onCancelCapture(cv); return promiseToPromise(p3); }, cancelationToken);
+                    onAdoptCallbackAdded(ref p3);
+                    onCallbackAdded(ref p3);
+                }
             }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<T> p2 = default(Promise<T>);
-                p2 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .CatchCancelation(captureValue, cv => { onCancelCapture(cv); return TValue; }, cancelationToken);
-                onCallbackAdded(ref p2);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<T> p3 = default(Promise<T>);
-                p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .CatchCancelation(() => { onCancel(); return promiseToPromise(p3); }, cancelationToken);
-                onAdoptCallbackAdded(ref p3);
-                onCallbackAdded(ref p3);
-            }
-            foreach (var p in GetTestablePromises(promise))
-            {
-                Promise<T> p3 = default(Promise<T>);
-                p3 = p.ConfigureAwait(configureAwaitType, configureAwaitForceAsync, waitAsyncCancelationToken)
-                    .CatchCancelation(captureValue, cv => { onCancelCapture(cv); return promiseToPromise(p3); }, cancelationToken);
-                onAdoptCallbackAdded(ref p3);
-                onCallbackAdded(ref p3);
-            }
-
-            promise.Forget();
         }
 
         public static Action<Promise>[] ResolveActionsVoid(Action onResolved = null)


### PR DESCRIPTION
Resolves #423.

Deprecated `Promise(<T>).Preserve()` and `Promise(<T>).Duplicate()`.

AsyncLazy benchmarks using the new API:

develop:

| Method    | Mean     | Allocated |
|---------- |---------:|----------:|
| AsyncLazy | 1.259 us |     416 B |

PR:

| Method    | Mean     | Allocated |
|---------- |---------:|----------:|
| AsyncLazy | 854.4 ns |     368 B |