### PR TITLE
Ignore AsValueTask context capture

### DIFF
--- a/Package/Core/Promises/Internal/AsValueTaskInternal.cs
+++ b/Package/Core/Promises/Internal/AsValueTaskInternal.cs
@@ -29,7 +29,7 @@ namespace Proto.Promises
                     return new ValueTask();
                 }
 
-                var source = PooledValueTaskSource<VoidResult>.GetOrCreate(this);
+                var source = PooledValueTaskSource<VoidResult>.GetOrCreate(_ignoreValueTaskContextScheduling);
                 HookupNewWaiter(id, source);
                 return source.TaskVoid;
             }
@@ -45,7 +45,7 @@ namespace Proto.Promises
                         return new ValueTask<TResult>(result);
                     }
 
-                    var source = PooledValueTaskSource<TResult>.GetOrCreate(this);
+                    var source = PooledValueTaskSource<TResult>.GetOrCreate(_ignoreValueTaskContextScheduling);
                     HookupNewWaiter(id, source);
                     return source.Task;
                 }
@@ -83,12 +83,12 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal static PooledValueTaskSource<TResult> GetOrCreate(PromiseRefBase promise)
+                internal static PooledValueTaskSource<TResult> GetOrCreate(bool ignoreValueTaskContextScheduling)
                 {
                     var source = GetOrCreate();
                     // If the promise we're converting to a ValueTask is already configured to execute on a certain context,
-                    // we ignore the context scheduling of the ValueTask continuation and continue synchronously.
-                    source._flagsMask = promise is IConfiguredPromise
+                    // we ignore the context scheduling of the ValueTask continuation, and continue synchronously.
+                    source._flagsMask = ignoreValueTaskContextScheduling
                         ? ~ValueTaskSourceOnCompletedFlags.UseSchedulingContext
                         : ~ValueTaskSourceOnCompletedFlags.None;
                     return source;

--- a/Package/Core/Promises/Internal/ConfiguredPromise.cs
+++ b/Package/Core/Promises/Internal/ConfiguredPromise.cs
@@ -15,13 +15,10 @@ namespace Proto.Promises
     {
         partial class PromiseRefBase : HandleablePromiseBase, ITraceable
         {
-            // A marker interface for AsValueTask.
-            internal interface IConfiguredPromise { }
-
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal sealed partial class ConfiguredPromise<TResult> : PromiseSingleAwait<TResult>, IConfiguredPromise
+            internal sealed partial class ConfiguredPromise<TResult> : PromiseSingleAwait<TResult>
             {
                 private ConfiguredPromise() { }
 
@@ -53,6 +50,11 @@ namespace Proto.Promises
 #endif
                     var promise = GetOrCreate();
                     promise.Reset();
+#if UNITY_2021_2_OR_NEWER || !UNITY_2018_3_OR_NEWER
+                    // If the promise is converted to ValueTask, we ignore the context scheduling,
+                    // since this is already configured to continue on a specified context.
+                    promise._ignoreValueTaskContextScheduling = true;
+#endif
                     promise._synchronizationContext = synchronizationContext;
                     promise._completedBehavior = completedBehavior;
                     return promise;

--- a/Package/Core/Promises/Internal/ConfiguredPromise.cs
+++ b/Package/Core/Promises/Internal/ConfiguredPromise.cs
@@ -15,10 +15,13 @@ namespace Proto.Promises
     {
         partial class PromiseRefBase : HandleablePromiseBase, ITraceable
         {
+            // A marker interface for AsValueTask.
+            internal interface IConfiguredPromise { }
+
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal sealed partial class ConfiguredPromise<TResult> : PromiseSingleAwait<TResult>
+            internal sealed partial class ConfiguredPromise<TResult> : PromiseSingleAwait<TResult>, IConfiguredPromise
             {
                 private ConfiguredPromise() { }
 

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -103,6 +103,9 @@ namespace Proto.Promises
             volatile private Promise.State _state;
             private bool _suppressRejection;
             private bool _wasAwaitedorForgotten;
+#if UNITY_2021_2_OR_NEWER || !UNITY_2018_3_OR_NEWER
+            internal bool _ignoreValueTaskContextScheduling;
+#endif
 
             partial class PromiseRef<TResult> : PromiseRefBase
             {

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -284,6 +284,9 @@ namespace Proto.Promises
                 _state = Promise.State.Pending;
                 _wasAwaitedorForgotten = false;
                 _suppressRejection = false;
+#if UNITY_2021_2_OR_NEWER || !UNITY_2018_3_OR_NEWER
+                _ignoreValueTaskContextScheduling = false;
+#endif
             }
 
             [MethodImpl(InlineOption)]


### PR DESCRIPTION
 if the converted promise was already configured.