### PR TITLE
Add `ManualSynchronizationContextCore` type

### DIFF
--- a/Package/Core/InternalShared/SpinLocker.cs
+++ b/Package/Core/InternalShared/SpinLocker.cs
@@ -25,11 +25,15 @@ namespace Proto.Promises
 
             internal void Enter()
             {
-                if (Interlocked.Exchange(ref _locker, 1) == 1)
+                if (!TryEnter())
                 {
                     EnterCore();
                 }
             }
+
+            [MethodImpl(InlineOption)]
+            internal bool TryEnter()
+                => Interlocked.Exchange(ref _locker, 1) == 0;
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             private void EnterCore()
@@ -40,7 +44,7 @@ namespace Proto.Promises
                 {
                     spinner.SpinOnce();
                 }
-                while (Interlocked.Exchange(ref _locker, 1) == 1);
+                while (!TryEnter());
             }
 
             [MethodImpl(InlineOption)]

--- a/Package/Core/Threading/ManualSynchronizationContextCore.cs
+++ b/Package/Core/Threading/ManualSynchronizationContextCore.cs
@@ -203,9 +203,10 @@ namespace Proto.Promises.Threading
         /// <summary>
         /// Schedule the delegate to execute on this context with the given state, and wait for it to complete.
         /// </summary>
-        /// <remarks>This method doe not check the <see cref="Thread.CurrentThread"/> or <see cref="SynchronizationContext.Current"/>.
-        /// Your <see cref="SynchronizationContext"/> should check for the appropriate current thread or context in order to invoke the callback synchronously when required.</remarks>
         /// <remarks>
+        /// This method does not check the <see cref="Thread.CurrentThread"/> or <see cref="SynchronizationContext.Current"/>.
+        /// Your <see cref="SynchronizationContext"/> should check for the appropriate current thread or context in order to invoke the callback synchronously when required.
+        /// <para/>
         /// This method is thread-safe.
         /// </remarks>
         public void Send(SendOrPostCallback d, object state)

