### PR TITLE
Use `RuntimeHelpers.IsReferenceOrContainsReferences`

### DIFF
--- a/Package/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/Package/Core/Cancelations/Internal/CancelationInternal.cs
@@ -700,7 +700,7 @@ namespace Proto.Promises
                     {
                         ++_nodeId;
                     }
-                    _cancelable = default;
+                    ClearReferences(ref _cancelable);
                     ObjectPool.MaybeRepool(this);
                 }
             } // class CallbackNodeImpl<TCancelable>

--- a/Package/Core/Collections/Internal/ConcurrentQueueSegmentInternal.cs
+++ b/Package/Core/Collections/Internal/ConcurrentQueueSegmentInternal.cs
@@ -149,7 +149,7 @@ namespace Proto.Promises.Collections
             Slot[] slots = _slots;
 
             // Loop in case of contention...
-            SpinWait spinner = default;
+            var spinner = new SpinWait();
             while (true)
             {
                 // Get the head at which to try to dequeue.
@@ -183,11 +183,7 @@ namespace Proto.Promises.Collections
                             // peeking.  And we don't update the sequence number,
                             // so that an enqueuer will see it as full and be forced to move to a new segment.
 
-                            // TODO
-                            //if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                            {
-                                slots[slotsIndex].item = default;
-                            }
+                            Internal.ClearReferences(ref slots[slotsIndex].item);
                             Volatile.Write(ref slots[slotsIndex].sequenceNumber, currentHead + slots.Length);
                         }
                         return true;
@@ -247,7 +243,7 @@ namespace Proto.Promises.Collections
             Slot[] slots = _slots;
 
             // Loop in case of contention...
-            SpinWait spinner = default;
+            var spinner = new SpinWait();
             while (true)
             {
                 // Get the head at which to try to peek.

--- a/Package/Core/Collections/Internal/PoolBackedConcurrentQueueInternal.cs
+++ b/Package/Core/Collections/Internal/PoolBackedConcurrentQueueInternal.cs
@@ -203,7 +203,7 @@ namespace Proto.Promises.Collections
         {
             get
             {
-                SpinWait spinner = default;
+                var spinner = new SpinWait();
                 while (true)
                 {
                     // Capture the head and tail, as well as the head's head and tail.

--- a/Package/Core/Collections/TempCollection.cs
+++ b/Package/Core/Collections/TempCollection.cs
@@ -278,7 +278,7 @@ namespace Proto.Promises.Collections
 
         internal void SetCapacityNoCopy(int capacity)
         {
-            Array.Clear(_items, 0, _count);
+            Internal.ClearReferences(_items, 0, _count);
             ArrayPool<T>.Shared.Return(_items, false);
             _items = ArrayPool<T>.Shared.Rent(capacity);
         }
@@ -287,7 +287,7 @@ namespace Proto.Promises.Collections
         {
             var newStorage = ArrayPool<T>.Shared.Rent(capacity);
             _items.CopyTo(newStorage, 0);
-            Array.Clear(_items, 0, _count);
+            Internal.ClearReferences(_items, 0, _count);
             ArrayPool<T>.Shared.Return(_items, false);
             _items = newStorage;
         }
@@ -312,7 +312,7 @@ namespace Proto.Promises.Collections
 
         internal void Clear()
         {
-            Array.Clear(_items, 0, _count);
+            Internal.ClearReferences(_items, 0, _count);
             _count = 0;
         }
 
@@ -323,7 +323,7 @@ namespace Proto.Promises.Collections
             _disposedChecker._isDisposed = true;
             Internal.Discard(_disposedChecker);
 #endif
-            Array.Clear(_items, 0, _count);
+            Internal.ClearReferences(_items, 0, _count);
             ArrayPool<T>.Shared.Return(_items, false);
             this = default;
         }

--- a/Package/Core/Collections/TempCollection.cs
+++ b/Package/Core/Collections/TempCollection.cs
@@ -276,29 +276,18 @@ namespace Proto.Promises.Collections
 #endif
         }
 
-        internal void SetCapacityNoCopy(int capacity)
-        {
-            Internal.ClearReferences(_items, 0, _count);
-            ArrayPool<T>.Shared.Return(_items, false);
-            _items = ArrayPool<T>.Shared.Rent(capacity);
-        }
-
-        internal void SetCapacityAndCopy(int capacity)
-        {
-            var newStorage = ArrayPool<T>.Shared.Rent(capacity);
-            _items.CopyTo(newStorage, 0);
-            Internal.ClearReferences(_items, 0, _count);
-            ArrayPool<T>.Shared.Return(_items, false);
-            _items = newStorage;
-        }
-
         internal void EnsureCapacity(int capacity)
         {
             if (capacity <= _items.Length)
             {
                 return;
             }
-            SetCapacityAndCopy(capacity);
+
+            var newStorage = ArrayPool<T>.Shared.Rent(capacity);
+            _items.CopyTo(newStorage, 0);
+            Internal.ClearReferences(_items, 0, _count);
+            ArrayPool<T>.Shared.Return(_items, false);
+            _items = newStorage;
         }
 
         internal void Add(T item)

--- a/Package/Core/ForOldRuntime/Span/SpanExtensions.cs
+++ b/Package/Core/ForOldRuntime/Span/SpanExtensions.cs
@@ -22,6 +22,9 @@ namespace Proto.Promises
         // AsSpan extension exists in netstandard2.1 and in the Span nuget package. We only add this in Unity where we're not using nuget packages.
         public static Span<T> AsSpan<T>(this T[] array, int start)
             => new Span<T>(array, start, array.Length);
+            
+        public static Span<T> AsSpan<T>(this T[] array)
+            => new Span<T>(array, 0, array.Length);
 #endif
     }
 }

--- a/Package/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/Package/Core/InternalShared/HelperFunctionsInternal.cs
@@ -252,5 +252,27 @@ namespace Proto.Promises
         internal static void SpinOnce(this ref SpinWait spinner, int sleep1Threshold)
             => spinner.SpinOnce();
 #endif
