### PR TITLE
Use `CancelationRegistration.Dispose`

### DIFF
--- a/Package/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/Package/Core/Cancelations/Internal/CancelationInternal.cs
@@ -7,6 +7,7 @@
 #pragma warning disable IDE0090 // Use 'new(...)'
 #pragma warning disable IDE0251 // Make member 'readonly'
 #pragma warning disable IDE0270 // Use coalesce expression
+#pragma warning disable IDE0290 // Use primary constructor
 
 using System;
 using System.Collections.Generic;
@@ -498,13 +499,27 @@ namespace Proto.Promises
                 }
 
                 ThrowIfInPool(this);
+                DisposeLocked();
+                return true;
+            }
+
+            // Internal dispose method skipping the id check.
+            internal void DisposeUnsafe()
+            {
+                ThrowIfInPool(this);
+                _smallFields._locker.Enter();
+                unchecked { ++_sourceId; }
+                DisposeLocked();
+            }
+
+            private void DisposeLocked()
+            {
                 if (_state == State.Pending)
                 {
                     _state = State.Disposed;
                     UnregisterAll();
                 }
                 MaybeResetAndRepoolAlreadyLocked();
-                return true;
             }
 
             [MethodImpl(InlineOption)]

--- a/Package/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/Package/Core/InternalShared/HelperFunctionsInternal.cs
@@ -155,14 +155,6 @@ namespace Proto.Promises
 #endif
         }
 
-        [MethodImpl(InlineOption)]
-        internal static bool TryUnregisterAndIsNotCanceling(ref CancelationRegistration cancelationRegistration)
-        {
-            // We check isCanceling in case the token is not cancelable (in which case TryUnregister returns false).
-            bool unregistered = cancelationRegistration.TryUnregister(out bool isCanceling);
-            return unregistered | !isCanceling;
-        }
-
         // TODO: Use Microsoft.Bcl.HashCode nuget package.
         internal static int BuildHashCode(object _ref, int hashcode1, int hashcode2)
         {

--- a/Package/Core/Linq/Internal/MergeInternal.cs
+++ b/Package/Core/Linq/Internal/MergeInternal.cs
@@ -391,7 +391,7 @@ namespace Proto.Promises
                     _readyQueue.Dispose();
                     _enumeratorsAndRejectContainers.Dispose();
                     // We stored the CancelationRef we created in the token field, so we extract it to dispose here.
-                    _cancelationToken._ref.TryDispose(_cancelationToken._ref.SourceId);
+                    _cancelationToken._ref.DisposeUnsafe();
 
 #pragma warning disable CA2219 // Do not raise exceptions in finally clauses
                     if (_exceptions != null)
@@ -636,7 +636,7 @@ namespace Proto.Promises
                     _readyQueue.Dispose();
                     _enumeratorsAndRejectContainers.Dispose();
                     // We stored the CancelationRef we created in the token field, so we extract it to dispose here.
-                    _cancelationToken._ref.TryDispose(_cancelationToken._ref.SourceId);
+                    _cancelationToken._ref.DisposeUnsafe();
 
 #pragma warning disable CA2219 // Do not raise exceptions in finally clauses
                     if (_exceptions != null)

--- a/Package/Core/Promises/Internal/ParallelAsyncInternal.cs
+++ b/Package/Core/Promises/Internal/ParallelAsyncInternal.cs
@@ -466,7 +466,7 @@ namespace Proto.Promises
                 {
                     _externalCancelationRegistration.Dispose();
                     _externalCancelationRegistration = default;
-                    _cancelationRef.TryDispose(_cancelationRef.SourceId);
+                    _cancelationRef.DisposeUnsafe();
                     _cancelationRef = null;
 
                     // Finally, complete the promise returned to the ParallelForEachAsync caller.

--- a/Package/Core/Promises/Internal/ParallelInternal.cs
+++ b/Package/Core/Promises/Internal/ParallelInternal.cs
@@ -446,7 +446,7 @@ namespace Proto.Promises
 
                     _externalCancelationRegistration.Dispose();
                     _externalCancelationRegistration = default;
-                    _cancelationRef.TryDispose(_cancelationRef.SourceId);
+                    _cancelationRef.DisposeUnsafe();
                     _cancelationRef = null;
 
                     try

--- a/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseFieldsInternal.cs
@@ -289,6 +289,10 @@ namespace Proto.Promises
             partial struct CancelationHelper
             {
                 private CancelationRegistration _cancelationRegistration;
+                // int for Interlocked.Exchange.
+                private int _isCompletedFlag;
+                // The retain counter is to ensure the async op(s) we're waiting for and the cancelation callback
+                // are completed or guaranteed to never invoke before we return the object to the pool.
                 private int _retainCounter;
             }
 

--- a/Package/Core/Promises/Internal/PromiseInternal.cs
+++ b/Package/Core/Promises/Internal/PromiseInternal.cs
@@ -188,7 +188,7 @@ namespace Proto.Promises
                 where TPromise : PromiseRefBase, ICancelable
             {
                 promise.SetPrevious(this);
-                cancelationHelper.Register(cancelationToken, promise); // Very important, must register after promise is fully setup.
+                cancelationHelper.Register(cancelationToken, promise); // IMPORTANT - must register after promise is fully setup.
                 HookupNewWaiter(promiseId, promise);
                 return promise;
             }
@@ -639,59 +639,6 @@ namespace Proto.Promises
                     handler.SetCompletionState(state);
                     HandleSelf(handler, state);
                 }
-            }
-
-#if !PROTO_PROMISE_DEVELOPER_MODE
-            [DebuggerNonUserCode, StackTraceHidden]
-#endif
-            internal sealed partial class PromiseDuplicateCancel<TResult> : PromiseSingleAwait<TResult>, ICancelable
-            {
-                private PromiseDuplicateCancel() { }
-
-                internal override void MaybeDispose()
-                {
-                    if (_cancelationHelper.TryRelease())
-                    {
-                        Dispose();
-                        ObjectPool.MaybeRepool(this);
-                    }
-                }
-
-                [MethodImpl(InlineOption)]
-                private static PromiseDuplicateCancel<TResult> GetOrCreateInstance()
-                {
-                    var obj = ObjectPool.TryTakeOrInvalid<PromiseDuplicateCancel<TResult>>();
-                    return obj == InvalidAwaitSentinel.s_instance
-                        ? new PromiseDuplicateCancel<TResult>()
-                        : obj.UnsafeAs<PromiseDuplicateCancel<TResult>>();
-                }
-
-                [MethodImpl(InlineOption)]
-                internal static PromiseDuplicateCancel<TResult> GetOrCreate()
-                {
-                    var promise = GetOrCreateInstance();
-                    promise.Reset();
-                    promise._cancelationHelper.Reset();
-                    return promise;
-                }
-
-                internal override void Handle(PromiseRefBase handler, Promise.State state)
-                {
-                    ThrowIfInPool(this);
-                    handler.SetCompletionState(state);
-                    if (_cancelationHelper.TryUnregister(this))
-                    {
-                        _cancelationHelper.TryRelease();
-                        HandleSelf(handler, state);
-                    }
-                    else
-                    {
-                        MaybeDispose();
-                        handler.MaybeReportUnhandledAndDispose(state);
-                    }
-                }
-
-                void ICancelable.Cancel() => HandleFromCancelation();
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE


### PR DESCRIPTION
Refactored `CancelationHelper` to use `CancelationRegistration.Dispose` instead of `TryUnregister`.
Refactored types listening for cancelation to use `CancelationHelper`.