### PR TITLE
Add `bool continueOnCapturedContext` overloads

### DIFF
--- a/Package/Core/Channels/ChannelReader.cs
+++ b/Package/Core/Channels/ChannelReader.cs
@@ -38,13 +38,46 @@ namespace Proto.Promises.Channels
         /// <summary>
         /// Asynchronously waits for data to be available to be read.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> that will resolve with <see langword="true"/> when data is available to be read,
+        /// or <see langword="false"/> when the channel is closed.
+        /// </returns>
+        public Promise<bool> WaitToReadAsync()
+            => WaitToReadAsync(CancelationToken.None);
+
+        /// <summary>
+        /// Asynchronously waits for data to be available to be read.
+        /// </summary>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> that will resolve with <see langword="true"/> when data is available to be read,
+        /// or <see langword="false"/> when the channel is closed.
+        /// </returns>
+        public Promise<bool> WaitToReadAsync(ContinuationOptions continuationOptions)
+            => _channel.ValidateAndGetRef().WaitToReadAsync(_channel._id, default, continuationOptions.GetValidated());
+
+        /// <summary>
+        /// Asynchronously waits for data to be available to be read.
+        /// </summary>
         /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the wait operation.</param>
         /// <returns>
         /// A <see cref="Promise{T}"/> that will resolve with <see langword="true"/> when data is available to be read,
         /// or <see langword="false"/> when the channel is closed.
         /// </returns>
