### PR TITLE
Split `ContinueWith` methods

### DIFF
--- a/Package/Core/Promises/Internal/CallbackHelperInternal.cs
+++ b/Package/Core/Promises/Internal/CallbackHelperInternal.cs
@@ -109,14 +109,42 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal static Promise AddContinue<TDelegateContinue>(Promise<TArg> _this, TDelegateContinue continuer, CancelationToken cancelationToken)
+                internal static Promise AddContinue<TDelegateContinue>(Promise<TArg> _this, TDelegateContinue continuer)
                     where TDelegateContinue : IAction<TArg>, IDelegateContinue
                 {
                     if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
                     {
-                        return cancelationToken.IsCancelationRequested
-                            ? CallbackHelperVoid.Canceled(_this._ref, _this._id)
-                            : InvokeCallbackDirect(continuer, _this);
+                        return InvokeCallbackDirect(continuer, _this);
+                    }
+                    var promise = PromiseContinue<VoidResult, TDelegateContinue>.GetOrCreate(continuer);
+                    _this._ref.HookupNewPromise(_this._id, promise);
+                    return new Promise(promise, promise.Id);
+                }
+
+                [MethodImpl(InlineOption)]
+                internal static Promise AddContinueWait<TDelegateContinue>(Promise<TArg> _this, TDelegateContinue continuer)
+                    where TDelegateContinue : IFunc<TArg, Promise>, IDelegateContinuePromise
+                {
+                    if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
+                    {
+                        return InvokeCallbackAndAdoptDirect(continuer, _this);
+                    }
+                    var promise = PromiseContinuePromise<VoidResult, TDelegateContinue>.GetOrCreate(continuer);
+                    _this._ref.HookupNewPromise(_this._id, promise);
+                    return new Promise(promise, promise.Id);
+                }
+
+                [MethodImpl(InlineOption)]
+                internal static Promise AddContinue<TDelegateContinue>(Promise<TArg> _this, TDelegateContinue continuer, CancelationToken cancelationToken)
+                    where TDelegateContinue : IAction<TArg>, IDelegateContinue
+                {
+                    if (cancelationToken.IsCancelationRequested)
+                    {
+                        return CallbackHelperVoid.Canceled(_this._ref, _this._id);
+                    }
+                    if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
+                    {
+                        return InvokeCallbackDirect(continuer, _this);
                     }
                     PromiseRefBase promise;
                     if (cancelationToken.CanBeCanceled)
@@ -136,11 +164,13 @@ namespace Proto.Promises
                 internal static Promise AddContinueWait<TDelegateContinue>(Promise<TArg> _this, TDelegateContinue continuer, CancelationToken cancelationToken)
                     where TDelegateContinue : IFunc<TArg, Promise>, IDelegateContinuePromise
                 {
+                    if (cancelationToken.IsCancelationRequested)
+                    {
+                        return CallbackHelperVoid.Canceled(_this._ref, _this._id);
+                    }
                     if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
                     {
-                        return cancelationToken.IsCancelationRequested
-                            ? CallbackHelperVoid.Canceled(_this._ref, _this._id)
-                            : InvokeCallbackAndAdoptDirect(continuer, _this);
+                        return InvokeCallbackAndAdoptDirect(continuer, _this);
                     }
                     PromiseRefBase promise;
                     if (cancelationToken.CanBeCanceled)
@@ -378,14 +408,42 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal static Promise<TResult> AddContinue<TDelegateContinue>(Promise _this, TDelegateContinue continuer, CancelationToken cancelationToken)
+                internal static Promise<TResult> AddContinue<TDelegateContinue>(Promise _this, TDelegateContinue continuer)
                     where TDelegateContinue : IFunc<TResult>, IDelegateContinue
                 {
                     if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
                     {
-                        return cancelationToken.IsCancelationRequested
-                            ? Canceled(_this._ref, _this._id)
-                            : InvokeCallbackDirect(continuer, _this);
+                        return InvokeCallbackDirect(continuer, _this);
+                    }
+                    var promise = PromiseContinue<TResult, TDelegateContinue>.GetOrCreate(continuer);
+                    _this._ref.HookupNewPromise(_this._id, promise);
+                    return new Promise<TResult>(promise, promise.Id);
+                }
+
+                [MethodImpl(InlineOption)]
+                internal static Promise<TResult> AddContinueWait<TDelegateContinue>(Promise _this, TDelegateContinue continuer)
+                    where TDelegateContinue : IFunc<Promise<TResult>>, IDelegateContinuePromise
+                {
+                    if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
+                    {
+                        return InvokeCallbackAndAdoptDirect(continuer, _this);
+                    }
+                    var promise = PromiseContinuePromise<TResult, TDelegateContinue>.GetOrCreate(continuer);
+                    _this._ref.HookupNewPromise(_this._id, promise);
+                    return new Promise<TResult>(promise, promise.Id);
+                }
+
+                [MethodImpl(InlineOption)]
+                internal static Promise<TResult> AddContinue<TDelegateContinue>(Promise _this, TDelegateContinue continuer, CancelationToken cancelationToken)
+                    where TDelegateContinue : IFunc<TResult>, IDelegateContinue
+                {
+                    if (cancelationToken.IsCancelationRequested)
+                    {
+                        return Canceled(_this._ref, _this._id);
+                    }
+                    if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
+                    {
+                        return InvokeCallbackDirect(continuer, _this);
                     }
                     PromiseRef<TResult> promise;
                     if (cancelationToken.CanBeCanceled)
@@ -405,11 +463,13 @@ namespace Proto.Promises
                 internal static Promise<TResult> AddContinueWait<TDelegateContinue>(Promise _this, TDelegateContinue continuer, CancelationToken cancelationToken)
                     where TDelegateContinue : IFunc<Promise<TResult>>, IDelegateContinuePromise
                 {
+                    if (cancelationToken.IsCancelationRequested)
+                    {
+                        return Canceled(_this._ref, _this._id);
+                    }
                     if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
                     {
-                        return cancelationToken.IsCancelationRequested
-                            ? Canceled(_this._ref, _this._id)
-                            : InvokeCallbackAndAdoptDirect(continuer, _this);
+                        return InvokeCallbackAndAdoptDirect(continuer, _this);
                     }
                     PromiseRef<TResult> promise;
                     if (cancelationToken.CanBeCanceled)
@@ -543,14 +603,42 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal static Promise<TResult> AddContinue<TDelegateContinue>(Promise<TArg> _this, TDelegateContinue continuer, CancelationToken cancelationToken)
+                internal static Promise<TResult> AddContinue<TDelegateContinue>(Promise<TArg> _this, TDelegateContinue continuer)
                     where TDelegateContinue : IFunc<TArg, TResult>, IDelegateContinue
                 {
                     if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
                     {
-                        return cancelationToken.IsCancelationRequested
-                            ? CallbackHelperResult<TResult>.Canceled(_this._ref, _this._id)
-                            : InvokeCallbackDirect(continuer, _this);
+                        return InvokeCallbackDirect(continuer, _this);
+                    }
+                    var promise = PromiseContinue<TResult, TDelegateContinue>.GetOrCreate(continuer);
+                    _this._ref.HookupNewPromise(_this._id, promise);
+                    return new Promise<TResult>(promise, promise.Id);
+                }
+
+                [MethodImpl(InlineOption)]
+                internal static Promise<TResult> AddContinueWait<TDelegateContinue>(Promise<TArg> _this, TDelegateContinue continuer)
+                    where TDelegateContinue : IFunc<TArg, Promise<TResult>>, IDelegateContinuePromise
+                {
+                    if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
+                    {
+                        return InvokeCallbackAndAdoptDirect(continuer, _this);
+                    }
+                    var promise = PromiseContinuePromise<TResult, TDelegateContinue>.GetOrCreate(continuer);
+                    _this._ref.HookupNewPromise(_this._id, promise);
+                    return new Promise<TResult>(promise, promise.Id);
+                }
+
+                [MethodImpl(InlineOption)]
+                internal static Promise<TResult> AddContinue<TDelegateContinue>(Promise<TArg> _this, TDelegateContinue continuer, CancelationToken cancelationToken)
+                    where TDelegateContinue : IFunc<TArg, TResult>, IDelegateContinue
+                {
+                    if (cancelationToken.IsCancelationRequested)
+                    {
+                        return CallbackHelperResult<TResult>.Canceled(_this._ref, _this._id);
+                    }
+                    if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
+                    {
+                        return InvokeCallbackDirect(continuer, _this);
                     }
                     PromiseRef<TResult> promise;
                     if (cancelationToken.CanBeCanceled)
@@ -570,11 +658,13 @@ namespace Proto.Promises
                 internal static Promise<TResult> AddContinueWait<TDelegateContinue>(Promise<TArg> _this, TDelegateContinue continuer, CancelationToken cancelationToken)
                     where TDelegateContinue : IFunc<TArg, Promise<TResult>>, IDelegateContinuePromise
                 {
+                    if (cancelationToken.IsCancelationRequested)
+                    {
+                        return CallbackHelperResult<TResult>.Canceled(_this._ref, _this._id);
+                    }
                     if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
                     {
-                        return cancelationToken.IsCancelationRequested
-                            ? CallbackHelperResult<TResult>.Canceled(_this._ref, _this._id)
-                            : InvokeCallbackAndAdoptDirect(continuer, _this);
+                        return InvokeCallbackAndAdoptDirect(continuer, _this);
                     }
                     PromiseRef<TResult> promise;
                     if (cancelationToken.CanBeCanceled)
@@ -824,14 +914,42 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal static Promise AddContinue<TDelegateContinue>(Promise _this, TDelegateContinue continuer, CancelationToken cancelationToken)
+                internal static Promise AddContinue<TDelegateContinue>(Promise _this, TDelegateContinue continuer)
                     where TDelegateContinue : IAction, IDelegateContinue
                 {
                     if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
                     {
-                        return cancelationToken.IsCancelationRequested
-                            ? Canceled(_this._ref, _this._id)
-                            : InvokeCallbackDirect(continuer, _this);
+                        return InvokeCallbackDirect(continuer, _this);
+                    }
+                    var promise = PromiseContinue<VoidResult, TDelegateContinue>.GetOrCreate(continuer);
+                    _this._ref.HookupNewPromise(_this._id, promise);
+                    return new Promise(promise, promise.Id);
+                }
+
+                [MethodImpl(InlineOption)]
+                internal static Promise AddContinueWait<TDelegateContinue>(Promise _this, TDelegateContinue continuer)
+                    where TDelegateContinue : IFunc<Promise>, IDelegateContinuePromise
+                {
+                    if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
+                    {
+                        return InvokeCallbackAndAdoptDirect(continuer, _this);
+                    }
+                    var promise = PromiseContinuePromise<VoidResult, TDelegateContinue>.GetOrCreate(continuer);
+                    _this._ref.HookupNewPromise(_this._id, promise);
+                    return new Promise(promise, promise.Id);
+                }
+
+                [MethodImpl(InlineOption)]
+                internal static Promise AddContinue<TDelegateContinue>(Promise _this, TDelegateContinue continuer, CancelationToken cancelationToken)
+                    where TDelegateContinue : IAction, IDelegateContinue
+                {
+                    if (cancelationToken.IsCancelationRequested)
+                    {
+                        return Canceled(_this._ref, _this._id);
+                    }
+                    if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
+                    {
+                        return InvokeCallbackDirect(continuer, _this);
                     }
                     PromiseRefBase promise;
                     if (cancelationToken.CanBeCanceled)
@@ -851,11 +969,13 @@ namespace Proto.Promises
                 internal static Promise AddContinueWait<TDelegateContinue>(Promise _this, TDelegateContinue continuer, CancelationToken cancelationToken)
                     where TDelegateContinue : IFunc<Promise>, IDelegateContinuePromise
                 {
+                    if (cancelationToken.IsCancelationRequested)
+                    {
+                        return Canceled(_this._ref, _this._id);
+                    }
                     if (_this._ref == null || _this._ref.State == Promise.State.Resolved)
                     {
-                        return cancelationToken.IsCancelationRequested
-                            ? Canceled(_this._ref, _this._id)
-                            : InvokeCallbackAndAdoptDirect(continuer, _this);
+                        return InvokeCallbackAndAdoptDirect(continuer, _this);
                     }
                     PromiseRefBase promise;
                     if (cancelationToken.CanBeCanceled)

--- a/Package/Core/Promises/Promise.cs
+++ b/Package/Core/Promises/Promise.cs
@@ -652,8 +652,59 @@ namespace Proto.Promises
         }
         #endregion
 
-        // TODO: Split methods without CancelationToken for efficiency.
         #region Continue Callbacks
+        /// <summary>
+        /// Add a continuation callback. Returns a new <see cref="Promise"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will be resolved when it returns.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise ContinueWith(Action<ResultContainer> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelperVoid.AddContinue(this, Internal.PromiseRefBase.DelegateWrapper.Create(onContinue));
+        }
+
+        /// <summary>
+        /// Add a continuation callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="TResult"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise<TResult> ContinueWith<TResult>(Func<ResultContainer, TResult> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelperResult<TResult>.AddContinue(this, Internal.PromiseRefBase.DelegateWrapper.Create(onContinue));
+        }
+
+        /// <summary>
+        /// Add a continuation callback. Returns a new <see cref="Promise"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise ContinueWith(Func<ResultContainer, Promise> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelperVoid.AddContinueWait(this, Internal.PromiseRefBase.DelegateWrapper.Create(onContinue));
+        }
+
+        /// <summary>
+        /// Add a continuation callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="TResult"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise<TResult> ContinueWith<TResult>(Func<ResultContainer, Promise<TResult>> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelperResult<TResult>.AddContinueWait(this, Internal.PromiseRefBase.DelegateWrapper.Create(onContinue));
+        }
+
         /// <summary>
         /// Add a continuation callback. Returns a new <see cref="Promise"/>.
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will be resolved when it returns.
@@ -1857,6 +1908,58 @@ namespace Proto.Promises
         #endregion
 
         #region Continue Callbacks
+        /// <summary>
+        /// Capture a value and add a continuation callback. Returns a new <see cref="Promise"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will be resolved when it returns.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise ContinueWith<TCapture>(TCapture continueCaptureValue, Action<TCapture, ResultContainer> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelperVoid.AddContinue(this, Internal.PromiseRefBase.DelegateWrapper.Create(continueCaptureValue, onContinue));
+        }
+
+        /// <summary>
+        /// Capture a value and add a continuation callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="TResult"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise<TResult> ContinueWith<TCapture, TResult>(TCapture continueCaptureValue, Func<TCapture, ResultContainer, TResult> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelperResult<TResult>.AddContinue(this, Internal.PromiseRefBase.DelegateWrapper.Create(continueCaptureValue, onContinue));
+        }
+
+        /// <summary>
+        /// Capture a value and add a continuation callback. Returns a new <see cref="Promise"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise ContinueWith<TCapture>(TCapture continueCaptureValue, Func<TCapture, ResultContainer, Promise> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelperVoid.AddContinueWait(this, Internal.PromiseRefBase.DelegateWrapper.Create(continueCaptureValue, onContinue));
+        }
+
+        /// <summary>
+        /// Add a continuation callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="TResult"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise<TResult> ContinueWith<TCapture, TResult>(TCapture continueCaptureValue, Func<TCapture, ResultContainer, Promise<TResult>> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelperResult<TResult>.AddContinueWait(this, Internal.PromiseRefBase.DelegateWrapper.Create(continueCaptureValue, onContinue));
+        }
+
         /// <summary>
         /// Capture a value and add a continuation callback. Returns a new <see cref="Promise"/>.
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will be resolved when it returns.

