### PR TITLE
Optimize object pool contention

### DIFF
--- a/Package/Core/Collections/Internal/ConcurrentQueueSegmentInternal.cs
+++ b/Package/Core/Collections/Internal/ConcurrentQueueSegmentInternal.cs
@@ -219,11 +219,7 @@ namespace Proto.Promises.Collections
                     // situation since this thread is waiting for another to write to the slot and
                     // this thread may have to check the same slot multiple times. Spin-wait to avoid
                     // a potential busy-wait, and then try again.
-#if NETCOREAPP3_0_OR_GREATER
                     spinner.SpinOnce(sleep1Threshold: -1);
-#else
-                    spinner.SpinOnce();
-#endif
                 }
                 else
                 {
@@ -292,11 +288,7 @@ namespace Proto.Promises.Collections
                     // situation since this thread is waiting for another to write to the slot and
                     // this thread may have to check the same slot multiple times. Spin-wait to avoid
                     // a potential busy-wait, and then try again.
-#if NETCOREAPP3_0_OR_GREATER
                     spinner.SpinOnce(sleep1Threshold: -1);
-#else
-                    spinner.SpinOnce();
-#endif
                 }
                 else
                 {

--- a/Package/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/Package/Core/InternalShared/HelperFunctionsInternal.cs
@@ -245,5 +245,12 @@ namespace Proto.Promises
                 list.RemoveAt(--listCount);
             }
         }
+
+        // SpinWait.SpinOnce(int sleep1Threshold) API was added in netcoreapp3.0. We just route it to SpinOnce() for older runtimes.
+#if !NETCOREAPP3_0_OR_GREATER
+        [MethodImpl(InlineOption)]
+        internal static void SpinOnce(this ref SpinWait spinner, int sleep1Threshold)
+            => spinner.SpinOnce();
+#endif
     } // class Internal
 } // namespace Proto.Promises

--- a/Package/Core/InternalShared/ValueCollectionsInternal.cs
+++ b/Package/Core/InternalShared/ValueCollectionsInternal.cs
@@ -225,7 +225,7 @@ namespace Proto.Promises
             {
                 AssertNotInCollection(item);
 
-                _locker.Enter();
+                _locker.EnterWithoutSleep1();
                 item._next = _head;
                 _head = item;
                 _locker.Exit();
@@ -235,7 +235,7 @@ namespace Proto.Promises
             internal HandleablePromiseBase PopOrInvalid()
             {
                 // We use InvalidAwaitSentinel as the sentinel, so we don't need a branch here to check the bottom of the stack, because it references itself.
-                _locker.Enter();
+                _locker.EnterWithoutSleep1();
                 var head = _head;
                 _head = head._next;
                 _locker.Exit();


### PR DESCRIPTION
Pass `sleep1Threshold: -1` to `SpinWait.SpinOnce` when there is contention on the object pool.