+
+        [MethodImpl(InlineOption)]
+        internal static void ClearReferences<T>(ref T location)
+        {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP || UNITY_2021_2_OR_NEWER
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+#endif
+            {
+                location = default;
+            }
+        }
+
+        [MethodImpl(InlineOption)]
+        internal static void ClearReferences<T>(T[] array, int index, int length)
+        {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP || UNITY_2021_2_OR_NEWER
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+#endif
+            {
+                Array.Clear(array, index, length);
+            }
+        }
     } // class Internal
 } // namespace Proto.Promises

--- a/Package/Core/InternalShared/ValueCollectionsInternal.cs
+++ b/Package/Core/InternalShared/ValueCollectionsInternal.cs
@@ -508,7 +508,7 @@ namespace Proto.Promises
             internal void Clear()
             {
                 _count = 0;
-                Array.Clear(_storage, 0, _storage.Length);
+                ClearReferences(_storage, 0, _storage.Length);
             }
         }
     } // class Internal

--- a/Package/Core/Linq/Generators/Repeat.cs
+++ b/Package/Core/Linq/Generators/Repeat.cs
@@ -122,7 +122,7 @@ namespace Proto.Promises
             {
                 PrepareEarlyDispose();
                 base.Dispose();
-                _current = default;
+                ClearReferences(ref _current);
                 _disposed = true;
                 ObjectPool.MaybeRepool(this);
             }

--- a/Package/Core/Linq/Generators/Return.cs
+++ b/Package/Core/Linq/Generators/Return.cs
@@ -93,7 +93,7 @@ namespace Proto.Promises
             {
                 PrepareEarlyDispose();
                 base.Dispose();
-                _current = default;
+                ClearReferences(ref _current);
                 _disposed = true;
                 ObjectPool.MaybeRepool(this);
             }

--- a/Package/Core/Linq/Internal/AggregateByInternal.cs
+++ b/Package/Core/Linq/Internal/AggregateByInternal.cs
@@ -48,7 +48,6 @@ namespace Proto.Promises
                     // We need to propagate the token that was passed in, so we assign it before starting iteration.
                     _asyncEnumerator._target._cancelationToken = cancelationToken;
 
-                    LookupSingleValue<TKey, TAccumulate, TEqualityComparer> dict = default;
                     try
                     {
                         // Make sure at least 1 element exists before creating the dictionary.
@@ -57,28 +56,29 @@ namespace Proto.Promises
                             return;
                         }
 
-                        dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer);
-                        do
+                        using (var dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer))
                         {
-                            var element = _asyncEnumerator.Current;
-                            var accNode = dict.GetOrCreateNode(_keySelector.Invoke(element), out bool exists);
-                            accNode._value = _accumulator.Invoke(exists ? accNode._value : _seed, element);
-                        } while (await _asyncEnumerator.MoveNextAsync());
+                            do
+                            {
+                                var element = _asyncEnumerator.Current;
+                                var accNode = dict.GetOrCreateNode(_keySelector.Invoke(element), out bool exists);
+                                accNode._value = _accumulator.Invoke(exists ? accNode._value : _seed, element);
+                            } while (await _asyncEnumerator.MoveNextAsync());
 
-                        // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var node = dict._lastNode;
-                        do
-                        {
-                            node = node._nextNode;
-                            await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
-                        } while (node != dict._lastNode);
+                            // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var node = dict._lastNode;
+                            do
+                            {
+                                node = node._nextNode;
+                                await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
+                            } while (node != dict._lastNode);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
                     }
                     finally
                     {
-                        dict.Dispose();
                         await _asyncEnumerator.DisposeAsync();
                     }
                 }
@@ -125,7 +125,6 @@ namespace Proto.Promises
                     // We need to propagate the token that was passed in, so we assign it before starting iteration.
                     _asyncEnumerator._target._cancelationToken = cancelationToken;
 
-                    LookupSingleValue<TKey, TAccumulate, TEqualityComparer> dict = default;
                     try
                     {
                         // Make sure at least 1 element exists before creating the dictionary.
@@ -134,28 +133,29 @@ namespace Proto.Promises
                             return;
                         }
 
-                        dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer);
-                        do
+                        using (var dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer))
                         {
-                            var element = _asyncEnumerator.Current;
-                            var accNode = dict.GetOrCreateNode(await _keySelector.Invoke(element), out bool exists);
-                            accNode._value = await _accumulator.Invoke(exists ? accNode._value : _seed, element);
-                        } while (await _asyncEnumerator.MoveNextAsync());
+                            do
+                            {
+                                var element = _asyncEnumerator.Current;
+                                var accNode = dict.GetOrCreateNode(await _keySelector.Invoke(element), out bool exists);
+                                accNode._value = await _accumulator.Invoke(exists ? accNode._value : _seed, element);
+                            } while (await _asyncEnumerator.MoveNextAsync());
 
-                        // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var node = dict._lastNode;
-                        do
-                        {
-                            node = node._nextNode;
-                            await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
-                        } while (node != dict._lastNode);
+                            // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var node = dict._lastNode;
+                            do
+                            {
+                                node = node._nextNode;
+                                await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
+                            } while (node != dict._lastNode);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
                     }
                     finally
                     {
-                        dict.Dispose();
                         await _asyncEnumerator.DisposeAsync();
                     }
                 }
@@ -202,7 +202,6 @@ namespace Proto.Promises
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
                     var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
-                    LookupSingleValue<TKey, TAccumulate, TEqualityComparer> dict = default;
                     try
                     {
                         // Make sure at least 1 element exists before creating the dictionary.
@@ -211,21 +210,23 @@ namespace Proto.Promises
                             return;
                         }
 
-                        dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer);
-                        do
+                        using (var dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer))
                         {
-                            var element = _configuredAsyncEnumerator.Current;
-                            var accNode = dict.GetOrCreateNode(_keySelector.Invoke(element), out bool exists);
-                            accNode._value = _accumulator.Invoke(exists ? accNode._value : _seed, element);
-                        } while (await _configuredAsyncEnumerator.MoveNextAsync());
+                            do
+                            {
+                                var element = _configuredAsyncEnumerator.Current;
+                                var accNode = dict.GetOrCreateNode(_keySelector.Invoke(element), out bool exists);
+                                accNode._value = _accumulator.Invoke(exists ? accNode._value : _seed, element);
+                            } while (await _configuredAsyncEnumerator.MoveNextAsync());
 