--- a/Package/Core/Promises/PromiseT.cs
+++ b/Package/Core/Promises/PromiseT.cs
@@ -9,7 +9,6 @@
 using Proto.Promises.CompilerServices;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -684,9 +683,62 @@ namespace Proto.Promises
             return Internal.PromiseRefBase.CallbackHelper<T, TResult>
                 .AddResolveRejectWait(this, Internal.PromiseRefBase.DelegateWrapper.Create(onResolved), Internal.PromiseRefBase.DelegateWrapper.Create(onRejected));
         }
-#endregion
-        
-#region Continue Callbacks
+        #endregion
+
+        #region Continue Callbacks
+        /// <summary>
+        /// Add a continuation callback. Returns a new <see cref="Promise"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will be resolved when it returns.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise ContinueWith(Action<ResultContainer> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelperArg<T>.AddContinue(this, Internal.PromiseRefBase.DelegateWrapper.Create(onContinue));
+        }
+
+        /// <summary>
+        /// Add a continuation callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="TResult"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise<TResult> ContinueWith<TResult>(Func<ResultContainer, TResult> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelper<T, TResult>.AddContinue(this, Internal.PromiseRefBase.DelegateWrapper.Create(onContinue));
+        }
+
+
+        /// <summary>
+        /// Add a continuation callback. Returns a new <see cref="Promise"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise ContinueWith(Func<ResultContainer, Promise> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelperArg<T>.AddContinueWait(this, Internal.PromiseRefBase.DelegateWrapper.Create(onContinue));
+        }
+
+        /// <summary>
+        /// Add a continuation callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="TResult"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise<TResult> ContinueWith<TResult>(Func<ResultContainer, Promise<TResult>> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelper<T, TResult>.AddContinueWait(this, Internal.PromiseRefBase.DelegateWrapper.Create(onContinue));
+        }
+
         /// <summary>
         /// Add a continuation callback. Returns a new <see cref="Promise"/>.
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will be resolved when it returns.
@@ -1896,6 +1948,58 @@ namespace Proto.Promises
         /// Capture a value and add a continuation callback. Returns a new <see cref="Promise"/>.
         /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will be resolved when it returns.
         /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise ContinueWith<TCapture>(TCapture continueCaptureValue, Action<TCapture, ResultContainer> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelperArg<T>.AddContinue(this, Internal.PromiseRefBase.DelegateWrapper.Create(continueCaptureValue, onContinue));
+        }
+
+        /// <summary>
+        /// Capture a value and add a continuation callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="TResult"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will be resolved with the returned value.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise<TResult> ContinueWith<TCapture, TResult>(TCapture continueCaptureValue, Func<TCapture, ResultContainer, TResult> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelper<T, TResult>.AddContinue(this, Internal.PromiseRefBase.DelegateWrapper.Create(continueCaptureValue, onContinue));
+        }
+
+        /// <summary>
+        /// Capture a value and add a continuation callback. Returns a new <see cref="Promise"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will adopt the state of the returned <see cref="Promise"/>.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise ContinueWith<TCapture>(TCapture continueCaptureValue, Func<TCapture, ResultContainer, Promise> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelperArg<T>.AddContinueWait(this, Internal.PromiseRefBase.DelegateWrapper.Create(continueCaptureValue, onContinue));
+        }
+
+        /// <summary>
+        /// Add a continuation callback. Returns a new <see cref="Promise{T}"/> of <typeparamref name="TResult"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise{T}"/> will adopt the state of the returned <see cref="Promise{T}"/>.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise{T}"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
+        /// </summary>
+        public Promise<TResult> ContinueWith<TCapture, TResult>(TCapture continueCaptureValue, Func<TCapture, ResultContainer, Promise<TResult>> onContinue)
+        {
+            ValidateOperation(1);
+            ValidateArgument(onContinue, nameof(onContinue), 1);
+
+            return Internal.PromiseRefBase.CallbackHelper<T, TResult>.AddContinueWait(this, Internal.PromiseRefBase.DelegateWrapper.Create(continueCaptureValue, onContinue));
+        }
+
+        /// <summary>
+        /// Capture a value and add a continuation callback. Returns a new <see cref="Promise"/>.
+        /// <para/>When this is resolved, rejected, or canceled, <paramref name="onContinue"/> will be invoked with <paramref name="continueCaptureValue"/> and the <see cref="ResultContainer"/>, and the new <see cref="Promise"/> will be resolved when it returns.
+        /// If if throws an <see cref="Exception"/>, the new <see cref="Promise"/> will be rejected with that <see cref="Exception"/>, unless it is a Special Exception (see README).
         ///
         /// <para/>If the <paramref name="cancelationToken"/> is canceled while this is pending, the new <see cref="Promise"/> will be canceled, and <paramref name="onContinue"/> will not be invoked.
         /// </summary>