--- a/Package/Core/Threading/ManualSynchronizationContextCore.cs
+++ b/Package/Core/Threading/ManualSynchronizationContextCore.cs
@@ -1,0 +1,307 @@
+﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+
+#pragma warning disable IDE0016 // Use 'throw' expression
+#pragma warning disable IDE0090 // Use 'new(...)'
+#pragma warning disable IDE0290 // Use primary constructor
+
+namespace Proto.Promises.Threading
+{
+    /// <summary>
+    /// The core implementation of a <see cref="SynchronizationContext"/>, used to schedule callbacks to a certain context.
+    /// You may use this type as a base to build your own custom <see cref="SynchronizationContext"/>.
+    /// </summary>
+    /// <remarks>
+    /// This type is a mutable struct, and so should not be used as a readonly field. This type is thread-safe as long as the field of this type is not overwritten, and only methods are called on it.
+    /// <para/>
+    /// This type does not check the <see cref="Thread.CurrentThread"/> or <see cref="SynchronizationContext.Current"/>. If your context requires it, you must implement that yourself.
+    /// </remarks>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+    [DebuggerNonUserCode, StackTraceHidden]
+#endif
+    public struct ManualSynchronizationContextCore
+    {
+        // Send callbacks are implemented as a linked-list, because we have to make sure the ExceptionDispatchInfo is still valid by the time the original thread reads it.
+        // Post callbacks are implemented as a contiguous list for fast add and invoke, with minimal memory.
+        // Post is also expected to be used more frequently than Send, so we want it to be as efficient as possible, rather than sharing an implementation.
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        // Wrapping struct fields smaller than 64-bits in another struct fixes issue with extra padding
+        // (see https://stackoverflow.com/questions/24742325/why-does-struct-alignment-depend-on-whether-a-field-type-is-primitive-or-user-de).
+        private struct LockAndCount
+        {
+            internal Internal.SpinLocker _locker;
+            internal int _postCount;
+        }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        private readonly struct PostCallback
+        {
+            internal readonly SendOrPostCallback _callback;
+            internal readonly object _state;
+
+            [MethodImpl(Internal.InlineOption)]
+            internal PostCallback(SendOrPostCallback callback, object state)
+            {
+                _callback = callback;
+                _state = state;
+            }
+
+            [MethodImpl(Internal.InlineOption)]
+            internal void Invoke()
+                => _callback.Invoke(_state);
+        }
+
+#if !PROTO_PROMISE_DEVELOPER_MODE
+        [DebuggerNonUserCode, StackTraceHidden]
+#endif
+        private sealed class SendCallback : Internal.HandleablePromiseBase, Internal.ILinked<SendCallback>
+        {
+            SendCallback Internal.ILinked<SendCallback>.Next
+            {
+                get => _next.UnsafeAs<SendCallback>();
+                set => _next = value;
+            }
+
+            private PostCallback _callback;
+            private ExceptionDispatchInfo _capturedInfo;
+            private readonly AutoResetEvent _callbackCompletedEvent = new AutoResetEvent(false);
+
+            private SendCallback() { }
+
+            [MethodImpl(Internal.InlineOption)]
+            private static SendCallback GetOrCreate()
+            {
+                var obj = Internal.ObjectPool.TryTakeOrInvalid<SendCallback>();
+                return obj == Internal.PromiseRefBase.InvalidAwaitSentinel.s_instance
+                    ? new SendCallback()
+                    : obj.UnsafeAs<SendCallback>();
+            }
+
+            internal static SendCallback GetOrCreate(SendOrPostCallback callback, object state)
+            {
+                var sc = GetOrCreate();
+                sc._next = null;
+                sc._callback = new PostCallback(callback, state);
+                return sc;
+            }
+
+            internal void Invoke()
+            {
+                try
+                {
+                    _callback.Invoke();
+                }
+                catch (Exception e)
+                {
+                    _capturedInfo = ExceptionDispatchInfo.Capture(e);
+                }
+                finally
+                {
+                    _callbackCompletedEvent.Set();
+                }
+            }
+
+            internal void Send(ref ManualSynchronizationContextCore parent)
+            {
+                parent._lockAndCount._locker.Enter();
+                parent._sendQueue.Enqueue(this);
+                parent._lockAndCount._locker.Exit();
+
+                _callbackCompletedEvent.WaitOne();
+                var capturedInfo = _capturedInfo;
+
+                Dispose(); // Dispose after invoke.
+                capturedInfo?.Throw();
+            }
+
+            private void Dispose()
+            {
+                _callback = default;
+                _capturedInfo = default;
+                Internal.ObjectPool.MaybeRepool(this);
+            }
+        }
+
+        // We swap these when Execute() is called.
+        private PostCallback[] _postQueue;
+        private PostCallback[] _executing;
+        // These must not be readonly.
+        private Internal.ValueLinkedQueue<SendCallback> _sendQueue;
+        private LockAndCount _lockAndCount;
+
+        /// <summary>
+        /// Create a new <see cref="ManualSynchronizationContextCore"/> with an initial capacity.
+        /// </summary>
+        /// <param name="initialCapacity">The initial capacity of the queue of <see cref="Post"/> callbacks. The capacity will grow if more callbacks are added.</param>
+        public ManualSynchronizationContextCore(int initialCapacity)
+        {
+            if (initialCapacity < 0)
+            {
+                throw new System.ArgumentOutOfRangeException(nameof(initialCapacity), $"{nameof(initialCapacity)} must be greater than or equal to zero.");
+            }
+            else if (initialCapacity == 0)
+            {
+#pragma warning disable IDE0301 // Simplify collection initialization
+                _postQueue = Array.Empty<PostCallback>();
+                _executing = Array.Empty<PostCallback>();
+#pragma warning restore IDE0301 // Simplify collection initialization
+            }
+            else
+            {
+                _postQueue = new PostCallback[initialCapacity];
+                _executing = new PostCallback[initialCapacity];
+            }
+
+            _sendQueue = new Internal.ValueLinkedQueue<SendCallback>();
+            _lockAndCount = default;
+        }
+
+        /// <summary>
+        /// Schedule the delegate to execute on this context with the given state asynchronously, without waiting for it to complete.
+        /// </summary>
+        public void Post(SendOrPostCallback d, object state)
+        {
+            if (d == null)
+            {
+                throw new System.ArgumentNullException(nameof(d), "SendOrPostCallback may not be null.");
+            }
+
+            _lockAndCount._locker.Enter();
+            int count = _lockAndCount._postCount;
+            if (count >= _postQueue.Length)
+            {
+                Array.Resize(ref _postQueue, checked((count * 2) + 1));
+            }
+            _postQueue[count] = new PostCallback(d, state);
+            _lockAndCount._postCount = count + 1;
+            _lockAndCount._locker.Exit();
+        }
+
+        /// <summary>
+        /// Schedule the delegate to execute on this context with the given state, and wait for it to complete.
+        /// </summary>
+        /// <remarks>This method doe not check the <see cref="Thread.CurrentThread"/> or <see cref="SynchronizationContext.Current"/>.
+        /// Your <see cref="SynchronizationContext"/> should check for the appropriate current thread or context in order to invoke the callback synchronously when required.</remarks>
+        public void Send(SendOrPostCallback d, object state)
+        {
+            if (d == null)
+            {
+                throw new System.ArgumentNullException(nameof(d), "SendOrPostCallback may not be null.");
+            }
+
+            SendCallback.GetOrCreate(d, state).Send(ref this);
+        }
+
+        /// <summary>
+        /// Invoke all callbacks that were scheduled to run on this context,
+        /// and all callbacks that are scheduled to run on this context while this is executing,
+        /// exhaustively, until no more callbacks remain.
+        /// </summary>
+        /// <remarks>
+        /// This method should not be invoked recursively. If it is invoked recursively, behavior is undefined.
+        /// There is no validation on this type to prevent it, so you should be careful to avoid it.
+        /// </remarks>
+        /// <exception cref="System.InvalidOperationException">This is called recursively.</exception>
+        /// <exception cref="AggregateException">One or more callbacks threw an exception.</exception>
+        public void ExecuteExhaustive()
+        {
+            // Catch all exceptions and continue executing callbacks until all are exhausted, then if there are any, throw all exceptions wrapped in AggregateException.
+            List<Exception> exceptions = null;
+
+            while (true)
+            {
+
+                var (sendStack, postQueue, postCount) = GetSendsAndPosts();
+                if (sendStack.IsEmpty & postCount == 0)
+                {
+                    break;
+                }
+
+                ExecuteCore(sendStack, postQueue, postCount, ref exceptions);
+            }
+
+            if (exceptions != null)
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+
+        /// <summary>
+        /// Invoke all callbacks that were scheduled to run on this context.
+        /// Any callbacks that are scheduled to run on this context while this is executing will not be invoked until the next time this is called.
+        /// </summary>
+        /// <remarks>
+        /// This method should not be invoked recursively. If it is invoked recursively, behavior is undefined.
+        /// There is no validation on this type to prevent it, so you should be careful to avoid it.
+        /// </remarks>
+        /// <exception cref="System.InvalidOperationException">This is called recursively.</exception>
+        /// <exception cref="AggregateException">One or more callbacks threw an exception.</exception>
+        public void ExecuteNonExhaustive()
+        {
+            // Catch all exceptions and continue executing callbacks until all are exhausted, then if there are any, throw all exceptions wrapped in AggregateException.
+            List<Exception> exceptions = null;
+
+            var (sendStack, postQueue, postCount) = GetSendsAndPosts();
+            ExecuteCore(sendStack, postQueue, postCount, ref exceptions);
+
+            if (exceptions != null)
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+
+        private (Internal.ValueLinkedStack<SendCallback> sendStack, PostCallback[] postQueue, int postCount) GetSendsAndPosts()
+        {
+            _lockAndCount._locker.Enter();
+            var sendStack = _sendQueue.MoveElementsToStack();
+            var postQueue = _postQueue;
+            int postCount = _lockAndCount._postCount;
+            _lockAndCount._postCount = 0;
+            // Swap the executing and pending arrays.
+            _postQueue = _executing;
+            _executing = postQueue;
+            _lockAndCount._locker.Exit();
+
+            return (sendStack, postQueue, postCount);
+        }
+
+        private static void ExecuteCore(Internal.ValueLinkedStack<SendCallback> sendStack, PostCallback[] postQueue, int postCount, ref List<Exception> exceptions)
+        {
+            // Execute Send callbacks first so that their waiting threads may continue sooner.
+            // We don't need to catch exceptions here because it's already handled in the SendCallback.Invoke().
+            while (sendStack.IsNotEmpty)
+            {
+                sendStack.Pop().Invoke();
+            }
+
+            for (int i = 0; i < postCount; ++i)
+            {
+                ref var callback = ref postQueue[i];
+                try
+                {
+                    callback.Invoke();
+                }
+                catch (Exception e)
+                {
+                    Internal.RecordException(e, ref exceptions);
+                }
+                callback = default;
+            }
+        }
+    }
+}

--- a/Package/Core/Threading/ManualSynchronizationContextCore.cs.meta
+++ b/Package/Core/Threading/ManualSynchronizationContextCore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e3c41b0694d6d24e8b49aa35ec040ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Core/Threading/PromiseSynchronizationContext.cs
+++ b/Package/Core/Threading/PromiseSynchronizationContext.cs
@@ -5,10 +5,7 @@
 #endif
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 
 #pragma warning disable IDE0016 // Use 'throw' expression
@@ -24,110 +21,10 @@ namespace Proto.Promises.Threading
 #endif
     public sealed class PromiseSynchronizationContext : SynchronizationContext
     {
-        // Send callbacks are implemented as a linked-list, because we have to make sure the ExceptionDispatchInfo is still valid by the time the original thread reads it.
-        // Post callbacks are implemented as a contiguous list for fast add and invoke, with minimal memory.
-        // Post is also expected to be used more frequently than Send, so we want it to be as efficient as possible, rather than sharing an implementation.
-
-#if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode, StackTraceHidden]
-#endif
-        private readonly struct PostCallback
-        {
-            internal readonly SendOrPostCallback _callback;
-            internal readonly object _state;
-
-            [MethodImpl(Internal.InlineOption)]
-            internal PostCallback(SendOrPostCallback callback, object state)
-            {
-                _callback = callback;
-                _state = state;
-            }
-
-            [MethodImpl(Internal.InlineOption)]
-            internal void Invoke()
-                => _callback.Invoke(_state);
-        }
-
-#if !PROTO_PROMISE_DEVELOPER_MODE
-        [DebuggerNonUserCode, StackTraceHidden]
-#endif
-        private sealed class SendCallback : Internal.HandleablePromiseBase, Internal.ILinked<SendCallback>
-        {
-            SendCallback Internal.ILinked<SendCallback>.Next
-            {
-                get => _next.UnsafeAs<SendCallback>();
-                set => _next = value;
-            }
-
-            private PostCallback _callback;
-            private ExceptionDispatchInfo _capturedInfo;
-            private readonly AutoResetEvent _callbackCompletedEvent = new AutoResetEvent(false);
-
-            private SendCallback() { }
-
-            [MethodImpl(Internal.InlineOption)]
-            private static SendCallback GetOrCreate()
-            {
-                var obj = Internal.ObjectPool.TryTakeOrInvalid<SendCallback>();
-                return obj == Internal.PromiseRefBase.InvalidAwaitSentinel.s_instance
-                    ? new SendCallback()
-                    : obj.UnsafeAs<SendCallback>();
-            }
-
-            internal static SendCallback GetOrCreate(SendOrPostCallback callback, object state)
-            {
-                var sc = GetOrCreate();
-                sc._next = null;
-                sc._callback = new PostCallback(callback, state);
-                return sc;
-            }
-
-            internal void Invoke()
-            {
-                try
-                {
-                    _callback.Invoke();
-                }
-                catch (Exception e)
-                {
-                    _capturedInfo = ExceptionDispatchInfo.Capture(e);
-                }
-                finally
-                {
-                    _callbackCompletedEvent.Set();
-                }
-            }
-
-            internal void Send(PromiseSynchronizationContext parent)
-            {
-                parent._syncLocker.Enter();
-                parent._sendQueue.Enqueue(this);
-                parent._syncLocker.Exit();
-
-                _callbackCompletedEvent.WaitOne();
-                var capturedInfo = _capturedInfo;
-
-                Dispose(); // Dispose after invoke.
-                capturedInfo?.Throw();
-            }
-
-            private void Dispose()
-            {
-                _callback = default;
-                _capturedInfo = default;
-                Internal.ObjectPool.MaybeRepool(this);
-            }
-        }
-
+        // ManualSynchronizationContextCore is not associated with a thread, we do it in this type.
         private readonly Thread _thread;
-        // We swap these when Execute() is called.
-        private PostCallback[] _postQueue;
-        private PostCallback[] _executing;
-        // These must not be readonly.
-        private Internal.ValueLinkedQueue<SendCallback> _sendQueue = new Internal.ValueLinkedQueue<SendCallback>();
-        private Internal.SpinLocker _syncLocker;
-        private int _postCount;
-        private bool _isInvoking;
+        private ManualSynchronizationContextCore _core;
+        private bool _isExecuting;
 
         /// <summary>
         /// Create a new <see cref="PromiseSynchronizationContext"/> affiliated with the current thread.
@@ -145,8 +42,7 @@ namespace Proto.Promises.Threading
             }
             _thread = runThread;
             // Start with a modest initial capacity. This will grow in Post() if necessary.
-            _postQueue = new PostCallback[8];
-            _executing = new PostCallback[8];
+            _core = new ManualSynchronizationContextCore(8);
         }
 
         /// <summary>
@@ -159,109 +55,71 @@ namespace Proto.Promises.Threading
         /// Schedule the delegate to execute on this context with the given state asynchronously, without waiting for it to complete.
         /// </summary>
         public override void Post(SendOrPostCallback d, object state)
-        {
-            if (d == null)
-            {
-                throw new System.ArgumentNullException(nameof(d), "SendOrPostCallback may not be null.");
-            }
-
-            _syncLocker.Enter();
-            int count = _postCount;
-            if (count >= _postQueue.Length)
-            {
-                Array.Resize(ref _postQueue, count * 2);
-            }
-            _postQueue[count] = new PostCallback(d, state);
-            _postCount = count + 1;
-            _syncLocker.Exit();
-        }
+            => _core.Post(d, state);
 
         /// <summary>
         /// Schedule the delegate to execute on this context with the given state, and wait for it to complete.
         /// </summary>
         public override void Send(SendOrPostCallback d, object state)
         {
+            if (Thread.CurrentThread != _thread)
+            {
+                // The callback is checked for null in core, so we don't need to do it here.
+                _core.Send(d, state);
+                return;
+            }
+
             if (d == null)
             {
                 throw new System.ArgumentNullException(nameof(d), "SendOrPostCallback may not be null.");
             }
-
-            if (Thread.CurrentThread == _thread)
-            {
-                d.Invoke(state);
-                return;
-            }
-
-            SendCallback.GetOrCreate(d, state).Send(this);
+            d.Invoke(state);
         }
 
         /// <summary>
-        /// Execute all callbacks that have been scheduled to run on this context.
+        /// Invoke all callbacks that were scheduled to run on this context,
+        /// and all callbacks that are scheduled to run on this context while this is executing,
+        /// exhaustively, until no more callbacks remain.
         /// </summary>
-        /// <exception cref="System.InvalidOperationException">If this is called on a different thread than this was created on, or if this is called recursively.</exception>
-        /// <exception cref="AggregateException">If one or more callbacks throw an exception, they will be wrapped and rethrown as <see cref="AggregateException"/>.</exception>
+        /// <exception cref="System.InvalidOperationException">If this is called on a different thread than this context is associated, or if this is called recursively.</exception>
+        /// <exception cref="AggregateException">One or more callbacks threw an exception.</exception>
         public void Execute()
+            => Execute(true);
+
+        /// <summary>
+        /// Invoke all callbacks that were scheduled to run on this context, exhaustively or non-exhaustively according to <paramref name="exhaustive"/>.
+        /// </summary>
+        /// <param name="exhaustive">
+        /// If <see langword="true"/>, all callbacks that are scheduled to run on this context while this is executing will be invoked exhaustively, until no more callbacks remain;
+        /// otherwise, any callbacks that are scheduled to run on this context while this is executing will not be invoked until the next time this is called.
+        /// </param>
+        /// <exception cref="System.InvalidOperationException">If this is called on a different thread than this context is associated, or if this is called recursively.</exception>
+        /// <exception cref="AggregateException">One or more callbacks threw an exception.</exception>
+        public void Execute(bool exhaustive)
         {
-            if (Thread.CurrentThread != _thread | _isInvoking)
+            if (Thread.CurrentThread != _thread | _isExecuting)
             {
                 throw new System.InvalidOperationException(Thread.CurrentThread != _thread
-                    ? "Execute may only be called from the thread on which the PromiseSynchronizationContext is affiliated."
-                    : "Execute invoked recursively. This is not supported.");
+                    ? $"{nameof(Execute)} may only be called from the thread on which the {nameof(PromiseSynchronizationContext)} is affiliated."
+                    : $"{nameof(Execute)} called recursively. This is not supported.");
             }
 
             try
             {
-                _isInvoking = true;
+                _isExecuting = true;
 
-                while (true)
+                if (exhaustive)
                 {
-                    _syncLocker.Enter();
-                    var sendStack = _sendQueue.MoveElementsToStack();
-                    var postQueue = _postQueue;
-                    int postCount = _postCount;
-                    _postCount = 0;
-                    // Swap the executing and pending arrays.
-                    _postQueue = _executing;
-                    _executing = postQueue;
-                    _syncLocker.Exit();
-
-                    if (sendStack.IsEmpty & postCount == 0)
-                    {
-                        break;
-                    }
-
-                    // Execute Send callbacks first so that their waiting threads may continue sooner.
-                    // We don't need to catch exceptions here because it's already handled in the SendCallback.Invoke().
-                    while (sendStack.IsNotEmpty)
-                    {
-                        sendStack.Pop().Invoke();
-                    }
-
-                    // Catch all exceptions and continue executing callbacks until all are exhausted, then if there are any, throw all exceptions wrapped in AggregateException.
-                    List<Exception> exceptions = null;
-                    for (int i = 0; i < postCount; ++i)
-                    {
-                        ref var callback = ref postQueue[i];
-                        try
-                        {
-                            callback.Invoke();
-                        }
-                        catch (Exception e)
-                        {
-                            Internal.RecordException(e, ref exceptions);
-                        }
-                        callback = default;
-                    }
-
-                    if (exceptions != null)
-                    {
-                        throw new AggregateException(exceptions);
-                    }
+                    _core.ExecuteExhaustive();
+                }
+                else
+                {
+                    _core.ExecuteNonExhaustive();
                 }
             }
             finally
             {
-                _isInvoking = false;
+                _isExecuting = false;
             }
         }
     }


### PR DESCRIPTION
Allows users to implement their own `SynchronizationContext` on top of the optimized core behavior, without relying on `PromiseSynchronizationContext`.

Also added `PromiseSynchronizationContext.Execute(bool exhaustive)` API.