-                        // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var node = dict._lastNode;
-                        do
-                        {
-                            node = node._nextNode;
-                            await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
-                        } while (node != dict._lastNode);
+                            // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var node = dict._lastNode;
+                            do
+                            {
+                                node = node._nextNode;
+                                await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
+                            } while (node != dict._lastNode);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
@@ -233,7 +234,6 @@ namespace Proto.Promises
                     finally
                     {
                         joinedCancelationSource.TryDispose();
-                        dict.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -281,7 +281,6 @@ namespace Proto.Promises
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
                     var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
-                    LookupSingleValue<TKey, TAccumulate, TEqualityComparer> dict = default;
                     try
                     {
                         // Make sure at least 1 element exists before creating the dictionary.
@@ -290,23 +289,25 @@ namespace Proto.Promises
                             return;
                         }
 
-                        dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer);
-                        do
+                        using (var dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer))
                         {
-                            var element = _configuredAsyncEnumerator.Current;
-                            // The key selector function could have switched context, make sure we're on the configured context before invoking the comparer and accumulator.
-                            var key = await _keySelector.Invoke(element).ConfigureAwait(_configuredAsyncEnumerator.ContinuationOptions);
-                            var accNode = dict.GetOrCreateNode(key, out bool exists);
-                            accNode._value = await _accumulator.Invoke(exists ? accNode._value : _seed, element);
-                        } while (await _configuredAsyncEnumerator.MoveNextAsync());
+                            do
+                            {
+                                var element = _configuredAsyncEnumerator.Current;
+                                // The key selector function could have switched context, make sure we're on the configured context before invoking the comparer and accumulator.
+                                var key = await _keySelector.Invoke(element).ConfigureAwait(_configuredAsyncEnumerator.ContinuationOptions);
+                                var accNode = dict.GetOrCreateNode(key, out bool exists);
+                                accNode._value = await _accumulator.Invoke(exists ? accNode._value : _seed, element);
+                            } while (await _configuredAsyncEnumerator.MoveNextAsync());
 
-                        // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var node = dict._lastNode;
-                        do
-                        {
-                            node = node._nextNode;
-                            await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
-                        } while (node != dict._lastNode);
+                            // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var node = dict._lastNode;
+                            do
+                            {
+                                node = node._nextNode;
+                                await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
+                            } while (node != dict._lastNode);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
@@ -314,7 +315,6 @@ namespace Proto.Promises
                     finally
                     {
                         joinedCancelationSource.TryDispose();
-                        dict.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -369,7 +369,6 @@ namespace Proto.Promises
                     // We need to propagate the token that was passed in, so we assign it before starting iteration.
                     _asyncEnumerator._target._cancelationToken = cancelationToken;
 
-                    LookupSingleValue<TKey, TAccumulate, TEqualityComparer> dict = default;
                     try
                     {
                         // Make sure at least 1 element exists before creating the dictionary.
@@ -378,29 +377,30 @@ namespace Proto.Promises
                             return;
                         }
 
-                        dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer);
-                        do
+                        using (var dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer))
                         {
-                            var element = _asyncEnumerator.Current;
-                            var key = _keySelector.Invoke(element);
-                            var accNode = dict.GetOrCreateNode(key, out bool exists);
-                            accNode._value = _accumulator.Invoke(exists ? accNode._value : _seedSelector.Invoke(key), element);
-                        } while (await _asyncEnumerator.MoveNextAsync());
+                            do
+                            {
+                                var element = _asyncEnumerator.Current;
+                                var key = _keySelector.Invoke(element);
+                                var accNode = dict.GetOrCreateNode(key, out bool exists);
+                                accNode._value = _accumulator.Invoke(exists ? accNode._value : _seedSelector.Invoke(key), element);
+                            } while (await _asyncEnumerator.MoveNextAsync());
 
-                        // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var node = dict._lastNode;
-                        do
-                        {
-                            node = node._nextNode;
-                            await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
-                        } while (node != dict._lastNode);
+                            // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var node = dict._lastNode;
+                            do
+                            {
+                                node = node._nextNode;
+                                await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
+                            } while (node != dict._lastNode);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
                     }
                     finally
                     {
-                        dict.Dispose();
                         await _asyncEnumerator.DisposeAsync();
                     }
                 }
@@ -450,7 +450,6 @@ namespace Proto.Promises
                     // We need to propagate the token that was passed in, so we assign it before starting iteration.
                     _asyncEnumerator._target._cancelationToken = cancelationToken;
 
-                    LookupSingleValue<TKey, TAccumulate, TEqualityComparer> dict = default;
                     try
                     {
                         // Make sure at least 1 element exists before creating the dictionary.
@@ -459,29 +458,30 @@ namespace Proto.Promises
                             return;
                         }
 
-                        dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer);
-                        do
+                        using (var dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer))
                         {
-                            var element = _asyncEnumerator.Current;
-                            var key = await _keySelector.Invoke(element);
-                            var accNode = dict.GetOrCreateNode(key, out bool exists);
-                            accNode._value = await _accumulator.Invoke(exists ? accNode._value : await _seedSelector.Invoke(key), element);
-                        } while (await _asyncEnumerator.MoveNextAsync());
+                            do
+                            {
+                                var element = _asyncEnumerator.Current;
+                                var key = await _keySelector.Invoke(element);
+                                var accNode = dict.GetOrCreateNode(key, out bool exists);
+                                accNode._value = await _accumulator.Invoke(exists ? accNode._value : await _seedSelector.Invoke(key), element);
+                            } while (await _asyncEnumerator.MoveNextAsync());
 
-                        // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var node = dict._lastNode;
-                        do
-                        {
-                            node = node._nextNode;
-                            await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
-                        } while (node != dict._lastNode);
+                            // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var node = dict._lastNode;
+                            do
+                            {
+                                node = node._nextNode;
+                                await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
+                            } while (node != dict._lastNode);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
                     }
                     finally
                     {
-                        dict.Dispose();
                         await _asyncEnumerator.DisposeAsync();
                     }
                 }
@@ -531,7 +531,6 @@ namespace Proto.Promises
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
                     var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