@@ -1951,7 +2055,7 @@ namespace Proto.Promises
 
             return Internal.PromiseRefBase.CallbackHelper<T, TResult>.AddContinueWait(this, Internal.PromiseRefBase.DelegateWrapper.Create(continueCaptureValue, onContinue), cancelationToken);
         }
-#endregion
+        #endregion
     }
 
     // Inherited from Promise (must copy since structs cannot inherit).

--- a/Package/Tests/Helpers/TestHelper.cs
+++ b/Package/Tests/Helpers/TestHelper.cs
@@ -2920,18 +2920,114 @@ namespace ProtoPromiseTests
             {
                 retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-                AddContinueCallbacksWithCancelation(
-                    retainer.WaitAsync(),
-                    onContinue, convertValue,
-                    onContinueCapture, captureValue,
-                    promiseToPromise, promiseToPromiseConvert,
-                    onCallbackAdded, onCallbackAddedConvert,
-                    default(CancelationToken),
-                    onCancel,
-                    onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
-                    continuationOptions
-                );
+                // Add empty delegate so no need for null check.
+                onContinue += _ => { };
+                onContinueCapture += (_, __) => { };
+                if (promiseToPromise == null)
+                {
+                    promiseToPromise = _ => Promise.Resolved();
+                }
+                if (promiseToPromiseConvert == null)
+                {
+                    promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
+                }
+                if (onCallbackAdded == null)
+                {
+                    onCallbackAdded = (ref Promise p) => p.Forget();
+                }
+                if (onCallbackAddedConvert == null)
+                {
+                    onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
+                }
+                if (onAdoptCallbackAdded == null)
+                {
+                    onAdoptCallbackAdded = (ref Promise p) => { };
+                }
+                if (onAdoptCallbackAddedConvert == null)
+                {
+                    onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
+                }
+                onCancel += () => { };
 
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p1 = default(Promise);
+                    p1 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(r => { onContinue(r); })
+                        .CatchCancelation(onCancel);
+                    onCallbackAdded(ref p1);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p2 = default(Promise<TConvert>);
+                    p2 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(r => { onContinue(r); return convertValue; })
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onCallbackAddedConvert(ref p2);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p3 = default(Promise);
+                    p3 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(r => { onContinue(r); return promiseToPromise(p3); })
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p3);
+                    onCallbackAdded(ref p3);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p4 = default(Promise<TConvert>);
+                    p4 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(r => { onContinue(r); return promiseToPromiseConvert(p4); })
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p4);
+                    onCallbackAddedConvert(ref p4);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p5 = default(Promise);
+                    p5 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); })
+                        .CatchCancelation(onCancel);
+                    onCallbackAdded(ref p5);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p6 = default(Promise<TConvert>);
+                    p6 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return convertValue; })
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onCallbackAddedConvert(ref p6);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p7 = default(Promise);
+                    p7 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return promiseToPromise(p7); })
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p7);
+                    onCallbackAdded(ref p7);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p8 = default(Promise<TConvert>);
+                    p8 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return promiseToPromiseConvert(p8); })
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p8);
+                    onCallbackAddedConvert(ref p8);
+                }
+
+                // Also call overloads accepting CancelationToken
                 CancelationSource cancelationSource = CancelationSource.New();
                 AddContinueCallbacksWithCancelation(
                     retainer.WaitAsync(),
@@ -3084,18 +3180,114 @@ namespace ProtoPromiseTests
             {
                 retainer.WaitAsync().Catch(() => { }).Forget(); // Suppress any rejections from the retained promise.
 
-                AddContinueCallbacksWithCancelation(
-                    retainer.WaitAsync(),
-                    onContinue, convertValue,
-                    onContinueCapture, captureValue,
-                    promiseToPromise, promiseToPromiseConvert,
-                    onCallbackAdded, onCallbackAddedConvert,
-                    default(CancelationToken),
-                    onCancel,
-                    onAdoptCallbackAdded, onAdoptCallbackAddedConvert,
-                    continuationOptions
-                );
+                // Add empty delegate so no need for null check.
+                onContinue += _ => { };
+                onContinueCapture += (_, __) => { };
+                if (promiseToPromise == null)
+                {
+                    promiseToPromise = _ => Promise.Resolved();
+                }
+                if (promiseToPromiseConvert == null)
+                {
+                    promiseToPromiseConvert = _ => Promise.Resolved(convertValue);
+                }
+                if (onCallbackAdded == null)
+                {
+                    onCallbackAdded = (ref Promise p) => p.Forget();
+                }
+                if (onCallbackAddedConvert == null)
+                {
+                    onCallbackAddedConvert = (ref Promise<TConvert> p) => p.Forget();
+                }
+                if (onAdoptCallbackAdded == null)
+                {
+                    onAdoptCallbackAdded = (ref Promise p) => { };
+                }
+                if (onAdoptCallbackAddedConvert == null)
+                {
+                    onAdoptCallbackAddedConvert = (ref Promise<TConvert> p) => { };
+                }
+                onCancel += () => { };
 
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p1 = default(Promise);
+                    p1 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(r => { onContinue(r); })
+                        .CatchCancelation(onCancel);
+                    onCallbackAdded(ref p1);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p2 = default(Promise<TConvert>);
+                    p2 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(r => { onContinue(r); return convertValue; })
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onCallbackAddedConvert(ref p2);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p3 = default(Promise);
+                    p3 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(r => { onContinue(r); return promiseToPromise(p3); })
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p3);
+                    onCallbackAdded(ref p3);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p4 = default(Promise<TConvert>);
+                    p4 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(r => { onContinue(r); return promiseToPromiseConvert(p4); })
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p4);
+                    onCallbackAddedConvert(ref p4);
+                }
+
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p5 = default(Promise);
+                    p5 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); })
+                        .CatchCancelation(onCancel);
+                    onCallbackAdded(ref p5);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p6 = default(Promise<TConvert>);
+                    p6 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return convertValue; })
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onCallbackAddedConvert(ref p6);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise p7 = default(Promise);
+                    p7 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return promiseToPromise(p7); })
+                        .CatchCancelation(onCancel);
+                    onAdoptCallbackAdded(ref p7);
+                    onCallbackAdded(ref p7);
+                }
+                foreach (var p in GetTestablePromises(retainer))
+                {
+                    Promise<TConvert> p8 = default(Promise<TConvert>);
+                    p8 = p
+                        .ConfigureContinuation(continuationOptions)
+                        .ContinueWith(captureValue, (cv, r) => { onContinueCapture(cv, r); onContinue(r); return promiseToPromiseConvert(p8); })
+                        .CatchCancelation(() => { onCancel(); return convertValue; });
+                    onAdoptCallbackAddedConvert(ref p8);
+                    onCallbackAddedConvert(ref p8);
+                }
+
+                // Also call overloads accepting CancelationToken
                 CancelationSource cancelationSource = CancelationSource.New();
                 AddContinueCallbacksWithCancelation(
                     retainer.WaitAsync(),


### PR DESCRIPTION
For the same optimization as #502, but without deprecating the existing methods.