### PR TITLE
Update Unity tests

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -107,6 +107,14 @@ jobs:
           DefineReplace="  scriptingDefineSymbols: \\n    ${{ matrix.buildTargetId }}: ${{ matrix.configuration.symbol }};${{ matrix.objectPooling.symbol }}"
           sed -i "{s/$DefineOriginal/$DefineReplace/g}" ProtoPromise_Unity/ProjectSettings/ProjectSettings.asset
 
+      # Linux IL2CPP builds consume extra disk space, so we free up some disk space to prevent the build from failing.
+      - name: Delete Extra ProjectSettings
+        run: rm -r -f .github/unityci
+        if: matrix.testMode.name == 'Standalone'
+
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        if: matrix.testMode.name == 'Standalone'
+
       - name: Run tests
         id: tests
         uses: game-ci/unity-test-runner@v4
@@ -120,36 +128,12 @@ jobs:
           unityVersion: ${{ matrix.unity.version }}
         timeout-minutes: 120
 
-      # Workaround for NUnit XML (see https://github.com/dorny/test-reporter/issues/98#issuecomment-867106931)
-      - name: Install NUnit
-        if: always()
-        run: |
-          nuget install NUnit.Console -Version 3.12.0
-
-      - name: Fetch transform code
-        if: always()
-        run: |
-          wget https://raw.githubusercontent.com/nunit/nunit-transforms/master/nunit3-junit/nunit3-junit.xslt
-        shell: bash
-
-      - name: Transform NUnit3 to JUnit
-        if: always()
-        run: |
-          Get-ChildItem . -Filter artifacts/*.xml | Foreach-Object {
-            $xml = Resolve-Path $_.FullName
-            $output = Join-Path ($pwd) ($_.BaseName + '_junit.xml')
-            $xslt = New-Object System.Xml.Xsl.XslCompiledTransform;
-            $xslt.Load("nunit3-junit.xslt");
-            $xslt.Transform($xml, $output);
-          }
-        shell: pwsh
-
-      - uses: dorny/test-reporter@v1
+      - uses: dorny/test-reporter@main
         if: always()
         with:
           name: unity-test-results-${{ matrix.unity.major }}-${{ matrix.testMode.name }}-${{ matrix.configuration.name }}-${{ matrix.objectPooling.name }}
-          path: "*_junit.xml"
-          reporter: java-junit
+          path: 'artifacts/*.xml'
+          reporter: dotnet-nunit
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/Package/Tests/CoreTests/APIs/PromiseGroups/PromiseMergeResultsGroupTests.cs
+++ b/Package/Tests/CoreTests/APIs/PromiseGroups/PromiseMergeResultsGroupTests.cs
@@ -804,8 +804,6 @@ namespace ProtoPromiseTests.APIs.PromiseGroups
             }
         }
 
-        // Using PromiseMergeResultsGroupExtended in IL2CPP causes the build to fail.
-#if !ENABLE_IL2CPP
         [Test]
         public void PromiseMergeResultsGroupIsResolvedWhenAllPromisesAreCompleted_T_void_T_void_T_T_void_void(
             [Values] CancelationType cancelationType,
@@ -1368,6 +1366,5 @@ namespace ProtoPromiseTests.APIs.PromiseGroups
                 Assert.IsTrue(completed);
             }
         }
-#endif
     }
 }


### PR DESCRIPTION
Re-enable PromiseMergeResultsGroup extended tests.
Free disk space.
Update test-reporter for native nunit support.