-                    LookupSingleValue<TKey, TAccumulate, TEqualityComparer> dict = default;
                     try
                     {
                         // Make sure at least 1 element exists before creating the dictionary.
@@ -540,22 +539,24 @@ namespace Proto.Promises
                             return;
                         }
 
-                        dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer);
-                        do
+                        using (var dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer))
                         {
-                            var element = _configuredAsyncEnumerator.Current;
-                            var key = _keySelector.Invoke(element);
-                            var accNode = dict.GetOrCreateNode(key, out bool exists);
-                            accNode._value = _accumulator.Invoke(exists ? accNode._value : _seedSelector.Invoke(key), element);
-                        } while (await _configuredAsyncEnumerator.MoveNextAsync());
+                            do
+                            {
+                                var element = _configuredAsyncEnumerator.Current;
+                                var key = _keySelector.Invoke(element);
+                                var accNode = dict.GetOrCreateNode(key, out bool exists);
+                                accNode._value = _accumulator.Invoke(exists ? accNode._value : _seedSelector.Invoke(key), element);
+                            } while (await _configuredAsyncEnumerator.MoveNextAsync());
 
-                        // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var node = dict._lastNode;
-                        do
-                        {
-                            node = node._nextNode;
-                            await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
-                        } while (node != dict._lastNode);
+                            // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var node = dict._lastNode;
+                            do
+                            {
+                                node = node._nextNode;
+                                await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
+                            } while (node != dict._lastNode);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
@@ -563,7 +564,6 @@ namespace Proto.Promises
                     finally
                     {
                         joinedCancelationSource.TryDispose();
-                        dict.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -613,7 +613,6 @@ namespace Proto.Promises
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
                     var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
-                    LookupSingleValue<TKey, TAccumulate, TEqualityComparer> dict = default;
                     try
                     {
                         // Make sure at least 1 element exists before creating the dictionary.
@@ -622,33 +621,35 @@ namespace Proto.Promises
                             return;
                         }
 
-                        dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer);
-                        do
+                        using (var dict = new LookupSingleValue<TKey, TAccumulate, TEqualityComparer>(_comparer))
                         {
-                            var element = _configuredAsyncEnumerator.Current;
-                            // The key selector function could have switched context, make sure we're on the configured context before invoking the comparer and seed selector.
-                            var key = await _keySelector.Invoke(element).ConfigureAwait(_configuredAsyncEnumerator.ContinuationOptions);
-                            var accNode = dict.GetOrCreateNode(key, out bool exists);
-                            TAccumulate acc;
-                            if (exists)
+                            do
                             {
-                                acc = accNode._value;
-                            }
-                            else
-                            {
-                                // The seed selector function could have switched context, make sure we're on the configured context before invoking the accumulator.
-                                acc = await _seedSelector.Invoke(key).ConfigureAwait(_configuredAsyncEnumerator.ContinuationOptions);
-                            }
-                            accNode._value = await _accumulator.Invoke(acc, element);
-                        } while (await _configuredAsyncEnumerator.MoveNextAsync());
+                                var element = _configuredAsyncEnumerator.Current;
+                                // The key selector function could have switched context, make sure we're on the configured context before invoking the comparer and seed selector.
+                                var key = await _keySelector.Invoke(element).ConfigureAwait(_configuredAsyncEnumerator.ContinuationOptions);
+                                var accNode = dict.GetOrCreateNode(key, out bool exists);
+                                TAccumulate acc;
+                                if (exists)
+                                {
+                                    acc = accNode._value;
+                                }
+                                else
+                                {
+                                    // The seed selector function could have switched context, make sure we're on the configured context before invoking the accumulator.
+                                    acc = await _seedSelector.Invoke(key).ConfigureAwait(_configuredAsyncEnumerator.ContinuationOptions);
+                                }
+                                accNode._value = await _accumulator.Invoke(acc, element);
+                            } while (await _configuredAsyncEnumerator.MoveNextAsync());
 
-                        // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var node = dict._lastNode;
-                        do
-                        {
-                            node = node._nextNode;
-                            await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
-                        } while (node != dict._lastNode);
+                            // We don't need to check if node is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var node = dict._lastNode;
+                            do
+                            {
+                                node = node._nextNode;
+                                await writer.YieldAsync(new KeyValuePair<TKey, TAccumulate>(node._key, node._value));
+                            } while (node != dict._lastNode);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
@@ -656,7 +657,6 @@ namespace Proto.Promises
                     finally
                     {
                         joinedCancelationSource.TryDispose();
-                        dict.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }

--- a/Package/Core/Linq/Internal/AppendPrependInternal.cs
+++ b/Package/Core/Linq/Internal/AppendPrependInternal.cs
@@ -115,7 +115,7 @@ namespace Proto.Promises
             private void Dispose()
             {
                 _source = default;
-                _prepended = default;
+                ClearReferences(ref _prepended);
                 ObjectPool.MaybeRepool(this);
             }
 
@@ -203,7 +203,7 @@ namespace Proto.Promises
             private void Dispose()
             {
                 _source = default;
-                _appended = default;
+                ClearReferences(ref _appended);
                 ObjectPool.MaybeRepool(this);
             }
 
@@ -293,8 +293,8 @@ namespace Proto.Promises
             private void Dispose()
             {
                 _source = default;
-                _prepended = default;
-                _appended = default;
+                ClearReferences(ref _prepended);
+                ClearReferences(ref _appended);
                 ObjectPool.MaybeRepool(this);
             }
 
@@ -404,7 +404,7 @@ namespace Proto.Promises
             private void RepoolWithoutDispose()
             {
                 _source = default;
-                _prepended = default;
+                ClearReferences(ref _prepended);
                 ObjectPool.MaybeRepool(this);
             }
 

--- a/Package/Core/Linq/Internal/CountByInternal.cs
+++ b/Package/Core/Linq/Internal/CountByInternal.cs
@@ -4,7 +4,6 @@
 #undef PROMISE_DEBUG
 #endif
 
-using Proto.Promises.Collections;
 using Proto.Promises.CompilerServices;
 using Proto.Promises.Linq;
 using System;
