### PR TITLE
Fix race condition with `Promise.New`

### DIFF
--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -174,6 +174,7 @@ namespace Proto.Promises
             partial class DeferredNewPromise<TResult, TDelegate> : DeferredPromise<TResult>
                 where TDelegate : IDelegateNew<TResult>
             {
+                private int _disposeCounter;
                 private TDelegate _runner;
             }
 


### PR DESCRIPTION
The race condition will not show up in most cases. It requires the callback to complete the deferred and then throw an exception.