### PR TITLE
Optimize contexts

### DIFF
--- a/Package/Core/Linq/CompilerServices/AsyncStreamYielder.cs
+++ b/Package/Core/Linq/CompilerServices/AsyncStreamYielder.cs
@@ -13,7 +13,7 @@ namespace Proto.Promises.CompilerServices
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode, StackTraceHidden]
 #endif
-    public readonly partial struct AsyncStreamYielder<T> : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+    public readonly partial struct AsyncStreamYielder<T> : ICriticalNotifyCompletion, Internal.IPromiseAwareAwaiter
     {
         private readonly Internal.PromiseRefBase.AsyncEnumerableWithIterator<T> _target;
         private readonly int _enumerableId;
@@ -62,7 +62,7 @@ namespace Proto.Promises.CompilerServices
             => _target.GetResultForAsyncStreamYielder(_enumerableId);
 
         [MethodImpl(Internal.InlineOption)]
-        void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
+        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
             => _target.AwaitOnCompletedForAsyncStreamYielder(asyncPromiseRef, _enumerableId);
 
         void INotifyCompletion.OnCompleted(Action continuation)

--- a/Package/Core/Linq/CompilerServices/AsyncStreamYielder.cs
+++ b/Package/Core/Linq/CompilerServices/AsyncStreamYielder.cs
@@ -62,7 +62,7 @@ namespace Proto.Promises.CompilerServices
             => _target.GetResultForAsyncStreamYielder(_enumerableId);
 
         [MethodImpl(Internal.InlineOption)]
-        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
+        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
             => _target.AwaitOnCompletedForAsyncStreamYielder(asyncPromiseRef, _enumerableId);
 
         void INotifyCompletion.OnCompleted(Action continuation)

--- a/Package/Core/Linq/Internal/AsyncEnumerableInternal.cs
+++ b/Package/Core/Linq/Internal/AsyncEnumerableInternal.cs
@@ -280,12 +280,12 @@ namespace Proto.Promises
                     if (Interlocked.CompareExchange(ref _enumerableId, _iteratorCompleteId, _iteratorCompleteExpectedId) != _iteratorCompleteExpectedId)
                     {
                         handler.MaybeReportUnhandledAndDispose(state);
-                        _rejectContainer = CreateRejectContainer(new InvalidOperationException("AsyncEnumerable.Create async iterator completed invalidly. Did you YieldAsync without await?"), int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(new InvalidOperationException("AsyncEnumerable.Create async iterator completed invalidly. Did you YieldAsync without await?"), int.MinValue, null, this);
                         state = Promise.State.Rejected;
                     }
                     else
                     {
-                        _rejectContainer = handler._rejectContainer;
+                        RejectContainer = handler.RejectContainer;
                         handler.SuppressRejection = true;
                         handler.MaybeDispose();
                     }
@@ -298,7 +298,7 @@ namespace Proto.Promises
                     Promise.State state = Promise.State.Resolved;
                     if (Interlocked.CompareExchange(ref _enumerableId, _iteratorCompleteId, _iteratorCompleteExpectedId) != _iteratorCompleteExpectedId)
                     {
-                        _rejectContainer = CreateRejectContainer(new InvalidOperationException("AsyncEnumerable.Create async iterator completed invalidly. Did you YieldAsync without await?"), int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(new InvalidOperationException("AsyncEnumerable.Create async iterator completed invalidly. Did you YieldAsync without await?"), int.MinValue, null, this);
                         state = Promise.State.Rejected;
                     }
                     HandleNextInternal(state);

--- a/Package/Core/Linq/Internal/AsyncStreamAwaiterForLinqExtensionInternal.cs
+++ b/Package/Core/Linq/Internal/AsyncStreamAwaiterForLinqExtensionInternal.cs
@@ -17,7 +17,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal readonly partial struct AsyncStreamAwaiterForLinqExtension<T> : ICriticalNotifyCompletion, IPromiseAwaiter
+            internal readonly partial struct AsyncStreamAwaiterForLinqExtension<T> : ICriticalNotifyCompletion, IPromiseAwareAwaiter
             {
                 private readonly AsyncEnumerableWithIterator<T> _target;
                 private readonly int _enumerableId;
@@ -63,7 +63,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IPromiseAwaiter.AwaitOnCompletedInternal(PromiseRefBase asyncPromiseRef)
+                void IPromiseAwareAwaiter.AwaitOnCompletedInternal(PromiseRefBase asyncPromiseRef, ref object continuationContext)
                     => _target.AwaitOnCompletedForAsyncStreamYielder(asyncPromiseRef, _enumerableId, hasValue: false);
 
                 void INotifyCompletion.OnCompleted(Action continuation) => throw new System.InvalidOperationException("Must only be used in async Linq extension methods.");

--- a/Package/Core/Linq/Internal/AsyncStreamAwaiterForLinqExtensionInternal.cs
+++ b/Package/Core/Linq/Internal/AsyncStreamAwaiterForLinqExtensionInternal.cs
@@ -63,7 +63,7 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                void IPromiseAwareAwaiter.AwaitOnCompletedInternal(PromiseRefBase asyncPromiseRef, ref object continuationContext)
+                void IPromiseAwareAwaiter.AwaitOnCompletedInternal(PromiseRefBase asyncPromiseRef)
                     => _target.AwaitOnCompletedForAsyncStreamYielder(asyncPromiseRef, _enumerableId, hasValue: false);
 
                 void INotifyCompletion.OnCompleted(Action continuation) => throw new System.InvalidOperationException("Must only be used in async Linq extension methods.");

--- a/Package/Core/Linq/Internal/MergeInternal.cs
+++ b/Package/Core/Linq/Internal/MergeInternal.cs
@@ -85,7 +85,7 @@ namespace Proto.Promises
                         // The async enumerator was canceled or rejected, notify all enumerators that they don't need to continue executing.
                         CancelEnumerators();
                     }
-                    _enumeratorsAndRejectContainers[index].rejectContainer = handler._rejectContainer;
+                    _enumeratorsAndRejectContainers[index].rejectContainer = handler.RejectContainer;
                     _readyQueue.RemoveProducer();
                 }
             }

--- a/Package/Core/PromiseGroups/Internal/PromiseAllGroupInternal.cs
+++ b/Package/Core/PromiseGroups/Internal/PromiseAllGroupInternal.cs
@@ -73,7 +73,7 @@ namespace Proto.Promises
                         _result[passthrough.Index] = owner.GetResult<T>();
                         if (owner.State == Promise.State.Rejected)
                         {
-                            RecordException(owner._rejectContainer.GetValueAsException());
+                            RecordException(owner.RejectContainer.GetValueAsException());
                         }
                         passthrough.Dispose();
                     }
@@ -81,7 +81,7 @@ namespace Proto.Promises
                     if (_exceptions != null)
                     {
                         state = Promise.State.Rejected;
-                        _rejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
                         _exceptions = null;
                     }
 

--- a/Package/Core/PromiseGroups/Internal/PromiseAllResultsGroupInternal.cs
+++ b/Package/Core/PromiseGroups/Internal/PromiseAllResultsGroupInternal.cs
@@ -70,7 +70,7 @@ namespace Proto.Promises
                     if (_exceptions != null)
                     {
                         state = Promise.State.Rejected;
-                        _rejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
                         _exceptions = null;
                     }
 
@@ -79,7 +79,7 @@ namespace Proto.Promises
                     {
                         var passthrough = passthroughs.Pop();
                         var owner = passthrough.Owner;
-                        _result[passthrough.Index] = new Promise.ResultContainer(owner._rejectContainer, owner.State);
+                        _result[passthrough.Index] = new Promise.ResultContainer(owner.RejectContainer, owner.State);
                         passthrough.Dispose();
                     }
 
@@ -153,7 +153,7 @@ namespace Proto.Promises
                     if (_exceptions != null)
                     {
                         state = Promise.State.Rejected;
-                        _rejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
                         _exceptions = null;
                     }
 
@@ -162,7 +162,7 @@ namespace Proto.Promises
                     {
                         var passthrough = passthroughs.Pop();
                         var owner = passthrough.Owner;
-                        _result[passthrough.Index] = new Promise<T>.ResultContainer(owner.GetResult<T>(), owner._rejectContainer, owner.State);
+                        _result[passthrough.Index] = new Promise<T>.ResultContainer(owner.GetResult<T>(), owner.RejectContainer, owner.State);
                         passthrough.Dispose();
                     }
 

--- a/Package/Core/PromiseGroups/Internal/PromiseEachGroupInternal.cs
+++ b/Package/Core/PromiseGroups/Internal/PromiseEachGroupInternal.cs
@@ -272,7 +272,7 @@ namespace Proto.Promises
                         return;
                     }
 
-                    _rejectContainer = CreateRejectContainer(exception, int.MinValue, null, this);
+                    RejectContainer = CreateRejectContainer(exception, int.MinValue, null, this);
                     HandleNextInternal(Promise.State.Rejected);
                 }
 

--- a/Package/Core/PromiseGroups/Internal/PromiseMergeGroupInternal.cs
+++ b/Package/Core/PromiseGroups/Internal/PromiseMergeGroupInternal.cs
@@ -129,7 +129,7 @@ namespace Proto.Promises
                         CancelGroup();
                         if (state == Promise.State.Rejected)
                         {
-                            RecordException(handler._rejectContainer.GetValueAsException());
+                            RecordException(handler.RejectContainer.GetValueAsException());
                         }
                     }
                     handler.MaybeDispose();
@@ -147,7 +147,7 @@ namespace Proto.Promises
                         return _completeState;
                     }
 
-                    _rejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
+                    RejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
                     _exceptions = null;
                     return Promise.State.Rejected;
                 }