@@ -12,6 +11,8 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+
+#pragma warning disable IDE0251 // Make member 'readonly'
 
 namespace Proto.Promises
 {

--- a/Package/Core/Linq/Internal/CountByInternal.cs
+++ b/Package/Core/Linq/Internal/CountByInternal.cs
@@ -168,7 +168,7 @@ namespace Proto.Promises
                     _hashNext = null;
                     _nextNode = null;
                     ClearReferences(ref _key);
-                    ClearReferences(ref _value);
+                    _value = default;
                     ObjectPool.MaybeRepool(this);
                 }
             }

--- a/Package/Core/Linq/Internal/CountByInternal.cs
+++ b/Package/Core/Linq/Internal/CountByInternal.cs
@@ -164,8 +164,8 @@ namespace Proto.Promises
                 {
                     _hashNext = null;
                     _nextNode = null;
-                    _key = default;
-                    _value = default;
+                    ClearReferences(ref _key);
+                    ClearReferences(ref _value);
                     ObjectPool.MaybeRepool(this);
                 }
             }

--- a/Package/Core/Linq/Internal/GroupByInternal.cs
+++ b/Package/Core/Linq/Internal/GroupByInternal.cs
@@ -47,7 +47,6 @@ namespace Proto.Promises
                     _asyncEnumerator._target._cancelationToken = cancelationToken;
 
                     // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
-                    LookupImpl<TKey, TElement, TEqualityComparer> lookup = default;
                     try
                     {
                         if (!await _asyncEnumerator.MoveNextAsync())
@@ -56,33 +55,34 @@ namespace Proto.Promises
                             return;
                         }
 
-                        lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true);
-                        do
+                        using (var lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true))
                         {
-                            var item = _asyncEnumerator.Current;
-                            var key = _keySelector.Invoke(item);
-                            var group = lookup.GetOrCreateGrouping(key, true);
+                            do
+                            {
+                                var item = _asyncEnumerator.Current;
+                                var key = _keySelector.Invoke(item);
+                                var group = lookup.GetOrCreateGrouping(key, true);
 
-                            var element = _elementSelector.Invoke(item);
-                            group.Add(element);
-                        } while (await _asyncEnumerator.MoveNextAsync());
-                        // We don't dispose the source enumerator until the owner is disposed.
-                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+                                var element = _elementSelector.Invoke(item);
+                                group.Add(element);
+                            } while (await _asyncEnumerator.MoveNextAsync());
+                            // We don't dispose the source enumerator until the owner is disposed.
+                            // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
 
-                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var g = lookup._lastGrouping;
-                        do
-                        {
-                            g = g._nextGrouping;
-                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
-                        } while (g != lookup._lastGrouping);
+                            // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var g = lookup._lastGrouping;
+                            do
+                            {
+                                g = g._nextGrouping;
+                                await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                            } while (g != lookup._lastGrouping);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
                     }
                     finally
                     {
-                        lookup.Dispose();
                         await _asyncEnumerator.DisposeAsync();
                     }
                 }
@@ -130,7 +130,6 @@ namespace Proto.Promises
                     _asyncEnumerator._target._cancelationToken = cancelationToken;
 
                     // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
-                    LookupImpl<TKey, TElement, TEqualityComparer> lookup = default;
                     try
                     {
                         if (!await _asyncEnumerator.MoveNextAsync())
@@ -139,30 +138,31 @@ namespace Proto.Promises
                             return;
                         }
 
-                        lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true);
-                        do
+                        using (var lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true))
                         {
-                            var item = _asyncEnumerator.Current;
-                            var key = _keySelector.Invoke(item);
-                            lookup.GetOrCreateGrouping(key, true).Add(item);
-                        } while (await _asyncEnumerator.MoveNextAsync());
-                        // We don't dispose the source enumerator until the owner is disposed.
-                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+                            do
+                            {
+                                var item = _asyncEnumerator.Current;
+                                var key = _keySelector.Invoke(item);
+                                lookup.GetOrCreateGrouping(key, true).Add(item);
+                            } while (await _asyncEnumerator.MoveNextAsync());
+                            // We don't dispose the source enumerator until the owner is disposed.
+                            // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
 
-                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var g = lookup._lastGrouping;
-                        do
-                        {
-                            g = g._nextGrouping;
-                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
-                        } while (g != lookup._lastGrouping);
+                            // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var g = lookup._lastGrouping;
+                            do
+                            {
+                                g = g._nextGrouping;
+                                await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                            } while (g != lookup._lastGrouping);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
                     }
                     finally
                     {
-                        lookup.Dispose();
                         await _asyncEnumerator.DisposeAsync();
                     }
                 }
@@ -211,7 +211,6 @@ namespace Proto.Promises
                     _asyncEnumerator._target._cancelationToken = cancelationToken;
 
                     // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
-                    LookupImpl<TKey, TElement, TEqualityComparer> lookup = default;
                     try
                     {
                         if (!await _asyncEnumerator.MoveNextAsync())
@@ -220,33 +219,34 @@ namespace Proto.Promises
                             return;
                         }
 
-                        lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true);
-                        do
+                        using (var lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true))
                         {
-                            var item = _asyncEnumerator.Current;
-                            var key = await _keySelector.Invoke(item);
-                            var group = lookup.GetOrCreateGrouping(key, true);
+                            do
+                            {
+                                var item = _asyncEnumerator.Current;
+                                var key = await _keySelector.Invoke(item);
+                                var group = lookup.GetOrCreateGrouping(key, true);
 
-                            var element = await _elementSelector.Invoke(item);
-                            group.Add(element);
-                        } while (await _asyncEnumerator.MoveNextAsync());
-                        // We don't dispose the source enumerator until the owner is disposed.
-                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+                                var element = await _elementSelector.Invoke(item);
+                                group.Add(element);
+                            } while (await _asyncEnumerator.MoveNextAsync());
+                            // We don't dispose the source enumerator until the owner is disposed.
+                            // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
 
-                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var g = lookup._lastGrouping;
-                        do
-                        {
-                            g = g._nextGrouping;
-                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
-                        } while (g != lookup._lastGrouping);
+                            // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var g = lookup._lastGrouping;
+                            do
+                            {
+                                g = g._nextGrouping;
+                                await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                            } while (g != lookup._lastGrouping);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
                     }
                     finally
                     {
-                        lookup.Dispose();
                         await _asyncEnumerator.DisposeAsync();
                     }
                 }