-        public Promise<bool> WaitToReadAsync(CancelationToken cancelationToken = default)
-            => _channel.ValidateAndGetRef().WaitToReadAsync(_channel._id, cancelationToken);
+        public Promise<bool> WaitToReadAsync(CancelationToken cancelationToken)
+            => _channel.ValidateAndGetRef().WaitToReadAsync(_channel._id, cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously waits for data to be available to be read.
+        /// </summary>
+        /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the wait operation.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> that will resolve with <see langword="true"/> when data is available to be read,
+        /// or <see langword="false"/> when the channel is closed.
+        /// </returns>
+        public Promise<bool> WaitToReadAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => _channel.ValidateAndGetRef().WaitToReadAsync(_channel._id, cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Attempts to peek at an item from the channel in a non-blocking manner.
@@ -63,10 +96,34 @@ namespace Proto.Promises.Channels
         /// <summary>
         /// Asynchronously reads an item from the channel.
         /// </summary>
+        /// <returns>A <see cref="Promise{T}"/> that yields the result of the read operation.</returns>
+        public Promise<ChannelReadResult<T>> ReadAsync()
+            => ReadAsync(CancelationToken.None);
+
+        /// <summary>
+        /// Asynchronously reads an item from the channel.
+        /// </summary>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <returns>A <see cref="Promise{T}"/> that yields the result of the read operation.</returns>
+        public Promise<ChannelReadResult<T>> ReadAsync(ContinuationOptions continuationOptions)
+            => _channel.ValidateAndGetRef().ReadAsync(_channel._id, default, continuationOptions.GetValidated());
+
+        /// <summary>
+        /// Asynchronously reads an item from the channel.
+        /// </summary>
         /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the read operation.</param>
         /// <returns>A <see cref="Promise{T}"/> that yields the result of the read operation.</returns>
-        public Promise<ChannelReadResult<T>> ReadAsync(CancelationToken cancelationToken = default)
-            => _channel.ValidateAndGetRef().ReadAsync(_channel._id, cancelationToken);
+        public Promise<ChannelReadResult<T>> ReadAsync(CancelationToken cancelationToken)
+            => _channel.ValidateAndGetRef().ReadAsync(_channel._id, cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously reads an item from the channel.
+        /// </summary>
+        /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the read operation.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <returns>A <see cref="Promise{T}"/> that yields the result of the read operation.</returns>
+        public Promise<ChannelReadResult<T>> ReadAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => _channel.ValidateAndGetRef().ReadAsync(_channel._id, cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that enables reading all of the data from the channel.

--- a/Package/Core/Channels/ChannelReader.cs
+++ b/Package/Core/Channels/ChannelReader.cs
@@ -43,18 +43,18 @@ namespace Proto.Promises.Channels
         /// or <see langword="false"/> when the channel is closed.
         /// </returns>
         public Promise<bool> WaitToReadAsync()
-            => WaitToReadAsync(CancelationToken.None);
+            => WaitToReadAsync(CancelationToken.None, true);
 
         /// <summary>
         /// Asynchronously waits for data to be available to be read.
         /// </summary>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and data is not immediately available, the async continuation will be executed on the captured context.</param>
         /// <returns>
         /// A <see cref="Promise{T}"/> that will resolve with <see langword="true"/> when data is available to be read,
         /// or <see langword="false"/> when the channel is closed.
         /// </returns>
-        public Promise<bool> WaitToReadAsync(ContinuationOptions continuationOptions)
-            => _channel.ValidateAndGetRef().WaitToReadAsync(_channel._id, default, continuationOptions.GetValidated());
+        public Promise<bool> WaitToReadAsync(bool continueOnCapturedContext)
+            => WaitToReadAsync(CancelationToken.None, continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously waits for data to be available to be read.
@@ -65,19 +65,19 @@ namespace Proto.Promises.Channels
         /// or <see langword="false"/> when the channel is closed.
         /// </returns>
         public Promise<bool> WaitToReadAsync(CancelationToken cancelationToken)
-            => _channel.ValidateAndGetRef().WaitToReadAsync(_channel._id, cancelationToken, ContinuationOptions.CapturedContext);
+            => WaitToReadAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously waits for data to be available to be read.
         /// </summary>
         /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the wait operation.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and data is not immediately available, the async continuation will be executed on the captured context.</param>
         /// <returns>
         /// A <see cref="Promise{T}"/> that will resolve with <see langword="true"/> when data is available to be read,
         /// or <see langword="false"/> when the channel is closed.
         /// </returns>
-        public Promise<bool> WaitToReadAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => _channel.ValidateAndGetRef().WaitToReadAsync(_channel._id, cancelationToken, continuationOptions.GetValidated());
+        public Promise<bool> WaitToReadAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => _channel.ValidateAndGetRef().WaitToReadAsync(_channel._id, cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Attempts to peek at an item from the channel in a non-blocking manner.
@@ -98,15 +98,15 @@ namespace Proto.Promises.Channels
         /// </summary>
         /// <returns>A <see cref="Promise{T}"/> that yields the result of the read operation.</returns>
         public Promise<ChannelReadResult<T>> ReadAsync()
-            => ReadAsync(CancelationToken.None);
+            => ReadAsync(CancelationToken.None, true);
 
         /// <summary>
         /// Asynchronously reads an item from the channel.
         /// </summary>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and data is not immediately available, the async continuation will be executed on the captured context.</param>
         /// <returns>A <see cref="Promise{T}"/> that yields the result of the read operation.</returns>
-        public Promise<ChannelReadResult<T>> ReadAsync(ContinuationOptions continuationOptions)
-            => _channel.ValidateAndGetRef().ReadAsync(_channel._id, default, continuationOptions.GetValidated());
+        public Promise<ChannelReadResult<T>> ReadAsync(bool continueOnCapturedContext)
+            => ReadAsync(CancelationToken.None, continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously reads an item from the channel.
@@ -114,16 +114,16 @@ namespace Proto.Promises.Channels
         /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the read operation.</param>
         /// <returns>A <see cref="Promise{T}"/> that yields the result of the read operation.</returns>
         public Promise<ChannelReadResult<T>> ReadAsync(CancelationToken cancelationToken)
-            => _channel.ValidateAndGetRef().ReadAsync(_channel._id, cancelationToken, ContinuationOptions.CapturedContext);
+            => ReadAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously reads an item from the channel.
         /// </summary>
         /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the read operation.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and data is not immediately available, the async continuation will be executed on the captured context.</param>
         /// <returns>A <see cref="Promise{T}"/> that yields the result of the read operation.</returns>
-        public Promise<ChannelReadResult<T>> ReadAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => _channel.ValidateAndGetRef().ReadAsync(_channel._id, cancelationToken, continuationOptions.GetValidated());
+        public Promise<ChannelReadResult<T>> ReadAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => _channel.ValidateAndGetRef().ReadAsync(_channel._id, cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that enables reading all of the data from the channel.

--- a/Package/Core/Channels/ChannelWriter.cs
+++ b/Package/Core/Channels/ChannelWriter.cs
@@ -30,13 +30,46 @@ namespace Proto.Promises.Channels
         /// <summary>
         /// Asynchronously waits for space to be available to write an item.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> that will resolve with <see langword="true"/> when space is available to write an item,
+        /// or <see langword="false"/> when the channel is closed.
+        /// </returns>
+        public Promise<bool> WaitToWriteAsync()
+            => WaitToWriteAsync(CancelationToken.None);
+
+        /// <summary>
+        /// Asynchronously waits for space to be available to write an item.
+        /// </summary>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> that will resolve with <see langword="true"/> when space is available to write an item,
+        /// or <see langword="false"/> when the channel is closed.
+        /// </returns>
+        public Promise<bool> WaitToWriteAsync(ContinuationOptions continuationOptions)
+            => _channel.ValidateAndGetRef().WaitToWriteAsync(_channel._id, default, continuationOptions.GetValidated());
+
+        /// <summary>
+        /// Asynchronously waits for space to be available to write an item.
+        /// </summary>
         /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the wait operation.</param>
         /// <returns>
         /// A <see cref="Promise{T}"/> that will resolve with <see langword="true"/> when space is available to write an item,
         /// or <see langword="false"/> when the channel is closed.
         /// </returns>
-        public Promise<bool> WaitToWriteAsync(CancelationToken cancelationToken = default)
-            => _channel.ValidateAndGetRef().WaitToWriteAsync(_channel._id, cancelationToken);
+        public Promise<bool> WaitToWriteAsync(CancelationToken cancelationToken)
+            => _channel.ValidateAndGetRef().WaitToWriteAsync(_channel._id, cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously waits for space to be available to write an item.
+        /// </summary>
+        /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the wait operation.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> that will resolve with <see langword="true"/> when space is available to write an item,
+        /// or <see langword="false"/> when the channel is closed.
+        /// </returns>
+        public Promise<bool> WaitToWriteAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => _channel.ValidateAndGetRef().WaitToWriteAsync(_channel._id, cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Attempts to write an item to the channel in a non-blocking manner.
@@ -50,10 +83,37 @@ namespace Proto.Promises.Channels
         /// Asynchronously writes an item to the channel.
         /// </summary>
         /// <param name="item">The value to write to the channel.</param>
+        /// <returns>A <see cref="Promise{T}"/> that yields the result of the write operation.</returns>
+        public Promise<ChannelWriteResult<T>> WriteAsync(T item)
+            => _channel.ValidateAndGetRef().WriteAsync(item, _channel._id, default, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously writes an item to the channel.
+        /// </summary>
+        /// <param name="item">The value to write to the channel.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <returns>A <see cref="Promise{T}"/> that yields the result of the write operation.</returns>
+        public Promise<ChannelWriteResult<T>> WriteAsync(T item, ContinuationOptions continuationOptions)
+            => _channel.ValidateAndGetRef().WriteAsync(item, _channel._id, default, continuationOptions.GetValidated());
+
+        /// <summary>
+        /// Asynchronously writes an item to the channel.
+        /// </summary>
+        /// <param name="item">The value to write to the channel.</param>
         /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the write operation.</param>
         /// <returns>A <see cref="Promise{T}"/> that yields the result of the write operation.</returns>
-        public Promise<ChannelWriteResult<T>> WriteAsync(T item, CancelationToken cancelationToken = default)
-            => _channel.ValidateAndGetRef().WriteAsync(item, _channel._id, cancelationToken);
+        public Promise<ChannelWriteResult<T>> WriteAsync(T item, CancelationToken cancelationToken)
+            => _channel.ValidateAndGetRef().WriteAsync(item, _channel._id, cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously writes an item to the channel.
+        /// </summary>
+        /// <param name="item">The value to write to the channel.</param>
+        /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the write operation.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <returns>A <see cref="Promise{T}"/> that yields the result of the write operation.</returns>
+        public Promise<ChannelWriteResult<T>> WriteAsync(T item, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => _channel.ValidateAndGetRef().WriteAsync(item, _channel._id, cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Attempts to close the channel in a rejected state.

--- a/Package/Core/Channels/ChannelWriter.cs
+++ b/Package/Core/Channels/ChannelWriter.cs
@@ -35,18 +35,18 @@ namespace Proto.Promises.Channels
         /// or <see langword="false"/> when the channel is closed.
         /// </returns>
         public Promise<bool> WaitToWriteAsync()
-            => WaitToWriteAsync(CancelationToken.None);
+            => WaitToWriteAsync(CancelationToken.None, true);
 
         /// <summary>
         /// Asynchronously waits for space to be available to write an item.
         /// </summary>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and space is not immediately available, the async continuation will be executed on the captured context.</param>
         /// <returns>
         /// A <see cref="Promise{T}"/> that will resolve with <see langword="true"/> when space is available to write an item,
         /// or <see langword="false"/> when the channel is closed.
         /// </returns>
-        public Promise<bool> WaitToWriteAsync(ContinuationOptions continuationOptions)
-            => _channel.ValidateAndGetRef().WaitToWriteAsync(_channel._id, default, continuationOptions.GetValidated());
+        public Promise<bool> WaitToWriteAsync(bool continueOnCapturedContext)
+            => WaitToWriteAsync(CancelationToken.None, continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously waits for space to be available to write an item.
@@ -57,19 +57,19 @@ namespace Proto.Promises.Channels
         /// or <see langword="false"/> when the channel is closed.
         /// </returns>
         public Promise<bool> WaitToWriteAsync(CancelationToken cancelationToken)
-            => _channel.ValidateAndGetRef().WaitToWriteAsync(_channel._id, cancelationToken, ContinuationOptions.CapturedContext);
+            => WaitToWriteAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously waits for space to be available to write an item.
         /// </summary>
         /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the wait operation.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and space is not immediately available, the async continuation will be executed on the captured context.</param>
         /// <returns>
         /// A <see cref="Promise{T}"/> that will resolve with <see langword="true"/> when space is available to write an item,
         /// or <see langword="false"/> when the channel is closed.
         /// </returns>
-        public Promise<bool> WaitToWriteAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => _channel.ValidateAndGetRef().WaitToWriteAsync(_channel._id, cancelationToken, continuationOptions.GetValidated());
+        public Promise<bool> WaitToWriteAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => _channel.ValidateAndGetRef().WaitToWriteAsync(_channel._id, cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Attempts to write an item to the channel in a non-blocking manner.
@@ -85,16 +85,16 @@ namespace Proto.Promises.Channels
         /// <param name="item">The value to write to the channel.</param>
         /// <returns>A <see cref="Promise{T}"/> that yields the result of the write operation.</returns>
         public Promise<ChannelWriteResult<T>> WriteAsync(T item)
-            => _channel.ValidateAndGetRef().WriteAsync(item, _channel._id, default, ContinuationOptions.CapturedContext);
+            => WriteAsync(item, CancelationToken.None, true);
 
         /// <summary>
         /// Asynchronously writes an item to the channel.
         /// </summary>
         /// <param name="item">The value to write to the channel.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and space is not immediately available, the async continuation will be executed on the captured context.</param>
         /// <returns>A <see cref="Promise{T}"/> that yields the result of the write operation.</returns>
-        public Promise<ChannelWriteResult<T>> WriteAsync(T item, ContinuationOptions continuationOptions)
-            => _channel.ValidateAndGetRef().WriteAsync(item, _channel._id, default, continuationOptions.GetValidated());
+        public Promise<ChannelWriteResult<T>> WriteAsync(T item, bool continueOnCapturedContext)
+            => WriteAsync(item, CancelationToken.None, continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously writes an item to the channel.
@@ -103,17 +103,17 @@ namespace Proto.Promises.Channels
         /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the write operation.</param>
         /// <returns>A <see cref="Promise{T}"/> that yields the result of the write operation.</returns>
         public Promise<ChannelWriteResult<T>> WriteAsync(T item, CancelationToken cancelationToken)
-            => _channel.ValidateAndGetRef().WriteAsync(item, _channel._id, cancelationToken, ContinuationOptions.CapturedContext);
+            => WriteAsync(item, cancelationToken, true);
 
         /// <summary>
         /// Asynchronously writes an item to the channel.
         /// </summary>
         /// <param name="item">The value to write to the channel.</param>
         /// <param name="cancelationToken">A <see cref="CancelationToken"/> used to cancel the write operation.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and space is not immediately available, the async continuation will be executed on the captured context.</param>
         /// <returns>A <see cref="Promise{T}"/> that yields the result of the write operation.</returns>
-        public Promise<ChannelWriteResult<T>> WriteAsync(T item, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => _channel.ValidateAndGetRef().WriteAsync(item, _channel._id, cancelationToken, continuationOptions.GetValidated());
+        public Promise<ChannelWriteResult<T>> WriteAsync(T item, CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => _channel.ValidateAndGetRef().WriteAsync(item, _channel._id, cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Attempts to close the channel in a rejected state.

--- a/Package/Core/Channels/Internal/ChannelBaseInternal.cs
+++ b/Package/Core/Channels/Internal/ChannelBaseInternal.cs
@@ -105,10 +105,10 @@ namespace Proto.Promises
             internal abstract ChannelPeekResult<T> TryPeek(int id);
             internal abstract ChannelReadResult<T> TryRead(int id);
             internal abstract ChannelWriteResult<T> TryWrite(in T item, int id);
-            internal abstract Promise<ChannelReadResult<T>> ReadAsync(int id, CancelationToken cancelationToken);
-            internal abstract Promise<ChannelWriteResult<T>> WriteAsync(in T item, int id, CancelationToken cancelationToken);
-            internal abstract Promise<bool> WaitToReadAsync(int id, CancelationToken cancelationToken);
-            internal abstract Promise<bool> WaitToWriteAsync(int id, CancelationToken cancelationToken);
+            internal abstract Promise<ChannelReadResult<T>> ReadAsync(int id, CancelationToken cancelationToken, ContinuationOptions continuationOptions);
+            internal abstract Promise<ChannelWriteResult<T>> WriteAsync(in T item, int id, CancelationToken cancelationToken, ContinuationOptions continuationOptions);
+            internal abstract Promise<bool> WaitToReadAsync(int id, CancelationToken cancelationToken, ContinuationOptions continuationOptions);
+            internal abstract Promise<bool> WaitToWriteAsync(int id, CancelationToken cancelationToken, ContinuationOptions continuationOptions);
             internal abstract bool TryReject(object reason, int id);
             internal abstract bool TryCancel(int id);
             internal abstract bool TryClose(int id);

--- a/Package/Core/Channels/Internal/ChannelBaseInternal.cs
+++ b/Package/Core/Channels/Internal/ChannelBaseInternal.cs
@@ -105,10 +105,10 @@ namespace Proto.Promises
             internal abstract ChannelPeekResult<T> TryPeek(int id);
             internal abstract ChannelReadResult<T> TryRead(int id);
             internal abstract ChannelWriteResult<T> TryWrite(in T item, int id);
-            internal abstract Promise<ChannelReadResult<T>> ReadAsync(int id, CancelationToken cancelationToken, ContinuationOptions continuationOptions);
-            internal abstract Promise<ChannelWriteResult<T>> WriteAsync(in T item, int id, CancelationToken cancelationToken, ContinuationOptions continuationOptions);
-            internal abstract Promise<bool> WaitToReadAsync(int id, CancelationToken cancelationToken, ContinuationOptions continuationOptions);
-            internal abstract Promise<bool> WaitToWriteAsync(int id, CancelationToken cancelationToken, ContinuationOptions continuationOptions);
+            internal abstract Promise<ChannelReadResult<T>> ReadAsync(int id, CancelationToken cancelationToken, bool continueOnCapturedContext);
+            internal abstract Promise<ChannelWriteResult<T>> WriteAsync(in T item, int id, CancelationToken cancelationToken, bool continueOnCapturedContext);
+            internal abstract Promise<bool> WaitToReadAsync(int id, CancelationToken cancelationToken, bool continueOnCapturedContext);
+            internal abstract Promise<bool> WaitToWriteAsync(int id, CancelationToken cancelationToken, bool continueOnCapturedContext);
             internal abstract bool TryReject(object reason, int id);
             internal abstract bool TryCancel(int id);
             internal abstract bool TryClose(int id);

--- a/Package/Core/Channels/Internal/ChannelPromisesInternal.cs
+++ b/Package/Core/Channels/Internal/ChannelPromisesInternal.cs
@@ -68,10 +68,10 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static ChannelWritePromise<T> GetOrCreate(in T item, BoundedChannel<T> owner, ContinuationOptions continuationOptions)
+            internal static ChannelWritePromise<T> GetOrCreate(in T item, BoundedChannel<T> owner, bool continueOnCapturedContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset(continuationOptions);
+                promise.Reset(continueOnCapturedContext);
                 promise._owner = owner;
                 // We store the item in the result so it can be added to the buffer when this is resolved.
                 promise._result = new ChannelWriteResult<T>(item, ChannelWriteResult.Success);
@@ -134,10 +134,10 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static ChannelReadPromise<T> GetOrCreate(ChannelBase<T> owner, ContinuationOptions continuationOptions)
+            internal static ChannelReadPromise<T> GetOrCreate(ChannelBase<T> owner, bool continueOnCapturedContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset(continuationOptions);
+                promise.Reset(continueOnCapturedContext);
                 promise._owner = owner;
                 return promise;
             }
@@ -191,10 +191,10 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static ChannelWaitToWritePromise GetOrCreate(ChannelBase owner, ContinuationOptions continuationOptions)
+            internal static ChannelWaitToWritePromise GetOrCreate(ChannelBase owner, bool continueOnCapturedContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset(continuationOptions);
+                promise.Reset(continueOnCapturedContext);
                 promise._owner = owner;
                 return promise;
             }
@@ -248,10 +248,10 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static ChannelWaitToReadPromise GetOrCreate(ChannelBase owner, ContinuationOptions continuationOptions)
+            internal static ChannelWaitToReadPromise GetOrCreate(ChannelBase owner, bool continueOnCapturedContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset(continuationOptions);
+                promise.Reset(continueOnCapturedContext);
                 promise._owner = owner;
                 return promise;
             }

--- a/Package/Core/Channels/Internal/ChannelPromisesInternal.cs
+++ b/Package/Core/Channels/Internal/ChannelPromisesInternal.cs
@@ -68,10 +68,10 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static ChannelWritePromise<T> GetOrCreate(in T item, BoundedChannel<T> owner, SynchronizationContext callerContext)
+            internal static ChannelWritePromise<T> GetOrCreate(in T item, BoundedChannel<T> owner, ContinuationOptions continuationOptions)
             {
                 var promise = GetOrCreate();
-                promise.Reset(callerContext);
+                promise.Reset(continuationOptions);
                 promise._owner = owner;
                 // We store the item in the result so it can be added to the buffer when this is resolved.
                 promise._result = new ChannelWriteResult<T>(item, ChannelWriteResult.Success);
@@ -134,10 +134,10 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static ChannelReadPromise<T> GetOrCreate(ChannelBase<T> owner, SynchronizationContext callerContext)
+            internal static ChannelReadPromise<T> GetOrCreate(ChannelBase<T> owner, ContinuationOptions continuationOptions)
             {
                 var promise = GetOrCreate();
-                promise.Reset(callerContext);
+                promise.Reset(continuationOptions);
                 promise._owner = owner;
                 return promise;
             }
@@ -191,10 +191,10 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static ChannelWaitToWritePromise GetOrCreate(ChannelBase owner, SynchronizationContext callerContext)
+            internal static ChannelWaitToWritePromise GetOrCreate(ChannelBase owner, ContinuationOptions continuationOptions)
             {
                 var promise = GetOrCreate();
-                promise.Reset(callerContext);
+                promise.Reset(continuationOptions);
                 promise._owner = owner;
                 return promise;
             }
@@ -248,10 +248,10 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static ChannelWaitToReadPromise GetOrCreate(ChannelBase owner, SynchronizationContext callerContext)
+            internal static ChannelWaitToReadPromise GetOrCreate(ChannelBase owner, ContinuationOptions continuationOptions)
             {
                 var promise = GetOrCreate();
-                promise.Reset(callerContext);
+                promise.Reset(continuationOptions);
                 promise._owner = owner;
                 return promise;
             }

--- a/Package/Core/Channels/Internal/UnboundedChannelInternal.cs
+++ b/Package/Core/Channels/Internal/UnboundedChannelInternal.cs
@@ -240,7 +240,7 @@ namespace Proto.Promises
                 }
             }
 
-            internal override Promise<ChannelReadResult<T>> ReadAsync(int id, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            internal override Promise<ChannelReadResult<T>> ReadAsync(int id, CancelationToken cancelationToken, bool continueOnCapturedContext)
             {
                 ValidateAndRetain(id);
 
@@ -248,15 +248,13 @@ namespace Proto.Promises
                 if (cancelationToken.IsCancelationRequested)
                 {
                     _queue.Release();
-                    return Promise<ChannelReadResult<T>>.Canceled()
-                        .ConfigureContinuation(continuationOptions);
+                    return Promise<ChannelReadResult<T>>.Canceled();
                 }
 
                 if (_queue.TryDequeue(out T item))
                 {
                     _queue.Release();
-                    return Promise.Resolved(new ChannelReadResult<T>(item, ChannelReadResult.Success))
-                        .ConfigureContinuation(continuationOptions);
+                    return Promise.Resolved(new ChannelReadResult<T>(item, ChannelReadResult.Success));
                 }
 
                 _smallFields._locker.Enter();
@@ -266,8 +264,7 @@ namespace Proto.Promises
                     {
                         _smallFields._locker.Exit();
                         _queue.Release();
-                        return Promise.Resolved(new ChannelReadResult<T>(item, ChannelReadResult.Success))
-                            .ConfigureContinuation(continuationOptions);
+                        return Promise.Resolved(new ChannelReadResult<T>(item, ChannelReadResult.Success));
                     }
 
                     var closedReason = _closedReason;
@@ -275,20 +272,18 @@ namespace Proto.Promises
                     {
                         _smallFields._locker.Exit();
                         _queue.Release();
-                        var returnPromise = closedReason == ChannelSmallFields.ClosedResolvedReason ? Promise.Resolved(new ChannelReadResult<T>(default, ChannelReadResult.Closed))
+                        return closedReason == ChannelSmallFields.ClosedResolvedReason ? Promise.Resolved(new ChannelReadResult<T>(default, ChannelReadResult.Closed))
                             : closedReason == ChannelSmallFields.ClosedCanceledReason ? Promise<ChannelReadResult<T>>.Canceled()
                             : closedReason == ChannelSmallFields.DisposedReason ? Promise<ChannelReadResult<T>>.Rejected(new System.ObjectDisposedException(nameof(Channel<T>)))
                             : Promise<ChannelReadResult<T>>.Rejected(closedReason);
-                        return returnPromise.ConfigureContinuation(continuationOptions);
                     }
 
-                    var promise = ChannelReadPromise<T>.GetOrCreate(this, continuationOptions);
+                    var promise = ChannelReadPromise<T>.GetOrCreate(this, continueOnCapturedContext);
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
                         _smallFields._locker.Exit();
                         promise.DisposeImmediate();
-                        return Promise<ChannelReadResult<T>>.Canceled()
-                            .ConfigureContinuation(continuationOptions);
+                        return Promise<ChannelReadResult<T>>.Canceled();
                     }
 
                     _readers.Enqueue(promise);
@@ -298,7 +293,7 @@ namespace Proto.Promises
                 }
             }
 
-            internal override Promise<ChannelWriteResult<T>> WriteAsync(in T item, int id, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            internal override Promise<ChannelWriteResult<T>> WriteAsync(in T item, int id, CancelationToken cancelationToken, bool continueOnCapturedContext)
             {
                 ValidateAndRetain(id);
 
@@ -307,8 +302,7 @@ namespace Proto.Promises
                 {
                     _smallFields._locker.Exit();
                     _queue.Release();
-                    return Promise<ChannelWriteResult<T>>.Canceled()
-                        .ConfigureContinuation(continuationOptions);
+                    return Promise<ChannelWriteResult<T>>.Canceled();
                 }
 
                 _smallFields._locker.Enter();
@@ -318,11 +312,10 @@ namespace Proto.Promises
                     {
                         _smallFields._locker.Exit();
                         _queue.Release();
-                        var returnPromise = closedReason == ChannelSmallFields.ClosedResolvedReason ? Promise.Resolved(new ChannelWriteResult<T>(default, ChannelWriteResult.Closed))
+                        return closedReason == ChannelSmallFields.ClosedResolvedReason ? Promise.Resolved(new ChannelWriteResult<T>(default, ChannelWriteResult.Closed))
                             : closedReason == ChannelSmallFields.ClosedCanceledReason ? Promise<ChannelWriteResult<T>>.Canceled()
                             : closedReason == ChannelSmallFields.DisposedReason ? Promise<ChannelWriteResult<T>>.Rejected(new System.ObjectDisposedException(nameof(Channel<T>)))
                             : Promise<ChannelWriteResult<T>>.Rejected(closedReason);
-                        return returnPromise.ConfigureContinuation(continuationOptions);
                     }
 
                     // If there is at least 1 reader, we grab one and complete it outside of the lock.
@@ -332,8 +325,7 @@ namespace Proto.Promises
                         _smallFields._locker.Exit();
                         _queue.Release();
                         reader.Resolve(new ChannelReadResult<T>(item, ChannelReadResult.Success));
-                        return Promise.Resolved(new ChannelWriteResult<T>(default, ChannelWriteResult.Success))
-                            .ConfigureContinuation(continuationOptions);
+                        return Promise.Resolved(new ChannelWriteResult<T>(default, ChannelWriteResult.Success));
                     }
 
                     // Otherwise, we just add the item to the queue, and notify waiting readers.
@@ -346,12 +338,11 @@ namespace Proto.Promises
                     {
                         waitToReaders.Pop().Resolve(true);
                     }
-                    return Promise.Resolved(new ChannelWriteResult<T>(default, ChannelWriteResult.Success))
-                        .ConfigureContinuation(continuationOptions);
+                    return Promise.Resolved(new ChannelWriteResult<T>(default, ChannelWriteResult.Success));
                 }
             }
 
-            internal override Promise<bool> WaitToReadAsync(int id, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            internal override Promise<bool> WaitToReadAsync(int id, CancelationToken cancelationToken, bool continueOnCapturedContext)
             {
                 ValidateAndRetain(id);
 
@@ -359,15 +350,13 @@ namespace Proto.Promises
                 if (cancelationToken.IsCancelationRequested)
                 {
                     _queue.Release();
-                    return Promise<bool>.Canceled()
-                        .ConfigureContinuation(continuationOptions);
+                    return Promise<bool>.Canceled();
                 }
 
                 if (!_queue.IsEmpty)
                 {
                     _queue.Release();
-                    return Promise.Resolved(true)
-                        .ConfigureContinuation(continuationOptions);
+                    return Promise.Resolved(true);
                 }
 
                 _smallFields._locker.Enter();
@@ -377,8 +366,7 @@ namespace Proto.Promises
                     {
                         _smallFields._locker.Exit();
                         _queue.Release();
-                        return Promise.Resolved(true)
-                            .ConfigureContinuation(continuationOptions);
+                        return Promise.Resolved(true);
                     }
 
                     var closedReason = _closedReason;
@@ -386,20 +374,18 @@ namespace Proto.Promises
                     {
                         _smallFields._locker.Exit();
                         _queue.Release();
-                        var returnPromise = closedReason == ChannelSmallFields.ClosedResolvedReason ? Promise.Resolved(false)
+                        return closedReason == ChannelSmallFields.ClosedResolvedReason ? Promise.Resolved(false)
                             : closedReason == ChannelSmallFields.ClosedCanceledReason ? Promise<bool>.Canceled()
                             : closedReason == ChannelSmallFields.DisposedReason ? Promise<bool>.Rejected(new System.ObjectDisposedException(nameof(Channel<T>)))
                             : Promise<bool>.Rejected(closedReason);
-                        return returnPromise.ConfigureContinuation(continuationOptions);
                     }
 
-                    var promise = ChannelWaitToReadPromise.GetOrCreate(this, continuationOptions);
+                    var promise = ChannelWaitToReadPromise.GetOrCreate(this, continueOnCapturedContext);
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
                         _smallFields._locker.Exit();
                         promise.DisposeImmediate();
-                        return Promise<bool>.Canceled()
-                            .ConfigureContinuation(continuationOptions);
+                        return Promise<bool>.Canceled();
                     }
 
                     _waitToReaders.Enqueue(promise);
@@ -409,17 +395,16 @@ namespace Proto.Promises
                 }
             }
 
-            internal override Promise<bool> WaitToWriteAsync(int id, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            internal override Promise<bool> WaitToWriteAsync(int id, CancelationToken cancelationToken, bool continueOnCapturedContext)
             {
                 var closedReason = _closedReason;
                 if (id != Id | closedReason == ChannelSmallFields.DisposedReason)
                 {
                     throw new System.ObjectDisposedException(nameof(Channel<T>));
                 }
-                var returnPromise = cancelationToken.IsCancelationRequested | closedReason == ChannelSmallFields.ClosedCanceledReason ? Promise<bool>.Canceled()
+                return cancelationToken.IsCancelationRequested | closedReason == ChannelSmallFields.ClosedCanceledReason ? Promise<bool>.Canceled()
                     : closedReason == null | closedReason == ChannelSmallFields.ClosedResolvedReason ? Promise.Resolved(closedReason == null)
                     : Promise<bool>.Rejected(closedReason);
-                return returnPromise.ConfigureContinuation(continuationOptions);
             }
 
             internal override bool TryReject(object reason, int id)

--- a/Package/Core/Promises/ContinuationOptions.cs
+++ b/Package/Core/Promises/ContinuationOptions.cs
@@ -299,7 +299,7 @@ namespace Proto.Promises
             return context;
         }
 
-        private static SynchronizationContext CaptureContext()
+        internal static SynchronizationContext CaptureContext()
         {
             // Capture the current context. If it's null, use the background context.
             return Promise.Manager.ThreadStaticSynchronizationContext
@@ -312,12 +312,5 @@ namespace Proto.Promises
                 ?? Promise.Config.BackgroundContext
                 ?? Internal.BackgroundSynchronizationContextSentinel.s_instance;
         }
-
-        // If this is configured with foreground, and the foreground context is null, GetForegroundContext will throw.
-        // We do this before starting actual work to prevent deadlocks in case of an exception.
-        internal ContinuationOptions GetValidated()
-            => _option == Option.Foreground
-            ? new ContinuationOptions(GetForegroundContext(), _completedBehavior)
-            : this;
     }
 }

--- a/Package/Core/Promises/Internal/ConfiguredPromise.cs
+++ b/Package/Core/Promises/Internal/ConfiguredPromise.cs
@@ -127,7 +127,7 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 private bool GetShouldContinueImmediately()
                     => _completedBehavior == CompletedContinuationBehavior.Synchronous
-                    || (_completedBehavior == CompletedContinuationBehavior.SynchronousIfSameContext
+                    || (_completedBehavior == CompletedContinuationBehavior.AllowSynchronous
                         && _synchronizationContext == Promise.Manager.ThreadStaticSynchronizationContext);
 
                 // This is unusual, only happens when the promise already completed, or if a promise is incorrectly awaited twice.

--- a/Package/Core/Threading/AsyncAutoResetEvent.cs
+++ b/Package/Core/Threading/AsyncAutoResetEvent.cs
@@ -51,15 +51,15 @@ namespace Proto.Promises.Threading
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync()
-            => WaitAsyncImpl(ContinuationOptions.CapturedContext);
+            => WaitAsync(true);
 
         /// <summary>
         /// Asynchronously wait for this event to be set.
         /// </summary>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and this is not set, the async continuation will be executed on the captured context.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Promise WaitAsync(ContinuationOptions continuationOptions)
-            => WaitAsyncImpl(continuationOptions.GetValidated());
+        public Promise WaitAsync(bool continueOnCapturedContext)
+            => WaitAsyncImpl(continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -71,20 +71,20 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
-            => TryWaitAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+            => TryWaitAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and this is not set, the async continuation will be executed on the captured context.</param>
         /// <remarks>
         /// The result of the returned <see cref="Promise{T}"/> will be <see langword="true"/> if this is set before the <paramref name="cancelationToken"/> was canceled, otherwise it will be <see langword="false"/>.
         /// If this is already set, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => TryWaitAsyncImpl(cancelationToken, continuationOptions.GetValidated());
+        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => TryWaitAsyncImpl(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously wait for this event to be set.

--- a/Package/Core/Threading/AsyncAutoResetEvent.cs
+++ b/Package/Core/Threading/AsyncAutoResetEvent.cs
@@ -51,7 +51,15 @@ namespace Proto.Promises.Threading
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync()
-            => WaitAsyncImpl();
+            => WaitAsyncImpl(ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously wait for this event to be set.
+        /// </summary>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise"/>.</param>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise WaitAsync(ContinuationOptions continuationOptions)
+            => WaitAsyncImpl(continuationOptions.GetValidated());
 
         /// <summary>
         /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -63,7 +71,20 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
-            => TryWaitAsyncImpl(cancelationToken);
+            => TryWaitAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
+        /// </summary>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <remarks>
+        /// The result of the returned <see cref="Promise{T}"/> will be <see langword="true"/> if this is set before the <paramref name="cancelationToken"/> was canceled, otherwise it will be <see langword="false"/>.
+        /// If this is already set, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => TryWaitAsyncImpl(cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously wait for this event to be set.

--- a/Package/Core/Threading/AsyncConditionVariable.cs
+++ b/Package/Core/Threading/AsyncConditionVariable.cs
@@ -82,20 +82,20 @@ namespace Proto.Promises.Threading
         /// </returns>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync(AsyncLock.Key asyncLockKey)
-            => asyncLockKey.WaitAsync(this, ContinuationOptions.CapturedContext);
+            => WaitAsync(asyncLockKey, true);
 
         /// <summary>
         /// Release the lock and asynchronously wait for a notify signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.
         /// The lock will be re-acquired before the returned <see cref="Promise{T}"/> is resolved.
         /// </summary>
         /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/>, the async continuation will be executed on the captured context.</param>
         /// <returns>
         /// A <see cref="Promise"/> that will be resolved when the lock is re-acquired.
         /// </returns>
         [MethodImpl(Internal.InlineOption)]
-        public Promise WaitAsync(AsyncLock.Key asyncLockKey, ContinuationOptions continuationOptions)
-            => asyncLockKey.WaitAsync(this, continuationOptions.GetValidated());
+        public Promise WaitAsync(AsyncLock.Key asyncLockKey, bool continueOnCapturedContext)
+            => asyncLockKey.WaitAsync(this, continueOnCapturedContext);
 
         /// <summary>
         /// Release the lock and asynchronously wait for a notify signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>, while observing a <see cref="CancelationToken"/>.
@@ -110,7 +110,7 @@ namespace Proto.Promises.Threading
         /// </returns>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken)
-            => asyncLockKey.TryWaitAsync(this, cancelationToken, ContinuationOptions.CapturedContext);
+            => TryWaitAsync(asyncLockKey, cancelationToken, true);
 
         /// <summary>
         /// Release the lock and asynchronously wait for a notify signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>, while observing a <see cref="CancelationToken"/>.
@@ -118,15 +118,15 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/>, the async continuation will be executed on the captured context.</param>
         /// <returns>
         /// A <see cref="Promise{T}"/> that will be resolved when the lock is re-acquired.
         /// Its result will be <see langword="true"/> if the lock was re-acquired before the <paramref name="cancelationToken"/> was canceled,
         /// <see langword="false"/> if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
         /// </returns>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<bool> TryWaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => asyncLockKey.TryWaitAsync(this, cancelationToken, continuationOptions.GetValidated());
+        public Promise<bool> TryWaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => asyncLockKey.TryWaitAsync(this, cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Release the lock and synchronously wait for a notify signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.

--- a/Package/Core/Threading/AsyncConditionVariable.cs
+++ b/Package/Core/Threading/AsyncConditionVariable.cs
@@ -82,7 +82,20 @@ namespace Proto.Promises.Threading
         /// </returns>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync(AsyncLock.Key asyncLockKey)
-            => asyncLockKey.WaitAsync(this);
+            => asyncLockKey.WaitAsync(this, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Release the lock and asynchronously wait for a notify signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.
+        /// The lock will be re-acquired before the returned <see cref="Promise{T}"/> is resolved.
+        /// </summary>
+        /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise"/>.</param>
+        /// <returns>
+        /// A <see cref="Promise"/> that will be resolved when the lock is re-acquired.
+        /// </returns>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise WaitAsync(AsyncLock.Key asyncLockKey, ContinuationOptions continuationOptions)
+            => asyncLockKey.WaitAsync(this, continuationOptions.GetValidated());
 
         /// <summary>
         /// Release the lock and asynchronously wait for a notify signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>, while observing a <see cref="CancelationToken"/>.
@@ -97,7 +110,23 @@ namespace Proto.Promises.Threading
         /// </returns>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken)
-            => asyncLockKey.TryWaitAsync(this, cancelationToken);
+            => asyncLockKey.TryWaitAsync(this, cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Release the lock and asynchronously wait for a notify signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>, while observing a <see cref="CancelationToken"/>.
+        /// The lock will be re-acquired before the returned <see cref="Promise{T}"/> is resolved.
+        /// </summary>
+        /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> that will be resolved when the lock is re-acquired.
+        /// Its result will be <see langword="true"/> if the lock was re-acquired before the <paramref name="cancelationToken"/> was canceled,
+        /// <see langword="false"/> if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
+        /// </returns>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise<bool> TryWaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => asyncLockKey.TryWaitAsync(this, cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Release the lock and synchronously wait for a notify signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.

--- a/Package/Core/Threading/AsyncCountdownEvent.cs
+++ b/Package/Core/Threading/AsyncCountdownEvent.cs
@@ -143,15 +143,15 @@ namespace Proto.Promises.Threading
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync()
-            => WaitAsyncImpl(ContinuationOptions.CapturedContext);
+            => WaitAsync(true);
 
         /// <summary>
         /// Asynchronously wait for this event to be set.
         /// </summary>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and this is not set, the async continuation will be executed on the captured context.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Promise WaitAsync(ContinuationOptions continuationOptions)
-            => WaitAsyncImpl(continuationOptions.GetValidated());
+        public Promise WaitAsync(bool continueOnCapturedContext)
+            => WaitAsyncImpl(continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -163,20 +163,20 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
-            => TryWaitAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+            => TryWaitAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and this is not set, the async continuation will be executed on the captured context.</param>
         /// <remarks>
         /// The result of the returned <see cref="Promise{T}"/> will be <see langword="true"/> if this is set before the <paramref name="cancelationToken"/> was canceled, otherwise it will be <see langword="false"/>.
         /// If this is already set, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => TryWaitAsyncImpl(cancelationToken, continuationOptions.GetValidated());
+        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => TryWaitAsyncImpl(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously wait for this event to be set.

--- a/Package/Core/Threading/AsyncCountdownEvent.cs
+++ b/Package/Core/Threading/AsyncCountdownEvent.cs
@@ -143,7 +143,15 @@ namespace Proto.Promises.Threading
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync()
-            => WaitAsyncImpl();
+            => WaitAsyncImpl(ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously wait for this event to be set.
+        /// </summary>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise"/>.</param>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise WaitAsync(ContinuationOptions continuationOptions)
+            => WaitAsyncImpl(continuationOptions.GetValidated());
 
         /// <summary>
         /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -155,7 +163,20 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
-            => TryWaitAsyncImpl(cancelationToken);
+            => TryWaitAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
+        /// </summary>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <remarks>
+        /// The result of the returned <see cref="Promise{T}"/> will be <see langword="true"/> if this is set before the <paramref name="cancelationToken"/> was canceled, otherwise it will be <see langword="false"/>.
+        /// If this is already set, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => TryWaitAsyncImpl(cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously wait for this event to be set.

--- a/Package/Core/Threading/AsyncLock.cs
+++ b/Package/Core/Threading/AsyncLock.cs
@@ -66,6 +66,16 @@ namespace Proto.Promises.Threading
             => LockAsyncImpl(ContinuationOptions.CapturedContext);
 
         /// <summary>
+        /// Asynchronously acquire the lock.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise<Key> LockAsync(ContinuationOptions continuationOptions)
+            => LockAsyncImpl(continuationOptions.GetValidated());
+
+        /// <summary>
         /// Asynchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
         /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
         /// The result of the promise is the key that will release the lock when it is disposed.

--- a/Package/Core/Threading/AsyncLock.cs
+++ b/Package/Core/Threading/AsyncLock.cs
@@ -62,7 +62,8 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<Key> LockAsync() => LockAsyncImpl();
+        public Promise<Key> LockAsync()
+            => LockAsyncImpl(ContinuationOptions.CapturedContext);
 
         /// <summary>
         /// Asynchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
@@ -71,13 +72,26 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<Key> LockAsync(CancelationToken cancelationToken) => LockAsyncImpl(cancelationToken);
+        public Promise<Key> LockAsync(CancelationToken cancelationToken)
+            => LockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise<Key> LockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => LockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously acquire the lock. Returns the key that will release the lock when it is disposed.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
-        public Key Lock() => LockImpl();
+        public Key Lock()
+            => LockImpl();
 
         /// <summary>
         /// Synchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
@@ -85,7 +99,8 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, a <see cref="CanceledException"/> will be thrown.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Key Lock(CancelationToken cancelationToken) => LockImpl(cancelationToken);
+        public Key Lock(CancelationToken cancelationToken)
+            => LockImpl(cancelationToken);
 
         /// <summary>
         /// A disposable object used to release the associated <see cref="AsyncLock"/>.
@@ -98,22 +113,28 @@ namespace Proto.Promises.Threading
             /// <summary>
             /// Release the lock on the associated <see cref="AsyncLock"/>.
             /// </summary>
-            public void Dispose() => Release();
+            public void Dispose()
+                => Release();
 
             /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="Key"/>.</summary>
-            public bool Equals(Key other) => this == other;
+            public bool Equals(Key other)
+                => this == other;
 
             /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
-            public override bool Equals(object obj) => obj is Key token && Equals(token);
+            public override bool Equals(object obj)
+                => obj is Key token && Equals(token);
 
             /// <summary>Returns the hash code for this instance.</summary>
-            public override int GetHashCode() => Internal.BuildHashCode(_owner, _key.GetHashCode(), 0);
+            public override int GetHashCode()
+                => Internal.BuildHashCode(_owner, _key.GetHashCode(), 0);
 
             /// <summary>Returns a value indicating whether two <see cref="Key"/> values are equal.</summary>
-            public static bool operator ==(Key lhs, Key rhs) => lhs._owner == rhs._owner & lhs._key == rhs._key;
+            public static bool operator ==(Key lhs, Key rhs)
+                => lhs._owner == rhs._owner & lhs._key == rhs._key;
 
             /// <summary>Returns a value indicating whether two <see cref="Key"/> values are not equal.</summary>
-            public static bool operator !=(Key lhs, Key rhs) => !(lhs == rhs);
+            public static bool operator !=(Key lhs, Key rhs)
+                => !(lhs == rhs);
         }
     } // class AsyncLock
 

--- a/Package/Core/Threading/AsyncLock.cs
+++ b/Package/Core/Threading/AsyncLock.cs
@@ -63,17 +63,17 @@ namespace Proto.Promises.Threading
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise<Key> LockAsync()
-            => LockAsyncImpl(ContinuationOptions.CapturedContext);
+            => LockAsync(true);
 
         /// <summary>
         /// Asynchronously acquire the lock.
         /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is already acquired, the async continuation will be executed on the captured context.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<Key> LockAsync(ContinuationOptions continuationOptions)
-            => LockAsyncImpl(continuationOptions.GetValidated());
+        public Promise<Key> LockAsync(bool continueOnCapturedContext)
+            => LockAsyncImpl(continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
@@ -83,7 +83,7 @@ namespace Proto.Promises.Threading
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         [MethodImpl(Internal.InlineOption)]
         public Promise<Key> LockAsync(CancelationToken cancelationToken)
-            => LockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+            => LockAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously acquire the lock, while observing a <see cref="CancelationToken"/>.
@@ -91,10 +91,10 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is already acquired, the async continuation will be executed on the captured context.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<Key> LockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => LockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
+        public Promise<Key> LockAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => LockAsyncImpl(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously acquire the lock. Returns the key that will release the lock when it is disposed.

--- a/Package/Core/Threading/AsyncManualResetEvent.cs
+++ b/Package/Core/Threading/AsyncManualResetEvent.cs
@@ -51,15 +51,15 @@ namespace Proto.Promises.Threading
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync()
-            => WaitAsyncImpl(ContinuationOptions.CapturedContext);
+            => WaitAsync(true);
 
         /// <summary>
         /// Asynchronously wait for this event to be set.
         /// </summary>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and this is not set, the async continuation will be executed on the captured context.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Promise WaitAsync(ContinuationOptions continuationOptions)
-            => WaitAsyncImpl(continuationOptions.GetValidated());
+        public Promise WaitAsync(bool continueOnCapturedContext)
+            => WaitAsyncImpl(continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -71,20 +71,20 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
-            => TryWaitAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+            => TryWaitAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and this is not set, the async continuation will be executed on the captured context.</param>
         /// <remarks>
         /// The result of the returned <see cref="Promise{T}"/> will be <see langword="true"/> if this is set before the <paramref name="cancelationToken"/> was canceled, otherwise it will be <see langword="false"/>.
         /// If this is already set, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => TryWaitAsyncImpl(cancelationToken, continuationOptions.GetValidated());
+        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => TryWaitAsyncImpl(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously wait for this event to be set.

--- a/Package/Core/Threading/AsyncManualResetEvent.cs
+++ b/Package/Core/Threading/AsyncManualResetEvent.cs
@@ -51,7 +51,15 @@ namespace Proto.Promises.Threading
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync()
-            => WaitAsyncImpl();
+            => WaitAsyncImpl(ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously wait for this event to be set.
+        /// </summary>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise"/>.</param>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise WaitAsync(ContinuationOptions continuationOptions)
+            => WaitAsyncImpl(continuationOptions.GetValidated());
 
         /// <summary>
         /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -63,7 +71,20 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
-            => TryWaitAsyncImpl(cancelationToken);
+            => TryWaitAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously wait for this event to be set, or for the <paramref name="cancelationToken"/> to be canceled.
+        /// </summary>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <remarks>
+        /// The result of the returned <see cref="Promise{T}"/> will be <see langword="true"/> if this is set before the <paramref name="cancelationToken"/> was canceled, otherwise it will be <see langword="false"/>.
+        /// If this is already set, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => TryWaitAsyncImpl(cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously wait for this event to be set.

--- a/Package/Core/Threading/AsyncMonitor.cs
+++ b/Package/Core/Threading/AsyncMonitor.cs
@@ -37,6 +37,17 @@ namespace Proto.Promises.Threading
             => asyncLock.LockAsync();
 
         /// <summary>
+        /// Asynchronously acquire the lock on the specified <see cref="AsyncLock"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="asyncLock">The async lock instance that is being entered.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        [MethodImpl(Internal.InlineOption)]
+        public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock, ContinuationOptions continuationOptions)
+            => asyncLock.LockAsync(continuationOptions);
+
+        /// <summary>
         /// Asynchronously acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
         /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
         /// The result of the promise is the key that will release the lock when it is disposed.
@@ -46,6 +57,18 @@ namespace Proto.Promises.Threading
         [MethodImpl(Internal.InlineOption)]
         public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken)
             => asyncLock.LockAsync(cancelationToken);
+
+        /// <summary>
+        /// Asynchronously acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="asyncLock">The async lock instance that is being entered.</param>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        [MethodImpl(Internal.InlineOption)]
+        public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => asyncLock.LockAsync(cancelationToken, continuationOptions);
 
         /// <summary>
         /// Synchronously acquire the lock on the specified <see cref="AsyncLock"/>.
@@ -148,6 +171,18 @@ namespace Proto.Promises.Threading
             => GetConditionVariable(asyncLockKey).WaitAsync(asyncLockKey);
 
         /// <summary>
+        /// Release the lock and asynchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.
+        /// The lock will be re-acquired before the returned <see cref="Promise{T}"/> is resolved.
+        /// </summary>
+        /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <returns>
+        /// A <see cref="Promise"/> that will be resolved when the lock is re-acquired.
+        /// </returns>
+        public static Promise WaitAsync(AsyncLock.Key asyncLockKey, ContinuationOptions continuationOptions)
+            => GetConditionVariable(asyncLockKey).WaitAsync(asyncLockKey, continuationOptions);
+
+        /// <summary>
         /// Release the lock and asynchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>, while observing a <see cref="CancelationToken"/>.
         /// The lock will be re-acquired before the returned <see cref="Promise{T}"/> is resolved.
         /// </summary>
@@ -160,6 +195,21 @@ namespace Proto.Promises.Threading
         /// </returns>
         public static Promise<bool> TryWaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken)
             => GetConditionVariable(asyncLockKey).TryWaitAsync(asyncLockKey, cancelationToken);
+
+        /// <summary>
+        /// Release the lock and asynchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>, while observing a <see cref="CancelationToken"/>.
+        /// The lock will be re-acquired before the returned <see cref="Promise{T}"/> is resolved.
+        /// </summary>
+        /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <returns>
+        /// A <see cref="Promise{T}"/> that will be resolved when the lock is re-acquired.
+        /// Its result will be <see langword="true"/> if the lock was re-acquired before the <paramref name="cancelationToken"/> was canceled,
+        /// <see langword="false"/> if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
+        /// </returns>
+        public static Promise<bool> TryWaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => GetConditionVariable(asyncLockKey).TryWaitAsync(asyncLockKey, cancelationToken, continuationOptions);
 
         /// <summary>
         /// Release the lock and synchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.

--- a/Package/Core/Threading/AsyncMonitor.cs
+++ b/Package/Core/Threading/AsyncMonitor.cs
@@ -34,7 +34,7 @@ namespace Proto.Promises.Threading
         /// <param name="asyncLock">The async lock instance that is being entered.</param>
         [MethodImpl(Internal.InlineOption)]
         public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock)
-            => asyncLock.LockAsync();
+            => EnterAsync(asyncLock, true);
 
         /// <summary>
         /// Asynchronously acquire the lock on the specified <see cref="AsyncLock"/>.
@@ -42,10 +42,10 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         /// <param name="asyncLock">The async lock instance that is being entered.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is already acquired, the async continuation will be executed on the captured context.</param>
         [MethodImpl(Internal.InlineOption)]
-        public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock, ContinuationOptions continuationOptions)
-            => asyncLock.LockAsync(continuationOptions);
+        public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock, bool continueOnCapturedContext)
+            => asyncLock.LockAsync(continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
@@ -56,7 +56,7 @@ namespace Proto.Promises.Threading
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         [MethodImpl(Internal.InlineOption)]
         public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken)
-            => asyncLock.LockAsync(cancelationToken);
+            => EnterAsync(asyncLock, cancelationToken, true);
 
         /// <summary>
         /// Asynchronously acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
@@ -65,10 +65,10 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="asyncLock">The async lock instance that is being entered.</param>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is already acquired, the async continuation will be executed on the captured context.</param>
         [MethodImpl(Internal.InlineOption)]
-        public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => asyncLock.LockAsync(cancelationToken, continuationOptions);
+        public static Promise<AsyncLock.Key> EnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => asyncLock.LockAsync(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously acquire the lock on the specified <see cref="AsyncLock"/>.
@@ -115,7 +115,7 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public static Promise<(bool didEnter, AsyncLock.Key key)> TryEnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken)
-            => asyncLock.TryEnterAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+            => TryEnterAsync(asyncLock, cancelationToken, true);
 
         /// <summary>
         /// Asynchronously try to acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
@@ -126,14 +126,14 @@ namespace Proto.Promises.Threading
         /// <param name="cancelationToken">
         /// The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the success state of the returned <see cref="Promise{T}"/> will be <see langword="false"/>.
         /// </param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is already acquired, the async continuation will be executed on the captured context.</param>
         /// <remarks>
         /// This first tries to take the lock before checking the <paramref name="cancelationToken"/>>.
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
-        public static Promise<(bool didEnter, AsyncLock.Key key)> TryEnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => asyncLock.TryEnterAsyncImpl(cancelationToken, continuationOptions.GetValidated());
+        public static Promise<(bool didEnter, AsyncLock.Key key)> TryEnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => asyncLock.TryEnterAsyncImpl(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously try to acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
@@ -168,19 +168,19 @@ namespace Proto.Promises.Threading
         /// A <see cref="Promise"/> that will be resolved when the lock is re-acquired.
         /// </returns>
         public static Promise WaitAsync(AsyncLock.Key asyncLockKey)
-            => GetConditionVariable(asyncLockKey).WaitAsync(asyncLockKey);
+            => WaitAsync(asyncLockKey, true);
 
         /// <summary>
         /// Release the lock and asynchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.
         /// The lock will be re-acquired before the returned <see cref="Promise{T}"/> is resolved.
         /// </summary>
         /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/>, the async continuation will be executed on the captured context.</param>
         /// <returns>
         /// A <see cref="Promise"/> that will be resolved when the lock is re-acquired.
         /// </returns>
-        public static Promise WaitAsync(AsyncLock.Key asyncLockKey, ContinuationOptions continuationOptions)
-            => GetConditionVariable(asyncLockKey).WaitAsync(asyncLockKey, continuationOptions);
+        public static Promise WaitAsync(AsyncLock.Key asyncLockKey, bool continueOnCapturedContext)
+            => GetConditionVariable(asyncLockKey).WaitAsync(asyncLockKey, continueOnCapturedContext);
 
         /// <summary>
         /// Release the lock and asynchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>, while observing a <see cref="CancelationToken"/>.
@@ -194,7 +194,7 @@ namespace Proto.Promises.Threading
         /// <see langword="false"/> if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
         /// </returns>
         public static Promise<bool> TryWaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken)
-            => GetConditionVariable(asyncLockKey).TryWaitAsync(asyncLockKey, cancelationToken);
+            => TryWaitAsync(asyncLockKey, cancelationToken, true);
 
         /// <summary>
         /// Release the lock and asynchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>, while observing a <see cref="CancelationToken"/>.
@@ -202,14 +202,14 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="asyncLockKey">The key to the <see cref="AsyncLock"/> that is currently acquired.</param>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/>, the async continuation will be executed on the captured context.</param>
         /// <returns>
         /// A <see cref="Promise{T}"/> that will be resolved when the lock is re-acquired.
         /// Its result will be <see langword="true"/> if the lock was re-acquired before the <paramref name="cancelationToken"/> was canceled,
         /// <see langword="false"/> if the lock was re-acquired after the <paramref name="cancelationToken"/> was canceled
         /// </returns>
-        public static Promise<bool> TryWaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => GetConditionVariable(asyncLockKey).TryWaitAsync(asyncLockKey, cancelationToken, continuationOptions);
+        public static Promise<bool> TryWaitAsync(AsyncLock.Key asyncLockKey, CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => GetConditionVariable(asyncLockKey).TryWaitAsync(asyncLockKey, cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Release the lock and synchronously wait for a pulse signal on the <see cref="AsyncLock"/> associated with the <paramref name="asyncLockKey"/>.

--- a/Package/Core/Threading/AsyncMonitor.cs
+++ b/Package/Core/Threading/AsyncMonitor.cs
@@ -92,7 +92,25 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public static Promise<(bool didEnter, AsyncLock.Key key)> TryEnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken)
-            => asyncLock.TryEnterAsyncImpl(cancelationToken);
+            => asyncLock.TryEnterAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously try to acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired, or the <paramref name="cancelationToken"/> has been canceled, with the success state and key.
+        /// If successful, the key will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="asyncLock">The async lock instance that is being entered.</param>
+        /// <param name="cancelationToken">
+        /// The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the success state of the returned <see cref="Promise{T}"/> will be <see langword="false"/>.
+        /// </param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <remarks>
+        /// This first tries to take the lock before checking the <paramref name="cancelationToken"/>>.
+        /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public static Promise<(bool didEnter, AsyncLock.Key key)> TryEnterAsync(AsyncLock asyncLock, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => asyncLock.TryEnterAsyncImpl(cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously try to acquire the lock on the specified <see cref="AsyncLock"/>, while observing a <see cref="CancelationToken"/>.

--- a/Package/Core/Threading/AsyncReaderWriterLock.cs
+++ b/Package/Core/Threading/AsyncReaderWriterLock.cs
@@ -86,7 +86,16 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         public Promise<ReaderKey> ReaderLockAsync()
-            => ReaderLockAsyncImpl();
+            => ReaderLockAsyncImpl(ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously acquire the lock as a reader.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        public Promise<ReaderKey> ReaderLockAsync(ContinuationOptions continuationOptions)
+            => ReaderLockAsyncImpl(continuationOptions.GetValidated());
 
         /// <summary>
         /// Asynchronously acquire the lock as a reader, while observing a <see cref="CancelationToken"/>.
@@ -95,7 +104,17 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         public Promise<ReaderKey> ReaderLockAsync(CancelationToken cancelationToken)
-            => ReaderLockAsyncImpl(cancelationToken);
+            => ReaderLockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously acquire the lock as a reader, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        public Promise<ReaderKey> ReaderLockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => ReaderLockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously acquire the lock as a reader.
@@ -134,7 +153,23 @@ namespace Proto.Promises.Threading
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public Promise<(bool didEnter, ReaderKey readerKey)> TryEnterReaderLockAsync(CancelationToken cancelationToken)
-            => TryEnterReaderLockAsyncImpl(cancelationToken);
+            => TryEnterReaderLockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously try to acquire the lock as a reader, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired, or the <paramref name="cancelationToken"/> has been canceled, with the success state and key.
+        /// If successful, the key will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="cancelationToken">
+        /// The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the success state of the returned <see cref="Promise{T}"/> will be <see langword="false"/>.
+        /// </param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <remarks>
+        /// This first tries to take the lock before checking the <paramref name="cancelationToken"/>>.
+        /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        public Promise<(bool didEnter, ReaderKey readerKey)> TryEnterReaderLockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => TryEnterReaderLockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously try to acquire the lock as a reader, while observing a <see cref="CancelationToken"/>.
@@ -156,7 +191,16 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         public Promise<WriterKey> WriterLockAsync()
-            => WriterLockAsyncImpl();
+            => WriterLockAsyncImpl(ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously acquire the lock as a writer.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        public Promise<WriterKey> WriterLockAsync(ContinuationOptions continuationOptions)
+            => WriterLockAsyncImpl(continuationOptions.GetValidated());
 
         /// <summary>
         /// Asynchronously acquire the lock as a writer, while observing a <see cref="CancelationToken"/>.
@@ -165,7 +209,17 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         public Promise<WriterKey> WriterLockAsync(CancelationToken cancelationToken)
-            => WriterLockAsyncImpl(cancelationToken);
+            => WriterLockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously acquire the lock as a writer, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        public Promise<WriterKey> WriterLockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => WriterLockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously acquire the lock as a writer.
@@ -204,7 +258,23 @@ namespace Proto.Promises.Threading
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public Promise<(bool didEnter, WriterKey writerKey)> TryEnterWriterLockAsync(CancelationToken cancelationToken)
-            => TryEnterWriterLockAsyncImpl(cancelationToken);
+            => TryEnterWriterLockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously try to acquire the lock as a writer, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired, or the <paramref name="cancelationToken"/> has been canceled, with the success state and key.
+        /// If successful, the key will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="cancelationToken">
+        /// The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the success state of the returned <see cref="Promise{T}"/> will be <see langword="false"/>.
+        /// </param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <remarks>
+        /// This first tries to take the lock before checking the <paramref name="cancelationToken"/>>.
+        /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        public Promise<(bool didEnter, WriterKey writerKey)> TryEnterWriterLockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => TryEnterWriterLockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously try to acquire the lock as a writer, while observing a <see cref="CancelationToken"/>.
@@ -230,7 +300,20 @@ namespace Proto.Promises.Threading
         /// Only 1 upgradeable reader lock may be entered at a time.
         /// </remarks>
         public Promise<UpgradeableReaderKey> UpgradeableReaderLockAsync()
-            => UpgradeableReaderLockAsyncImpl();
+            => UpgradeableReaderLockAsyncImpl(ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously acquire the lock as an upgradeable reader.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <remarks>
+        /// Upgradeable reader locks may be entered concurrently with normal reader locks, but they are mutually exclusive with respect to other upgradeable reader locks and writer locks.
+        /// Only 1 upgradeable reader lock may be entered at a time.
+        /// </remarks>
+        public Promise<UpgradeableReaderKey> UpgradeableReaderLockAsync(ContinuationOptions continuationOptions)
+            => UpgradeableReaderLockAsyncImpl(continuationOptions.GetValidated());
 
         /// <summary>
         /// Asynchronously acquire the lock as an upgradeable reader, while observing a <see cref="CancelationToken"/>.
@@ -243,7 +326,21 @@ namespace Proto.Promises.Threading
         /// Only 1 upgradeable reader lock may be entered at a time.
         /// </remarks>
         public Promise<UpgradeableReaderKey> UpgradeableReaderLockAsync(CancelationToken cancelationToken)
-            => UpgradeableReaderLockAsyncImpl(cancelationToken);
+            => UpgradeableReaderLockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously acquire the lock as an upgradeable reader, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
+        /// The result of the promise is the key that will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <remarks>
+        /// Upgradeable reader locks may be entered concurrently with normal reader locks, but they are mutually exclusive with respect to other upgradeable reader locks and writer locks.
+        /// Only 1 upgradeable reader lock may be entered at a time.
+        /// </remarks>
+        public Promise<UpgradeableReaderKey> UpgradeableReaderLockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => UpgradeableReaderLockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously acquire the lock as an upgradeable reader.
@@ -294,7 +391,23 @@ namespace Proto.Promises.Threading
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public Promise<(bool didEnter, UpgradeableReaderKey readerKey)> TryEnterUpgradeableReaderLockAsync(CancelationToken cancelationToken)
-            => TryEnterUpgradeableReaderLockAsyncImpl(cancelationToken);
+            => TryEnterUpgradeableReaderLockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously try to acquire the lock as an upgradeable reader, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired, or the <paramref name="cancelationToken"/> has been canceled, with the success state and key.
+        /// If successful, the key will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="cancelationToken">
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the success state of the returned <see cref="Promise{T}"/> will be <see langword="false"/>.
+        /// </param>
+        /// <remarks>
+        /// This first tries to take the lock before checking the <paramref name="cancelationToken"/>>.
+        /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        public Promise<(bool didEnter, UpgradeableReaderKey readerKey)> TryEnterUpgradeableReaderLockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => TryEnterUpgradeableReaderLockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously try to acquire the lock as an upgradeable reader, while observing a <see cref="CancelationToken"/>.
@@ -317,7 +430,17 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="readerKey">The key required to upgrade the lock.</param>
         public Promise<UpgradedWriterKey> UpgradeToWriterLockAsync(UpgradeableReaderKey readerKey)
-            => UpgradeToWriterLockAsyncImpl(readerKey);
+            => UpgradeToWriterLockAsyncImpl(readerKey, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously upgrade the lock from an upgradeable reader lock to a writer lock.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been upgraded.
+        /// The result of the promise is the key that will downgrade the lock to an upgradeable reader lock when it is disposed.
+        /// </summary>
+        /// <param name="readerKey">The key required to upgrade the lock.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        public Promise<UpgradedWriterKey> UpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, ContinuationOptions continuationOptions)
+            => UpgradeToWriterLockAsyncImpl(readerKey, continuationOptions.GetValidated());
 
         /// <summary>
         /// Asynchronously upgrade the lock from an upgradeable reader lock to a writer lock, while observing a <see cref="CancelationToken"/>.
@@ -327,7 +450,18 @@ namespace Proto.Promises.Threading
         /// <param name="readerKey">The key required to upgrade the lock.</param>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the upgrade. If the token is canceled before the lock has been upgraded, the returned <see cref="Promise{T}"/> will be canceled.</param>
         public Promise<UpgradedWriterKey> UpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, CancelationToken cancelationToken)
-            => UpgradeToWriterLockAsyncImpl(readerKey, cancelationToken);
+            => UpgradeToWriterLockAsyncImpl(readerKey, cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously upgrade the lock from an upgradeable reader lock to a writer lock, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been upgraded.
+        /// The result of the promise is the key that will downgrade the lock to an upgradeable reader lock when it is disposed.
+        /// </summary>
+        /// <param name="readerKey">The key required to upgrade the lock.</param>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the upgrade. If the token is canceled before the lock has been upgraded, the returned <see cref="Promise{T}"/> will be canceled.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        public Promise<UpgradedWriterKey> UpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => UpgradeToWriterLockAsyncImpl(readerKey, cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously upgrade the lock from an upgradeable reader lock to a writer lock.
@@ -370,7 +504,24 @@ namespace Proto.Promises.Threading
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public Promise<(bool didEnter, UpgradedWriterKey upgradedWriterKey)> TryUpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, CancelationToken cancelationToken)
-            => TryUpgradeToWriterLockAsyncImpl(readerKey, cancelationToken);
+            => TryUpgradeToWriterLockAsyncImpl(readerKey, cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously try to upgrade the lock from an upgradeable reader lock to a writer lock, while observing a <see cref="CancelationToken"/>.
+        /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired, or the <paramref name="cancelationToken"/> has been canceled, with the success state and key.
+        /// If successful, the key will release the lock when it is disposed.
+        /// </summary>
+        /// <param name="readerKey">The key required to upgrade the lock.</param>
+        /// <param name="cancelationToken">
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the success state of the returned <see cref="Promise{T}"/> will be <see langword="false"/>.
+        /// </param>
+        /// <remarks>
+        /// This first tries to take the lock before checking the <paramref name="cancelationToken"/>>.
+        /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        public Promise<(bool didEnter, UpgradedWriterKey upgradedWriterKey)> TryUpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => TryUpgradeToWriterLockAsyncImpl(readerKey, cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously try to upgrade the lock from an upgradeable reader lock to a writer lock, while observing a <see cref="CancelationToken"/>.
@@ -398,22 +549,28 @@ namespace Proto.Promises.Threading
             /// <summary>
             /// Release the reader lock on the associated <see cref="AsyncReaderWriterLock"/>.
             /// </summary>
-            public void Dispose() => _impl.ReleaseReaderLock();
+            public void Dispose()
+                => _impl.ReleaseReaderLock();
 
             /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="ReaderKey"/>.</summary>
-            public bool Equals(ReaderKey other) => this == other;
+            public bool Equals(ReaderKey other)
+                => this == other;
 
             /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
-            public override bool Equals(object obj) => obj is ReaderKey token && Equals(token);
+            public override bool Equals(object obj)
+                => obj is ReaderKey token && Equals(token);
 
             /// <summary>Returns the hash code for this instance.</summary>
-            public override int GetHashCode() => _impl.GetHashCode();
+            public override int GetHashCode()
+                => _impl.GetHashCode();
 
             /// <summary>Returns a value indicating whether two <see cref="ReaderKey"/> values are equal.</summary>
-            public static bool operator ==(ReaderKey lhs, ReaderKey rhs) => lhs._impl == rhs._impl;
+            public static bool operator ==(ReaderKey lhs, ReaderKey rhs)
+                => lhs._impl == rhs._impl;
 
             /// <summary>Returns a value indicating whether two <see cref="ReaderKey"/> values are not equal.</summary>
-            public static bool operator !=(ReaderKey lhs, ReaderKey rhs) => lhs._impl != rhs._impl;
+            public static bool operator !=(ReaderKey lhs, ReaderKey rhs)
+                => lhs._impl != rhs._impl;
         }
 
         /// <summary>
@@ -427,22 +584,28 @@ namespace Proto.Promises.Threading
             /// <summary>
             /// Release the writer lock on the associated <see cref="AsyncReaderWriterLock"/>.
             /// </summary>
-            public void Dispose() => _impl.ReleaseWriterLock();
+            public void Dispose()
+                => _impl.ReleaseWriterLock();
 
             /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="WriterKey"/>.</summary>
-            public bool Equals(WriterKey other) => this == other;
+            public bool Equals(WriterKey other)
+                => this == other;
 
             /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
-            public override bool Equals(object obj) => obj is WriterKey token && Equals(token);
+            public override bool Equals(object obj)
+                => obj is WriterKey token && Equals(token);
 
             /// <summary>Returns the hash code for this instance.</summary>
-            public override int GetHashCode() => _impl.GetHashCode();
+            public override int GetHashCode()
+                => _impl.GetHashCode();
 
             /// <summary>Returns a value indicating whether two <see cref="WriterKey"/> values are equal.</summary>
-            public static bool operator ==(WriterKey lhs, WriterKey rhs) => lhs._impl == rhs._impl;
+            public static bool operator ==(WriterKey lhs, WriterKey rhs)
+                => lhs._impl == rhs._impl;
 
             /// <summary>Returns a value indicating whether two <see cref="WriterKey"/> values are not equal.</summary>
-            public static bool operator !=(WriterKey lhs, WriterKey rhs) => lhs._impl != rhs._impl;
+            public static bool operator !=(WriterKey lhs, WriterKey rhs)
+                => lhs._impl != rhs._impl;
         }
 
         /// <summary>
@@ -456,22 +619,28 @@ namespace Proto.Promises.Threading
             /// <summary>
             /// Release the upgradeable reader lock on the associated <see cref="AsyncReaderWriterLock"/>.
             /// </summary>
-            public void Dispose() => _impl.ReleaseUpgradeableReaderLock();
+            public void Dispose()
+                => _impl.ReleaseUpgradeableReaderLock();
 
             /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="UpgradeableReaderKey"/>.</summary>
-            public bool Equals(UpgradeableReaderKey other) => this == other;
+            public bool Equals(UpgradeableReaderKey other)
+                => this == other;
 
             /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
-            public override bool Equals(object obj) => obj is UpgradeableReaderKey token && Equals(token);
+            public override bool Equals(object obj)
+                => obj is UpgradeableReaderKey token && Equals(token);
 
             /// <summary>Returns the hash code for this instance.</summary>
-            public override int GetHashCode() => _impl.GetHashCode();
+            public override int GetHashCode()
+                => _impl.GetHashCode();
 
             /// <summary>Returns a value indicating whether two <see cref="UpgradeableReaderKey"/> values are equal.</summary>
-            public static bool operator ==(UpgradeableReaderKey lhs, UpgradeableReaderKey rhs) => lhs._impl == rhs._impl;
+            public static bool operator ==(UpgradeableReaderKey lhs, UpgradeableReaderKey rhs)
+                => lhs._impl == rhs._impl;
 
             /// <summary>Returns a value indicating whether two <see cref="UpgradeableReaderKey"/> values are not equal.</summary>
-            public static bool operator !=(UpgradeableReaderKey lhs, UpgradeableReaderKey rhs) => lhs._impl != rhs._impl;
+            public static bool operator !=(UpgradeableReaderKey lhs, UpgradeableReaderKey rhs)
+                => lhs._impl != rhs._impl;
         }
 
         /// <summary>
@@ -485,22 +654,28 @@ namespace Proto.Promises.Threading
             /// <summary>
             /// Release the upgraded writer lock and downgrade back to an upgradeable reader lock on the associated <see cref="AsyncReaderWriterLock"/>.
             /// </summary>
-            public void Dispose() => _impl.ReleaseUpgradedWriterLock();
+            public void Dispose()
+                => _impl.ReleaseUpgradedWriterLock();
 
             /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="WriterKey"/>.</summary>
-            public bool Equals(UpgradedWriterKey other) => this == other;
+            public bool Equals(UpgradedWriterKey other)
+                => this == other;
 
             /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
-            public override bool Equals(object obj) => obj is UpgradedWriterKey token && Equals(token);
+            public override bool Equals(object obj)
+                => obj is UpgradedWriterKey token && Equals(token);
 
             /// <summary>Returns the hash code for this instance.</summary>
-            public override int GetHashCode() => _impl.GetHashCode();
+            public override int GetHashCode()
+                => _impl.GetHashCode();
 
             /// <summary>Returns a value indicating whether two <see cref="UpgradedWriterKey"/> values are equal.</summary>
-            public static bool operator ==(UpgradedWriterKey lhs, UpgradedWriterKey rhs) => lhs._impl == rhs._impl;
+            public static bool operator ==(UpgradedWriterKey lhs, UpgradedWriterKey rhs)
+                => lhs._impl == rhs._impl;
 
             /// <summary>Returns a value indicating whether two <see cref="UpgradedWriterKey"/> values are not equal.</summary>
-            public static bool operator !=(UpgradedWriterKey lhs, UpgradedWriterKey rhs) => lhs._impl != rhs._impl;
+            public static bool operator !=(UpgradedWriterKey lhs, UpgradedWriterKey rhs)
+                => lhs._impl != rhs._impl;
         }
     } // class AsyncReaderWriterLock
 

--- a/Package/Core/Threading/AsyncReaderWriterLock.cs
+++ b/Package/Core/Threading/AsyncReaderWriterLock.cs
@@ -86,16 +86,16 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         public Promise<ReaderKey> ReaderLockAsync()
-            => ReaderLockAsyncImpl(ContinuationOptions.CapturedContext);
+            => ReaderLockAsync(true);
 
         /// <summary>
         /// Asynchronously acquire the lock as a reader.
         /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
-        public Promise<ReaderKey> ReaderLockAsync(ContinuationOptions continuationOptions)
-            => ReaderLockAsyncImpl(continuationOptions.GetValidated());
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is not acquired immediately, the async continuation will be executed on the captured context.</param>
+        public Promise<ReaderKey> ReaderLockAsync(bool continueOnCapturedContext)
+            => ReaderLockAsyncImpl(continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously acquire the lock as a reader, while observing a <see cref="CancelationToken"/>.
@@ -104,7 +104,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         public Promise<ReaderKey> ReaderLockAsync(CancelationToken cancelationToken)
-            => ReaderLockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+            => ReaderLockAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously acquire the lock as a reader, while observing a <see cref="CancelationToken"/>.
@@ -112,9 +112,9 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
-        public Promise<ReaderKey> ReaderLockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => ReaderLockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is not acquired immediately, the async continuation will be executed on the captured context.</param>
+        public Promise<ReaderKey> ReaderLockAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => ReaderLockAsyncImpl(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously acquire the lock as a reader.
@@ -153,7 +153,7 @@ namespace Proto.Promises.Threading
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public Promise<(bool didEnter, ReaderKey readerKey)> TryEnterReaderLockAsync(CancelationToken cancelationToken)
-            => TryEnterReaderLockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+            => TryEnterReaderLockAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously try to acquire the lock as a reader, while observing a <see cref="CancelationToken"/>.
@@ -163,13 +163,13 @@ namespace Proto.Promises.Threading
         /// <param name="cancelationToken">
         /// The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the success state of the returned <see cref="Promise{T}"/> will be <see langword="false"/>.
         /// </param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is not acquired immediately, the async continuation will be executed on the captured context.</param>
         /// <remarks>
         /// This first tries to take the lock before checking the <paramref name="cancelationToken"/>>.
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
-        public Promise<(bool didEnter, ReaderKey readerKey)> TryEnterReaderLockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => TryEnterReaderLockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
+        public Promise<(bool didEnter, ReaderKey readerKey)> TryEnterReaderLockAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => TryEnterReaderLockAsyncImpl(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously try to acquire the lock as a reader, while observing a <see cref="CancelationToken"/>.
@@ -191,16 +191,16 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         public Promise<WriterKey> WriterLockAsync()
-            => WriterLockAsyncImpl(ContinuationOptions.CapturedContext);
+            => WriterLockAsync(true);
 
         /// <summary>
         /// Asynchronously acquire the lock as a writer.
         /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
-        public Promise<WriterKey> WriterLockAsync(ContinuationOptions continuationOptions)
-            => WriterLockAsyncImpl(continuationOptions.GetValidated());
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is not acquired immediately, the async continuation will be executed on the captured context.</param>
+        public Promise<WriterKey> WriterLockAsync(bool continueOnCapturedContext)
+            => WriterLockAsyncImpl(continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously acquire the lock as a writer, while observing a <see cref="CancelationToken"/>.
@@ -209,7 +209,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
         public Promise<WriterKey> WriterLockAsync(CancelationToken cancelationToken)
-            => WriterLockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+            => WriterLockAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously acquire the lock as a writer, while observing a <see cref="CancelationToken"/>.
@@ -217,9 +217,9 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
-        public Promise<WriterKey> WriterLockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => WriterLockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is not acquired immediately, the async continuation will be executed on the captured context.</param>
+        public Promise<WriterKey> WriterLockAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => WriterLockAsyncImpl(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously acquire the lock as a writer.
@@ -258,7 +258,7 @@ namespace Proto.Promises.Threading
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public Promise<(bool didEnter, WriterKey writerKey)> TryEnterWriterLockAsync(CancelationToken cancelationToken)
-            => TryEnterWriterLockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+            => TryEnterWriterLockAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously try to acquire the lock as a writer, while observing a <see cref="CancelationToken"/>.
@@ -268,13 +268,13 @@ namespace Proto.Promises.Threading
         /// <param name="cancelationToken">
         /// The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the success state of the returned <see cref="Promise{T}"/> will be <see langword="false"/>.
         /// </param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is not acquired immediately, the async continuation will be executed on the captured context.</param>
         /// <remarks>
         /// This first tries to take the lock before checking the <paramref name="cancelationToken"/>>.
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
-        public Promise<(bool didEnter, WriterKey writerKey)> TryEnterWriterLockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => TryEnterWriterLockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
+        public Promise<(bool didEnter, WriterKey writerKey)> TryEnterWriterLockAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => TryEnterWriterLockAsyncImpl(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously try to acquire the lock as a writer, while observing a <see cref="CancelationToken"/>.
@@ -300,20 +300,20 @@ namespace Proto.Promises.Threading
         /// Only 1 upgradeable reader lock may be entered at a time.
         /// </remarks>
         public Promise<UpgradeableReaderKey> UpgradeableReaderLockAsync()
-            => UpgradeableReaderLockAsyncImpl(ContinuationOptions.CapturedContext);
+            => UpgradeableReaderLockAsync(true);
 
         /// <summary>
         /// Asynchronously acquire the lock as an upgradeable reader.
         /// Returns a <see cref="Promise{T}"/> that will be resolved when the lock has been acquired.
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is not acquired immediately, the async continuation will be executed on the captured context.</param>
         /// <remarks>
         /// Upgradeable reader locks may be entered concurrently with normal reader locks, but they are mutually exclusive with respect to other upgradeable reader locks and writer locks.
         /// Only 1 upgradeable reader lock may be entered at a time.
         /// </remarks>
-        public Promise<UpgradeableReaderKey> UpgradeableReaderLockAsync(ContinuationOptions continuationOptions)
-            => UpgradeableReaderLockAsyncImpl(continuationOptions.GetValidated());
+        public Promise<UpgradeableReaderKey> UpgradeableReaderLockAsync(bool continueOnCapturedContext)
+            => UpgradeableReaderLockAsyncImpl(continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously acquire the lock as an upgradeable reader, while observing a <see cref="CancelationToken"/>.
@@ -326,7 +326,7 @@ namespace Proto.Promises.Threading
         /// Only 1 upgradeable reader lock may be entered at a time.
         /// </remarks>
         public Promise<UpgradeableReaderKey> UpgradeableReaderLockAsync(CancelationToken cancelationToken)
-            => UpgradeableReaderLockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+            => UpgradeableReaderLockAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously acquire the lock as an upgradeable reader, while observing a <see cref="CancelationToken"/>.
@@ -334,13 +334,13 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will release the lock when it is disposed.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the returned <see cref="Promise{T}"/> will be canceled.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is not acquired immediately, the async continuation will be executed on the captured context.</param>
         /// <remarks>
         /// Upgradeable reader locks may be entered concurrently with normal reader locks, but they are mutually exclusive with respect to other upgradeable reader locks and writer locks.
         /// Only 1 upgradeable reader lock may be entered at a time.
         /// </remarks>
-        public Promise<UpgradeableReaderKey> UpgradeableReaderLockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => UpgradeableReaderLockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
+        public Promise<UpgradeableReaderKey> UpgradeableReaderLockAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => UpgradeableReaderLockAsyncImpl(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously acquire the lock as an upgradeable reader.
@@ -391,7 +391,7 @@ namespace Proto.Promises.Threading
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public Promise<(bool didEnter, UpgradeableReaderKey readerKey)> TryEnterUpgradeableReaderLockAsync(CancelationToken cancelationToken)
-            => TryEnterUpgradeableReaderLockAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+            => TryEnterUpgradeableReaderLockAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously try to acquire the lock as an upgradeable reader, while observing a <see cref="CancelationToken"/>.
@@ -399,15 +399,15 @@ namespace Proto.Promises.Threading
         /// If successful, the key will release the lock when it is disposed.
         /// </summary>
         /// <param name="cancelationToken">
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is not acquired immediately, the async continuation will be executed on the captured context.</param>
         /// The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the success state of the returned <see cref="Promise{T}"/> will be <see langword="false"/>.
         /// </param>
         /// <remarks>
         /// This first tries to take the lock before checking the <paramref name="cancelationToken"/>>.
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
-        public Promise<(bool didEnter, UpgradeableReaderKey readerKey)> TryEnterUpgradeableReaderLockAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => TryEnterUpgradeableReaderLockAsyncImpl(cancelationToken, continuationOptions.GetValidated());
+        public Promise<(bool didEnter, UpgradeableReaderKey readerKey)> TryEnterUpgradeableReaderLockAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => TryEnterUpgradeableReaderLockAsyncImpl(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously try to acquire the lock as an upgradeable reader, while observing a <see cref="CancelationToken"/>.
@@ -430,7 +430,7 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="readerKey">The key required to upgrade the lock.</param>
         public Promise<UpgradedWriterKey> UpgradeToWriterLockAsync(UpgradeableReaderKey readerKey)
-            => UpgradeToWriterLockAsyncImpl(readerKey, ContinuationOptions.CapturedContext);
+            => UpgradeToWriterLockAsync(readerKey, true);
 
         /// <summary>
         /// Asynchronously upgrade the lock from an upgradeable reader lock to a writer lock.
@@ -438,9 +438,9 @@ namespace Proto.Promises.Threading
         /// The result of the promise is the key that will downgrade the lock to an upgradeable reader lock when it is disposed.
         /// </summary>
         /// <param name="readerKey">The key required to upgrade the lock.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
-        public Promise<UpgradedWriterKey> UpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, ContinuationOptions continuationOptions)
-            => UpgradeToWriterLockAsyncImpl(readerKey, continuationOptions.GetValidated());
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is not acquired immediately, the async continuation will be executed on the captured context.</param>
+        public Promise<UpgradedWriterKey> UpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, bool continueOnCapturedContext)
+            => UpgradeToWriterLockAsyncImpl(readerKey, continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously upgrade the lock from an upgradeable reader lock to a writer lock, while observing a <see cref="CancelationToken"/>.
@@ -450,7 +450,7 @@ namespace Proto.Promises.Threading
         /// <param name="readerKey">The key required to upgrade the lock.</param>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the upgrade. If the token is canceled before the lock has been upgraded, the returned <see cref="Promise{T}"/> will be canceled.</param>
         public Promise<UpgradedWriterKey> UpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, CancelationToken cancelationToken)
-            => UpgradeToWriterLockAsyncImpl(readerKey, cancelationToken, ContinuationOptions.CapturedContext);
+            => UpgradeToWriterLockAsync(readerKey, cancelationToken, true);
 
         /// <summary>
         /// Asynchronously upgrade the lock from an upgradeable reader lock to a writer lock, while observing a <see cref="CancelationToken"/>.
@@ -459,9 +459,9 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="readerKey">The key required to upgrade the lock.</param>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the upgrade. If the token is canceled before the lock has been upgraded, the returned <see cref="Promise{T}"/> will be canceled.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
-        public Promise<UpgradedWriterKey> UpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => UpgradeToWriterLockAsyncImpl(readerKey, cancelationToken, continuationOptions.GetValidated());
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is not acquired immediately, the async continuation will be executed on the captured context.</param>
+        public Promise<UpgradedWriterKey> UpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => UpgradeToWriterLockAsyncImpl(readerKey, cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously upgrade the lock from an upgradeable reader lock to a writer lock.
@@ -504,7 +504,7 @@ namespace Proto.Promises.Threading
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         public Promise<(bool didEnter, UpgradedWriterKey upgradedWriterKey)> TryUpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, CancelationToken cancelationToken)
-            => TryUpgradeToWriterLockAsyncImpl(readerKey, cancelationToken, ContinuationOptions.CapturedContext);
+            => TryUpgradeToWriterLockAsync(readerKey, cancelationToken, true);
 
         /// <summary>
         /// Asynchronously try to upgrade the lock from an upgradeable reader lock to a writer lock, while observing a <see cref="CancelationToken"/>.
@@ -513,15 +513,15 @@ namespace Proto.Promises.Threading
         /// </summary>
         /// <param name="readerKey">The key required to upgrade the lock.</param>
         /// <param name="cancelationToken">
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and the lock is not acquired immediately, the async continuation will be executed on the captured context.</param>
         /// The <see cref="CancelationToken"/> used to cancel the lock. If the token is canceled before the lock has been acquired, the success state of the returned <see cref="Promise{T}"/> will be <see langword="false"/>.
         /// </param>
         /// <remarks>
         /// This first tries to take the lock before checking the <paramref name="cancelationToken"/>>.
         /// If the lock is available, the result will be (<see langword="true"/>, key), even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
-        public Promise<(bool didEnter, UpgradedWriterKey upgradedWriterKey)> TryUpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => TryUpgradeToWriterLockAsyncImpl(readerKey, cancelationToken, continuationOptions.GetValidated());
+        public Promise<(bool didEnter, UpgradedWriterKey upgradedWriterKey)> TryUpgradeToWriterLockAsync(UpgradeableReaderKey readerKey, CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => TryUpgradeToWriterLockAsyncImpl(readerKey, cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously try to upgrade the lock from an upgradeable reader lock to a writer lock, while observing a <see cref="CancelationToken"/>.

--- a/Package/Core/Threading/AsyncSemaphore.cs
+++ b/Package/Core/Threading/AsyncSemaphore.cs
@@ -73,15 +73,15 @@ namespace Proto.Promises.Threading
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync()
-            => WaitAsyncImpl(ContinuationOptions.CapturedContext);
+            => WaitAsync(true);
 
         /// <summary>
         /// Asynchronously wait to enter this <see cref="AsyncSemaphore"/>.
         /// </summary>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and this does not have capacity, the async continuation will be executed on the captured context.</param>
         [MethodImpl(Internal.InlineOption)]
-        public Promise WaitAsync(ContinuationOptions continuationOptions)
-            => WaitAsyncImpl(continuationOptions.GetValidated());
+        public Promise WaitAsync(bool continueOnCapturedContext)
+            => WaitAsyncImpl(continueOnCapturedContext);
 
         /// <summary>
         /// Asynchronously wait to enter this <see cref="AsyncSemaphore"/>, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -93,20 +93,20 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
-            => TryWaitAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+            => TryWaitAsync(cancelationToken, true);
 
         /// <summary>
         /// Asynchronously wait to enter this <see cref="AsyncSemaphore"/>, or for the <paramref name="cancelationToken"/> to be canceled.
         /// </summary>
         /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
-        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <param name="continueOnCapturedContext">If <see langword="true"/> and this does not have capacity, the async continuation will be executed on the captured context.</param>
         /// <remarks>
         /// The result of the returned <see cref="Promise{T}"/> will be <see langword="true"/> if this is entered before the <paramref name="cancelationToken"/> was canceled, otherwise it will be <see langword="false"/>.
         /// If this is available to be entered, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
-        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
-            => TryWaitAsyncImpl(cancelationToken, continuationOptions.GetValidated());
+        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken, bool continueOnCapturedContext)
+            => TryWaitAsyncImpl(cancelationToken, continueOnCapturedContext);
 
         /// <summary>
         /// Synchronously wait to enter this <see cref="AsyncSemaphore"/>.

--- a/Package/Core/Threading/AsyncSemaphore.cs
+++ b/Package/Core/Threading/AsyncSemaphore.cs
@@ -73,7 +73,15 @@ namespace Proto.Promises.Threading
         /// </summary>
         [MethodImpl(Internal.InlineOption)]
         public Promise WaitAsync()
-            => WaitAsyncImpl();
+            => WaitAsyncImpl(ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously wait to enter this <see cref="AsyncSemaphore"/>.
+        /// </summary>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise"/>.</param>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise WaitAsync(ContinuationOptions continuationOptions)
+            => WaitAsyncImpl(continuationOptions.GetValidated());
 
         /// <summary>
         /// Asynchronously wait to enter this <see cref="AsyncSemaphore"/>, or for the <paramref name="cancelationToken"/> to be canceled.
@@ -85,7 +93,20 @@ namespace Proto.Promises.Threading
         /// </remarks>
         [MethodImpl(Internal.InlineOption)]
         public Promise<bool> TryWaitAsync(CancelationToken cancelationToken)
-            => TryWaitAsyncImpl(cancelationToken);
+            => TryWaitAsyncImpl(cancelationToken, ContinuationOptions.CapturedContext);
+
+        /// <summary>
+        /// Asynchronously wait to enter this <see cref="AsyncSemaphore"/>, or for the <paramref name="cancelationToken"/> to be canceled.
+        /// </summary>
+        /// <param name="cancelationToken">The <see cref="CancelationToken"/> used to cancel the wait.</param>
+        /// <param name="continuationOptions">The options used to configure the continuation behavior of the returned <see cref="Promise{T}"/>.</param>
+        /// <remarks>
+        /// The result of the returned <see cref="Promise{T}"/> will be <see langword="true"/> if this is entered before the <paramref name="cancelationToken"/> was canceled, otherwise it will be <see langword="false"/>.
+        /// If this is available to be entered, the result will be <see langword="true"/>, even if the <paramref name="cancelationToken"/> is already canceled.
+        /// </remarks>
+        [MethodImpl(Internal.InlineOption)]
+        public Promise<bool> TryWaitAsync(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            => TryWaitAsyncImpl(cancelationToken, continuationOptions.GetValidated());
 
         /// <summary>
         /// Synchronously wait to enter this <see cref="AsyncSemaphore"/>.

--- a/Package/Core/Threading/Internal/AsyncCountdownEventInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncCountdownEventInternal.cs
@@ -30,10 +30,10 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static AsyncCountdownEventPromise GetOrCreate(Threading.AsyncCountdownEvent owner, ContinuationOptions continuationOptions)
+            internal static AsyncCountdownEventPromise GetOrCreate(Threading.AsyncCountdownEvent owner, bool continueOnCapturedContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset(continuationOptions);
+                promise.Reset(continueOnCapturedContext);
                 promise._owner = owner;
                 return promise;
             }
@@ -108,13 +108,12 @@ namespace Proto.Promises
             }
 #endif // PROMISE_DEBUG
 
-            private Promise WaitAsyncImpl(ContinuationOptions continuationOptions)
+            private Promise WaitAsyncImpl(bool continueOnCapturedContext)
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
                 if (_currentCount == 0)
                 {
-                    return Promise.Resolved()
-                        .ConfigureContinuation(continuationOptions);
+                    return Promise.Resolved();
                 }
 
                 Internal.AsyncCountdownEventPromise promise;
@@ -124,24 +123,22 @@ namespace Proto.Promises
                     if (_currentCount == 0)
                     {
                         _locker.Exit();
-                        return Promise.Resolved()
-                            .ConfigureContinuation(continuationOptions);
+                        return Promise.Resolved();
                     }
-                    promise = Internal.AsyncCountdownEventPromise.GetOrCreate(this, continuationOptions);
+                    promise = Internal.AsyncCountdownEventPromise.GetOrCreate(this, continueOnCapturedContext);
                     _waiters.Enqueue(promise);
                 }
                 _locker.Exit();
                 return new Promise(promise, promise.Id);
             }
 
-            private Promise<bool> TryWaitAsyncImpl(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            private Promise<bool> TryWaitAsyncImpl(CancelationToken cancelationToken, bool continueOnCapturedContext)
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
                 bool isSet = _currentCount == 0;
                 if (isSet | cancelationToken.IsCancelationRequested)
                 {
-                    return Promise.Resolved(isSet)
-                        .ConfigureContinuation(continuationOptions);
+                    return Promise.Resolved(isSet);
                 }
 
                 Internal.AsyncCountdownEventPromise promise;
@@ -151,16 +148,14 @@ namespace Proto.Promises
                     if (_currentCount == 0)
                     {
                         _locker.Exit();
-                        return Promise.Resolved(true)
-                            .ConfigureContinuation(continuationOptions);
+                        return Promise.Resolved(true);
                     }
-                    promise = Internal.AsyncCountdownEventPromise.GetOrCreate(this, continuationOptions);
+                    promise = Internal.AsyncCountdownEventPromise.GetOrCreate(this, continueOnCapturedContext);
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
                         _locker.Exit();
                         promise.DisposeImmediate();
-                        return Promise.Resolved(false)
-                            .ConfigureContinuation(continuationOptions);
+                        return Promise.Resolved(false);
                     }
                     _waiters.Enqueue(promise);
                 }
@@ -177,7 +172,7 @@ namespace Proto.Promises
                     spinner.SpinOnce();
                 }
 
-                WaitAsyncImpl(ContinuationOptions.Synchronous).Wait();
+                WaitAsyncImpl(false).Wait();
             }
 
             private bool TryWaitImpl(CancelationToken cancelationToken)
@@ -189,7 +184,7 @@ namespace Proto.Promises
                     spinner.SpinOnce();
                 }
 
-                return TryWaitAsyncImpl(cancelationToken, ContinuationOptions.Synchronous).WaitForResult();
+                return TryWaitAsyncImpl(cancelationToken, false).WaitForResult();
             }
 
             private bool SignalImpl(int signalCount)

--- a/Package/Core/Threading/Internal/AsyncLockInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncLockInternal.cs
@@ -57,10 +57,10 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal static AsyncLockPromise GetOrCreate(AsyncLock owner, SynchronizationContext callerContext)
+                internal static AsyncLockPromise GetOrCreate(AsyncLock owner, ContinuationOptions continuationOptions)
                 {
                     var promise = GetOrCreate();
-                    promise.Reset(callerContext);
+                    promise.Reset(continuationOptions);
                     promise._result = new AsyncLock.Key(owner); // This will be overwritten when this is resolved, we just store the owner here for cancelation.
                     return promise;
                 }
@@ -134,10 +134,10 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal static AsyncLockWaitPromise GetOrCreate(AsyncConditionVariable owner, long key, SynchronizationContext callerContext)
+                internal static AsyncLockWaitPromise GetOrCreate(AsyncConditionVariable owner, long key, ContinuationOptions continuationOptions)
                 {
                     var promise = GetOrCreate();
-                    promise.Reset(callerContext);
+                    promise.Reset(continuationOptions);
                     promise._owner = owner;
                     promise._lock = owner._lock;
                     promise._key = key;
@@ -236,7 +236,7 @@ namespace Proto.Promises
             private void SetNextKey()
                 => _currentKey = Internal.KeyGenerator<AsyncLock>.Next();
 
-            private Promise<Key> LockAsyncImpl()
+            private Promise<Key> LockAsyncImpl(ContinuationOptions continuationOptions)
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
 
@@ -250,17 +250,18 @@ namespace Proto.Promises
                     {
                         SetNextKey();
                         _locker.Exit();
-                        return Promise.Resolved(new Key(this, _currentKey, null));
+                        return Promise.Resolved(new Key(this, _currentKey, null))
+                            .ConfigureContinuation(continuationOptions);
                     }
 
-                    promise = Internal.PromiseRefBase.AsyncLockPromise.GetOrCreate(this, ContinuationOptions.CaptureContext());
+                    promise = Internal.PromiseRefBase.AsyncLockPromise.GetOrCreate(this, continuationOptions);
                     _queue.Enqueue(promise);
                 }
                 _locker.Exit();
                 return new Promise<Key>(promise, promise.Id);
             }
 
-            private Promise<Key> LockAsyncImpl(CancelationToken cancelationToken)
+            private Promise<Key> LockAsyncImpl(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
 
@@ -269,7 +270,8 @@ namespace Proto.Promises
                 {
                     ValidateNotAbandoned();
 
-                    return Promise<Key>.Canceled();
+                    return Promise<Key>.Canceled()
+                        .ConfigureContinuation(continuationOptions);
                 }
 
                 // Unfortunately, there is no way to detect async recursive lock enter. A deadlock will occur, instead of throw.
@@ -282,15 +284,17 @@ namespace Proto.Promises
                     {
                         SetNextKey();
                         _locker.Exit();
-                        return Promise.Resolved(new Key(this, _currentKey, null));
+                        return Promise.Resolved(new Key(this, _currentKey, null))
+                            .ConfigureContinuation(continuationOptions);
                     }
 
-                    promise = Internal.PromiseRefBase.AsyncLockPromise.GetOrCreate(this, ContinuationOptions.CaptureContext());
+                    promise = Internal.PromiseRefBase.AsyncLockPromise.GetOrCreate(this, continuationOptions);
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
                         _locker.Exit();
                         promise.DisposeImmediate();
-                        return Promise<Key>.Canceled();
+                        return Promise<Key>.Canceled()
+                            .ConfigureContinuation(continuationOptions);
                     }
                     _queue.Enqueue(promise);
                 }
@@ -307,73 +311,19 @@ namespace Proto.Promises
                     spinner.SpinOnce();
                 }
 
-                // Unfortunately, there is no way to detect async recursive lock enter. A deadlock will occur, instead of throw.
-                Internal.PromiseRefBase.AsyncLockPromise promise;
-                _locker.Enter();
-                {
-                    ValidateNotAbandoned();
-
-                    if (_currentKey == 0)
-                    {
-                        SetNextKey();
-                        _locker.Exit();
-                        return new Key(this, _currentKey, null);
-                    }
-
-                    promise = Internal.PromiseRefBase.AsyncLockPromise.GetOrCreate(this, null);
-                    _queue.Enqueue(promise);
-                }
-                _locker.Exit();
-                Internal.PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, Timeout.InfiniteTimeSpan, out var resultContainer);
-                resultContainer.RethrowIfRejectedOrCanceled();
-                return resultContainer.Value;
+                return LockAsyncImpl(ContinuationOptions.Synchronous).WaitForResult();
             }
 
             private Key LockImpl(CancelationToken cancelationToken)
             {
                 // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
                 var spinner = new SpinWait();
-                bool isCanceled = cancelationToken.IsCancelationRequested;
-                while (Volatile.Read(ref _currentKey) != 0 & !isCanceled & !spinner.NextSpinWillYield)
+                while (Volatile.Read(ref _currentKey) != 0 & !spinner.NextSpinWillYield & !cancelationToken.IsCancelationRequested)
                 {
                     spinner.SpinOnce();
-                    isCanceled = cancelationToken.IsCancelationRequested;
                 }
 
-                // Quick check to see if the token is already canceled before entering.
-                if (isCanceled)
-                {
-                    ValidateNotAbandoned();
-
-                    throw Promise.CancelException();
-                }
-
-                // Unfortunately, there is no way to detect async recursive lock enter. A deadlock will occur, instead of throw.
-                Internal.PromiseRefBase.AsyncLockPromise promise;
-                _locker.Enter();
-                {
-                    ValidateNotAbandoned();
-
-                    if (_currentKey == 0)
-                    {
-                        SetNextKey();
-                        _locker.Exit();
-                        return new Key(this, _currentKey, null);
-                    }
-
-                    promise = Internal.PromiseRefBase.AsyncLockPromise.GetOrCreate(this, null);
-                    if (promise.HookupAndGetIsCanceled(cancelationToken))
-                    {
-                        _locker.Exit();
-                        promise.DisposeImmediate();
-                        throw Promise.CancelException();
-                    }
-                    _queue.Enqueue(promise);
-                }
-                _locker.Exit();
-                Internal.PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, Timeout.InfiniteTimeSpan, out var resultContainer);
-                resultContainer.RethrowIfRejectedOrCanceled();
-                return resultContainer.Value;
+                return LockAsyncImpl(cancelationToken, ContinuationOptions.Synchronous).WaitForResult();
             }
 
             internal bool TryEnterImpl(out Key key)
@@ -395,7 +345,7 @@ namespace Proto.Promises
                 return false;
             }
 
-            internal Promise<(bool didEnter, Key key)> TryEnterAsyncImpl(CancelationToken cancelationToken)
+            internal Promise<(bool didEnter, Key key)> TryEnterAsyncImpl(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
             {
                 Internal.PromiseRefBase.AsyncLockPromise promise;
                 _locker.Enter();
@@ -406,21 +356,24 @@ namespace Proto.Promises
                     {
                         SetNextKey();
                         _locker.Exit();
-                        return Promise.Resolved((true, new Key(this, _currentKey, null)));
+                        return Promise.Resolved((true, new Key(this, _currentKey, null)))
+                            .ConfigureContinuation(continuationOptions);
                     }
                     // Quick check to see if the token is already canceled before waiting.
                     if (cancelationToken.IsCancelationRequested)
                     {
                         _locker.Exit();
-                        return Promise.Resolved((false, default(Key)));
+                        return Promise.Resolved((false, default(Key)))
+                            .ConfigureContinuation(continuationOptions);
                     }
 
-                    promise = Internal.PromiseRefBase.AsyncLockPromise.GetOrCreate(this, ContinuationOptions.CaptureContext());
+                    promise = Internal.PromiseRefBase.AsyncLockPromise.GetOrCreate(this, continuationOptions);
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
                         _locker.Exit();
                         promise.DisposeImmediate();
-                        return Promise.Resolved((false, default(Key)));
+                        return Promise.Resolved((false, default(Key)))
+                            .ConfigureContinuation(continuationOptions);
                     }
                     _queue.Enqueue(promise);
                 }
@@ -437,49 +390,14 @@ namespace Proto.Promises
             {
                 // Because this is a synchronous wait, we do a short spinwait before yielding the thread.
                 var spinner = new SpinWait();
-                bool isCanceled = cancelationToken.IsCancelationRequested;
-                while (Volatile.Read(ref _currentKey) != 0 & !isCanceled & !spinner.NextSpinWillYield)
+                while (Volatile.Read(ref _currentKey) != 0 & !spinner.NextSpinWillYield & !cancelationToken.IsCancelationRequested)
                 {
                     spinner.SpinOnce();
-                    isCanceled = cancelationToken.IsCancelationRequested;
                 }
 
-                // Unfortunately, there is no way to detect async recursive lock enter. A deadlock will occur, instead of throw.
-                Internal.PromiseRefBase.AsyncLockPromise promise;
-                _locker.Enter();
-                {
-                    ValidateNotAbandoned();
-
-                    if (_currentKey == 0)
-                    {
-                        SetNextKey();
-                        _locker.Exit();
-                        key = new Key(this, _currentKey, null);
-                        return true;
-                    }
-                    // Quick check to see if the token is already canceled before waiting.
-                    if (isCanceled)
-                    {
-                        _locker.Exit();
-                        key = default;
-                        return false;
-                    }
-
-                    promise = Internal.PromiseRefBase.AsyncLockPromise.GetOrCreate(this, null);
-                    if (promise.HookupAndGetIsCanceled(cancelationToken))
-                    {
-                        _locker.Exit();
-                        promise.DisposeImmediate();
-                        key = default;
-                        return false;
-                    }
-                    _queue.Enqueue(promise);
-                }
-                _locker.Exit();
-                Internal.PromiseSynchronousWaiter.TryWaitForResult(promise, promise.Id, Timeout.InfiniteTimeSpan, out var resultContainer);
-                resultContainer.RethrowIfRejected();
-                key = resultContainer.Value;
-                return resultContainer.State == Promise.State.Resolved;
+                var (success, k) = TryEnterAsyncImpl(cancelationToken, ContinuationOptions.Synchronous).WaitForResult();
+                key = k;
+                return success;
             }
 
             private void ReleaseLock(long key)
@@ -507,7 +425,7 @@ namespace Proto.Promises
                 next.Resolve(ref _currentKey);
             }
 
-            private Promise WaitAsyncImpl(AsyncConditionVariable condVar, long key, SynchronizationContext callerContext)
+            private Promise WaitAsyncImpl(AsyncConditionVariable condVar, long key, ContinuationOptions continuationOptions)
             {
                 Internal.PromiseRefBase.AsyncLockWaitPromise promise;
                 _locker.Enter();
@@ -525,14 +443,14 @@ namespace Proto.Promises
                         ThrowConditionVariableAlreadyInUse(3);
                     }
 
-                    promise = Internal.PromiseRefBase.AsyncLockWaitPromise.GetOrCreate(condVar, key, callerContext);
+                    promise = Internal.PromiseRefBase.AsyncLockWaitPromise.GetOrCreate(condVar, key, continuationOptions);
                     condVar._queue.Enqueue(promise);
                 }
                 _locker.Exit();
                 return new Promise(promise, promise.Id);
             }
 
-            private Promise<bool> TryWaitAsyncImpl(AsyncConditionVariable condVar, long key, CancelationToken cancelationToken, SynchronizationContext callerContext)
+            private Promise<bool> TryWaitAsyncImpl(AsyncConditionVariable condVar, long key, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
             {
                 Internal.PromiseRefBase.AsyncLockWaitPromise promise;
                 _locker.Enter();
@@ -560,10 +478,11 @@ namespace Proto.Promises
                             condVar._lock = null;
                         }
                         _locker.Exit();
-                        return Promise.Resolved(false);
+                        return Promise.Resolved(false)
+                            .ConfigureContinuation(continuationOptions);
                     }
 
-                    promise = Internal.PromiseRefBase.AsyncLockWaitPromise.GetOrCreate(condVar, key, callerContext);
+                    promise = Internal.PromiseRefBase.AsyncLockWaitPromise.GetOrCreate(condVar, key, continuationOptions);
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
                         if (condVar._queue.IsEmpty)
@@ -573,7 +492,8 @@ namespace Proto.Promises
                         }
                         _locker.Exit();
                         promise.DisposeImmediate();
-                        return Promise.Resolved(false);
+                        return Promise.Resolved(false)
+                            .ConfigureContinuation(continuationOptions);
                     }
                     condVar._queue.Enqueue(promise);
                 }
@@ -809,11 +729,11 @@ namespace Proto.Promises
                         _owner.NotifyAbandoned("An AsyncLock.Key was never disposed.", this);
                     }
 
-                    internal Promise<bool> TryWaitAsync(AsyncConditionVariable condVar, long key, CancelationToken cancelationToken, SynchronizationContext callerContext)
+                    internal Promise<bool> TryWaitAsync(AsyncConditionVariable condVar, long key, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
                     {
                         ValidateCall();
 
-                        var promise = _owner.TryWaitAsyncImpl(condVar, key, cancelationToken, callerContext);
+                        var promise = _owner.TryWaitAsyncImpl(condVar, key, cancelationToken, continuationOptions);
                         _waitPromise = promise._ref;
                         return promise
                             .Finally(this, _this => _this._waitPromise = null);
@@ -870,23 +790,23 @@ namespace Proto.Promises
                     }
                 }
 
-                internal Promise WaitAsync(AsyncConditionVariable condVar)
+                internal Promise WaitAsync(AsyncConditionVariable condVar, ContinuationOptions continuationOptions)
                 {
                     var copy = this;
                     copy.ValidateOwnerAndDisposedChecker();
                     lock (copy._disposedChecker)
                     {
-                        return copy._disposedChecker.TryWaitAsync(condVar, copy._key, default, ContinuationOptions.CaptureContext());
+                        return copy._disposedChecker.TryWaitAsync(condVar, copy._key, default, continuationOptions);
                     }
                 }
 
-                internal Promise<bool> TryWaitAsync(AsyncConditionVariable condVar, CancelationToken cancelationToken)
+                internal Promise<bool> TryWaitAsync(AsyncConditionVariable condVar, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
                 {
                     var copy = this;
                     copy.ValidateOwnerAndDisposedChecker();
                     lock (copy._disposedChecker)
                     {
-                        return copy._disposedChecker.TryWaitAsync(condVar, copy._key, cancelationToken, ContinuationOptions.CaptureContext());
+                        return copy._disposedChecker.TryWaitAsync(condVar, copy._key, cancelationToken, continuationOptions);
                     }
                 }
 
@@ -896,7 +816,7 @@ namespace Proto.Promises
                     copy.ValidateOwnerAndDisposedChecker();
                     lock (copy._disposedChecker)
                     {
-                        copy._disposedChecker.TryWaitAsync(condVar, copy._key, default, null).WaitForResult();
+                        copy._disposedChecker.TryWaitAsync(condVar, copy._key, default, ContinuationOptions.Synchronous).WaitForResult();
                     }
                 }
 
@@ -906,7 +826,7 @@ namespace Proto.Promises
                     copy.ValidateOwnerAndDisposedChecker();
                     lock (copy._disposedChecker)
                     {
-                        return copy._disposedChecker.TryWaitAsync(condVar, copy._key, cancelationToken, null).WaitForResult();
+                        return copy._disposedChecker.TryWaitAsync(condVar, copy._key, cancelationToken, ContinuationOptions.Synchronous).WaitForResult();
                     }
                 }
 
@@ -970,17 +890,17 @@ namespace Proto.Promises
                     ValidateAndGetOwner().ReleaseLock(_key);
                 }
 
-                internal Promise WaitAsync(AsyncConditionVariable condVar)
-                    => ValidateAndGetOwner().WaitAsyncImpl(condVar, _key, ContinuationOptions.CaptureContext());
+                internal Promise WaitAsync(AsyncConditionVariable condVar, ContinuationOptions continuationOptions)
+                    => ValidateAndGetOwner().WaitAsyncImpl(condVar, _key, continuationOptions);
 
-                internal Promise<bool> TryWaitAsync(AsyncConditionVariable condVar, CancelationToken cancelationToken)
-                    => ValidateAndGetOwner().TryWaitAsyncImpl(condVar, _key, cancelationToken, ContinuationOptions.CaptureContext());
+                internal Promise<bool> TryWaitAsync(AsyncConditionVariable condVar, CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+                    => ValidateAndGetOwner().TryWaitAsyncImpl(condVar, _key, cancelationToken, continuationOptions);
 
                 internal void Wait(AsyncConditionVariable condVar)
-                    => ValidateAndGetOwner().WaitAsyncImpl(condVar, _key, null).Wait();
+                    => ValidateAndGetOwner().WaitAsyncImpl(condVar, _key, ContinuationOptions.Synchronous).Wait();
 
                 internal bool TryWait(AsyncConditionVariable condVar, CancelationToken cancelationToken)
-                    => ValidateAndGetOwner().TryWaitAsyncImpl(condVar, _key, cancelationToken, null).WaitForResult();
+                    => ValidateAndGetOwner().TryWaitAsyncImpl(condVar, _key, cancelationToken, ContinuationOptions.Synchronous).WaitForResult();
 
                 internal void Pulse(AsyncConditionVariable condVar)
                     => ValidateAndGetOwner().Pulse(condVar, _key);

--- a/Package/Core/Threading/Internal/AsyncManualResetEventInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncManualResetEventInternal.cs
@@ -30,10 +30,10 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static AsyncManualResetEventPromise GetOrCreate(Threading.AsyncManualResetEvent owner, ContinuationOptions continuationOptions)
+            internal static AsyncManualResetEventPromise GetOrCreate(Threading.AsyncManualResetEvent owner, bool continueOnCapturedContext)
             {
                 var promise = GetOrCreate();
-                promise.Reset(continuationOptions);
+                promise.Reset(continueOnCapturedContext);
                 promise._owner = owner;
                 return promise;
             }
@@ -108,13 +108,12 @@ namespace Proto.Promises
             }
 #endif // PROMISE_DEBUG
 
-            private Promise WaitAsyncImpl(ContinuationOptions continuationOptions)
+            private Promise WaitAsyncImpl(bool continueOnCapturedContext)
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
                 if (_isSet)
                 {
-                    return Promise.Resolved()
-                        .ConfigureContinuation(continuationOptions);
+                    return Promise.Resolved();
                 }
 
                 Internal.AsyncManualResetEventPromise promise;
@@ -124,24 +123,22 @@ namespace Proto.Promises
                     if (_isSet)
                     {
                         _locker.Exit();
-                        return Promise.Resolved()
-                            .ConfigureContinuation(continuationOptions);
+                        return Promise.Resolved();
                     }
-                    promise = Internal.AsyncManualResetEventPromise.GetOrCreate(this, continuationOptions);
+                    promise = Internal.AsyncManualResetEventPromise.GetOrCreate(this, continueOnCapturedContext);
                     _waiters.Enqueue(promise);
                 }
                 _locker.Exit();
                 return new Promise(promise, promise.Id);
             }
 
-            private Promise<bool> TryWaitAsyncImpl(CancelationToken cancelationToken, ContinuationOptions continuationOptions)
+            private Promise<bool> TryWaitAsyncImpl(CancelationToken cancelationToken, bool continueOnCapturedContext)
             {
                 // We don't spinwait here because it's async; we want to return to caller as fast as possible.
                 bool isSet = _isSet;
                 if (isSet | cancelationToken.IsCancelationRequested)
                 {
-                    return Promise.Resolved(isSet)
-                        .ConfigureContinuation(continuationOptions);
+                    return Promise.Resolved(isSet);
                 }
 
                 Internal.AsyncManualResetEventPromise promise;
@@ -151,16 +148,14 @@ namespace Proto.Promises
                     if (_isSet)
                     {
                         _locker.Exit();
-                        return Promise.Resolved(true)
-                            .ConfigureContinuation(continuationOptions);
+                        return Promise.Resolved(true);
                     }
-                    promise = Internal.AsyncManualResetEventPromise.GetOrCreate(this, continuationOptions);
+                    promise = Internal.AsyncManualResetEventPromise.GetOrCreate(this, continueOnCapturedContext);
                     if (promise.HookupAndGetIsCanceled(cancelationToken))
                     {
                         _locker.Exit();
                         promise.DisposeImmediate();
-                        return Promise.Resolved(false)
-                            .ConfigureContinuation(continuationOptions);
+                        return Promise.Resolved(false);
                     }
                     _waiters.Enqueue(promise);
                 }
@@ -177,7 +172,7 @@ namespace Proto.Promises
                     spinner.SpinOnce();
                 }
 
-                WaitAsyncImpl(ContinuationOptions.Synchronous).Wait();
+                WaitAsyncImpl(false).Wait();
             }
 
             private bool TryWaitImpl(CancelationToken cancelationToken)
@@ -189,7 +184,7 @@ namespace Proto.Promises
                     spinner.SpinOnce();
                 }
 
-                return TryWaitAsyncImpl(cancelationToken, ContinuationOptions.Synchronous).WaitForResult();
+                return TryWaitAsyncImpl(cancelationToken, false).WaitForResult();
             }
 
             private void SetImpl()

--- a/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
@@ -28,10 +28,10 @@ namespace Proto.Promises
                 protected Promise.State _tempState;
 
                 [MethodImpl(InlineOption)]
-                protected void Reset(ContinuationOptions continuationOptions)
+                protected void Reset(bool continueOnCapturedContext)
                 {
                     Reset();
-                    _continuationContext = continuationOptions.GetContinuationContext();
+                    _continuationContext = continueOnCapturedContext ? ContinuationOptions.CaptureContext() : null;
                     // Assume the resolved state will occur. If this is actually canceled or rejected, the state will be set at that time.
                     _tempState = Promise.State.Resolved;
                 }
@@ -45,14 +45,15 @@ namespace Proto.Promises
 
                 protected void Continue()
                 {
-                    if (_continuationContext == null)
+                    var context = _continuationContext;
+                    if (context == null)
                     {
                         // This was configured to continue synchronously.
                         HandleNextInternal(_tempState);
                         return;
                     }
                     // This was configured to continuation on the context.
-                    ScheduleContextCallback(_continuationContext, this,
+                    ScheduleContextCallback(context, this,
                         obj => obj.UnsafeAs<AsyncSynchronizationPromiseBase<TResult>>().HandleFromContext(),
                         obj => obj.UnsafeAs<AsyncSynchronizationPromiseBase<TResult>>().HandleFromContext()
                     );

--- a/Package/Tests/CoreTests/APIs/Channels/BoundedChannelTests.cs
+++ b/Package/Tests/CoreTests/APIs/Channels/BoundedChannelTests.cs
@@ -739,7 +739,11 @@ namespace ProtoPromiseTests.APIs.Channels
         public void WriteAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;
@@ -778,7 +782,11 @@ namespace ProtoPromiseTests.APIs.Channels
         public void WaitToWriteAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;
@@ -817,7 +825,11 @@ namespace ProtoPromiseTests.APIs.Channels
         public void ReadAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;
@@ -856,7 +868,11 @@ namespace ProtoPromiseTests.APIs.Channels
         public void WaitToReadAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;

--- a/Package/Tests/CoreTests/APIs/Channels/UnboundedChannelTests.cs
+++ b/Package/Tests/CoreTests/APIs/Channels/UnboundedChannelTests.cs
@@ -662,7 +662,11 @@ namespace ProtoPromiseTests.APIs.Channels
         public void ReadAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;
@@ -700,7 +704,11 @@ namespace ProtoPromiseTests.APIs.Channels
         public void WaitToReadAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;

--- a/Package/Tests/CoreTests/APIs/Threading/AsyncAutoResetEventTests.cs
+++ b/Package/Tests/CoreTests/APIs/Threading/AsyncAutoResetEventTests.cs
@@ -399,7 +399,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncAutoResetEvent_WaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_Then(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var are = new AsyncAutoResetEvent(false);
@@ -422,7 +426,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncAutoResetEvent_TryWaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_Then(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var are = new AsyncAutoResetEvent(false);
@@ -449,7 +457,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncAutoResetEvent_WaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var are = new AsyncAutoResetEvent(false);
@@ -472,7 +484,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncAutoResetEvent_TryWaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var are = new AsyncAutoResetEvent(false);

--- a/Package/Tests/CoreTests/APIs/Threading/AsyncConditionVariableTests.cs
+++ b/Package/Tests/CoreTests/APIs/Threading/AsyncConditionVariableTests.cs
@@ -767,7 +767,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncConditionVariable_WaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_Then(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var mutex = new AsyncLock();
@@ -800,7 +804,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncConditionVariable_TryWaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_Then(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var mutex = new AsyncLock();
@@ -837,7 +845,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncConditionVariable_WaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var mutex = new AsyncLock();
@@ -869,7 +881,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncConditionVariable_TryWaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var mutex = new AsyncLock();

--- a/Package/Tests/CoreTests/APIs/Threading/AsyncConditionVariableTests.cs
+++ b/Package/Tests/CoreTests/APIs/Threading/AsyncConditionVariableTests.cs
@@ -784,6 +784,7 @@ namespace ProtoPromiseTests.APIs.Threading
                         .Then(() =>
                         {
                             TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                            key.Dispose();
                         });
                 });
 
@@ -823,6 +824,7 @@ namespace ProtoPromiseTests.APIs.Threading
                         {
                             Assert.True(success);
                             TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                            key.Dispose();
                         });
                 });
 

--- a/Package/Tests/CoreTests/APIs/Threading/AsyncCountdownEventTests.cs
+++ b/Package/Tests/CoreTests/APIs/Threading/AsyncCountdownEventTests.cs
@@ -273,7 +273,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncCountdownEvent_WaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_Then(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var ce = new AsyncCountdownEvent(1);
@@ -295,7 +299,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncCountdownEvent_TryWaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_Then(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var ce = new AsyncCountdownEvent(1);
@@ -321,7 +329,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncCountdownEvent_WaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var ce = new AsyncCountdownEvent(1);
@@ -343,7 +355,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncCountdownEvent_TryWaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var ce = new AsyncCountdownEvent(1);

--- a/Package/Tests/CoreTests/APIs/Threading/AsyncLockTests.cs
+++ b/Package/Tests/CoreTests/APIs/Threading/AsyncLockTests.cs
@@ -561,7 +561,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncLock_LockAsync_ContinuesOnConfiguredContext_Then(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var asyncLock = new AsyncLock();
@@ -586,7 +590,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncLock_LockAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var asyncLock = new AsyncLock();

--- a/Package/Tests/CoreTests/APIs/Threading/AsyncManualResetEventTests.cs
+++ b/Package/Tests/CoreTests/APIs/Threading/AsyncManualResetEventTests.cs
@@ -7,6 +7,7 @@
 using NUnit.Framework;
 using Proto.Promises;
 using Proto.Promises.Threading;
+using ProtoPromiseTests.Concurrency;
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -405,6 +406,106 @@ namespace ProtoPromiseTests.APIs.Threading
 
             mre.Wait();
             mre.Wait();
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_WaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_Then(
+            [Values] SynchronizationType continuationContext,
+            [Values] CompletedContinuationBehavior completedBehavior,
+            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            var mre = new AsyncManualResetEvent(false);
+
+            var promise = mre.WaitAsync(TestHelper.GetContinuationOptions(continuationContext, completedBehavior))
+                .Then(() =>
+                {
+                    TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                });
+
+            Assert.False(mre.IsSet);
+            new ThreadHelper().ExecuteSynchronousOrOnThread(
+                () => mre.Set(),
+                invokeContext == SynchronizationType.Foreground
+            );
+            promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_TryWaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_Then(
+            [Values] SynchronizationType continuationContext,
+            [Values] CompletedContinuationBehavior completedBehavior,
+            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            var mre = new AsyncManualResetEvent(false);
+            var cancelationSource = CancelationSource.New();
+
+            var promise = mre.TryWaitAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior))
+                .Then(success =>
+                {
+                    Assert.True(success);
+                    TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                });
+
+            Assert.False(mre.IsSet);
+            new ThreadHelper().ExecuteSynchronousOrOnThread(
+                () => mre.Set(),
+                invokeContext == SynchronizationType.Foreground
+            );
+            promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+
+            cancelationSource.Dispose();
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_WaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_await(
+            [Values] SynchronizationType continuationContext,
+            [Values] CompletedContinuationBehavior completedBehavior,
+            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            var mre = new AsyncManualResetEvent(false);
+
+            var promise = Promise.Run(async () =>
+            {
+                await mre.WaitAsync(TestHelper.GetContinuationOptions(continuationContext, completedBehavior));
+                TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+            }, SynchronizationOption.Synchronous);
+
+            Assert.False(mre.IsSet);
+            new ThreadHelper().ExecuteSynchronousOrOnThread(
+                () => mre.Set(),
+                invokeContext == SynchronizationType.Foreground
+            );
+            promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void AsyncManualResetEvent_TryWaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_await(
+            [Values] SynchronizationType continuationContext,
+            [Values] CompletedContinuationBehavior completedBehavior,
+            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            var mre = new AsyncManualResetEvent(false);
+            var cancelationSource = CancelationSource.New();
+
+            var promise = Promise.Run(async () =>
+            {
+                var success = await mre.TryWaitAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior));
+                Assert.True(success);
+                TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+            }, SynchronizationOption.Synchronous);
+
+            Assert.False(mre.IsSet);
+            new ThreadHelper().ExecuteSynchronousOrOnThread(
+                () => mre.Set(),
+                invokeContext == SynchronizationType.Foreground
+            );
+            promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+
+            cancelationSource.Dispose();
         }
 
 #if PROTO_PROMISE_TEST_GC_ENABLED

--- a/Package/Tests/CoreTests/APIs/Threading/AsyncManualResetEventTests.cs
+++ b/Package/Tests/CoreTests/APIs/Threading/AsyncManualResetEventTests.cs
@@ -412,7 +412,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncManualResetEvent_WaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_Then(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var mre = new AsyncManualResetEvent(false);
@@ -435,7 +439,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncManualResetEvent_TryWaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_Then(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var mre = new AsyncManualResetEvent(false);
@@ -462,7 +470,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncManualResetEvent_WaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var mre = new AsyncManualResetEvent(false);
@@ -485,7 +497,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncManualResetEvent_TryWaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var mre = new AsyncManualResetEvent(false);

--- a/Package/Tests/CoreTests/APIs/Threading/AsyncReaderWriterLockTests.cs
+++ b/Package/Tests/CoreTests/APIs/Threading/AsyncReaderWriterLockTests.cs
@@ -7,6 +7,7 @@
 using NUnit.Framework;
 using Proto.Promises;
 using Proto.Promises.Threading;
+using ProtoPromiseTests.Concurrency;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -2885,6 +2886,274 @@ namespace ProtoPromiseTests.APIs.Threading
             upgradeableReaderKey.Dispose();
             TestHelper.ExecuteForegroundCallbacks();
             Assert.True(enteredWriterLock);
+        }
+
+        [Test]
+        public void AsyncReaderWriterLock_WriterLockAsync_ContinuesOnConfiguredContext_await(
+            [Values] SynchronizationType continuationContext,
+            [Values] CompletedContinuationBehavior completedBehavior,
+            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values] bool withCancelationToken)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
+            var cancelationSource = CancelationSource.New();
+
+            var initialKey = rwl.WriterLock();
+
+            var promise = Promise.Run(async () =>
+            {
+                if (withCancelationToken)
+                {
+                    using (var key = await rwl.WriterLockAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    {
+                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                    }
+                }
+                else
+                {
+                    using (var key = await rwl.WriterLockAsync(TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    {
+                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                    }
+                }
+            }, SynchronizationOption.Synchronous);
+
+            new ThreadHelper().ExecuteSynchronousOrOnThread(
+                () => initialKey.Dispose(),
+                invokeContext == SynchronizationType.Foreground
+            );
+            promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+            cancelationSource.Dispose();
+        }
+
+        [Test]
+        public void AsyncReaderWriterLock_TryEnterWriterLockAsync_ContinuesOnConfiguredContext_await(
+            [Values] SynchronizationType continuationContext,
+            [Values] CompletedContinuationBehavior completedBehavior,
+            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
+            var cancelationSource = CancelationSource.New();
+
+            var initialKey = rwl.WriterLock();
+
+            var promise = Promise.Run(async () =>
+            {
+                var (success, key) = await rwl.TryEnterWriterLockAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior));
+                TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                key.Dispose();
+            }, SynchronizationOption.Synchronous);
+
+            new ThreadHelper().ExecuteSynchronousOrOnThread(
+                () => initialKey.Dispose(),
+                invokeContext == SynchronizationType.Foreground
+            );
+            promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+            cancelationSource.Dispose();
+        }
+
+        [Test]
+        public void AsyncReaderWriterLock_ReaderLockAsync_ContinuesOnConfiguredContext_await(
+            [Values] SynchronizationType continuationContext,
+            [Values] CompletedContinuationBehavior completedBehavior,
+            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values] bool withCancelationToken)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
+            var cancelationSource = CancelationSource.New();
+
+            var initialKey = rwl.WriterLock();
+
+            var promise = Promise.Run(async () =>
+            {
+                if (withCancelationToken)
+                {
+                    using (var key = await rwl.ReaderLockAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    {
+                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                    }
+                }
+                else
+                {
+                    using (var key = await rwl.ReaderLockAsync(TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    {
+                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                    }
+                }
+            }, SynchronizationOption.Synchronous);
+
+            new ThreadHelper().ExecuteSynchronousOrOnThread(
+                () => initialKey.Dispose(),
+                invokeContext == SynchronizationType.Foreground
+            );
+            promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+            cancelationSource.Dispose();
+        }
+
+        [Test]
+        public void AsyncReaderWriterLock_TryEnterReaderLockAsync_ContinuesOnConfiguredContext_await(
+            [Values] SynchronizationType continuationContext,
+            [Values] CompletedContinuationBehavior completedBehavior,
+            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
+            var cancelationSource = CancelationSource.New();
+
+            var initialKey = rwl.WriterLock();
+
+            var promise = Promise.Run(async () =>
+            {
+                var (success, key) = await rwl.TryEnterReaderLockAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior));
+                TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                key.Dispose();
+            }, SynchronizationOption.Synchronous);
+
+            new ThreadHelper().ExecuteSynchronousOrOnThread(
+                () => initialKey.Dispose(),
+                invokeContext == SynchronizationType.Foreground
+            );
+            promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+            cancelationSource.Dispose();
+        }
+
+        [Test]
+        public void AsyncReaderWriterLock_UpgradeableReaderLockAsync_ContinuesOnConfiguredContext_await(
+            [Values] SynchronizationType continuationContext,
+            [Values] CompletedContinuationBehavior completedBehavior,
+            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values] bool withCancelationToken)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
+            var cancelationSource = CancelationSource.New();
+
+            var initialKey = rwl.WriterLock();
+
+            var promise = Promise.Run(async () =>
+            {
+                if (withCancelationToken)
+                {
+                    using (var key = await rwl.UpgradeableReaderLockAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    {
+                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                    }
+                }
+                else
+                {
+                    using (var key = await rwl.UpgradeableReaderLockAsync(TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    {
+                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                    }
+                }
+            }, SynchronizationOption.Synchronous);
+
+            new ThreadHelper().ExecuteSynchronousOrOnThread(
+                () => initialKey.Dispose(),
+                invokeContext == SynchronizationType.Foreground
+            );
+            promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+            cancelationSource.Dispose();
+        }
+
+        [Test]
+        public void AsyncReaderWriterLock_TryEnterUpgradeableReaderLockAsync_ContinuesOnConfiguredContext_await(
+            [Values] SynchronizationType continuationContext,
+            [Values] CompletedContinuationBehavior completedBehavior,
+            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
+            var cancelationSource = CancelationSource.New();
+
+            var initialKey = rwl.WriterLock();
+
+            var promise = Promise.Run(async () =>
+            {
+                var (success, key) = await rwl.TryEnterUpgradeableReaderLockAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior));
+                TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                key.Dispose();
+            }, SynchronizationOption.Synchronous);
+
+            new ThreadHelper().ExecuteSynchronousOrOnThread(
+                () => initialKey.Dispose(),
+                invokeContext == SynchronizationType.Foreground
+            );
+            promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+            cancelationSource.Dispose();
+        }
+
+        [Test]
+        public void AsyncReaderWriterLock_UpgradeToWriterLockAsync_ContinuesOnConfiguredContext_await(
+            [Values] SynchronizationType continuationContext,
+            [Values] CompletedContinuationBehavior completedBehavior,
+            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values] bool withCancelationToken)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
+            var cancelationSource = CancelationSource.New();
+
+            var upgradeableKey = rwl.UpgradeableReaderLock();
+            var readerKey = rwl.ReaderLock();
+
+            var promise = Promise.Run(async () =>
+            {
+                if (withCancelationToken)
+                {
+                    using (var key = await rwl.UpgradeToWriterLockAsync(upgradeableKey, cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    {
+                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                    }
+                }
+                else
+                {
+                    using (var key = await rwl.UpgradeToWriterLockAsync(upgradeableKey, TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    {
+                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                    }
+                }
+                upgradeableKey.Dispose();
+            }, SynchronizationOption.Synchronous);
+
+            new ThreadHelper().ExecuteSynchronousOrOnThread(
+                () => readerKey.Dispose(),
+                invokeContext == SynchronizationType.Foreground
+            );
+            promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+            cancelationSource.Dispose();
+        }
+
+        [Test]
+        public void AsyncReaderWriterLock_TryUpgradeToWriterLockAsync_ContinuesOnConfiguredContext_await(
+            [Values] SynchronizationType continuationContext,
+            [Values] CompletedContinuationBehavior completedBehavior,
+            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+        {
+            var foregroundThread = Thread.CurrentThread;
+            var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
+            var cancelationSource = CancelationSource.New();
+
+            var upgradeableKey = rwl.UpgradeableReaderLock();
+            var readerKey = rwl.ReaderLock();
+
+            var promise = Promise.Run(async () =>
+            {
+                var (success, key) = await rwl.TryUpgradeToWriterLockAsync(upgradeableKey, cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior));
+                TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                key.Dispose();
+                upgradeableKey.Dispose();
+            }, SynchronizationOption.Synchronous);
+
+            new ThreadHelper().ExecuteSynchronousOrOnThread(
+                () => readerKey.Dispose(),
+                invokeContext == SynchronizationType.Foreground
+            );
+            promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+            cancelationSource.Dispose();
         }
 
 #if PROTO_PROMISE_TEST_GC_ENABLED

--- a/Package/Tests/CoreTests/APIs/Threading/AsyncReaderWriterLockTests.cs
+++ b/Package/Tests/CoreTests/APIs/Threading/AsyncReaderWriterLockTests.cs
@@ -7,7 +7,6 @@
 using NUnit.Framework;
 using Proto.Promises;
 using Proto.Promises.Threading;
-using ProtoPromiseTests.Concurrency;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -2890,13 +2889,7 @@ namespace ProtoPromiseTests.APIs.Threading
 
         [Test]
         public void AsyncReaderWriterLock_WriterLockAsync_ContinuesOnConfiguredContext_await(
-            [Values] SynchronizationType continuationContext,
-            [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground
-#if !UNITY_WEBGL
-            , SynchronizationType.Background
-#endif
-            )] SynchronizationType invokeContext,
+            [Values] bool continueOnCapturedContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;
@@ -2905,41 +2898,35 @@ namespace ProtoPromiseTests.APIs.Threading
 
             var initialKey = rwl.WriterLock();
 
+            bool isExecuting = false;
             var promise = Promise.Run(async () =>
             {
                 if (withCancelationToken)
                 {
-                    using (var key = await rwl.WriterLockAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    using (var key = await rwl.WriterLockAsync(cancelationSource.Token, continueOnCapturedContext))
                     {
-                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                        Assert.AreNotEqual(continueOnCapturedContext, isExecuting);
                     }
                 }
                 else
                 {
-                    using (var key = await rwl.WriterLockAsync(TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    using (var key = await rwl.WriterLockAsync(continueOnCapturedContext))
                     {
-                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                        Assert.AreNotEqual(continueOnCapturedContext, isExecuting);
                     }
                 }
             }, SynchronizationOption.Synchronous);
 
-            new ThreadHelper().ExecuteSynchronousOrOnThread(
-                () => initialKey.Dispose(),
-                invokeContext == SynchronizationType.Foreground
-            );
+            isExecuting = true;
+            initialKey.Dispose();
+            isExecuting = false;
             promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
             cancelationSource.Dispose();
         }
 
         [Test]
         public void AsyncReaderWriterLock_TryEnterWriterLockAsync_ContinuesOnConfiguredContext_await(
-            [Values] SynchronizationType continuationContext,
-            [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground
-#if !UNITY_WEBGL
-            , SynchronizationType.Background
-#endif
-            )] SynchronizationType invokeContext)
+            [Values] bool continueOnCapturedContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
@@ -2947,30 +2934,24 @@ namespace ProtoPromiseTests.APIs.Threading
 
             var initialKey = rwl.WriterLock();
 
+            bool isExecuting = false;
             var promise = Promise.Run(async () =>
             {
-                var (success, key) = await rwl.TryEnterWriterLockAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior));
-                TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                var (success, key) = await rwl.TryEnterWriterLockAsync(cancelationSource.Token, continueOnCapturedContext);
+                Assert.AreNotEqual(continueOnCapturedContext, isExecuting);
                 key.Dispose();
             }, SynchronizationOption.Synchronous);
 
-            new ThreadHelper().ExecuteSynchronousOrOnThread(
-                () => initialKey.Dispose(),
-                invokeContext == SynchronizationType.Foreground
-            );
+            isExecuting = true;
+            initialKey.Dispose();
+            isExecuting = false;
             promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
             cancelationSource.Dispose();
         }
 
         [Test]
         public void AsyncReaderWriterLock_ReaderLockAsync_ContinuesOnConfiguredContext_await(
-            [Values] SynchronizationType continuationContext,
-            [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground
-#if !UNITY_WEBGL
-            , SynchronizationType.Background
-#endif
-            )] SynchronizationType invokeContext,
+            [Values] bool continueOnCapturedContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;
@@ -2979,41 +2960,35 @@ namespace ProtoPromiseTests.APIs.Threading
 
             var initialKey = rwl.WriterLock();
 
+            bool isExecuting = false;
             var promise = Promise.Run(async () =>
             {
                 if (withCancelationToken)
                 {
-                    using (var key = await rwl.ReaderLockAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    using (var key = await rwl.ReaderLockAsync(cancelationSource.Token, continueOnCapturedContext))
                     {
-                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                        Assert.AreNotEqual(continueOnCapturedContext, isExecuting);
                     }
                 }
                 else
                 {
-                    using (var key = await rwl.ReaderLockAsync(TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    using (var key = await rwl.ReaderLockAsync(continueOnCapturedContext))
                     {
-                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                        Assert.AreNotEqual(continueOnCapturedContext, isExecuting);
                     }
                 }
             }, SynchronizationOption.Synchronous);
 
-            new ThreadHelper().ExecuteSynchronousOrOnThread(
-                () => initialKey.Dispose(),
-                invokeContext == SynchronizationType.Foreground
-            );
+            isExecuting = true;
+            initialKey.Dispose();
+            isExecuting = false;
             promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
             cancelationSource.Dispose();
         }
 
         [Test]
         public void AsyncReaderWriterLock_TryEnterReaderLockAsync_ContinuesOnConfiguredContext_await(
-            [Values] SynchronizationType continuationContext,
-            [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground
-#if !UNITY_WEBGL
-            , SynchronizationType.Background
-#endif
-            )] SynchronizationType invokeContext)
+            [Values] bool continueOnCapturedContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
@@ -3021,30 +2996,24 @@ namespace ProtoPromiseTests.APIs.Threading
 
             var initialKey = rwl.WriterLock();
 
+            bool isExecuting = false;
             var promise = Promise.Run(async () =>
             {
-                var (success, key) = await rwl.TryEnterReaderLockAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior));
-                TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                var (success, key) = await rwl.TryEnterReaderLockAsync(cancelationSource.Token, continueOnCapturedContext);
+                Assert.AreNotEqual(continueOnCapturedContext, isExecuting);
                 key.Dispose();
             }, SynchronizationOption.Synchronous);
 
-            new ThreadHelper().ExecuteSynchronousOrOnThread(
-                () => initialKey.Dispose(),
-                invokeContext == SynchronizationType.Foreground
-            );
+            isExecuting = true;
+            initialKey.Dispose();
+            isExecuting = false;
             promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
             cancelationSource.Dispose();
         }
 
         [Test]
         public void AsyncReaderWriterLock_UpgradeableReaderLockAsync_ContinuesOnConfiguredContext_await(
-            [Values] SynchronizationType continuationContext,
-            [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground
-#if !UNITY_WEBGL
-            , SynchronizationType.Background
-#endif
-            )] SynchronizationType invokeContext,
+            [Values] bool continueOnCapturedContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;
@@ -3053,41 +3022,35 @@ namespace ProtoPromiseTests.APIs.Threading
 
             var initialKey = rwl.WriterLock();
 
+            bool isExecuting = false;
             var promise = Promise.Run(async () =>
             {
                 if (withCancelationToken)
                 {
-                    using (var key = await rwl.UpgradeableReaderLockAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    using (var key = await rwl.UpgradeableReaderLockAsync(cancelationSource.Token, continueOnCapturedContext))
                     {
-                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                        Assert.AreNotEqual(continueOnCapturedContext, isExecuting);
                     }
                 }
                 else
                 {
-                    using (var key = await rwl.UpgradeableReaderLockAsync(TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    using (var key = await rwl.UpgradeableReaderLockAsync(continueOnCapturedContext))
                     {
-                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                        Assert.AreNotEqual(continueOnCapturedContext, isExecuting);
                     }
                 }
             }, SynchronizationOption.Synchronous);
 
-            new ThreadHelper().ExecuteSynchronousOrOnThread(
-                () => initialKey.Dispose(),
-                invokeContext == SynchronizationType.Foreground
-            );
+            isExecuting = true;
+            initialKey.Dispose();
+            isExecuting = false;
             promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
             cancelationSource.Dispose();
         }
 
         [Test]
         public void AsyncReaderWriterLock_TryEnterUpgradeableReaderLockAsync_ContinuesOnConfiguredContext_await(
-            [Values] SynchronizationType continuationContext,
-            [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground
-#if !UNITY_WEBGL
-            , SynchronizationType.Background
-#endif
-            )] SynchronizationType invokeContext)
+            [Values] bool continueOnCapturedContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
@@ -3095,30 +3058,24 @@ namespace ProtoPromiseTests.APIs.Threading
 
             var initialKey = rwl.WriterLock();
 
+            bool isExecuting = false;
             var promise = Promise.Run(async () =>
             {
-                var (success, key) = await rwl.TryEnterUpgradeableReaderLockAsync(cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior));
-                TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                var (success, key) = await rwl.TryEnterUpgradeableReaderLockAsync(cancelationSource.Token, continueOnCapturedContext);
+                Assert.AreNotEqual(continueOnCapturedContext, isExecuting);
                 key.Dispose();
             }, SynchronizationOption.Synchronous);
 
-            new ThreadHelper().ExecuteSynchronousOrOnThread(
-                () => initialKey.Dispose(),
-                invokeContext == SynchronizationType.Foreground
-            );
+            isExecuting = true;
+            initialKey.Dispose();
+            isExecuting = false;
             promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
             cancelationSource.Dispose();
         }
 
         [Test]
         public void AsyncReaderWriterLock_UpgradeToWriterLockAsync_ContinuesOnConfiguredContext_await(
-            [Values] SynchronizationType continuationContext,
-            [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground
-#if !UNITY_WEBGL
-            , SynchronizationType.Background
-#endif
-            )] SynchronizationType invokeContext,
+            [Values] bool continueOnCapturedContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;
@@ -3128,42 +3085,36 @@ namespace ProtoPromiseTests.APIs.Threading
             var upgradeableKey = rwl.UpgradeableReaderLock();
             var readerKey = rwl.ReaderLock();
 
+            bool isExecuting = false;
             var promise = Promise.Run(async () =>
             {
                 if (withCancelationToken)
                 {
-                    using (var key = await rwl.UpgradeToWriterLockAsync(upgradeableKey, cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    using (var key = await rwl.UpgradeToWriterLockAsync(upgradeableKey, cancelationSource.Token, continueOnCapturedContext))
                     {
-                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                        Assert.AreNotEqual(continueOnCapturedContext, isExecuting);
                     }
                 }
                 else
                 {
-                    using (var key = await rwl.UpgradeToWriterLockAsync(upgradeableKey, TestHelper.GetContinuationOptions(continuationContext, completedBehavior)))
+                    using (var key = await rwl.UpgradeToWriterLockAsync(upgradeableKey, continueOnCapturedContext))
                     {
-                        TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                        Assert.AreNotEqual(continueOnCapturedContext, isExecuting);
                     }
                 }
                 upgradeableKey.Dispose();
             }, SynchronizationOption.Synchronous);
 
-            new ThreadHelper().ExecuteSynchronousOrOnThread(
-                () => readerKey.Dispose(),
-                invokeContext == SynchronizationType.Foreground
-            );
+            isExecuting = true;
+            readerKey.Dispose();
+            isExecuting = false;
             promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
             cancelationSource.Dispose();
         }
 
         [Test]
         public void AsyncReaderWriterLock_TryUpgradeToWriterLockAsync_ContinuesOnConfiguredContext_await(
-            [Values] SynchronizationType continuationContext,
-            [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground
-#if !UNITY_WEBGL
-            , SynchronizationType.Background
-#endif
-            )] SynchronizationType invokeContext)
+            [Values] bool continueOnCapturedContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
@@ -3172,18 +3123,18 @@ namespace ProtoPromiseTests.APIs.Threading
             var upgradeableKey = rwl.UpgradeableReaderLock();
             var readerKey = rwl.ReaderLock();
 
+            bool isExecuting = false;
             var promise = Promise.Run(async () =>
             {
-                var (success, key) = await rwl.TryUpgradeToWriterLockAsync(upgradeableKey, cancelationSource.Token, TestHelper.GetContinuationOptions(continuationContext, completedBehavior));
-                TestHelper.AssertCallbackContext(continuationContext, invokeContext, foregroundThread);
+                var (success, key) = await rwl.TryUpgradeToWriterLockAsync(upgradeableKey, cancelationSource.Token, continueOnCapturedContext);
+                Assert.AreNotEqual(continueOnCapturedContext, isExecuting);
                 key.Dispose();
                 upgradeableKey.Dispose();
             }, SynchronizationOption.Synchronous);
 
-            new ThreadHelper().ExecuteSynchronousOrOnThread(
-                () => readerKey.Dispose(),
-                invokeContext == SynchronizationType.Foreground
-            );
+            isExecuting = true;
+            readerKey.Dispose();
+            isExecuting = false;
             promise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
             cancelationSource.Dispose();
         }

--- a/Package/Tests/CoreTests/APIs/Threading/AsyncReaderWriterLockTests.cs
+++ b/Package/Tests/CoreTests/APIs/Threading/AsyncReaderWriterLockTests.cs
@@ -2892,7 +2892,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncReaderWriterLock_WriterLockAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;
@@ -2931,7 +2935,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncReaderWriterLock_TryEnterWriterLockAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
@@ -2958,7 +2966,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncReaderWriterLock_ReaderLockAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;
@@ -2997,7 +3009,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncReaderWriterLock_TryEnterReaderLockAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
@@ -3024,7 +3040,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncReaderWriterLock_UpgradeableReaderLockAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;
@@ -3063,7 +3083,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncReaderWriterLock_TryEnterUpgradeableReaderLockAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);
@@ -3090,7 +3114,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncReaderWriterLock_UpgradeToWriterLockAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext,
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext,
             [Values] bool withCancelationToken)
         {
             var foregroundThread = Thread.CurrentThread;
@@ -3131,7 +3159,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncReaderWriterLock_TryUpgradeToWriterLockAsync_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var rwl = new AsyncReaderWriterLock(AsyncReaderWriterLock.ContentionStrategy.PrioritizeUpgradeableReaders);

--- a/Package/Tests/CoreTests/APIs/Threading/AsyncSemaphoreTests.cs
+++ b/Package/Tests/CoreTests/APIs/Threading/AsyncSemaphoreTests.cs
@@ -561,7 +561,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncSemaphore_WaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_Then(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var semaphore = new AsyncSemaphore(0);
@@ -583,7 +587,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncSemaphore_TryWaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_Then(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var semaphore = new AsyncSemaphore(0);
@@ -609,7 +617,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncSemaphore_WaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var semaphore = new AsyncSemaphore(0);
@@ -631,7 +643,11 @@ namespace ProtoPromiseTests.APIs.Threading
         public void AsyncSemaphore_TryWaitAsyncWithContinuationOptions_ContinuesOnConfiguredContext_await(
             [Values] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values(SynchronizationType.Foreground, SynchronizationType.Background)] SynchronizationType invokeContext)
+            [Values(SynchronizationType.Foreground
+#if !UNITY_WEBGL
+            , SynchronizationType.Background
+#endif
+            )] SynchronizationType invokeContext)
         {
             var foregroundThread = Thread.CurrentThread;
             var semaphore = new AsyncSemaphore(0);

--- a/Package/Tests/Helpers/TestHelper.cs
+++ b/Package/Tests/Helpers/TestHelper.cs
@@ -552,7 +552,9 @@ namespace ProtoPromiseTests
                 }
                 case SynchronizationType.Synchronous:
                 {
-                    if (invokeContext == SynchronizationType.Foreground || invokeContext == SynchronizationType.Explicit)
+                    if (invokeContext == SynchronizationType.CapturedContext
+                        || invokeContext == SynchronizationType.Foreground
+                        || invokeContext == SynchronizationType.Explicit)
                     {
                         goto case SynchronizationType.Foreground;
                     }


### PR DESCRIPTION
Renamed `SynchronousIfSameContext` to `AllowSynchronous`.

Resolves #483.