@@ -231,7 +231,7 @@ namespace Proto.Promises
                         s_getResult.Invoke(owner, index, ref _result);
                         if (owner.State == Promise.State.Rejected)
                         {
-                            var exception = owner._rejectContainer.GetValueAsException();
+                            var exception = owner.RejectContainer.GetValueAsException();
                             if (_isExtended & index == 0)
                             {
                                 // If this is an extended merge group, we need to extract the inner exceptions of the first cluster to make a flattened AggregateException.
@@ -253,13 +253,13 @@ namespace Proto.Promises
                     if (group._exceptions != null)
                     {
                         state = Promise.State.Rejected;
-                        _rejectContainer = CreateRejectContainer(new AggregateException(group._exceptions), int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(new AggregateException(group._exceptions), int.MinValue, null, this);
                         group._exceptions = null;
                     }
                     else
                     {
                         // The group may have been completed by a void promise, in which case it already converted its exceptions to a reject container.
-                        _rejectContainer = handler._rejectContainer;
+                        RejectContainer = handler.RejectContainer;
                     }
                     group.MaybeDispose();
 

--- a/Package/Core/PromiseGroups/Internal/PromiseMergeResultsGroupInternal.cs
+++ b/Package/Core/PromiseGroups/Internal/PromiseMergeResultsGroupInternal.cs
@@ -66,7 +66,7 @@ namespace Proto.Promises
                         {
                             // If this is an extended merge group, we need to propagate the exceptions from cancelation token callbacks.
                             state = Promise.State.Rejected;
-                            _rejectContainer = owner._rejectContainer;
+                            RejectContainer = owner.RejectContainer;
                         }
                         passthrough.Dispose();
                     }
@@ -75,14 +75,14 @@ namespace Proto.Promises
                     {
                         // In case any cancelation token callbacks threw, we propagate them out of this promise instead of resolving this and ignoring the exceptions.
                         state = Promise.State.Rejected;
-                        _rejectContainer = CreateRejectContainer(new AggregateException(group._exceptions), int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(new AggregateException(group._exceptions), int.MinValue, null, this);
                         group._exceptions = null;
                     }
-                    else if (handler._rejectContainer != null)
+                    else if (handler.RejectContainer != null)
                     {
                         // The group may have been already completed, in which case it already converted its exceptions to a reject container.
                         state = Promise.State.Rejected;
-                        _rejectContainer = handler._rejectContainer;
+                        RejectContainer = handler.RejectContainer;
                     }
                     group.MaybeDispose();
 

--- a/Package/Core/PromiseGroups/Internal/PromiseRaceGroupInternal.cs
+++ b/Package/Core/PromiseGroups/Internal/PromiseRaceGroupInternal.cs
@@ -33,7 +33,7 @@ namespace Proto.Promises
                     if ((state != Promise.State.Resolved | _cancelationThrew) & _exceptions != null)
                     {
                         state = Promise.State.Rejected;
-                        _rejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
                     }
                     _exceptions = null;
                     return state;
@@ -143,7 +143,7 @@ namespace Proto.Promises
                     {
                         if (state == Promise.State.Rejected)
                         {
-                            RecordException(handler._rejectContainer.GetValueAsException());
+                            RecordException(handler.RejectContainer.GetValueAsException());
                         }
                         if (_cancelOnNonResolved)
                         {
@@ -203,7 +203,7 @@ namespace Proto.Promises
                     {
                         if (state == Promise.State.Rejected)
                         {
-                            RecordException(handler._rejectContainer.GetValueAsException());
+                            RecordException(handler.RejectContainer.GetValueAsException());
                         }
                         if (_cancelOnNonResolved)
                         {
@@ -263,7 +263,7 @@ namespace Proto.Promises
                     {
                         if (state == Promise.State.Rejected)
                         {
-                            RecordException(handler._rejectContainer.GetValueAsException());
+                            RecordException(handler.RejectContainer.GetValueAsException());
                         }
                         if (_cancelOnNonResolved)
                         {

--- a/Package/Core/PromiseGroups/PromiseMergeResultsGroup.cs
+++ b/Package/Core/PromiseGroups/PromiseMergeResultsGroup.cs
@@ -1359,7 +1359,7 @@ namespace Proto.Promises
                 [MethodImpl(Internal.InlineOption)]
                 private static void GetMergeResult(Internal.PromiseRefBase handler, int index, ref Promise<T>.ResultContainer result)
                 {
-                    result = new Promise<T>.ResultContainer(handler.GetResult<T>(), handler._rejectContainer, handler.State);
+                    result = new Promise<T>.ResultContainer(handler.GetResult<T>(), handler.RejectContainer, handler.State);
                 }
 
 #if NETCOREAPP || UNITY_2021_2_OR_NEWER
@@ -1385,7 +1385,7 @@ namespace Proto.Promises
                 [MethodImpl(Internal.InlineOption)]
                 private static void GetMergeResult(Internal.PromiseRefBase handler, int index, ref ResultContainer result)
                 {
-                    result = new ResultContainer(handler._rejectContainer, handler.State);
+                    result = new ResultContainer(handler.RejectContainer, handler.State);
                 }
 
 #if NETCOREAPP || UNITY_2021_2_OR_NEWER

--- a/Package/Core/Promises/CompilerServices/ConfiguredPromiseAwaiters.cs
+++ b/Package/Core/Promises/CompilerServices/ConfiguredPromiseAwaiters.cs
@@ -155,14 +155,14 @@ namespace Proto.Promises.CompilerServices
             => OnCompleted(continuation);
 
         [MethodImpl(Internal.InlineOption)]
-        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
+        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
         {
             if (_continuationOptions.IsSynchronous)
             {
                 asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
                 return;
             }
-            asyncPromiseRef.HookupAwaiterWithContext(_promise._ref, _promise._id, ref continuationContext, _continuationOptions.GetContinuationContext());
+            asyncPromiseRef.HookupAwaiterWithContext(_promise._ref, _promise._id, _continuationOptions.GetContinuationContext());
         }
 
         static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
@@ -268,14 +268,14 @@ namespace Proto.Promises.CompilerServices
             => OnCompleted(continuation);
 
         [MethodImpl(Internal.InlineOption)]
-        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
+        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
         {
             if (_continuationOptions.IsSynchronous)
             {
                 asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
                 return;
             }
-            asyncPromiseRef.HookupAwaiterWithContext(_promise._ref, _promise._id, ref continuationContext, _continuationOptions.GetContinuationContext());
+            asyncPromiseRef.HookupAwaiterWithContext(_promise._ref, _promise._id, _continuationOptions.GetContinuationContext());
         }
 
         static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
@@ -373,14 +373,14 @@ namespace Proto.Promises.CompilerServices
             => OnCompleted(continuation);
 
         [MethodImpl(Internal.InlineOption)]
-        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
+        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
         {
             if (_continuationOptions.IsSynchronous)
             {
                 asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
                 return;
             }
-            asyncPromiseRef.HookupAwaiterWithContext(_promise._ref, _promise._id, ref continuationContext, _continuationOptions.GetContinuationContext());
+            asyncPromiseRef.HookupAwaiterWithContext(_promise._ref, _promise._id, _continuationOptions.GetContinuationContext());
         }
 
         static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
@@ -478,14 +478,14 @@ namespace Proto.Promises.CompilerServices
             => OnCompleted(continuation);
 
         [MethodImpl(Internal.InlineOption)]
-        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
+        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
         {
             if (_continuationOptions.IsSynchronous)
             {
                 asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
                 return;
             }
-            asyncPromiseRef.HookupAwaiterWithContext(_promise._ref, _promise._id, ref continuationContext, _continuationOptions.GetContinuationContext());
+            asyncPromiseRef.HookupAwaiterWithContext(_promise._ref, _promise._id, _continuationOptions.GetContinuationContext());
         }
 
         static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);

--- a/Package/Core/Promises/CompilerServices/ConfiguredPromiseAwaiters.cs
+++ b/Package/Core/Promises/CompilerServices/ConfiguredPromiseAwaiters.cs
@@ -67,7 +67,7 @@ namespace Proto.Promises.CompilerServices
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode, StackTraceHidden]
 #endif
-    public readonly partial struct ConfiguredPromiseAwaiterVoid : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+    public readonly partial struct ConfiguredPromiseAwaiterVoid : ICriticalNotifyCompletion, Internal.IPromiseAwareAwaiter
     {
         private readonly Promise _promise;
         private readonly ContinuationOptions _continuationOptions;
@@ -155,14 +155,14 @@ namespace Proto.Promises.CompilerServices
             => OnCompleted(continuation);
 
         [MethodImpl(Internal.InlineOption)]
-        void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
+        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
         {
             if (_continuationOptions.IsSynchronous)
             {
                 asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
                 return;
             }
-            Internal.PromiseRefBase.ConfiguredAsyncPromiseContinuer.ConfigureAsyncContinuation(asyncPromiseRef, _continuationOptions.GetContinuationContext(), _promise._ref, _promise._id);
+            asyncPromiseRef.HookupAwaiterWithContext(_promise._ref, _promise._id, ref continuationContext, _continuationOptions.GetContinuationContext());
         }
 
         static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
@@ -179,7 +179,7 @@ namespace Proto.Promises.CompilerServices
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode, StackTraceHidden]
 #endif
-    public readonly partial struct ConfiguredPromiseAwaiter<T> : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+    public readonly partial struct ConfiguredPromiseAwaiter<T> : ICriticalNotifyCompletion, Internal.IPromiseAwareAwaiter
     {
         private readonly Promise<T> _promise;
         private readonly ContinuationOptions _continuationOptions;
@@ -268,14 +268,14 @@ namespace Proto.Promises.CompilerServices
             => OnCompleted(continuation);
 
         [MethodImpl(Internal.InlineOption)]
-        void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
+        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
         {
             if (_continuationOptions.IsSynchronous)
             {
                 asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
                 return;
             }
-            Internal.PromiseRefBase.ConfiguredAsyncPromiseContinuer.ConfigureAsyncContinuation(asyncPromiseRef, _continuationOptions.GetContinuationContext(), _promise._ref, _promise._id);
+            asyncPromiseRef.HookupAwaiterWithContext(_promise._ref, _promise._id, ref continuationContext, _continuationOptions.GetContinuationContext());
         }
 
         static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
@@ -292,7 +292,7 @@ namespace Proto.Promises.CompilerServices
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode, StackTraceHidden]
 #endif
-    public readonly partial struct ConfiguredPromiseNoThrowAwaiterVoid : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+    public readonly partial struct ConfiguredPromiseNoThrowAwaiterVoid : ICriticalNotifyCompletion, Internal.IPromiseAwareAwaiter
     {
         private readonly Promise _promise;
         private readonly ContinuationOptions _continuationOptions;
@@ -373,14 +373,14 @@ namespace Proto.Promises.CompilerServices
             => OnCompleted(continuation);
 
         [MethodImpl(Internal.InlineOption)]
-        void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
+        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
         {
             if (_continuationOptions.IsSynchronous)
             {
                 asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
                 return;
             }
-            Internal.PromiseRefBase.ConfiguredAsyncPromiseContinuer.ConfigureAsyncContinuation(asyncPromiseRef, _continuationOptions.GetContinuationContext(), _promise._ref, _promise._id);
+            asyncPromiseRef.HookupAwaiterWithContext(_promise._ref, _promise._id, ref continuationContext, _continuationOptions.GetContinuationContext());
         }
 
         static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
@@ -397,7 +397,7 @@ namespace Proto.Promises.CompilerServices
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode, StackTraceHidden]
 #endif
-    public readonly partial struct ConfiguredPromiseNoThrowAwaiter<T> : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+    public readonly partial struct ConfiguredPromiseNoThrowAwaiter<T> : ICriticalNotifyCompletion, Internal.IPromiseAwareAwaiter
     {
         private readonly Promise<T> _promise;
         private readonly ContinuationOptions _continuationOptions;
@@ -478,14 +478,14 @@ namespace Proto.Promises.CompilerServices
             => OnCompleted(continuation);
 
         [MethodImpl(Internal.InlineOption)]
-        void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
+        void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
         {
             if (_continuationOptions.IsSynchronous)
             {
                 asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
                 return;
             }
-            Internal.PromiseRefBase.ConfiguredAsyncPromiseContinuer.ConfigureAsyncContinuation(asyncPromiseRef, _continuationOptions.GetContinuationContext(), _promise._ref, _promise._id);
+            asyncPromiseRef.HookupAwaiterWithContext(_promise._ref, _promise._id, ref continuationContext, _continuationOptions.GetContinuationContext());
         }
 
         static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);

--- a/Package/Core/Promises/CompilerServices/PromiseAwaiters.cs
+++ b/Package/Core/Promises/CompilerServices/PromiseAwaiters.cs
@@ -119,7 +119,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
-        public readonly partial struct PromiseAwaiterVoid : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+        public readonly partial struct PromiseAwaiterVoid : ICriticalNotifyCompletion, Internal.IPromiseAwareAwaiter
         {
             private readonly Promise _promise;
 
@@ -189,7 +189,7 @@ namespace Proto.Promises
             }
 
             [MethodImpl(Internal.InlineOption)]
-            void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
+            void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
                 => asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
 
             static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
@@ -206,7 +206,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
-        public readonly partial struct PromiseAwaiter<T> : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+        public readonly partial struct PromiseAwaiter<T> : ICriticalNotifyCompletion, Internal.IPromiseAwareAwaiter
         {
             private readonly Promise<T> _promise;
 
@@ -275,7 +275,7 @@ namespace Proto.Promises
                 => OnCompleted(continuation);
 
             [MethodImpl(Internal.InlineOption)]
-            void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
+            void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
                 => asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
 
             static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
@@ -292,7 +292,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
-        public readonly partial struct PromiseNoThrowAwaiterVoid : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+        public readonly partial struct PromiseNoThrowAwaiterVoid : ICriticalNotifyCompletion, Internal.IPromiseAwareAwaiter
         {
             private readonly Promise _promise;
 
@@ -360,7 +360,7 @@ namespace Proto.Promises
                 => OnCompleted(continuation);
 
             [MethodImpl(Internal.InlineOption)]
-            void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
+            void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
                 => asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
 
             /// <summary>
@@ -386,7 +386,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
-        public readonly partial struct PromiseNoThrowAwaiter<T> : ICriticalNotifyCompletion, Internal.IPromiseAwaiter
+        public readonly partial struct PromiseNoThrowAwaiter<T> : ICriticalNotifyCompletion, Internal.IPromiseAwareAwaiter
         {
             private readonly Promise<T> _promise;
 
@@ -454,7 +454,7 @@ namespace Proto.Promises
                 => OnCompleted(continuation);
 
             [MethodImpl(Internal.InlineOption)]
-            void Internal.IPromiseAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
+            void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
                 => asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
 
             /// <summary>

--- a/Package/Core/Promises/CompilerServices/PromiseAwaiters.cs
+++ b/Package/Core/Promises/CompilerServices/PromiseAwaiters.cs
@@ -189,7 +189,7 @@ namespace Proto.Promises
             }
 
             [MethodImpl(Internal.InlineOption)]
-            void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
+            void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
                 => asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
 
             static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
@@ -275,7 +275,7 @@ namespace Proto.Promises
                 => OnCompleted(continuation);
 
             [MethodImpl(Internal.InlineOption)]
-            void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
+            void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
                 => asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
 
             static partial void ValidateArgument<TArg>(TArg arg, string argName, int skipFrames);
@@ -360,7 +360,7 @@ namespace Proto.Promises
                 => OnCompleted(continuation);
 
             [MethodImpl(Internal.InlineOption)]
-            void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
+            void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
                 => asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
 
             /// <summary>
@@ -454,7 +454,7 @@ namespace Proto.Promises
                 => OnCompleted(continuation);
 
             [MethodImpl(Internal.InlineOption)]
-            void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef, ref object continuationContext)
+            void Internal.IPromiseAwareAwaiter.AwaitOnCompletedInternal(Internal.PromiseRefBase asyncPromiseRef)
                 => asyncPromiseRef.HookupAwaiter(_promise._ref, _promise._id);
 
             /// <summary>

--- a/Package/Core/Promises/Config.cs
+++ b/Package/Core/Promises/Config.cs
@@ -156,7 +156,8 @@ namespace Proto.Promises
                     s_asyncFlowExecutionContextEnabled = true;
                 }
             }
-            private static bool s_asyncFlowExecutionContextEnabled;
+            // Internal so that tests can disable it directly.
+            internal static bool s_asyncFlowExecutionContextEnabled;
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             private static void ThrowCannotDisableAsyncFlow()

--- a/Package/Core/Promises/Internal/AsValueTaskInternal.cs
+++ b/Package/Core/Promises/Internal/AsValueTaskInternal.cs
@@ -113,7 +113,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        var exception = state == Promise.State.Rejected ? handler._rejectContainer.GetValueAsException() : Promise.CancelException();
+                        var exception = state == Promise.State.Rejected ? handler.RejectContainer.GetValueAsException() : Promise.CancelException();
                         handler.MaybeDispose();
                         _core.SetException(exception);
                     }

--- a/Package/Core/Promises/Internal/AsyncInternal.cs
+++ b/Package/Core/Promises/Internal/AsyncInternal.cs
@@ -73,12 +73,6 @@ namespace Proto.Promises
 #endif
             internal partial class AsyncPromiseRef<TResult> : PromiseSingleAwait<TResult>
             {
-                internal ref object ContinuationContext
-                {
-                    [MethodImpl(InlineOption)]
-                    get => ref _contextOrRejection._continuationContext;
-                }
-
                 [MethodImpl(InlineOption)]
                 private static AsyncPromiseRef<TResult> GetFromPoolOrCreate()
                 {

--- a/Package/Core/Promises/Internal/AsyncInternal.cs
+++ b/Package/Core/Promises/Internal/AsyncInternal.cs
@@ -363,7 +363,6 @@ namespace Proto.Promises
                     {
                         Dispose();
                         _stateMachine = default;
-                        ContinuationContext = null;
                         ObjectPool.MaybeRepool(this);
                     }
 

--- a/Package/Core/Promises/Internal/AsyncInternal.cs
+++ b/Package/Core/Promises/Internal/AsyncInternal.cs
@@ -32,8 +32,6 @@ namespace Proto.Promises
 
         partial class PromiseRefBase
         {
-            internal virtual void ContinueAsyncFunction() => throw new System.InvalidOperationException();
-
             [MethodImpl(InlineOption)]
             internal void HookupAwaiter(PromiseRefBase awaiter, short promiseId)
             {
@@ -41,6 +39,34 @@ namespace Proto.Promises
                 this.SetPrevious(awaiter);
                 awaiter.HookupExistingWaiter(promiseId, this);
             }
+
+            [MethodImpl(InlineOption)]
+            internal void HookupAwaiterWithContext(PromiseRefBase awaiter, short promiseId, ref object continuationContext, SynchronizationContext synchronizationContext)
+            {
+                ValidateAwait(awaiter, promiseId);
+
+                if (awaiter == null)
+                {
+                    // The awaited promise was already complete, and the await was configured to continue asynchronously.
+                    ContinueOnContext(synchronizationContext);
+                    return;
+                }
+
+                var context = continuationContext;
+                if (context != null)
+                {
+                    continuationContext = ConfiguredAwaitDualContext.GetOrCreate(synchronizationContext, context.UnsafeAs<ExecutionContext>());
+                }
+                else
+                {
+                    continuationContext = synchronizationContext;
+                }
+
+                this.SetPrevious(awaiter);
+                awaiter.HookupExistingWaiter(promiseId, this);
+            }
+
+            protected virtual void ContinueOnContext(SynchronizationContext synchronizationContext) => throw new System.InvalidOperationException();
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
@@ -101,9 +127,9 @@ namespace Proto.Promises
 #if NETCOREAPP
                     // These checks and cast are eliminated by the JIT.
 #pragma warning disable IDE0038 // Use pattern matching
-                    if (null != default(TAwaiter) && awaiter is IPromiseAwaiter)
+                    if (null != default(TAwaiter) && awaiter is IPromiseAwareAwaiter)
                     {
-                        ((IPromiseAwaiter) awaiter).AwaitOnCompletedInternal(_ref);
+                        ((IPromiseAwareAwaiter) awaiter).AwaitOnCompletedInternal(_ref, ref _ref._continuationContext);
                     }
                     else
                     {
@@ -112,7 +138,7 @@ namespace Proto.Promises
 #pragma warning restore IDE0038 // Use pattern matching
 #else
                     // Unity does not optimize the pattern, so we have to call through AwaitOverrider to avoid boxing allocations.
-                    AwaitOverrider<TAwaiter>.AwaitOnCompleted(ref awaiter, _ref, _ref.MoveNext);
+                    AwaitOverrider<TAwaiter>.AwaitOnCompleted(ref awaiter, _ref, ref _ref._continuationContext, _ref.MoveNext);
 #endif
                 }
 
@@ -125,9 +151,9 @@ namespace Proto.Promises
 #if NETCOREAPP
                     // These checks and cast are eliminated by the JIT.
 #pragma warning disable IDE0038 // Use pattern matching
-                    if (null != default(TAwaiter) && awaiter is IPromiseAwaiter)
+                    if (null != default(TAwaiter) && awaiter is IPromiseAwareAwaiter)
                     {
-                        ((IPromiseAwaiter) awaiter).AwaitOnCompletedInternal(_ref);
+                        ((IPromiseAwareAwaiter) awaiter).AwaitOnCompletedInternal(_ref, ref _ref._continuationContext);
                     }
                     else
                     {
@@ -136,10 +162,10 @@ namespace Proto.Promises
 #pragma warning restore IDE0038 // Use pattern matching
 #else
                     // Unity does not optimize the pattern, so we have to call through CriticalAwaitOverrider to avoid boxing allocations.
-                    CriticalAwaitOverrider<TAwaiter>.AwaitOnCompleted(ref awaiter, _ref, _ref.MoveNext);
+                    CriticalAwaitOverrider<TAwaiter>.AwaitOnCompleted(ref awaiter, _ref, ref _ref._continuationContext, _ref.MoveNext);
 #endif
                 }
-            }
+            } // class AsyncPromiseRef<TResult>
 
 #if !OPTIMIZED_ASYNC_MODE
             sealed partial class AsyncPromiseRef<TResult>
@@ -178,9 +204,6 @@ namespace Proto.Promises
 #endif
                     private sealed partial class Continuer<TStateMachine> : PromiseMethodContinuer where TStateMachine : IAsyncStateMachine
                     {
-                        private static readonly ContextCallback s_executionContextCallback = state
-                            => state.UnsafeAs<Continuer<TStateMachine>>()._stateMachine.MoveNext();
-
                         private Continuer()
                         {
                             _moveNext = ContinueMethod;
@@ -218,9 +241,10 @@ namespace Proto.Promises
                             try
 #endif
                             {
-                                if (_owner._executionContext != null)
+                                var continuationContext = _owner._continuationContext;
+                                if (continuationContext != null)
                                 {
-                                    ExecutionContext.Run(_owner._executionContext, s_executionContextCallback, this);
+                                    ContinueOnContext(continuationContext);
                                 }
                                 else
                                 {
@@ -233,6 +257,34 @@ namespace Proto.Promises
                                 ClearCurrentInvoker();
                             }
 #endif
+                        }
+
+                        private void ContinueOnContext(object continuationContext)
+                        {
+                            if (continuationContext is SynchronizationContext synchronizationContext)
+                            {
+                                _owner._continuationContext = null;
+                                ScheduleContextCallback(synchronizationContext, this,
+                                    obj => obj.UnsafeAs<Continuer<TStateMachine>>()._stateMachine.MoveNext(),
+                                    obj => obj.UnsafeAs<Continuer<TStateMachine>>()._stateMachine.MoveNext());
+                            }
+                            // TODO: Make ConfiguredAwaitDualContext inherit SynchronizationContext to eliminate an extra type check.
+                            else if (continuationContext is ConfiguredAwaitDualContext dualContext)
+                            {
+                                _owner._continuationContext = dualContext._executionContext;
+                                synchronizationContext = dualContext._synchronizationContext;
+                                dualContext.Dispose();
+                                ScheduleContextCallback(synchronizationContext, this,
+                                    obj => obj.UnsafeAs<Continuer<TStateMachine>>().ContinueMethod(),
+                                    obj => obj.UnsafeAs<Continuer<TStateMachine>>().ContinueMethod());
+                            }
+                            else
+                            {
+                                _owner._continuationContext = null;
+                                ExecutionContext.Run(continuationContext.UnsafeAs<ExecutionContext>(),
+                                    obj => obj.UnsafeAs<Continuer<TStateMachine>>()._stateMachine.MoveNext(),
+                                    this);
+                            }
                         }
                     }
                 }
@@ -250,7 +302,7 @@ namespace Proto.Promises
                     }
                     if (Promise.Config.AsyncFlowExecutionContextEnabled)
                     {
-                        _ref._executionContext = ExecutionContext.Capture();
+                        _ref._continuationContext = ExecutionContext.Capture();
                     }
                 }
 
@@ -262,7 +314,7 @@ namespace Proto.Promises
                         _continuer.Dispose();
                         _continuer = null;
                     }
-                    _executionContext = null;
+                    _continuationContext = null;
                     ObjectPool.MaybeRepool(this);
                 }
 
@@ -274,13 +326,11 @@ namespace Proto.Promises
                     _continuer.MoveNext.Invoke();
                 }
 
-                internal override void ContinueAsyncFunction()
-                {
-                    ThrowIfInPool(this);
-                    this.SetPrevious(null);
-                    _continuer.MoveNext.Invoke();
-                }
-            } // class AsyncPromiseRef
+                protected override void ContinueOnContext(SynchronizationContext synchronizationContext)
+                    => ScheduleContextCallback(synchronizationContext, _continuer.MoveNext,
+                        obj => obj.UnsafeAs<Action>().Invoke(),
+                        obj => obj.UnsafeAs<Action>().Invoke());
+            } // class AsyncPromiseRef<TResult>
 
 #else // !OPTIMIZED_ASYNC_MODE
 