@@ -294,7 +294,6 @@ namespace Proto.Promises
                     _asyncEnumerator._target._cancelationToken = cancelationToken;
 
                     // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
-                    LookupImpl<TKey, TElement, TEqualityComparer> lookup = default;
                     try
                     {
                         if (!await _asyncEnumerator.MoveNextAsync())
@@ -303,30 +302,31 @@ namespace Proto.Promises
                             return;
                         }
 
-                        lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true);
-                        do
+                        using (var lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true))
                         {
-                            var item = _asyncEnumerator.Current;
-                            var key = await _keySelector.Invoke(item);
-                            lookup.GetOrCreateGrouping(key, true).Add(item);
-                        } while (await _asyncEnumerator.MoveNextAsync());
-                        // We don't dispose the source enumerator until the owner is disposed.
-                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+                            do
+                            {
+                                var item = _asyncEnumerator.Current;
+                                var key = await _keySelector.Invoke(item);
+                                lookup.GetOrCreateGrouping(key, true).Add(item);
+                            } while (await _asyncEnumerator.MoveNextAsync());
+                            // We don't dispose the source enumerator until the owner is disposed.
+                            // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
 
-                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var g = lookup._lastGrouping;
-                        do
-                        {
-                            g = g._nextGrouping;
-                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
-                        } while (g != lookup._lastGrouping);
+                            // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var g = lookup._lastGrouping;
+                            do
+                            {
+                                g = g._nextGrouping;
+                                await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                            } while (g != lookup._lastGrouping);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
                     }
                     finally
                     {
-                        lookup.Dispose();
                         await _asyncEnumerator.DisposeAsync();
                     }
                 }
@@ -375,7 +375,6 @@ namespace Proto.Promises
                     var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
-                    LookupImpl<TKey, TElement, TEqualityComparer> lookup = default;
                     try
                     {
                         if (!await _configuredAsyncEnumerator.MoveNextAsync())
@@ -384,26 +383,28 @@ namespace Proto.Promises
                             return;
                         }
 
-                        lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true);
-                        do
+                        using (var lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true))
                         {
-                            var item = _configuredAsyncEnumerator.Current;
-                            var key = _keySelector.Invoke(item);
-                            var group = lookup.GetOrCreateGrouping(key, true);
+                            do
+                            {
+                                var item = _configuredAsyncEnumerator.Current;
+                                var key = _keySelector.Invoke(item);
+                                var group = lookup.GetOrCreateGrouping(key, true);
 
-                            var element = _elementSelector.Invoke(item);
-                            group.Add(element);
-                        } while (await _configuredAsyncEnumerator.MoveNextAsync());
-                        // We don't dispose the source enumerator until the owner is disposed.
-                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+                                var element = _elementSelector.Invoke(item);
+                                group.Add(element);
+                            } while (await _configuredAsyncEnumerator.MoveNextAsync());
+                            // We don't dispose the source enumerator until the owner is disposed.
+                            // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
 
-                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var g = lookup._lastGrouping;
-                        do
-                        {
-                            g = g._nextGrouping;
-                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
-                        } while (g != lookup._lastGrouping);
+                            // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var g = lookup._lastGrouping;
+                            do
+                            {
+                                g = g._nextGrouping;
+                                await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                            } while (g != lookup._lastGrouping);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
@@ -411,7 +412,6 @@ namespace Proto.Promises
                     finally
                     {
                         joinedCancelationSource.TryDispose();
-                        lookup.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -459,7 +459,6 @@ namespace Proto.Promises
                     var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
-                    LookupImpl<TKey, TElement, TEqualityComparer> lookup = default;
                     try
                     {
                         if (!await _configuredAsyncEnumerator.MoveNextAsync())
@@ -468,23 +467,25 @@ namespace Proto.Promises
                             return;
                         }
 
-                        lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true);
-                        do
+                        using (var lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true))
                         {
-                            var item = _configuredAsyncEnumerator.Current;
-                            var key = _keySelector.Invoke(item);
-                            lookup.GetOrCreateGrouping(key, true).Add(item);
-                        } while (await _configuredAsyncEnumerator.MoveNextAsync());
-                        // We don't dispose the source enumerator until the owner is disposed.
-                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+                            do
+                            {
+                                var item = _configuredAsyncEnumerator.Current;
+                                var key = _keySelector.Invoke(item);
+                                lookup.GetOrCreateGrouping(key, true).Add(item);
+                            } while (await _configuredAsyncEnumerator.MoveNextAsync());
+                            // We don't dispose the source enumerator until the owner is disposed.
+                            // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
 
-                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var g = lookup._lastGrouping;
-                        do
-                        {
-                            g = g._nextGrouping;
-                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
-                        } while (g != lookup._lastGrouping);
+                            // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var g = lookup._lastGrouping;
+                            do
+                            {
+                                g = g._nextGrouping;
+                                await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                            } while (g != lookup._lastGrouping);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
@@ -492,7 +493,6 @@ namespace Proto.Promises
                     finally
                     {
                         joinedCancelationSource.TryDispose();
-                        lookup.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -541,7 +541,6 @@ namespace Proto.Promises
                     var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
-                    LookupImpl<TKey, TElement, TEqualityComparer> lookup = default;
                     try
                     {
                         if (!await _configuredAsyncEnumerator.MoveNextAsync())
@@ -550,27 +549,29 @@ namespace Proto.Promises
                             return;
                         }
 
-                        lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true);
-                        do
+                        using (var lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true))
                         {
-                            var item = _configuredAsyncEnumerator.Current;
-                            // In case the key selector changed context, we need to make sure we're on the configured context before invoking the comparer and elementSelector.
-                            var key = await _keySelector.Invoke(item).ConfigureAwait(_configuredAsyncEnumerator.ContinuationOptions);
-                            var group = lookup.GetOrCreateGrouping(key, true);
+                            do
+                            {
+                                var item = _configuredAsyncEnumerator.Current;
+                                // In case the key selector changed context, we need to make sure we're on the configured context before invoking the comparer and elementSelector.
+                                var key = await _keySelector.Invoke(item).ConfigureAwait(_configuredAsyncEnumerator.ContinuationOptions);
+                                var group = lookup.GetOrCreateGrouping(key, true);
 
-                            var element = await _elementSelector.Invoke(item);
-                            group.Add(element);
-                        } while (await _configuredAsyncEnumerator.MoveNextAsync());
-                        // We don't dispose the source enumerator until the owner is disposed.
-                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+                                var element = await _elementSelector.Invoke(item);
+                                group.Add(element);
+                            } while (await _configuredAsyncEnumerator.MoveNextAsync());
+                            // We don't dispose the source enumerator until the owner is disposed.
+                            // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
 
