### PR TITLE
Remove unnecessary finalizers

### DIFF
--- a/Package/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/Package/Core/Cancelations/Internal/CancelationInternal.cs
@@ -658,20 +658,6 @@ namespace Proto.Promises
 
                 private CallbackNodeImpl() { }
 
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                private bool _disposed;
-
-                ~CallbackNodeImpl()
-                {
-                    if (!_disposed)
-                    {
-                        // For debugging. This should never happen.
-                        string message = $"A {GetType()} was garbage collected without it being disposed.";
-                        ReportRejection(new UnreleasedObjectException(message), this);
-                    }
-                }
-#endif
-
                 [MethodImpl(InlineOption)]
                 private static CallbackNodeImpl<TCancelable> GetOrCreate()
                 {
@@ -687,10 +673,6 @@ namespace Proto.Promises
                     var node = GetOrCreate();
                     node._parentId = parent._smallFields._instanceId;
                     node._cancelable = cancelable;
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    // If the CancelationRef was attached to a BCL token, it is possible this will not be disposed, so we won't check for it.
-                    node._disposed = parent._linkedToBclToken;
-#endif
                     SetCreatedStacktrace(node, 2);
                     return node;
                 }
@@ -719,9 +701,6 @@ namespace Proto.Promises
                         ++_nodeId;
                     }
                     _cancelable = default;
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    _disposed = true;
-#endif
                     ObjectPool.MaybeRepool(this);
                 }
             } // class CallbackNodeImpl<TCancelable>
@@ -737,20 +716,6 @@ namespace Proto.Promises
                 private CancelationRef _parent;
 
                 private LinkedCancelationNode() { }
-
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                private bool _disposed;
-
-                ~LinkedCancelationNode()
-                {
-                    if (!_disposed)
-                    {
-                        // For debugging. This should never happen.
-                        string message = "A LinkedCancelationNode was garbage collected without it being disposed.";
-                        ReportRejection(new UnreleasedObjectException(message), _target);
-                    }
-                }
-#endif
 
                 [MethodImpl(InlineOption)]
                 private static LinkedCancelationNode GetOrCreate()
@@ -800,9 +765,6 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 private void Repool()
                 {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    _disposed = true;
-#endif
                     ObjectPool.MaybeRepool(this);
                 }
 