@@ -291,9 +341,6 @@ namespace Proto.Promises
 #endif
                 private sealed partial class AsyncPromiseRefMachine<TStateMachine> : AsyncPromiseRef<TResult> where TStateMachine : IAsyncStateMachine
                 {
-                    private static readonly ContextCallback s_executionContextCallback = state
-                        => state.UnsafeAs<AsyncPromiseRefMachine<TStateMachine>>()._stateMachine.MoveNext();
-
                     private AsyncPromiseRefMachine()
                     {
                         _moveNext = Continue;
@@ -322,16 +369,17 @@ namespace Proto.Promises
                     {
                         Dispose();
                         _stateMachine = default;
-                        _executionContext = null;
+                        _continuationContext = null;
                         ObjectPool.MaybeRepool(this);
                     }
 
                     [MethodImpl(InlineOption)]
                     private void Continue()
                     {
-                        if (_executionContext != null)
+                        var continuationContext = _continuationContext;
+                        if (continuationContext != null)
                         {
-                            ExecutionContext.Run(_executionContext, s_executionContextCallback, this);
+                            ContinueOnContext(continuationContext);
                         }
                         else
                         {
@@ -346,11 +394,47 @@ namespace Proto.Promises
                         Continue();
                     }
 
-                    internal override void ContinueAsyncFunction()
+                    private void ContinueOnContext(object continuationContext)
                     {
-                        ThrowIfInPool(this);
-                        Continue();
+                        if (continuationContext is SynchronizationContext synchronizationContext)
+                        {
+                            _continuationContext = null;
+                            ScheduleContextCallback(synchronizationContext, this,
+                                obj => obj.UnsafeAs<AsyncPromiseRefMachine<TStateMachine>>()._stateMachine.MoveNext(),
+                                obj => obj.UnsafeAs<AsyncPromiseRefMachine<TStateMachine>>()._stateMachine.MoveNext());
+                        }
+                        // TODO: Make ConfiguredAwaitDualContext inherit SynchronizationContext to eliminate an extra type check.
+                        else if (continuationContext is ConfiguredAwaitDualContext dualContext)
+                        {
+                            _continuationContext = dualContext._executionContext;
+                            synchronizationContext = dualContext._synchronizationContext;
+                            dualContext.Dispose();
+                            ScheduleContextCallback(synchronizationContext, this,
+                                obj => obj.UnsafeAs<AsyncPromiseRefMachine<TStateMachine>>().ContinueWithExecutionContext(),
+                                obj => obj.UnsafeAs<AsyncPromiseRefMachine<TStateMachine>>().ContinueWithExecutionContext());
+                        }
+                        else
+                        {
+                            _continuationContext = null;
+                            ExecutionContext.Run(continuationContext.UnsafeAs<ExecutionContext>(),
+                                obj => obj.UnsafeAs<AsyncPromiseRefMachine<TStateMachine>>()._stateMachine.MoveNext(),
+                                this);
+                        }
                     }
+
+                    private void ContinueWithExecutionContext()
+                    {
+                        var continuationContext = _continuationContext;
+                        _continuationContext = null;
+                        ExecutionContext.Run(continuationContext.UnsafeAs<ExecutionContext>(),
+                            obj => obj.UnsafeAs<AsyncPromiseRefMachine<TStateMachine>>()._stateMachine.MoveNext(),
+                            this);
+                    }
+
+                    protected override void ContinueOnContext(SynchronizationContext synchronizationContext)
+                        => ScheduleContextCallback(synchronizationContext, this,
+                            obj => obj.UnsafeAs<AsyncPromiseRefMachine<TStateMachine>>().Continue(),
+                            obj => obj.UnsafeAs<AsyncPromiseRefMachine<TStateMachine>>().Continue());
                 }
 
                 private Action MoveNext
@@ -370,17 +454,17 @@ namespace Proto.Promises
                     }
                     if (Promise.Config.AsyncFlowExecutionContextEnabled)
                     {
-                        _ref._executionContext = ExecutionContext.Capture();
+                        _ref._continuationContext = ExecutionContext.Capture();
                     }
                 }
 
                 internal override void MaybeDispose()
                 {
                     Dispose();
-                    _executionContext = null;
+                    _continuationContext = null;
                     ObjectPool.MaybeRepool(this);
                 }