-                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var g = lookup._lastGrouping;
-                        do
-                        {
-                            g = g._nextGrouping;
-                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
-                        } while (g != lookup._lastGrouping);
+                            // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var g = lookup._lastGrouping;
+                            do
+                            {
+                                g = g._nextGrouping;
+                                await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                            } while (g != lookup._lastGrouping);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
@@ -578,7 +579,6 @@ namespace Proto.Promises
                     finally
                     {
                         joinedCancelationSource.TryDispose();
-                        lookup.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -626,7 +626,6 @@ namespace Proto.Promises
                     var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
-                    LookupImpl<TKey, TElement, TEqualityComparer> lookup = default;
                     try
                     {
                         if (!await _configuredAsyncEnumerator.MoveNextAsync())
@@ -635,24 +634,26 @@ namespace Proto.Promises
                             return;
                         }
 
-                        lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true);
-                        do
+                        using (var lookup = new LookupImpl<TKey, TElement, TEqualityComparer>(_comparer, true))
                         {
-                            var item = _configuredAsyncEnumerator.Current;
-                            // In case the key selector changed context, we need to make sure we're on the configured context before invoking the comparer.
-                            var key = await _keySelector.Invoke(item).ConfigureAwait(_configuredAsyncEnumerator.ContinuationOptions);
-                            lookup.GetOrCreateGrouping(key, true).Add(item);
-                        } while (await _configuredAsyncEnumerator.MoveNextAsync());
-                        // We don't dispose the source enumerator until the owner is disposed.
-                        // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
+                            do
+                            {
+                                var item = _configuredAsyncEnumerator.Current;
+                                // In case the key selector changed context, we need to make sure we're on the configured context before invoking the comparer.
+                                var key = await _keySelector.Invoke(item).ConfigureAwait(_configuredAsyncEnumerator.ContinuationOptions);
+                                lookup.GetOrCreateGrouping(key, true).Add(item);
+                            } while (await _configuredAsyncEnumerator.MoveNextAsync());
+                            // We don't dispose the source enumerator until the owner is disposed.
+                            // This is in case the source enumerator contains TempCollection that they will still be valid until the owner is disposed.
 
-                        // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
-                        var g = lookup._lastGrouping;
-                        do
-                        {
-                            g = g._nextGrouping;
-                            await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
-                        } while (g != lookup._lastGrouping);
+                            // We don't need to check if g is null, it's guaranteed to be not null since we checked that the source enumerable had at least 1 element.
+                            var g = lookup._lastGrouping;
+                            do
+                            {
+                                g = g._nextGrouping;
+                                await writer.YieldAsync(new Linq.Grouping<TKey, TElement>(g));
+                            } while (g != lookup._lastGrouping);
+                        }
 
                         // We yield and wait for the enumerator to be disposed, but only if there were no exceptions.
                         await writer.YieldAsync(default).ForLinqExtension();
@@ -660,7 +661,6 @@ namespace Proto.Promises
                     finally
                     {
                         joinedCancelationSource.TryDispose();
-                        lookup.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }

--- a/Package/Core/Linq/Internal/GroupingInternal.cs
+++ b/Package/Core/Linq/Internal/GroupingInternal.cs
@@ -97,7 +97,7 @@ namespace Proto.Promises
                 _nextGrouping = null;
                 _elements.Dispose();
                 _elements = default;
-                _key = default;
+                ClearReferences(ref _key);
                 ObjectPool.MaybeRepool(this);
             }
         }

--- a/Package/Core/Linq/Internal/LookupInternal.cs
+++ b/Package/Core/Linq/Internal/LookupInternal.cs
@@ -5,7 +5,6 @@
 #endif
 
 using Proto.Promises.CompilerServices;
-using Proto.Promises.Collections;
 using Proto.Promises.Linq;
 using System;
 using System.Collections;

--- a/Package/Core/Linq/Internal/OrderByInternal.cs
+++ b/Package/Core/Linq/Internal/OrderByInternal.cs
@@ -213,7 +213,7 @@ namespace Proto.Promises
 
                 protected void Dispose()
                 {
-                    _comparer = default;
+                    ClearReferences(ref _comparer);
                     // Dispose ThenBys
                     var next = _next;
                     _next = null;
@@ -439,7 +439,7 @@ namespace Proto.Promises
 
                 protected void Dispose()
                 {
-                    _comparer = default;
+                    ClearReferences(ref _comparer);
                     // Dispose ThenBys
                     var next = _next;
                     _next = null;
@@ -937,7 +937,7 @@ namespace Proto.Promises
                     {
                         _keys.Dispose();
                     }
-                    _comparer = default;
+                    ClearReferences(ref _comparer);
                 }
             }
 

--- a/Package/Core/Linq/Internal/PoolBackedQueueInternal.cs
+++ b/Package/Core/Linq/Internal/PoolBackedQueueInternal.cs
@@ -39,19 +39,24 @@ namespace Proto.Promises
 
             internal void Clear()
             {
-                if (_size != 0)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
+                if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+#endif
                 {
-                    if (_head < _tail)
+                    if (_size != 0)
                     {
-                        Array.Clear(_array, _head, _size);
-                    }
-                    else
-                    {
-                        Array.Clear(_array, _head, _array.Length - _head);
-                        Array.Clear(_array, 0, _tail);
-                    }
+                        if (_head < _tail)
+                        {
+                            Array.Clear(_array, _head, _size);
+                        }
+                        else
+                        {
+                            Array.Clear(_array, _head, _array.Length - _head);
+                            Array.Clear(_array, 0, _tail);
+                        }
 
-                    _size = 0;
+                        _size = 0;
+                    }
                 }
 
                 _head = 0;