--- a/Package/Core/Collections/Internal/ConcurrentQueueSegmentInternal.cs
+++ b/Package/Core/Collections/Internal/ConcurrentQueueSegmentInternal.cs
@@ -56,18 +56,6 @@ namespace Proto.Promises.Collections
 
         private ConcurrentQueueSegment() { }
 
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-        private bool _isDisposed;
-
-        ~ConcurrentQueueSegment()
-        {
-            if (!_isDisposed)
-            {
-                Internal.ReportRejection(new UnreleasedObjectException("A ConcurrentQueueSegment was garbage collected without being disposed"), null);
-            }
-        }
-#endif
-
         [MethodImpl(Internal.InlineOption)]
         private static ConcurrentQueueSegment<T> GetOrCreate()
         {
@@ -90,9 +78,6 @@ namespace Proto.Promises.Collections
 
             var segment = GetOrCreate();
             segment._next = null;
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-            segment._isDisposed = false;
-#endif
 
             var slots = ArrayPool<Slot>.Shared.Rent(boundedLength);
             segment._slots = slots;
@@ -126,9 +111,6 @@ namespace Proto.Promises.Collections
 
         public void Dispose()
         {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-            _isDisposed = true;
-#endif
             ArrayPool<Slot>.Shared.Return(_slots, true);
             _slots = null;
             Internal.ObjectPool.MaybeRepool(this);

--- a/Package/Core/Linq/Internal/CountByInternal.cs
+++ b/Package/Core/Linq/Internal/CountByInternal.cs
@@ -139,18 +139,6 @@ namespace Proto.Promises
                 internal TKey _key;
                 internal TValue _value;
                 internal int _hashCode;
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                private bool _disposed;
-
-                ~Node()
-                {
-                    if (!_disposed)
-                    {
-                        // For debugging. This should never happen.
-                        ReportRejection(new UnreleasedObjectException("A PreservedEnumerationDictionary<,,>.Node was garbage collected without it being disposed."), null);
-                    }
-                }
-#endif
 
                 private Node() { }
 
@@ -169,17 +157,11 @@ namespace Proto.Promises
                     node._key = key;
                     node._hashCode = hashCode;
                     node._hashNext = hashNext;
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    node._disposed = false;
-#endif
                     return node;
                 }
 
                 public void Dispose()
                 {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    _disposed = true;
-#endif
                     _hashNext = null;
                     _nextNode = null;
                     _key = default;

--- a/Package/Core/Linq/Internal/GroupingInternal.cs
+++ b/Package/Core/Linq/Internal/GroupingInternal.cs
@@ -26,18 +26,6 @@ namespace Proto.Promises
             internal TempCollectionBuilder<TElement> _elements;
             internal TKey _key;
             internal int _hashCode;
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-            private bool _disposed;
-
-            ~Grouping()
-            {
-                if (!_disposed)
-                {
-                    // For debugging. This should never happen.
-                    ReportRejection(new UnreleasedObjectException("A Grouping was garbage collected without it being disposed."), null);
-                }
-            }
-#endif
 
             private Grouping() { }
 
@@ -59,7 +47,6 @@ namespace Proto.Promises
                 grouping._hashNext = hashNext;
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
                 // ToLookupAsync does not dispose. GroupByAsync does.
-                grouping._disposed = !willBeDisposed;
                 if (!willBeDisposed)
                 {
                     Discard(grouping._elements._disposedChecker);
@@ -106,9 +93,6 @@ namespace Proto.Promises
 
             public void Dispose()
             {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                _disposed = true;
-#endif
                 _hashNext = null;
                 _nextGrouping = null;
                 _elements.Dispose();

--- a/Package/Core/PromiseGroups/Internal/PromiseMergeGroupInternal.cs
+++ b/Package/Core/PromiseGroups/Internal/PromiseMergeGroupInternal.cs
@@ -61,9 +61,6 @@ namespace Proto.Promises
                     passThrough._next = target;
                     passThrough._index = index;
                     passThrough._owner = owner;
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    passThrough._disposed = false;
-#endif
                     return passThrough;
                 }
 
@@ -77,9 +74,6 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
                     _owner.MaybeDispose();
                     _owner = null;
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    _disposed = true;
-#endif
                     ObjectPool.MaybeRepool(this);
                 }
             }

--- a/Package/Core/Promises/Internal/MergeInternal.cs
+++ b/Package/Core/Promises/Internal/MergeInternal.cs
@@ -259,9 +259,6 @@ namespace Proto.Promises
                     passThrough._index = index;
                     passThrough._owner = owner;
                     passThrough._id = id;
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    passThrough._disposed = false;
-#endif
                     return passThrough;
                 }
 
@@ -284,9 +281,6 @@ namespace Proto.Promises
                 {
                     ThrowIfInPool(this);
                     _owner = null;
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    _disposed = true;
-#endif
                     ObjectPool.MaybeRepool(this);
                 }
             }

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -353,7 +353,6 @@ namespace Proto.Promises
                 protected int _index;
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
                 protected PromiseRefBase _owner;
-                protected bool _disposed;
 #endif
             }
 

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -1910,18 +1910,6 @@ namespace Proto.Promises
 #endif
             internal partial class PromisePassThrough : HandleablePromiseBase
             {
-#if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                ~PromisePassThrough()
-                {
-                    if (!_disposed)
-                    {
-                        // For debugging. This should never happen.
-                        string message = $"A {GetType()} was garbage collected without it being released. _index: {_index}, _owner: {_owner}, _next: {_next}";
-                        ReportRejection(new UnreleasedObjectException(message), _owner);
-                    }
-                }
-#endif
-
                 protected PromisePassThrough() { }
 
                 [MethodImpl(InlineOption)]
@@ -1941,7 +1929,6 @@ namespace Proto.Promises
                     passThrough._index = index;
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
                     passThrough._owner = owner;
-                    passThrough._disposed = false;
 #endif
                     return passThrough;
                 }
@@ -1959,7 +1946,6 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
                     _owner = null;
-                    _disposed = true;
 #endif
                     ObjectPool.MaybeRepool(this);
                 }


### PR DESCRIPTION
Tests already cover these internal types not being cleaned up without relying on GC.