-            }
+            } // class AsyncPromiseRef<TResult>
 #endif // OPTIMIZED_ASYNC_MODE
         } // class PromiseRef
     } // class Internal

--- a/Package/Core/Promises/Internal/AwaitInternal.cs
+++ b/Package/Core/Promises/Internal/AwaitInternal.cs
@@ -35,7 +35,7 @@ namespace Proto.Promises
                 if (state == Promise.State.Rejected)
                 {
                     SuppressRejection = true;
-                    var exceptionDispatchInfo = _rejectContainer.GetExceptionDispatchInfo();
+                    var exceptionDispatchInfo = RejectContainer.GetExceptionDispatchInfo();
                     MaybeDispose();
                     return exceptionDispatchInfo;
                 }
@@ -64,7 +64,7 @@ namespace Proto.Promises
             [MethodImpl(InlineOption)]
             internal Promise.ResultContainer GetResultContainerAndMaybeDispose()
             {
-                var resultContainer = new Promise.ResultContainer(_rejectContainer, State);
+                var resultContainer = new Promise.ResultContainer(RejectContainer, State);
                 SuppressRejection = true;
                 MaybeDispose();
                 return resultContainer;
@@ -101,7 +101,7 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 new internal Promise<TResult>.ResultContainer GetResultContainerAndMaybeDispose()
                 {
-                    var resultContainer = new Promise<TResult>.ResultContainer(_result, _rejectContainer, State);
+                    var resultContainer = new Promise<TResult>.ResultContainer(_result, RejectContainer, State);
                     SuppressRejection = true;
                     MaybeDispose();
                     return resultContainer;

--- a/Package/Core/Promises/Internal/AwaitInternal.cs
+++ b/Package/Core/Promises/Internal/AwaitInternal.cs
@@ -175,7 +175,7 @@ namespace Proto.Promises
 
         internal interface IPromiseAwareAwaiter
         {
-            void AwaitOnCompletedInternal(PromiseRefBase asyncPromiseRef, ref object continuationContext);
+            void AwaitOnCompletedInternal(PromiseRefBase asyncPromiseRef);
         }
 
 #if !NETCOREAPP
@@ -183,30 +183,30 @@ namespace Proto.Promises
 #if UNITY_2021_2_OR_NEWER || NETSTANDARD2_1_OR_GREATER // Even though CIL has always had function pointers, Unity did not properly support the CIL instructions until C# 9/ .Net Standard 2.1 support was added.
         internal unsafe static class AwaitOverrider<TAwaiter> where TAwaiter : INotifyCompletion
         {
-            internal static delegate*<ref TAwaiter, PromiseRefBase, ref object, Action, void> s_awaitFunc = &DefaultAwaitOnCompleted;
+            internal static delegate*<ref TAwaiter, PromiseRefBase, Action, void> s_awaitFunc = &DefaultAwaitOnCompleted;
 
             [MethodImpl(InlineOption)]
-            private static void DefaultAwaitOnCompleted(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, ref object continuationContext, Action continuation)
+            private static void DefaultAwaitOnCompleted(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, Action continuation)
                 => awaiter.OnCompleted(continuation);
 
             [MethodImpl(InlineOption)]
-            internal static void AwaitOnCompleted(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, ref object continuationContext, Action continuation)
+            internal static void AwaitOnCompleted(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, Action continuation)
                 // We call the function without a branch. If the awaiter is not a known awaiter type, the default function will be called.
-                => s_awaitFunc(ref awaiter, asyncPromiseRef, ref continuationContext, continuation);
+                => s_awaitFunc(ref awaiter, asyncPromiseRef, continuation);
         }
 
         internal unsafe static class CriticalAwaitOverrider<TAwaiter> where TAwaiter : ICriticalNotifyCompletion
         {
-            internal static delegate*<ref TAwaiter, PromiseRefBase, ref object, Action, void> s_awaitFunc = &DefaultAwaitOnCompleted;
+            internal static delegate*<ref TAwaiter, PromiseRefBase, Action, void> s_awaitFunc = &DefaultAwaitOnCompleted;
 
             [MethodImpl(InlineOption)]
-            private static void DefaultAwaitOnCompleted(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, ref object continuationContext, Action continuation)
+            private static void DefaultAwaitOnCompleted(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, Action continuation)
                 => awaiter.UnsafeOnCompleted(continuation);
 
             [MethodImpl(InlineOption)]
-            internal static void AwaitOnCompleted(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, ref object continuationContext, Action continuation)
+            internal static void AwaitOnCompleted(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, Action continuation)
                 // We call the function without a branch. If the awaiter is not a known awaiter type, the default function will be called.
-                => s_awaitFunc(ref awaiter, asyncPromiseRef, ref continuationContext, continuation);
+                => s_awaitFunc(ref awaiter, asyncPromiseRef, continuation);
         }
 
         internal unsafe static class AwaitOverriderImpl<TAwaiter> where TAwaiter : struct, ICriticalNotifyCompletion, IPromiseAwareAwaiter
@@ -220,8 +220,8 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            private static void AwaitOnCompletedOverride(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, ref object continuationContext, Action continuation)
-                => awaiter.AwaitOnCompletedInternal(asyncPromiseRef, ref continuationContext);
+            private static void AwaitOnCompletedOverride(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, Action continuation)
+                => awaiter.AwaitOnCompletedInternal(asyncPromiseRef);
         }
 #else // UNITY_2021_2_OR_NEWER || NETSTANDARD2_1_OR_GREATER
         internal abstract class AwaitOverrider<TAwaiter> where TAwaiter : INotifyCompletion
@@ -229,11 +229,11 @@ namespace Proto.Promises
             internal static AwaitOverrider<TAwaiter> s_awaitOverrider;
 
             [MethodImpl(InlineOption)]
-            internal static void AwaitOnCompleted(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, ref object continuationContext, Action continuation)
+            internal static void AwaitOnCompleted(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, Action continuation)
             {
                 if (s_awaitOverrider != null)
                 {
-                    s_awaitOverrider.AwaitOnCompletedVirt(ref awaiter, asyncPromiseRef, ref continuationContext);
+                    s_awaitOverrider.AwaitOnCompletedVirt(ref awaiter, asyncPromiseRef);
                 }
                 else
                 {
@@ -241,17 +241,17 @@ namespace Proto.Promises
                 }
             }
 
-            internal abstract void AwaitOnCompletedVirt(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, ref object continuationContext);
+            internal abstract void AwaitOnCompletedVirt(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef);
         }
 
         internal static class CriticalAwaitOverrider<TAwaiter> where TAwaiter : ICriticalNotifyCompletion
         {
             [MethodImpl(InlineOption)]
-            internal static void AwaitOnCompleted(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, ref object continuationContext, Action continuation)
+            internal static void AwaitOnCompleted(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, Action continuation)
             {
                 if (AwaitOverrider<TAwaiter>.s_awaitOverrider != null)
                 {
-                    AwaitOverrider<TAwaiter>.s_awaitOverrider.AwaitOnCompletedVirt(ref awaiter, asyncPromiseRef, ref continuationContext);
+                    AwaitOverrider<TAwaiter>.s_awaitOverrider.AwaitOnCompletedVirt(ref awaiter, asyncPromiseRef);
                 }
                 else
                 {
@@ -274,9 +274,9 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal override void AwaitOnCompletedVirt(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef, ref object continuationContext)
+            internal override void AwaitOnCompletedVirt(ref TAwaiter awaiter, PromiseRefBase asyncPromiseRef)
             {
-                awaiter.AwaitOnCompletedInternal(asyncPromiseRef, ref continuationContext);
+                awaiter.AwaitOnCompletedInternal(asyncPromiseRef);
             }
         }
 #endif // UNITY_2021_2_OR_NEWER || NETSTANDARD2_1_OR_GREATER

--- a/Package/Core/Promises/Internal/CancelInternal.cs
+++ b/Package/Core/Promises/Internal/CancelInternal.cs
@@ -17,7 +17,7 @@ namespace Proto.Promises
             {
                 // PromiseSingleAwait
 
-                MaybeReportUnhandledRejection(_rejectContainer, state);
+                MaybeReportUnhandledRejection(state);
                 MaybeDispose();
             }
 
@@ -272,7 +272,7 @@ namespace Proto.Promises
                     }
                     else if (state == Promise.State.Rejected)
                     {
-                        var rejectContainer = handler._rejectContainer;
+                        var rejectContainer = handler.RejectContainer;
                         handler.SuppressRejection = true;
                         handler.MaybeDispose();
                         _cancelationHelper.TryRelease();
@@ -363,7 +363,7 @@ namespace Proto.Promises
                         handler.SuppressRejection = true;
                         _cancelationHelper.TryRelease();
                         invokingRejected = true;
-                        rejectCallback.InvokeRejecter(handler, handler._rejectContainer, this);
+                        rejectCallback.InvokeRejecter(handler, handler.RejectContainer, this);
                     }
                     else
                     {
@@ -424,7 +424,7 @@ namespace Proto.Promises
                     {
                         handler.SuppressRejection = true;
                         _cancelationHelper.TryRelease();
-                        _continuer.Invoke(handler, handler._rejectContainer, state, this);
+                        _continuer.Invoke(handler, handler.RejectContainer, state, this);
                     }
                     else
                     {
@@ -494,7 +494,7 @@ namespace Proto.Promises
                     {
                         handler.SuppressRejection = true;
                         _cancelationHelper.TryRelease();
-                        callback.Invoke(handler, handler._rejectContainer, state, this);
+                        callback.Invoke(handler, handler.RejectContainer, state, this);
                     }
                     else
                     {

--- a/Package/Core/Promises/Internal/ConfiguredPromise.cs
+++ b/Package/Core/Promises/Internal/ConfiguredPromise.cs
@@ -80,7 +80,7 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
 
                     handler.SetCompletionState(state);
-                    _rejectContainer = handler._rejectContainer;
+                    RejectContainer = handler.RejectContainer;
                     handler.SuppressRejection = true;
                     _result = handler.GetResult<TResult>();
                     _tempState = state;

--- a/Package/Core/Promises/Internal/ConfiguredPromise.cs
+++ b/Package/Core/Promises/Internal/ConfiguredPromise.cs
@@ -259,65 +259,49 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]
 #endif
-            internal sealed partial class ConfiguredAsyncPromiseContinuer : HandleablePromiseBase
+            internal sealed partial class ConfiguredAwaitDualContext : HandleablePromiseBase
             {
-                private SynchronizationContext _context;
+                internal SynchronizationContext _synchronizationContext;
+                internal ExecutionContext _executionContext;
 
-                private ConfiguredAsyncPromiseContinuer() { }
+                private ConfiguredAwaitDualContext() { }
 
                 [MethodImpl(InlineOption)]
-                private static ConfiguredAsyncPromiseContinuer GetOrCreate()
+                private static ConfiguredAwaitDualContext GetOrCreate()
                 {
-                    var obj = ObjectPool.TryTakeOrInvalid<ConfiguredAsyncPromiseContinuer>();
+                    var obj = ObjectPool.TryTakeOrInvalid<ConfiguredAwaitDualContext>();
                     return obj == InvalidAwaitSentinel.s_instance
-                        ? new ConfiguredAsyncPromiseContinuer()
-                        : obj.UnsafeAs<ConfiguredAsyncPromiseContinuer>();
+                        ? new ConfiguredAwaitDualContext()
+                        : obj.UnsafeAs<ConfiguredAwaitDualContext>();
                 }
 
-                internal static void ConfigureAsyncContinuation(PromiseRefBase asyncPromiseRef, SynchronizationContext context, PromiseRefBase awaiter, short promiseId)
+                [MethodImpl(InlineOption)]
+                internal static ConfiguredAwaitDualContext GetOrCreate(SynchronizationContext synchronizationContext, ExecutionContext executionContext)
                 {
 #if PROMISE_DEBUG || PROTO_PROMISE_DEVELOPER_MODE
-                    if (context == null)
+                    if (synchronizationContext == null)
                     {
-                        throw new InvalidOperationException("context cannot be null");
+                        throw new System.InvalidOperationException("synchronizationContext cannot be null");
+                    }
+                    if (executionContext == null)
+                    {
+                        throw new System.InvalidOperationException("executionContext cannot be null");
                     }
 #endif
 
-                    asyncPromiseRef.ValidateAwait(awaiter, promiseId);
-                    asyncPromiseRef.SetPrevious(awaiter);
-
-                    if (awaiter == null)
-                    {
-                        ScheduleContextCallback(context, asyncPromiseRef,
-                            obj => obj.UnsafeAs<PromiseRefBase>().ContinueAsyncFunction(),
-                            obj => obj.UnsafeAs<PromiseRefBase>().ContinueAsyncFunction()
-                        );
-                        return;
-                    }
-
-                    var continuer = GetOrCreate();
-                    continuer._next = asyncPromiseRef;
-                    continuer._context = context;
-
-                    awaiter.HookupNewWaiter(promiseId, continuer);
+                    var context = GetOrCreate();
+                    context._synchronizationContext = synchronizationContext;
+                    context._executionContext = executionContext;
+                    return context;
                 }
 
-                internal override void Handle(PromiseRefBase handler, Promise.State state)
+                internal void Dispose()
                 {
-                    ThrowIfInPool(this);
-                    handler.SetCompletionState(state);
-
-                    var asyncPromiseRef = _next;
-                    var context = _context;
-                    _context = null;
+                    _synchronizationContext = null;
+                    _executionContext = null;
                     ObjectPool.MaybeRepool(this);
-
-                    ScheduleContextCallback(context, asyncPromiseRef,
-                        obj => obj.UnsafeAs<PromiseRefBase>().ContinueAsyncFunction(),
-                        obj => obj.UnsafeAs<PromiseRefBase>().ContinueAsyncFunction()
-                    );
                 }
-            } // class ConfiguredAsyncPromiseContinuer
+            } // class ConfiguredAwaitDualContext
         } // class PromiseRefBase
     } // class Internal
 }