@@ -78,7 +83,7 @@ namespace Proto.Promises
 #endif
                 int head = _head;
                 T removed = _array[head];
-                _array[head] = default;
+                ClearReferences(ref _array[head]);
                 MoveNext(ref _head);
                 _size--;
                 return removed;
@@ -125,14 +130,14 @@ namespace Proto.Promises
                     if (_head < _tail)
                     {
                         Array.Copy(_array, _head, newarray, 0, _size);
-                        Array.Clear(_array, _head, _size);
+                        ClearReferences(_array, _head, _size);
                     }
                     else
                     {
                         Array.Copy(_array, _head, newarray, 0, _array.Length - _head);
                         Array.Copy(_array, 0, newarray, _array.Length - _head, _tail);
-                        Array.Clear(_array, _head, _array.Length - _head);
-                        Array.Clear(_array, 0, _tail);
+                        ClearReferences(_array, _head, _array.Length - _head);
+                        ClearReferences(_array, 0, _tail);
                     }
                 }
 
@@ -165,19 +170,7 @@ namespace Proto.Promises
 
             public void Dispose()
             {
-                if (_size > 0)
-                {
-                    if (_head < _tail)
-                    {
-                        Array.Clear(_array, _head, _size);
-                    }
-                    else
-                    {
-                        Array.Clear(_array, _head, _array.Length - _head);
-                        Array.Clear(_array, 0, _tail);
-                    }
-                }
-
+                Clear();
                 ArrayPool<T>.Shared.Return(_array, false);
             }
         }

--- a/Package/Core/Linq/Internal/PoolBackedSetInternal.cs
+++ b/Package/Core/Linq/Internal/PoolBackedSetInternal.cs
@@ -96,7 +96,7 @@ namespace Proto.Promises
                         }
 
                         _slots[i]._hashCode = -1;
-                        _slots[i]._value = default;
+                        ClearReferences(ref _slots[i]._value);
                         _slots[i]._next = -1;
                         return true;
                     }

--- a/Package/Core/Linq/Internal/UnionInternal.cs
+++ b/Package/Core/Linq/Internal/UnionInternal.cs
@@ -162,7 +162,7 @@ namespace Proto.Promises
 
             private void Dispose()
             {
-                _comparer = default;
+                ClearReferences(ref _comparer);
                 _first = default;
                 _second = default;
                 ObjectPool.MaybeRepool(this);
@@ -364,7 +364,7 @@ namespace Proto.Promises
 
             private void Dispose()
             {
-                _comparer = default;
+                ClearReferences(ref _comparer);
                 _nextEnumerator = default;
                 ObjectPool.MaybeRepool(this);
             }
@@ -530,7 +530,7 @@ namespace Proto.Promises
 
             private void Dispose()
             {
-                _comparer = default;
+                ClearReferences(ref _comparer);
                 _configuredFirst = default;
                 _second = default;
                 ObjectPool.MaybeRepool(this);

--- a/Package/Core/PromiseGroups/Internal/PromiseEachGroupInternal.cs
+++ b/Package/Core/PromiseGroups/Internal/PromiseEachGroupInternal.cs
@@ -106,7 +106,7 @@ namespace Proto.Promises
                     ValidateNoPending();
 
                     base.Dispose();
-                    _current = default;
+                    ClearReferences(ref _current);
                     _cancelationException = null;
                     _cancelationRef.TryDispose(_cancelationRef.SourceId);
                     _cancelationRef = null;

--- a/Package/Core/Promises/Internal/EachInternal.cs
+++ b/Package/Core/Promises/Internal/EachInternal.cs
@@ -90,7 +90,7 @@ namespace Proto.Promises
                     PrepareEarlyDispose();
                     base.Dispose();
                     _disposed = true;
-                    _current = default;
+                    ClearReferences(ref _current);
                     _queue.Dispose();
                     _queue = default;
                     ObjectPool.MaybeRepool(this);

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -214,7 +214,7 @@ namespace Proto.Promises
                 new protected void Dispose()
                 {
                     base.Dispose();
-                    _result = default;
+                    ClearReferences(ref _result);
                 }
             }
 

--- a/Package/Core/Threading/ManualSynchronizationContextCore.cs
+++ b/Package/Core/Threading/ManualSynchronizationContextCore.cs
@@ -137,7 +137,7 @@ namespace Proto.Promises.Threading
             private void Dispose()
             {
                 _callback = default;
-                _capturedInfo = default;
+                _capturedInfo = null;
                 Internal.ObjectPool.MaybeRepool(this);
             }
         }

--- a/Package/Core/Utilities/Internal/ProgressInternal.cs
+++ b/Package/Core/Utilities/Internal/ProgressInternal.cs
@@ -192,7 +192,7 @@ namespace Proto.Promises
 
             private void DisposeAndRepool()
             {
-                _progress = default;
+                ClearReferences(ref _progress);
                 _invokeContext = null;
                 ObjectPool.MaybeRepool(this);
             }

--- a/Package/UnityHelpers/2018.3/Internal/PromiseYielderInternal.cs
+++ b/Package/UnityHelpers/2018.3/Internal/PromiseYielderInternal.cs
@@ -188,7 +188,7 @@ namespace Proto.Promises
                 {
                     current[i].Invoke();
                 }
-                Array.Clear(_currentQueue, 0, max);
+                Array.Clear(current, 0, max);
             }
 
             internal void Clear()
@@ -292,7 +292,7 @@ namespace Proto.Promises
                 {
                     current[i].Invoke();
                 }
-                Array.Clear(_currentQueue, 0, max);
+                Array.Clear(current, 0, max);
             }
 
             internal void Clear()
@@ -465,7 +465,7 @@ namespace Proto.Promises
                         }
                         --_currentCount;
                     }
-                    Array.Clear(_currentQueue, 0, max);
+                    Internal.ClearReferences(current, 0, max);
                 }
 
                 internal override void Reset()


### PR DESCRIPTION
…to skip clearing types without references.
Also optimized async Linq lookup tables by implementing array pooling directly instead of using TempCollectionBuilder.
Fixed a potential issue in CountBy and AggregateBy with renting shared `int[]` if other code returns to the pool without clearing.

Resolves #462.