### PR TITLE
Prepare dispose 2

### DIFF
--- a/Package/Core/InternalShared/DebugInternal.cs
+++ b/Package/Core/InternalShared/DebugInternal.cs
@@ -464,15 +464,6 @@ namespace Proto.Promises
 
         internal static string GetFormattedStacktrace(ITraceable traceable) => null;
 #endif // PROMISE_DEBUG
-
-        // Dispose validates the state is not pending in Debug or Developer mode,
-        // so we only set the state for early dispose in those modes.
-        static partial void PrepareEarlyDispose(this PromiseRefBase promise);
-
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-        static partial void PrepareEarlyDispose(this PromiseRefBase promise)
-            => promise.SetCompletionState(Promise.State.Resolved);
-#endif
     } // class Internal
 
     partial struct Promise

--- a/Package/Core/Linq/Generators/Range.cs
+++ b/Package/Core/Linq/Generators/Range.cs
@@ -117,7 +117,7 @@ namespace Proto.Promises
 
             new private void Dispose()
             {
-                this.PrepareEarlyDispose();
+                PrepareEarlyDispose();
                 base.Dispose();
                 _disposed = true;
                 ObjectPool.MaybeRepool(this);

--- a/Package/Core/Linq/Generators/Repeat.cs
+++ b/Package/Core/Linq/Generators/Repeat.cs
@@ -120,7 +120,7 @@ namespace Proto.Promises
 
             new private void Dispose()
             {
-                this.PrepareEarlyDispose();
+                PrepareEarlyDispose();
                 base.Dispose();
                 _current = default;
                 _disposed = true;

--- a/Package/Core/Linq/Generators/Return.cs
+++ b/Package/Core/Linq/Generators/Return.cs
@@ -91,7 +91,7 @@ namespace Proto.Promises
 
             new private void Dispose()
             {
-                this.PrepareEarlyDispose();
+                PrepareEarlyDispose();
                 base.Dispose();
                 _current = default;
                 _disposed = true;

--- a/Package/Core/Linq/Internal/AsyncEnumerableInternal.cs
+++ b/Package/Core/Linq/Internal/AsyncEnumerableInternal.cs
@@ -148,17 +148,6 @@ namespace Proto.Promises
                 internal abstract Promise<bool> MoveNextAsync(int id);
                 internal abstract Promise DisposeAsync(int id);
 
-                [MethodImpl(InlineOption)]
-                protected void SetStateForDisposeWithoutStart()
-                {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    // Base Dispose checks the state in DEBUG mode.
-                    State = Promise.State.Resolved;
-#endif
-                    // This is never used as a backing reference for Promises, so we need to suppress the UnobservedPromiseException from the base finalizer.
-                    WasAwaitedOrForgotten = true;
-                }
-
                 protected void ResetForNextAwait()
                 {
                     // Invalidate the previous awaiter.
@@ -416,7 +405,7 @@ namespace Proto.Promises
 
             protected override Promise DisposeAsyncWithoutStart()
             {
-                SetStateForDisposeWithoutStart();
+                PrepareEarlyDispose();
                 var iterator = _iterator;
                 DisposeAndReturnToPool();
                 return iterator.DisposeAsyncWithoutStart();

--- a/Package/Core/Linq/Internal/AsyncEnumerablePartitionInternal.cs
+++ b/Package/Core/Linq/Internal/AsyncEnumerablePartitionInternal.cs
@@ -74,7 +74,7 @@ namespace Proto.Promises
 
             protected override Promise DisposeAsyncWithoutStart()
             {
-                SetStateForDisposeWithoutStart();
+                PrepareEarlyDispose();
                 var source = _source;
                 DisposeAndReturnToPool();
                 return source.DisposeAsync();
@@ -292,7 +292,7 @@ namespace Proto.Promises
 
             protected override Promise DisposeAsyncWithoutStart()
             {
-                SetStateForDisposeWithoutStart();
+                PrepareEarlyDispose();
                 var source = _source;
                 DisposeAndReturnToPool();
                 return source.DisposeAsync();

--- a/Package/Core/Linq/Internal/MergeInternal.cs
+++ b/Package/Core/Linq/Internal/MergeInternal.cs
@@ -214,7 +214,7 @@ namespace Proto.Promises
             protected override async Promise DisposeAsyncWithoutStart()
             {
                 var sources = _sourcesEnumerator;
-                SetStateForDisposeWithoutStart();
+                PrepareEarlyDispose();
                 DisposeAndReturnToPool();
                 // We can't be sure if the _sourcesEnumerator is from a collection with already existing AsyncEnumerables (like array.ToAsyncEnumerable()),
                 // or a lazy iterator, so we have to iterate it and dispose every AsyncEnumerable.
@@ -451,7 +451,7 @@ namespace Proto.Promises
             protected override async Promise DisposeAsyncWithoutStart()
             {
                 var sources = _sourcesEnumerator;
-                SetStateForDisposeWithoutStart();
+                PrepareEarlyDispose();
                 DisposeAndReturnToPool();
                 // We can't be sure if the _sourcesEnumerator is from a collection with already existing AsyncEnumerables (like an array or list),
                 // or a lazy iterator, so we have to iterate it and dispose every AsyncEnumerable.

--- a/Package/Core/PromiseGroups/Internal/PromiseEachGroupInternal.cs
+++ b/Package/Core/PromiseGroups/Internal/PromiseEachGroupInternal.cs
@@ -145,10 +145,8 @@ namespace Proto.Promises
 
                     var exception = GetAggregateException();
 
-                    // MoveNextAsync may have completed synchronously, or not called at all, in which case this will never have had a waiter added to it or had its promise state set.
-                    // So we need to mark it awaited to prevent the finalizer from reporting it as not awaited, and prepare the dispose.
-                    this.PrepareEarlyDispose();
-                    WasAwaitedOrForgotten = true;
+                    // MoveNextAsync may have completed synchronously, or not called at all.
+                    PrepareEarlyDispose();
                     Dispose();
                     return exception == null
                         ? Promise.Resolved()

--- a/Package/Core/Promises/Internal/EachInternal.cs
+++ b/Package/Core/Promises/Internal/EachInternal.cs
@@ -86,10 +86,8 @@ namespace Proto.Promises
                 {
                     ValidateNoPending();
 
-                    // MoveNextAsync/DisposeAsync may have completed synchronously, or not called at all, in which case this will never have had a waiter added to it or had its promise state set.
-                    // So we need to mark it awaited to prevent the finalizer from reporting it as not awaited, and prepare the dispose.
-                    this.PrepareEarlyDispose();
-                    WasAwaitedOrForgotten = true;
+                    // MoveNextAsync/DisposeAsync may have completed synchronously, or not called at all.
+                    PrepareEarlyDispose();
                     base.Dispose();
                     _disposed = true;
                     _current = default;

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -210,6 +210,7 @@ namespace Proto.Promises
 
                 internal abstract PromiseRef<TResult> GetDuplicateT(short promiseId);
 
+                [MethodImpl(InlineOption)]
                 new protected void Dispose()
                 {
                     base.Dispose();
@@ -292,6 +293,19 @@ namespace Proto.Promises
                 SetCreatedStacktrace(this, 3);
             }
 
+            [MethodImpl(InlineOption)]
+            protected void PrepareEarlyDispose()
+            {
+                // Dispose validates the state is not pending in Debug or Developer mode,
+                // so we only set the state for early dispose in those modes.
+#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
+                SetCompletionState(Promise.State.Resolved);
+#endif
+                // Suppress the UnobservedPromiseException from the finalizer.
+                WasAwaitedOrForgotten = true;
+            }
+
+            [MethodImpl(InlineOption)]
             private void Dispose()
             {
                 ThrowIfInPool(this);

--- a/Package/Core/Threading/Internal/AsyncAutoResetEventInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncAutoResetEventInternal.cs
@@ -48,7 +48,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal void DisposeImmediate()
             {
-                this.PrepareEarlyDispose();
+                PrepareEarlyDispose();
                 MaybeDispose();
             }
 

--- a/Package/Core/Threading/Internal/AsyncCountdownEventInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncCountdownEventInternal.cs
@@ -48,7 +48,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal void DisposeImmediate()
             {
-                this.PrepareEarlyDispose();
+                PrepareEarlyDispose();
                 MaybeDispose();
             }
 

--- a/Package/Core/Threading/Internal/AsyncLockInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncLockInternal.cs
@@ -74,7 +74,7 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 internal void DisposeImmediate()
                 {
-                    this.PrepareEarlyDispose();
+                    PrepareEarlyDispose();
                     MaybeDispose();
                 }
 
@@ -156,7 +156,7 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 internal void DisposeImmediate()
                 {
-                    this.PrepareEarlyDispose();
+                    PrepareEarlyDispose();
                     MaybeDispose();
                 }
 

--- a/Package/Core/Threading/Internal/AsyncManualResetEventInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncManualResetEventInternal.cs
@@ -48,7 +48,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal void DisposeImmediate()
             {
-                this.PrepareEarlyDispose();
+                PrepareEarlyDispose();
                 MaybeDispose();
             }
 

--- a/Package/Core/Threading/Internal/AsyncReaderWriterLockInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncReaderWriterLockInternal.cs
@@ -52,7 +52,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal void DisposeImmediate()
             {
-                this.PrepareEarlyDispose();
+                PrepareEarlyDispose();
                 MaybeDispose();
             }
 
@@ -115,7 +115,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal void DisposeImmediate()
             {
-                this.PrepareEarlyDispose();
+                PrepareEarlyDispose();
                 MaybeDispose();
             }
 
@@ -178,7 +178,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal void DisposeImmediate()
             {
-                this.PrepareEarlyDispose();
+                PrepareEarlyDispose();
                 MaybeDispose();
             }
 
@@ -241,7 +241,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal void DisposeImmediate()
             {
-                this.PrepareEarlyDispose();
+                PrepareEarlyDispose();
                 MaybeDispose();
             }
 

--- a/Package/Core/Threading/Internal/AsyncSemaphoreInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncSemaphoreInternal.cs
@@ -48,7 +48,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal void DisposeImmediate()
             {
-                this.PrepareEarlyDispose();
+                PrepareEarlyDispose();
                 MaybeDispose();
             }
 


### PR DESCRIPTION
Follow-up to #461. Added `WasAwaitedOrForgotten = true` to the method in case the object is not re-used from the pool, and called the method in more places that previously used a duplicate method.