--- a/Package/Core/Promises/Internal/ConfiguredPromise.cs
+++ b/Package/Core/Promises/Internal/ConfiguredPromise.cs
@@ -13,7 +13,7 @@ namespace Proto.Promises
 {
     partial class Internal
     {
-        partial class PromiseRefBase : HandleablePromiseBase, ITraceable
+        partial class PromiseRefBase
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]

--- a/Package/Core/Promises/Internal/DeferredInternal.cs
+++ b/Package/Core/Promises/Internal/DeferredInternal.cs
@@ -57,7 +57,7 @@ namespace Proto.Promises
 
                 public void RejectDirect(IRejectContainer reasonContainer)
                 {
-                    _rejectContainer = reasonContainer;
+                    RejectContainer = reasonContainer;
                     HandleNextInternal(Promise.State.Rejected);
                 }
 

--- a/Package/Core/Promises/Internal/DelegateWrappersInternal.cs
+++ b/Package/Core/Promises/Internal/DelegateWrappersInternal.cs
@@ -491,7 +491,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner._rejectContainer = rejectContainer;
+                        owner.RejectContainer = rejectContainer;
                         owner.HandleNextInternal(Promise.State.Rejected);
                     }
                 }
@@ -563,7 +563,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner._rejectContainer = rejectContainer;
+                        owner.RejectContainer = rejectContainer;
                         owner.HandleNextInternal(Promise.State.Rejected);
                     }
                 }
@@ -712,7 +712,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner._rejectContainer = rejectContainer;
+                        owner.RejectContainer = rejectContainer;
                         owner.HandleNextInternal(Promise.State.Rejected);
                     }
                 }
@@ -760,7 +760,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner._rejectContainer = rejectContainer;
+                        owner.RejectContainer = rejectContainer;
                         owner.HandleNextInternal(Promise.State.Rejected);
                     }
                 }
@@ -1328,7 +1328,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner._rejectContainer = rejectContainer;
+                        owner.RejectContainer = rejectContainer;
                         owner.HandleNextInternal(Promise.State.Rejected);
                     }
                 }
@@ -1402,7 +1402,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner._rejectContainer = rejectContainer;
+                        owner.RejectContainer = rejectContainer;
                         owner.HandleNextInternal(Promise.State.Rejected);
                     }
                 }
@@ -1557,7 +1557,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner._rejectContainer = rejectContainer;
+                        owner.RejectContainer = rejectContainer;
                         owner.HandleNextInternal(Promise.State.Rejected);
                     }
                 }
@@ -1607,7 +1607,7 @@ namespace Proto.Promises
                     }
                     else
                     {
-                        owner._rejectContainer = rejectContainer;
+                        owner.RejectContainer = rejectContainer;
                         owner.HandleNextInternal(Promise.State.Rejected);
                     }
                 }

--- a/Package/Core/Promises/Internal/MergeInternal.cs
+++ b/Package/Core/Promises/Internal/MergeInternal.cs
@@ -362,7 +362,7 @@ namespace Proto.Promises
                                 if (_isComplete == 0)
                                 {
                                     _next = PromiseCompletionSentinel.s_instance;
-                                    SetCompletionState(_rejectContainer == null ? stateIfComplete : Promise.State.Rejected);
+                                    SetCompletionState(RejectContainer == null ? stateIfComplete : Promise.State.Rejected);
                                 }
                                 break;
                             }
@@ -476,7 +476,7 @@ namespace Proto.Promises
                     }
                     if (isComplete)
                     {
-                        _rejectContainer = handler._rejectContainer;
+                        RejectContainer = handler.RejectContainer;
                         handler.SuppressRejection = true;
                         handler.MaybeDispose();
                         InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
@@ -496,7 +496,7 @@ namespace Proto.Promises
                         : TrySetComplete(handler);
                     if (isComplete)
                     {
-                        _rejectContainer = handler._rejectContainer;
+                        RejectContainer = handler.RejectContainer;
                         handler.SuppressRejection = true;
                         handler.MaybeDispose();
                         InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);

--- a/Package/Core/Promises/Internal/ParallelAsyncInternal.cs
+++ b/Package/Core/Promises/Internal/ParallelAsyncInternal.cs
@@ -55,7 +55,6 @@ namespace Proto.Promises
                 // Use the CancelationRef directly instead of CancelationSource struct to save memory.
                 private CancelationRef _cancelationRef;
                 private ExecutionContext _executionContext;
-                private SynchronizationContext _synchronizationContext;
                 private int _remainingAvailableWorkers;
                 private int _waitCounter;
                 private List<Exception> _exceptions;
@@ -85,7 +84,7 @@ namespace Proto.Promises
                     var promise = GetOrCreate();
                     promise.Reset();
                     promise._body = body;
-                    promise._synchronizationContext = synchronizationContext ?? BackgroundSynchronizationContextSentinel.s_instance;
+                    promise.ContinuationContext = synchronizationContext ?? BackgroundSynchronizationContextSentinel.s_instance;
                     promise._remainingAvailableWorkers = maxDegreeOfParallelism;
                     promise._completionState = Promise.State.Resolved;
                     promise._stopExecuting = false;
@@ -106,7 +105,6 @@ namespace Proto.Promises
                     ValidateNoPending();
                     Dispose();
                     _body = default;
-                    _synchronizationContext = null;
                     _executionContext = null;
                     ObjectPool.MaybeRepool(this);
                 }
@@ -161,7 +159,7 @@ namespace Proto.Promises
                         if ((int) newValue > 0)
                         {
                             // Another worker is waiting on the lock, schedule it on the context and jump to inside lock.
-                            ScheduleContextCallback(_synchronizationContext, this,
+                            ScheduleContextCallback(ContinuationContext.UnsafeAs<SynchronizationContext>(), this,
                                 obj => obj.UnsafeAs<PromiseParallelForEachAsync<TParallelBody, TSource>>().ExecuteWorkerInsideLock(),
                                 obj => obj.UnsafeAs<PromiseParallelForEachAsync<TParallelBody, TSource>>().ExecuteWorkerInsideLock()
                             );
@@ -191,7 +189,7 @@ namespace Proto.Promises
                         // We add to the wait counter before we run the worker to resolve a race condition where the counter could hit zero prematurely.
                         InterlockedAddWithUnsignedOverflowCheck(ref _waitCounter, 1);
 
-                        ScheduleContextCallback(_synchronizationContext, this,
+                        ScheduleContextCallback(ContinuationContext.UnsafeAs<SynchronizationContext>(), this,
                             obj => obj.UnsafeAs<PromiseParallelForEachAsync<TParallelBody, TSource>>().ExecuteWorkerAndLaunchNext(),
                             obj => obj.UnsafeAs<PromiseParallelForEachAsync<TParallelBody, TSource>>().ExecuteWorkerAndLaunchNext()
                         );
@@ -368,7 +366,7 @@ namespace Proto.Promises
                         if (!isMoveNextAsyncContinuation)
                         {
                             // Schedule the worker body to run again on the context, but without launching another worker.
-                            ScheduleContextCallback(_synchronizationContext, this,
+                            ScheduleContextCallback(ContinuationContext.UnsafeAs<SynchronizationContext>(), this,
                                 obj => obj.UnsafeAs<PromiseParallelForEachAsync<TParallelBody, TSource>>().ExecuteWorkerWithoutLaunchNext(),
                                 obj => obj.UnsafeAs<PromiseParallelForEachAsync<TParallelBody, TSource>>().ExecuteWorkerWithoutLaunchNext()
                             );
@@ -380,7 +378,7 @@ namespace Proto.Promises
                             return;
                         }
                         // Schedule the worker body to jump to after move next.
-                        ScheduleContextCallback(_synchronizationContext, this,
+                        ScheduleContextCallback(ContinuationContext.UnsafeAs<SynchronizationContext>(), this,
                                 obj => obj.UnsafeAs<PromiseParallelForEachAsync<TParallelBody, TSource>>().ExecuteWorkerAfterMoveNext(),
                                 obj => obj.UnsafeAs<PromiseParallelForEachAsync<TParallelBody, TSource>>().ExecuteWorkerAfterMoveNext()
                         );

--- a/Package/Core/Promises/Internal/ParallelAsyncInternal.cs
+++ b/Package/Core/Promises/Internal/ParallelAsyncInternal.cs
@@ -354,7 +354,7 @@ namespace Proto.Promises
                 internal override void Handle(PromiseRefBase handler, Promise.State state)
                 {
                     RemoveComplete(handler);
-                    var rejectContainer = handler._rejectContainer;
+                    var rejectContainer = handler.RejectContainer;
                     handler.SuppressRejection = true;
                     handler.SetCompletionState(state);
                     handler.MaybeDispose();
@@ -467,7 +467,7 @@ namespace Proto.Promises
                     // This must be the very last thing done.
                     if (_exceptions != null)
                     {
-                        _rejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
                         _exceptions = null;
                         HandleNextInternal(Promise.State.Rejected);
                     }
@@ -511,7 +511,7 @@ namespace Proto.Promises
                     handler.SetCompletionState(state);
                     if (state == Promise.State.Rejected)
                     {
-                        RecordException(handler._rejectContainer.GetValueAsException());
+                        RecordException(handler.RejectContainer.GetValueAsException());
                         handler.SuppressRejection = true;
                     }
                     handler.MaybeDispose();

--- a/Package/Core/Promises/Internal/ParallelInternal.cs
+++ b/Package/Core/Promises/Internal/ParallelInternal.cs
@@ -217,7 +217,6 @@ namespace Proto.Promises
                 private CancelationRegistration _externalCancelationRegistration;
                 // Use the CancelationRef directly instead of CancelationSource struct to save memory.
                 private CancelationRef _cancelationRef;
-                private SynchronizationContext _synchronizationContext;
                 private ExecutionContext _executionContext;
                 private int _remainingAvailableWorkers;
                 private int _waitCounter;
@@ -242,7 +241,7 @@ namespace Proto.Promises
                     promise.Reset();
                     promise._enumerator = enumerator;
                     promise._body = body;
-                    promise._synchronizationContext = synchronizationContext ?? BackgroundSynchronizationContextSentinel.s_instance;
+                    promise.ContinuationContext = synchronizationContext ?? BackgroundSynchronizationContextSentinel.s_instance;
                     promise._remainingAvailableWorkers = maxDegreeOfParallelism;
                     promise._completionState = Promise.State.Resolved;
                     promise._stopExecuting = false;
@@ -260,7 +259,6 @@ namespace Proto.Promises
                     ValidateNoPending();
                     Dispose();
                     _body = default;
-                    _synchronizationContext = null;
                     _executionContext = null;
                     ObjectPool.MaybeRepool(this);
                 }
@@ -279,7 +277,7 @@ namespace Proto.Promises
                         // We add to the wait counter before we run the worker to resolve a race condition where the counter could hit zero prematurely.
                         InterlockedAddWithUnsignedOverflowCheck(ref _waitCounter, 1);
 
-                        ScheduleContextCallback(_synchronizationContext, this,
+                        ScheduleContextCallback(ContinuationContext.UnsafeAs<SynchronizationContext>(), this,
                             obj => obj.UnsafeAs<PromiseParallelForEach<TEnumerator, TParallelBody, TSource>>().ExecuteWorkerAndLaunchNext(),
                             obj => obj.UnsafeAs<PromiseParallelForEach<TEnumerator, TParallelBody, TSource>>().ExecuteWorkerAndLaunchNext()
                         );
@@ -382,7 +380,7 @@ namespace Proto.Promises
                     if (state == Promise.State.Resolved)
                     {
                         // Schedule the worker body to run again on the context, but without launching another worker.
-                        ScheduleContextCallback(_synchronizationContext, this,
+                        ScheduleContextCallback(ContinuationContext.UnsafeAs<SynchronizationContext>(), this,
                             obj => obj.UnsafeAs<PromiseParallelForEach<TEnumerator, TParallelBody, TSource>>().ExecuteWorkerWithoutLaunchNext(),
                             obj => obj.UnsafeAs<PromiseParallelForEach<TEnumerator, TParallelBody, TSource>>().ExecuteWorkerWithoutLaunchNext()
                         );

--- a/Package/Core/Promises/Internal/ParallelInternal.cs
+++ b/Package/Core/Promises/Internal/ParallelInternal.cs
@@ -374,7 +374,7 @@ namespace Proto.Promises
                 internal override void Handle(PromiseRefBase handler, Promise.State state)
                 {
                     RemoveComplete(handler);
-                    var rejectContainer = handler._rejectContainer;
+                    var rejectContainer = handler.RejectContainer;
                     handler.SuppressRejection = true;
                     handler.SetCompletionState(state);
                     handler.MaybeDispose();
@@ -456,7 +456,7 @@ namespace Proto.Promises
                     // This must be the very last thing done.
                     if (_exceptions != null)
                     {
-                        _rejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(new AggregateException(_exceptions), int.MinValue, null, this);
                         _exceptions = null;
                         HandleNextInternal(Promise.State.Rejected);
                     }

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -93,20 +93,6 @@ namespace Proto.Promises
             volatile private int _waitState; // int for Interlocked.
         }
 
-        // We union the fields together to save space.
-        // The field may contain the ExecutionContext or SynchronizationContext of the yielded `async Promise` while it is pending.
-        // When the promise is complete in a rejected state, it will contain the IRejectContainer.
-        [StructLayout(LayoutKind.Explicit)]
-        private struct ContextRejectUnion
-        {
-            // Common case this is null. If Promise.Config.AsyncFlowExecutionContextEnabled is true, this may be ExecutionContext.
-            // If an awaited Promise was configured, this may be SynchronizationContext. If both cases occurred, this will be ConfiguredAwaitDualContext.
-            [FieldOffset(0)]
-            internal object _continuationContext;
-            [FieldOffset(0)]
-            internal IRejectContainer _rejectContainer;
-        }
-
         // We add a class between HandleablePromiseBase and PromiseRefBase so that we can have a union struct field without affecting derived types sizes.
         // https://github.com/dotnet/runtime/issues/109680
 #if !PROTO_PROMISE_DEVELOPER_MODE

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -434,11 +434,11 @@ namespace Proto.Promises
 
             partial class AsyncPromiseRef<TResult> : PromiseSingleAwait<TResult>
             {
-                // TODO: change this field to object. Either store ExecutionContext or SynchronizationContext.
-                // If both contexts need to be used, use ConfiguredAsyncPromiseContinuer to wrap them both.
-                // We already null-check it, so it won't cost anything in the common case. If it's not null, then we proceed to type-check.
-                // This should improve performance of Promise.ConfigureAwait so that it can avoid allocating ConfiguredAsyncPromiseContinuer in the common case.
-                private ExecutionContext _executionContext;
+                // TODO: Share the field with IRejectContainer on the base class. A promise will never have both a continuation context and a reject container.
+
+                // Common case this is null. If Promise.Config.AsyncFlowExecutionContextEnabled is true, this may be ExecutionContext.
+                // If an awaited Promise was configured, this may be SynchronizationContext. If both cases occurred, this will be ConfiguredAwaitDualContext.
+                private object _continuationContext;
 
 #if !OPTIMIZED_ASYNC_MODE
                 partial class PromiseMethodContinuer : HandleablePromiseBase

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -130,10 +130,12 @@ namespace Proto.Promises
 
             private ContextRejectUnion _contextOrRejection;
 
-            internal ref object ContinuationContext
+            internal object ContinuationContext
             {
                 [MethodImpl(InlineOption)]
-                get => ref _contextOrRejection._continuationContext;
+                get => _contextOrRejection._continuationContext;
+                [MethodImpl(InlineOption)]
+                set => _contextOrRejection._continuationContext = value;
             }
 
             internal IRejectContainer RejectContainer

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -185,7 +185,7 @@ namespace Proto.Promises
 #if !PROTO_PROMISE_DEVELOPER_MODE
         [DebuggerNonUserCode, StackTraceHidden]
 #endif
-        internal abstract partial class PromiseRefBase : HandleablePromiseBase, ITraceable
+        internal abstract partial class PromiseRefBase : PromiseRefBaseWithStructField, ITraceable
         {
             internal void HandleSelfWithoutResult(PromiseRefBase handler, Promise.State state)
             {
@@ -243,15 +243,6 @@ namespace Proto.Promises
                 [MethodImpl(InlineOption)]
                 private set => _state = value;
             }
-
-            internal IRejectContainer RejectContainer
-            {
-                [MethodImpl(InlineOption)]
-                get => _contextOrRejection._rejectContainer;
-                [MethodImpl(InlineOption)]
-                set => _contextOrRejection._rejectContainer = value;
-            }
-
             internal bool SuppressRejection
             {
                 [MethodImpl(InlineOption)]

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -190,7 +190,7 @@ namespace Proto.Promises
             internal void HandleSelfWithoutResult(PromiseRefBase handler, Promise.State state)
             {
                 ThrowIfInPool(this);
-                _rejectContainer = handler._rejectContainer;
+                RejectContainer = handler.RejectContainer;
                 handler.SuppressRejection = true;
                 handler.MaybeDispose();
                 HandleNextInternal(state);
@@ -244,6 +244,14 @@ namespace Proto.Promises
                 private set => _state = value;
             }
 
+            internal IRejectContainer RejectContainer
+            {
+                [MethodImpl(InlineOption)]
+                get => _contextOrRejection._rejectContainer;
+                [MethodImpl(InlineOption)]
+                set => _contextOrRejection._rejectContainer = value;
+            }
+
             internal bool SuppressRejection
             {
                 [MethodImpl(InlineOption)]
@@ -267,14 +275,10 @@ namespace Proto.Promises
                 if (!WasAwaitedOrForgotten)
                 {
                     // Promise was not awaited or forgotten.
-                    string message = "A Promise's resources were garbage collected without it being awaited. You must await, return, or forget each promise. " + this;
+                    string message = $"A Promise's resources were garbage collected without it being awaited. You must await, return, or forget each promise. {this}";
                     ReportRejection(new UnobservedPromiseException(message), this);
                 }
-                if (State == Promise.State.Rejected & !SuppressRejection)
-                {
-                    // Rejection maybe wasn't caught.
-                    _rejectContainer?.ReportUnhandled();
-                }
+                MaybeReportUnhandledRejection(State);
             }
 
             [MethodImpl(InlineOption)]
@@ -326,7 +330,7 @@ namespace Proto.Promises
             protected void IncrementPromiseIdAndClearPrevious()
             {
                 IncrementPromiseId();
-                _rejectContainer = null;
+                RejectContainer = null;
                 this.SetPrevious(null);
             }
 
@@ -462,12 +466,12 @@ namespace Proto.Promises
                 return nextWaiter;
             }
 
-            private void MaybeReportUnhandledRejection(IRejectContainer rejectContainer, Promise.State state)
+            private void MaybeReportUnhandledRejection(Promise.State state)
             {
                 if (state == Promise.State.Rejected & !SuppressRejection)
                 {
                     SuppressRejection = true;
-                    rejectContainer.ReportUnhandled();
+                    RejectContainer.ReportUnhandled();
                 }
             }
 
@@ -541,7 +545,7 @@ namespace Proto.Promises
                     handler.SetCompletionState(state);
 
                     // Handler is disposed in Execute, so we need to cache the reject container in case of a RethrowException.
-                    var rejectContainer = handler._rejectContainer;
+                    var rejectContainer = handler.RejectContainer;
                     bool invokingRejected = false;
                     SetCurrentInvoker(this);
                     try
@@ -552,11 +556,11 @@ namespace Proto.Promises
                     {
                         if (invokingRejected)
                         {
-                            _rejectContainer = rejectContainer;
+                            RejectContainer = rejectContainer;
                         }
                         else
                         {
-                            _rejectContainer = CreateRejectContainer(e, int.MinValue, null, this);
+                            RejectContainer = CreateRejectContainer(e, int.MinValue, null, this);
                             state = Promise.State.Rejected;
                         }
                         HandleNextInternal(state);
@@ -567,7 +571,7 @@ namespace Proto.Promises
                     }
                     catch (Exception e)
                     {
-                        _rejectContainer = CreateRejectContainer(e, int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(e, int.MinValue, null, this);
                         HandleNextInternal(Promise.State.Rejected);
                     }
                     ClearCurrentInvoker();
@@ -645,7 +649,7 @@ namespace Proto.Promises
                         _nextBranches.Dispose();
                         // Rejection maybe wasn't caught.
                         // We handle this directly here because we don't add the PromiseForgetSentinel to this type when it is forgotten.
-                        MaybeReportUnhandledRejection(_rejectContainer, State);
+                        MaybeReportUnhandledRejection(State);
                         Dispose();
                     }
                     ObjectPool.MaybeRepool(this);
@@ -738,7 +742,7 @@ namespace Proto.Promises
                 {
                     ThrowIfInPool(this);
                     handler.SetCompletionState(state);
-                    _rejectContainer = handler._rejectContainer;
+                    RejectContainer = handler.RejectContainer;
                     handler.SuppressRejection = true;
                     _result = handler.GetResult<TResult>();
                     SetCompletionState(state);
@@ -906,7 +910,7 @@ namespace Proto.Promises
                     }
                     catch (Exception e)
                     {
-                        _rejectContainer = CreateRejectContainer(e, int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(e, int.MinValue, null, this);
                         HandleNextInternal(Promise.State.Rejected);
                     }
                     ClearCurrentInvoker();
@@ -970,7 +974,7 @@ namespace Proto.Promises
                     }
                     catch (Exception e)
                     {
-                        _rejectContainer = CreateRejectContainer(e, int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(e, int.MinValue, null, this);
                         HandleNextInternal(Promise.State.Rejected);
                     }
                     ClearCurrentInvoker();
@@ -1249,7 +1253,7 @@ namespace Proto.Promises
                     }
                     else if (state == Promise.State.Rejected)
                     {
-                        var rejectContainer = handler._rejectContainer;
+                        var rejectContainer = handler.RejectContainer;
                         handler.SuppressRejection = true;
                         handler.MaybeDispose();
                         invokingRejected = true;
@@ -1317,7 +1321,7 @@ namespace Proto.Promises
                     {
                         handler.SuppressRejection = true;
                         invokingRejected = true;
-                        rejectCallback.InvokeRejecter(handler, handler._rejectContainer, this);
+                        rejectCallback.InvokeRejecter(handler, handler.RejectContainer, this);
                     }
                     else
                     {
@@ -1363,7 +1367,7 @@ namespace Proto.Promises
                     handler.SuppressRejection = true;
                     var callback = _continuer;
                     _continuer = default;
-                    callback.Invoke(handler, handler._rejectContainer, state, this);
+                    callback.Invoke(handler, handler.RejectContainer, state, this);
                 }
             }
 
@@ -1411,7 +1415,7 @@ namespace Proto.Promises
                     var callback = _continuer;
                     _continuer = default;
                     handler.SuppressRejection = true;
-                    callback.Invoke(handler, handler._rejectContainer, state, this);
+                    callback.Invoke(handler, handler.RejectContainer, state, this);
                 }
             }
 
@@ -1452,7 +1456,7 @@ namespace Proto.Promises
                     var callback = _finalizer;
                     _finalizer = default;
                     _result = handler.GetResult<TResult>();
-                    _rejectContainer = handler._rejectContainer;
+                    RejectContainer = handler.RejectContainer;
                     handler.SuppressRejection = true;
                     handler.MaybeDispose();
                     try
@@ -1464,8 +1468,8 @@ namespace Proto.Promises
                         // Unlike normal finally clauses, we don't swallow the previous rejection. Instead, we report it.
                         if (state == Promise.State.Rejected)
                         {
-                            _rejectContainer.ReportUnhandled();
-                            _rejectContainer = null; // Null it out in case it's a canceled exception.
+                            RejectContainer.ReportUnhandled();
+                            RejectContainer = null; // Null it out in case it's a canceled exception.
                         }
                         throw;
                     }
@@ -1515,7 +1519,7 @@ namespace Proto.Promises
                     }
 
                     _result = handler.GetResult<TResult>();
-                    _rejectContainer = handler._rejectContainer;
+                    RejectContainer = handler.RejectContainer;
                     handler.SuppressRejection = true;
                     handler.MaybeDispose();
                     var callback = _finalizer;
@@ -1530,8 +1534,8 @@ namespace Proto.Promises
                         if (state == Promise.State.Rejected)
                         {
                             // Unlike normal finally clauses, we don't swallow the previous rejection. Instead, we report it.
-                            _rejectContainer.ReportUnhandled();
-                            _rejectContainer = null; // Null it out in case it's a canceled exception.
+                            RejectContainer.ReportUnhandled();
+                            RejectContainer = null; // Null it out in case it's a canceled exception.
                         }
                         throw;
                     }
@@ -1551,9 +1555,9 @@ namespace Proto.Promises
                         if (_previousState == Promise.State.Rejected)
                         {
                             // Unlike normal finally clauses, we don't swallow the previous rejection. Instead, we report it.
-                            _rejectContainer.ReportUnhandled();
+                            RejectContainer.ReportUnhandled();
                         }
-                        _rejectContainer = handler._rejectContainer;
+                        RejectContainer = handler.RejectContainer;
                     }
                     handler.SuppressRejection = true;
                     handler.MaybeDispose();

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -322,6 +322,8 @@ namespace Proto.Promises
             {
                 IncrementPromiseId();
                 RejectContainer = null;
+                // RejectContainer shares a field with ContinuationContext.
+                //ContinuationContext = null;
                 this.SetPrevious(null);
             }
 

--- a/Package/Core/Promises/Internal/PromiseRetainerInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseRetainerInternal.cs
@@ -85,7 +85,7 @@ namespace Proto.Promises
                     _nextBranches.Dispose();
                     // Rejection maybe wasn't caught.
                     // We handle this directly here because we don't add the PromiseForgetSentinel to this type when it is disposed.
-                    MaybeReportUnhandledRejection(_rejectContainer, State);
+                    MaybeReportUnhandledRejection(State);
                     Dispose();
                     ObjectPool.MaybeRepool(this);
                 }
@@ -166,7 +166,7 @@ namespace Proto.Promises
                 {
                     ThrowIfInPool(this);
                     handler.SetCompletionState(state);
-                    _rejectContainer = handler._rejectContainer;
+                    RejectContainer = handler.RejectContainer;
                     handler.SuppressRejection = true;
                     _result = handler.GetResult<TResult>();
                     SetCompletionState(state);

--- a/Package/Core/Promises/Internal/RaceInternal.cs
+++ b/Package/Core/Promises/Internal/RaceInternal.cs
@@ -56,7 +56,7 @@ namespace Proto.Promises
                     if (TrySetComplete(handler))
                     {
                         _result = handler.GetResult<TResult>();
-                        _rejectContainer = handler._rejectContainer;
+                        RejectContainer = handler.RejectContainer;
                         handler.SuppressRejection = true;
                         handler.MaybeDispose();
                         InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
@@ -111,7 +111,7 @@ namespace Proto.Promises
                     if (TrySetComplete(handler))
                     {
                         _result = index;
-                        _rejectContainer = handler._rejectContainer;
+                        RejectContainer = handler.RejectContainer;
                         handler.SuppressRejection = true;
                         handler.MaybeDispose();
                         InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
@@ -166,7 +166,7 @@ namespace Proto.Promises
                     if (TrySetComplete(handler))
                     {
                         _result = (index, handler.GetResult<TResult>());
-                        _rejectContainer = handler._rejectContainer;
+                        RejectContainer = handler.RejectContainer;
                         handler.SuppressRejection = true;
                         handler.MaybeDispose();
                         InterlockedAddWithUnsignedOverflowCheck(ref _retainCounter, -1);
@@ -236,7 +236,7 @@ namespace Proto.Promises
                     bool isComplete = state == Promise.State.Resolved
                         ? TrySetComplete(handler)
                         : RemoveWaiterAndGetIsComplete(handler);
-                    _rejectContainer = handler._rejectContainer;
+                    RejectContainer = handler.RejectContainer;
                     handler.SuppressRejection = true;
                     if (isComplete)
                     {
@@ -294,7 +294,7 @@ namespace Proto.Promises
                     bool isComplete = handler.State == Promise.State.Resolved
                         ? TrySetComplete(handler)
                         : RemoveWaiterAndGetIsComplete(handler);
-                    _rejectContainer = handler._rejectContainer;
+                    RejectContainer = handler.RejectContainer;
                     handler.SuppressRejection = true;
                     if (isComplete)
                     {
@@ -352,7 +352,7 @@ namespace Proto.Promises
                     bool isComplete = handler.State == Promise.State.Resolved
                         ? TrySetComplete(handler)
                         : RemoveWaiterAndGetIsComplete(handler);
-                    _rejectContainer = handler._rejectContainer;
+                    RejectContainer = handler.RejectContainer;
                     handler.SuppressRejection = true;
                     if (isComplete)
                     {

--- a/Package/Core/Promises/Internal/SentinelsInternal.cs
+++ b/Package/Core/Promises/Internal/SentinelsInternal.cs
@@ -13,7 +13,7 @@ namespace Proto.Promises
 {
     partial class Internal
     {
-        internal abstract partial class PromiseRefBase : HandleablePromiseBase, ITraceable
+        internal abstract partial class PromiseRefBase
         {
 #if !PROTO_PROMISE_DEVELOPER_MODE
             [DebuggerNonUserCode, StackTraceHidden]

--- a/Package/Core/Promises/PromiseStaticMergeSettled.cs
+++ b/Package/Core/Promises/PromiseStaticMergeSettled.cs
@@ -15,7 +15,7 @@ namespace Proto.Promises
     {
         [MethodImpl(Internal.InlineOption)]
         private static void GetAllResultContainer(Internal.PromiseRefBase handler, int index, ref IList<ResultContainer> result)
-            => result[index] = new ResultContainer(handler._rejectContainer, handler.State);
+            => result[index] = new ResultContainer(handler.RejectContainer, handler.State);
 
 #if NETCOREAPP || UNITY_2021_2_OR_NEWER
         private static unsafe Internal.GetResultDelegate<IList<ResultContainer>> GetAllResultContainerFunc
@@ -283,10 +283,10 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item1 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item2 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -336,10 +336,10 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item2 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -389,10 +389,10 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -447,13 +447,13 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item1 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item2 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -506,13 +506,13 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item2 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -565,13 +565,13 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -624,13 +624,13 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -687,16 +687,16 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item1 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item2 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -751,16 +751,16 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item2 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -815,16 +815,16 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -879,16 +879,16 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -944,16 +944,16 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler._rejectContainer, handler.State);
+                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1013,19 +1013,19 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item1 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item2 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1082,19 +1082,19 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item2 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1151,19 +1151,19 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1220,19 +1220,19 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1290,19 +1290,19 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler._rejectContainer, handler.State);
+                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1360,19 +1360,19 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler._rejectContainer, handler.State);
+                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new Promise<T5>.ResultContainer(handler.GetResult<T5>(), handler._rejectContainer, handler.State);
+                            result.Item5 = new Promise<T5>.ResultContainer(handler.GetResult<T5>(), handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1434,22 +1434,22 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item1 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item2 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item6 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1509,22 +1509,22 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item2 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item6 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1584,22 +1584,22 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item6 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1659,22 +1659,22 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item6 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1734,22 +1734,22 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler._rejectContainer, handler.State);
+                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item6 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1809,22 +1809,22 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler._rejectContainer, handler.State);
+                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new Promise<T5>.ResultContainer(handler.GetResult<T5>(), handler._rejectContainer, handler.State);
+                            result.Item5 = new Promise<T5>.ResultContainer(handler.GetResult<T5>(), handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item6 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1884,22 +1884,22 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler._rejectContainer, handler.State);
+                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new Promise<T5>.ResultContainer(handler.GetResult<T5>(), handler._rejectContainer, handler.State);
+                            result.Item5 = new Promise<T5>.ResultContainer(handler.GetResult<T5>(), handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new Promise<T6>.ResultContainer(handler.GetResult<T6>(), handler._rejectContainer, handler.State);
+                            result.Item6 = new Promise<T6>.ResultContainer(handler.GetResult<T6>(), handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -1963,25 +1963,25 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item1 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item2 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item6 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 6:
-                            result.Item7 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item7 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -2043,25 +2043,25 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item2 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item6 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 6:
-                            result.Item7 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item7 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -2123,25 +2123,25 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item3 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item6 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 6:
-                            result.Item7 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item7 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -2203,25 +2203,25 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item4 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item6 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 6:
-                            result.Item7 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item7 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -2283,25 +2283,25 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler._rejectContainer, handler.State);
+                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item5 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item6 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 6:
-                            result.Item7 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item7 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -2363,25 +2363,25 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler._rejectContainer, handler.State);
+                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new Promise<T5>.ResultContainer(handler.GetResult<T5>(), handler._rejectContainer, handler.State);
+                            result.Item5 = new Promise<T5>.ResultContainer(handler.GetResult<T5>(), handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item6 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                         case 6:
-                            result.Item7 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item7 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -2443,25 +2443,25 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler._rejectContainer, handler.State);
+                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new Promise<T5>.ResultContainer(handler.GetResult<T5>(), handler._rejectContainer, handler.State);
+                            result.Item5 = new Promise<T5>.ResultContainer(handler.GetResult<T5>(), handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new Promise<T6>.ResultContainer(handler.GetResult<T6>(), handler._rejectContainer, handler.State);
+                            result.Item6 = new Promise<T6>.ResultContainer(handler.GetResult<T6>(), handler.RejectContainer, handler.State);
                             break;
                         case 6:
-                            result.Item7 = new ResultContainer(handler._rejectContainer, handler.State);
+                            result.Item7 = new ResultContainer(handler.RejectContainer, handler.State);
                             break;
                     }
                 }
@@ -2523,25 +2523,25 @@ namespace Proto.Promises
                     switch (index)
                     {
                         case 0:
-                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler._rejectContainer, handler.State);
+                            result.Item1 = new Promise<T1>.ResultContainer(handler.GetResult<T1>(), handler.RejectContainer, handler.State);
                             break;
                         case 1:
-                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler._rejectContainer, handler.State);
+                            result.Item2 = new Promise<T2>.ResultContainer(handler.GetResult<T2>(), handler.RejectContainer, handler.State);
                             break;
                         case 2:
-                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler._rejectContainer, handler.State);
+                            result.Item3 = new Promise<T3>.ResultContainer(handler.GetResult<T3>(), handler.RejectContainer, handler.State);
                             break;
                         case 3:
-                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler._rejectContainer, handler.State);
+                            result.Item4 = new Promise<T4>.ResultContainer(handler.GetResult<T4>(), handler.RejectContainer, handler.State);
                             break;
                         case 4:
-                            result.Item5 = new Promise<T5>.ResultContainer(handler.GetResult<T5>(), handler._rejectContainer, handler.State);
+                            result.Item5 = new Promise<T5>.ResultContainer(handler.GetResult<T5>(), handler.RejectContainer, handler.State);
                             break;
                         case 5:
-                            result.Item6 = new Promise<T6>.ResultContainer(handler.GetResult<T6>(), handler._rejectContainer, handler.State);
+                            result.Item6 = new Promise<T6>.ResultContainer(handler.GetResult<T6>(), handler.RejectContainer, handler.State);
                             break;
                         case 6:
-                            result.Item7 = new Promise<T7>.ResultContainer(handler.GetResult<T7>(), handler._rejectContainer, handler.State);
+                            result.Item7 = new Promise<T7>.ResultContainer(handler.GetResult<T7>(), handler.RejectContainer, handler.State);
                             break;
                     }
                 }

--- a/Package/Core/Promises/PromiseTStatic.cs
+++ b/Package/Core/Promises/PromiseTStatic.cs
@@ -604,7 +604,7 @@ namespace Proto.Promises
 
         [MethodImpl(Internal.InlineOption)]
         private static void GetAllResultContainer(Internal.PromiseRefBase handler, int index, ref IList<ResultContainer> result)
-            => result[index] = new ResultContainer(handler.GetResult<T>(), handler._rejectContainer, handler.State);
+            => result[index] = new ResultContainer(handler.GetResult<T>(), handler.RejectContainer, handler.State);
         
 #if NETCOREAPP || UNITY_2021_2_OR_NEWER
         private static unsafe Internal.GetResultDelegate<IList<ResultContainer>> GetAllResultContainerFunc

--- a/Package/Core/Threading/Internal/AsyncLockInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncLockInternal.cs
@@ -211,7 +211,7 @@ namespace Proto.Promises
                 void IAsyncLockPromise.Reject(IRejectContainer rejectContainer)
                 {
                     _cancelationRegistration.Dispose();
-                    _rejectContainer = rejectContainer;
+                    RejectContainer = rejectContainer;
                     _tempState = Promise.State.Rejected;
                     // Notify the lock so this will be placed on the ready queue to re-acquire the lock before continuing.
                     _lock.NotifyAbandonedConditionVariable(this);

--- a/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
@@ -79,7 +79,7 @@ namespace Proto.Promises
                 internal void Reject(IRejectContainer rejectContainer)
                 {
                     _cancelationRegistration.Dispose();
-                    _rejectContainer = rejectContainer;
+                    RejectContainer = rejectContainer;
                     _tempState = Promise.State.Rejected;
                     Continue();
                 }

--- a/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
@@ -22,7 +22,6 @@ namespace Proto.Promises
 #endif
             internal abstract class AsyncSynchronizationPromiseBase<TResult> : PromiseSingleAwait<TResult>, ICancelable
             {
-                private SynchronizationContext _continuationContext;
                 protected CancelationRegistration _cancelationRegistration;
                 // We have to store the state in a separate field until the next awaiter is ready to be invoked on the proper context.
                 protected Promise.State _tempState;
@@ -31,7 +30,7 @@ namespace Proto.Promises
                 protected void Reset(bool continueOnCapturedContext)
                 {
                     Reset();
-                    _continuationContext = continueOnCapturedContext ? ContinuationOptions.CaptureContext() : null;
+                    ContinuationContext = continueOnCapturedContext ? ContinuationOptions.CaptureContext() : null;
                     // Assume the resolved state will occur. If this is actually canceled or rejected, the state will be set at that time.
                     _tempState = Promise.State.Resolved;
                 }
@@ -39,21 +38,23 @@ namespace Proto.Promises
                 new protected void Dispose()
                 {
                     base.Dispose();
-                    _continuationContext = null;
                     _cancelationRegistration = default;
                 }
 
+                [MethodImpl(InlineOption)]
                 protected void Continue()
+                    => Continue(ContinuationContext);
+
+                private void Continue(object continuationContext)
                 {
-                    var context = _continuationContext;
-                    if (context == null)
+                    if (continuationContext == null)
                     {
                         // This was configured to continue synchronously.
                         HandleNextInternal(_tempState);
                         return;
                     }
                     // This was configured to continuation on the context.
-                    ScheduleContextCallback(context, this,
+                    ScheduleContextCallback(continuationContext.UnsafeAs<SynchronizationContext>(), this,
                         obj => obj.UnsafeAs<AsyncSynchronizationPromiseBase<TResult>>().HandleFromContext(),
                         obj => obj.UnsafeAs<AsyncSynchronizationPromiseBase<TResult>>().HandleFromContext()
                     );
@@ -79,9 +80,11 @@ namespace Proto.Promises
                 internal void Reject(IRejectContainer rejectContainer)
                 {
                     _cancelationRegistration.Dispose();
+                    // ContinuationContext shares a field with RejectContainer, so we have to read it before writing.
+                    var continuationContext = ContinuationContext;
                     RejectContainer = rejectContainer;
                     _tempState = Promise.State.Rejected;
-                    Continue();
+                    Continue(continuationContext);
                 }
 
                 internal void CancelDirect()

--- a/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
@@ -53,7 +53,7 @@ namespace Proto.Promises
                         HandleNextInternal(_tempState);
                         return;
                     }
-                    // This was configured to continuation on the context.
+                    // This was configured to continue on the context.
                     ScheduleContextCallback(continuationContext.UnsafeAs<SynchronizationContext>(), this,
                         obj => obj.UnsafeAs<AsyncSynchronizationPromiseBase<TResult>>().HandleFromContext(),
                         obj => obj.UnsafeAs<AsyncSynchronizationPromiseBase<TResult>>().HandleFromContext()

--- a/Package/Core/Utilities/Internal/AsyncLazyInternal.cs
+++ b/Package/Core/Utilities/Internal/AsyncLazyInternal.cs
@@ -143,7 +143,7 @@ namespace Proto.Promises
             {
                 handler.SetCompletionState(state);
                 _result = handler.GetResult<T>();
-                _rejectContainer = handler._rejectContainer;
+                RejectContainer = handler.RejectContainer;
                 handler.SuppressRejection = true;
                 handler.MaybeDispose();
                 OnComplete(state);
@@ -260,7 +260,7 @@ namespace Proto.Promises
             {
                 handler.SetCompletionState(state);
                 _result = handler.GetResult<T>();
-                _rejectContainer = handler._rejectContainer;
+                RejectContainer = handler.RejectContainer;
                 handler.SuppressRejection = true;
                 handler.MaybeDispose();
                 OnComplete(state);
@@ -335,7 +335,7 @@ namespace Proto.Promises
                     }
                     catch (Exception e)
                     {
-                        _rejectContainer = CreateRejectContainer(e, int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(e, int.MinValue, null, this);
                         OnComplete(Promise.State.Rejected);
                     }
                     ClearCurrentInvoker();
@@ -356,7 +356,7 @@ namespace Proto.Promises
                     }
                     catch (Exception e)
                     {
-                        _rejectContainer = CreateRejectContainer(e, int.MinValue, null, this);
+                        RejectContainer = CreateRejectContainer(e, int.MinValue, null, this);
                         OnComplete(Promise.State.Rejected);
                     }
                     ClearCurrentInvoker();
@@ -382,7 +382,7 @@ namespace Proto.Promises
                     {
                         var state = handler.State;
                         _owner._result = handler.GetResult<TResult>();
-                        _owner._rejectContainer = handler._rejectContainer;
+                        _owner.RejectContainer = handler.RejectContainer;
                         _owner.SuppressRejection = true;
                         handler.MaybeDispose();
                         _owner.OnComplete(state);

--- a/Package/Tests/CoreTests/APIs/ConfigureAwaitTests.cs
+++ b/Package/Tests/CoreTests/APIs/ConfigureAwaitTests.cs
@@ -45,8 +45,9 @@ namespace ProtoPromiseTests.APIs
             foreach (CompletedContinuationBehavior completedBehavior in Enum.GetValues(typeof(CompletedContinuationBehavior)))
             foreach (bool alreadyComplete in new[] { true, false })
             foreach (SynchronizationType completeContext in alreadyComplete ? foregroundOnlyContext : completeContexts)
+            foreach (bool asyncFlowExecutionContext in new[] { true, false })
             {
-                yield return new TestCaseData(completeType, continuationContext, completedBehavior, alreadyComplete, completeContext);
+                yield return new TestCaseData(completeType, continuationContext, completedBehavior, alreadyComplete, completeContext, asyncFlowExecutionContext);
             }
         }
 
@@ -56,8 +57,12 @@ namespace ProtoPromiseTests.APIs
             SynchronizationType continuationContext,
             CompletedContinuationBehavior completedBehavior,
             bool alreadyComplete,
-            SynchronizationType completeContext)
+            SynchronizationType completeContext,
+            bool asyncFlowExecutionContext)
         {
+            // Normally AsyncFlowExecutionContextEnabled cannot be disabled after it is enabled, but we need to test both configurations.
+            Promise.Config.s_asyncFlowExecutionContextEnabled = asyncFlowExecutionContext;
+
             var foregroundThread = Thread.CurrentThread;
             var threadHelper = new ThreadHelper();
 
@@ -108,8 +113,12 @@ namespace ProtoPromiseTests.APIs
             SynchronizationType continuationContext,
             CompletedContinuationBehavior completedBehavior,
             bool alreadyComplete,
-            SynchronizationType completeContext)
+            SynchronizationType completeContext,
+            bool asyncFlowExecutionContext)
         {
+            // Normally AsyncFlowExecutionContextEnabled cannot be disabled after it is enabled, but we need to test both configurations.
+            Promise.Config.s_asyncFlowExecutionContextEnabled = asyncFlowExecutionContext;
+
             var foregroundThread = Thread.CurrentThread;
             var threadHelper = new ThreadHelper();
 
@@ -162,8 +171,12 @@ namespace ProtoPromiseTests.APIs
 #endif
             )] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values] bool alreadyComplete)
+            [Values] bool alreadyComplete,
+            [Values] bool asyncFlowExecutionContext)
         {
+            // Normally AsyncFlowExecutionContextEnabled cannot be disabled after it is enabled, but we need to test both configurations.
+            Promise.Config.s_asyncFlowExecutionContextEnabled = asyncFlowExecutionContext;
+
             var foregroundThread = Thread.CurrentThread;
             var continuationOptions = TestHelper.GetContinuationOptions(continuationContext, completedBehavior);
 
@@ -219,8 +232,12 @@ namespace ProtoPromiseTests.APIs
 #endif
             )] SynchronizationType continuationContext,
             [Values] CompletedContinuationBehavior completedBehavior,
-            [Values] bool alreadyComplete)
+            [Values] bool alreadyComplete,
+            [Values] bool asyncFlowExecutionContext)
         {
+            // Normally AsyncFlowExecutionContextEnabled cannot be disabled after it is enabled, but we need to test both configurations.
+            Promise.Config.s_asyncFlowExecutionContextEnabled = asyncFlowExecutionContext;
+
             var foregroundThread = Thread.CurrentThread;
             var continuationOptions = TestHelper.GetContinuationOptions(continuationContext, completedBehavior);
 


### PR DESCRIPTION
- `Promise(<T>).ConfigureAwait(ContinuationOptions)` consumes no memory if `Promise.Config.AsyncFlowExecutionContextEnabled` is disabled.
- Unioned together some fields to reduce size of `async Promise(<T>)`, async synchronization primitive promises, and `Promise.ParallelFor*`.

develop:

| Type         | Pending | Allocated | Survived |
|------------- |-------- |----------:|---------:|
| AsyncAwait   | True    |         - |    648 B |
|              |         |           |          |
| ContinueWith | True    |         - |    336 B |

PR:

| Type         | Pending | Allocated | Survived |
|------------- |-------- |----------:|---------:|
| AsyncAwait   | True    |         - |    624 B |
|              |         |           |          |
| ContinueWith | True    |         - |    336 B |