### PR TITLE
Cancelation deprecations

### DIFF
--- a/Package/Core/Cancelations/CancelationSource.cs
+++ b/Package/Core/Cancelations/CancelationSource.cs
@@ -5,6 +5,7 @@
 #endif
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -115,52 +116,50 @@ namespace Proto.Promises
         /// Get whether or not this <see cref="CancelationSource"/> is valid.
         /// <para/>A <see cref="CancelationSource"/> is valid if it was created from <see cref="New()"/> and was not disposed.
         /// </summary>
+        [Obsolete("Due to object pooling, this property is inherently unsafe. Prefer != default, and remember to set your CancelationSource fields to default when you Dispose.", false), EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsValid
-            => Internal.CancelationRef.IsValidSource(_ref, _sourceId);
+            => _ref?.IsValidSource(_sourceId) == true;
 
         /// <summary>
         /// Gets whether cancelation has been requested for this source.
         /// </summary>
         public bool IsCancelationRequested
-            => Internal.CancelationRef.IsSourceCanceled(_ref, _sourceId);
+            => _ref?.IsSourceCanceled(_sourceId) == true;
 
         /// <summary>
         /// Try to communicate a request for cancelation, and invoke all callbacks that are registered to the associated <see cref="Token"/>. Returns true if successful, false otherwise.
         /// </summary>
         /// <returns>True if this is valid and was not already canceled, false otherwise.</returns>
+        [Obsolete("Prefer != default and Cancel.", false), EditorBrowsable(EditorBrowsableState.Never)]
         public bool TryCancel()
-            => Internal.CancelationRef.TrySetCanceled(_ref, _sourceId);
+            => _ref?.TryCancel(_sourceId) == true;
 
         /// <summary>
         /// Communicate a request for cancelation, and invoke all callbacks that are registered to the associated <see cref="Token"/>.
         /// </summary>
-        /// <exception cref="InvalidOperationException"/>
+        /// <remarks>
+        /// If this was already canceled, a call do this does nothing.
+        /// </remarks>
+        /// <exception cref="ObjectDisposedException">This was disposed.</exception>
+        /// <exception cref="NullReferenceException">This is a default value.</exception>
         public void Cancel()
-        {
-            if (!TryCancel())
-            {
-                throw new InvalidOperationException("CancelationSource.Cancel: source is not valid or was already canceled.", Internal.GetFormattedStacktrace(1));
-            }
-        }
+            => _ref.Cancel(_sourceId);
 
         /// <summary>
         /// Try to release all resources used by this <see cref="CancelationSource"/>. This instance will no longer be valid.
         /// </summary>
         /// <returns>True if this is valid and was not already disposed, false otherwise.</returns>
+        [Obsolete("Prefer != default and Dispose.", false), EditorBrowsable(EditorBrowsableState.Never)]
         public bool TryDispose()
-            => Internal.CancelationRef.TryDispose(_ref, _sourceId);
+            => _ref?.TryDispose(_sourceId) == true;
 
         /// <summary>
         /// Release all resources used by this <see cref="CancelationSource"/>. This instance will no longer be valid.
         /// </summary>
-        /// <exception cref="InvalidOperationException"/>
+        /// <exception cref="ObjectDisposedException">This was disposed.</exception>
+        /// <exception cref="NullReferenceException">This is a default value.</exception>
         public void Dispose()
-        {
-            if (!TryDispose())
-            {
-                throw new InvalidOperationException("CancelationSource.Dispose: source is not valid.", Internal.GetFormattedStacktrace(1));
-            }
-        }
+            => _ref.Dispose(_sourceId);
 
         /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="CancelationSource"/>.</summary>
         public bool Equals(CancelationSource other)

--- a/Package/Core/Cancelations/CancelationToken.cs
+++ b/Package/Core/Cancelations/CancelationToken.cs
@@ -52,13 +52,13 @@ namespace Proto.Promises
         /// or if the token is already canceled and it has been retained and not yet released.
         /// </remarks>
         public bool CanBeCanceled
-            => Internal.CancelationRef.CanTokenBeCanceled(_ref, _id);
+            => _ref?.CanTokenBeCanceled(_id) == true;
 
         /// <summary>
         /// Gets whether cancelation has been requested for this token.
         /// </summary>
         public bool IsCancelationRequested
-            => Internal.CancelationRef.IsTokenCanceled(_ref, _id);
+            => _ref?.IsTokenCanceled(_id) == true;
 
         /// <summary>
         /// If cancelation was requested on this token, throws a <see cref="CanceledException"/>.
@@ -77,8 +77,9 @@ namespace Proto.Promises
         /// If this is already canceled, the callback will be invoked immediately and this will return true.
         /// </summary>
         /// <param name="callback">The delegate to be executed when the <see cref="CancelationToken"/> is canceled.</param>
-        /// <param name="cancelationRegistration">The <see cref="CancelationRegistration"/> instance that can be used to unregister the callback.</param>
+        /// <param name="cancelationRegistration">The <see cref="CancelationRegistration"/> instance that can be used to unregister the <paramref name="callback"/>.</param>
         /// <returns>true if <paramref name="callback"/> was registered successfully, false otherwise.</returns>
+        [Obsolete("Prefer CanBeCanceled and Register", false)]
         public bool TryRegister(Action callback, out CancelationRegistration cancelationRegistration)
         {
             ValidateArgument(callback, nameof(callback), 1);
@@ -91,8 +92,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="captureValue">The value to pass into <paramref name="callback"/>.</param>
         /// <param name="callback">The delegate to be executed when the <see cref="CancelationToken"/> is canceled.</param>
-        /// <param name="cancelationRegistration">The <see cref="CancelationRegistration"/> instance that can be used to unregister the callback.</param>
+        /// <param name="cancelationRegistration">The <see cref="CancelationRegistration"/> instance that can be used to unregister the <paramref name="callback"/>.</param>
         /// <returns>true if <paramref name="callback"/> was registered successfully, false otherwise.</returns>
+        [Obsolete("Prefer CanBeCanceled and Register", false)]
         public bool TryRegister<TCapture>(TCapture captureValue, Action<TCapture> callback, out CancelationRegistration cancelationRegistration)
         {
             ValidateArgument(callback, nameof(callback), 1);
@@ -104,8 +106,9 @@ namespace Proto.Promises
         /// If this is already canceled, it will be canceled immediately and this will return true.
         /// </summary>
         /// <param name="cancelable">The cancelable to be canceled when the <see cref="CancelationToken"/> is canceled.</param>
-        /// <param name="cancelationRegistration">The <see cref="CancelationRegistration"/> instance that can be used to unregister the callback.</param>
+        /// <param name="cancelationRegistration">The <see cref="CancelationRegistration"/> instance that can be used to unregister the <paramref name="cancelable"/>.</param>
         /// <returns>true if <paramref name="cancelable"/> was registered successfully, false otherwise.</returns>
+        [Obsolete("Prefer CanBeCanceled and Register", false)]
         public bool TryRegister<TCancelable>(TCancelable cancelable, out CancelationRegistration cancelationRegistration) where TCancelable : ICancelable
         {
             ValidateArgument(cancelable, nameof(cancelable), 1);
@@ -117,9 +120,10 @@ namespace Proto.Promises
         /// If this is already canceled, the <paramref name="cancelable"/> will not be invoked and <paramref name="alreadyCanceled"/> will be set to <see langword="true"/>.
         /// </summary>
         /// <param name="cancelable">The cancelable to be canceled when the <see cref="CancelationToken"/> is canceled.</param>
-        /// <param name="cancelationRegistration">The <see cref="CancelationRegistration"/> instance that can be used to unregister the callback.</param>
+        /// <param name="cancelationRegistration">The <see cref="CancelationRegistration"/> instance that can be used to unregister the <paramref name="cancelable"/>.</param>
         /// <param name="alreadyCanceled">If true, this was already canceled and the <paramref name="cancelable"/> will not be invoked.</param>
         /// <returns>true if <paramref name="cancelable"/> was registered successfully or this was already canceled, false otherwise.</returns>
+        [Obsolete("Prefer CanBeCanceled and RegisterWithoutImmediateInvoke", false)]
         public bool TryRegisterWithoutImmediateInvoke<TCancelable>(TCancelable cancelable, out CancelationRegistration cancelationRegistration, out bool alreadyCanceled) where TCancelable : ICancelable
         {
             ValidateArgument(cancelable, nameof(cancelable), 1);
@@ -131,10 +135,12 @@ namespace Proto.Promises
         /// If this is already canceled, the callback will be invoked immediately.
         /// </summary>
         /// <param name="callback">The delegate to be executed when the <see cref="CancelationToken"/> is canceled.</param>
-        /// <returns>The <see cref="CancelationRegistration"/> instance that can be used to unregister the callback.</returns>
+        /// <returns>The <see cref="CancelationRegistration"/> instance that can be used to unregister the <paramref name="callback"/>.</returns>
         public CancelationRegistration Register(Action callback)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             TryRegister(callback, out var registration);
+#pragma warning restore CS0618 // Type or member is obsolete
             return registration;
         }
 
@@ -144,10 +150,12 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="captureValue">The value to pass into <paramref name="callback"/>.</param>
         /// <param name="callback">The delegate to be executed when the <see cref="CancelationToken"/> is canceled.</param>
-        /// <returns>The <see cref="CancelationRegistration"/> instance that can be used to unregister the callback.</returns>
+        /// <returns>The <see cref="CancelationRegistration"/> instance that can be used to unregister the <paramref name="callback"/>.</returns>
         public CancelationRegistration Register<TCapture>(TCapture captureValue, Action<TCapture> callback)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             TryRegister(captureValue, callback, out var registration);
+#pragma warning restore CS0618 // Type or member is obsolete
             return registration;
         }
 
@@ -156,10 +164,56 @@ namespace Proto.Promises
         /// If this is already canceled, it will be canceled immediately.
         /// </summary>
         /// <param name="cancelable">The cancelable to be canceled when the <see cref="CancelationToken"/> is canceled.</param>
-        /// <returns>The <see cref="CancelationRegistration"/> instance that can be used to unregister the callback.</returns>
+        /// <returns>The <see cref="CancelationRegistration"/> instance that can be used to unregister the <paramref name="cancelable"/>.</returns>
         public CancelationRegistration Register<TCancelable>(TCancelable cancelable) where TCancelable : ICancelable
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             TryRegister(cancelable, out var registration);
+#pragma warning restore CS0618 // Type or member is obsolete
+            return registration;
+        }
+
+        /// <summary>
+        /// Register a cancelable that will be canceled when this <see cref="CancelationToken"/> is canceled.
+        /// If this is already canceled, the <paramref name="cancelable"/> will not be invoked and <paramref name="alreadyCanceled"/> will be set to <see langword="true"/>.
+        /// </summary>
+        /// <param name="cancelable">The cancelable to be canceled when the <see cref="CancelationToken"/> is canceled.</param>
+        /// <param name="alreadyCanceled">If true, this was already canceled and the <paramref name="cancelable"/> will not be invoked.</param>
+        /// <returns>The <see cref="CancelationRegistration"/> instance that can be used to unregister the <paramref name="cancelable"/>.</returns>
+        public CancelationRegistration RegisterWithoutImmediateInvoke<TCancelable>(TCancelable cancelable, out bool alreadyCanceled) where TCancelable : ICancelable
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            TryRegisterWithoutImmediateInvoke(cancelable, out var registration, out alreadyCanceled);
+#pragma warning restore CS0618 // Type or member is obsolete
+            return registration;
+        }
+
+        /// <summary>
+        /// Register a delegate that will be invoked when this <see cref="CancelationToken"/> is canceled.
+        /// If this is already canceled, the callback will be invoked immediately.
+        /// </summary>
+        /// <param name="callback">The delegate to be executed when the <see cref="CancelationToken"/> is canceled.</param>
+        /// <param name="alreadyCanceled">If true, this was already canceled and the <paramref name="callback"/> will not be invoked.</param>
+        /// <returns>The <see cref="CancelationRegistration"/> instance that can be used to unregister the <paramref name="callback"/>.</returns>
+        public CancelationRegistration RegisterWithoutImmediateInvoke(Action callback, out bool alreadyCanceled)
+        {
+            ValidateArgument(callback, nameof(callback), 1);
+            Internal.CancelationRef.TryRegister(_ref, _id, new Internal.CancelDelegateTokenVoid(callback), out var registration, out alreadyCanceled);
+            return registration;
+        }
+
+        /// <summary>
+        /// Capture a value and register a delegate that will be invoked with the captured value when this <see cref="CancelationToken"/> is canceled.
+        /// If this is already canceled, the callback will be invoked immediately.
+        /// </summary>
+        /// <param name="captureValue">The value to pass into <paramref name="callback"/>.</param>
+        /// <param name="callback">The delegate to be executed when the <see cref="CancelationToken"/> is canceled.</param>
+        /// <param name="alreadyCanceled">If true, this was already canceled and the <paramref name="callback"/> will not be invoked.</param>
+        /// <returns>The <see cref="CancelationRegistration"/> instance that can be used to unregister the <paramref name="callback"/>.</returns>
+        public CancelationRegistration RegisterWithoutImmediateInvoke<TCapture>(TCapture captureValue, Action<TCapture> callback, out bool alreadyCanceled)
+        {
+            ValidateArgument(callback, nameof(callback), 1);
+            Internal.CancelationRef.TryRegister(_ref, _id, new Internal.CancelDelegateToken<TCapture>(captureValue, callback), out var registration, out alreadyCanceled);
             return registration;
         }
 
@@ -168,8 +222,11 @@ namespace Proto.Promises
         /// <para/>If successful, allows continued use of this instance, even after the associated <see cref="CancelationSource"/> has been disposed, until this is released.
         /// If successful, this should be paired with a call to <see cref="Release"/>.
         /// </summary>
+        /// <remarks>
+        /// This method returns the same result as <see cref="CanBeCanceled"/>.
+        /// </remarks>
         public bool TryRetain()
-            => Internal.CancelationRef.TryRetainUser(_ref, _id);
+            => _ref?.TryRetainUser(_id) == true;
 
         /// <summary>
         /// Release this instance. Allows resources to be released when the associated <see cref="CancelationSource"/> is disposed (if <see cref="Release"/> has been called for all <see cref="TryRetain"/> calls).
@@ -178,7 +235,7 @@ namespace Proto.Promises
         /// <exception cref="InvalidOperationException"/>
         public void Release()
         {
-            if (!Internal.CancelationRef.TryReleaseUser(_ref, _id))
+            if (_ref?.TryReleaseUser(_id) != true)
             {
                 throw new InvalidOperationException("CancelationToken.Release: you must call Retain before you call Release.", Internal.GetFormattedStacktrace(1));
             }

--- a/Package/Core/Cancelations/Internal/CancelationInternal.cs
+++ b/Package/Core/Cancelations/Internal/CancelationInternal.cs
@@ -215,31 +215,21 @@ namespace Proto.Promises
                 _previous = this;
             }
 
-            [MethodImpl(InlineOption)]
-            internal static bool IsValidSource(CancelationRef _this, int sourceId)
-                => _this != null && Volatile.Read(ref _this._sourceId) == sourceId;
+            internal bool IsValidSource(int sourceId)
+                => Volatile.Read(ref _sourceId) == sourceId;
 
             [MethodImpl(InlineOption)]
-            internal static bool IsSourceCanceled(CancelationRef _this, int sourceId)
-                => _this != null && _this.IsSourceCanceled(sourceId);
-
-            [MethodImpl(InlineOption)]
-            private bool IsSourceCanceled(int sourceId)
+            internal bool IsSourceCanceled(int sourceId)
                 // Volatile read the state before the id.
                 => _state >= State.Canceled & sourceId == SourceId;
 
             [MethodImpl(InlineOption)]
-            internal static bool CanTokenBeCanceled(CancelationRef _this, int tokenId)
-                => _this != null
-                    // Volatile read the state before the id.
-                    && (_this._state != State.Disposed & _this.TokenId == tokenId);
+            internal bool CanTokenBeCanceled(int tokenId)
+                // Volatile read the state before the id.
+                => _state != State.Disposed & TokenId == tokenId;
 
             [MethodImpl(InlineOption)]
-            internal static bool IsTokenCanceled(CancelationRef _this, int tokenId)
-                => _this != null && _this.IsTokenCanceled(tokenId);
-
-            [MethodImpl(InlineOption)]
-            private bool IsTokenCanceled(int tokenId)
+            internal bool IsTokenCanceled(int tokenId)
             {
                 // Volatile read the state before everything else.
                 var state = _state;
@@ -392,7 +382,7 @@ namespace Proto.Promises
                             ts_isLinkingToBclToken = false;
                             return;
                         }
-                        cancelRef.UnsafeAs<CancelationRef>().Cancel();
+                        cancelRef.UnsafeAs<CancelationRef>().CancelUnsafe();
                     }, this);
 
                     if (!ts_isLinkingToBclToken)
@@ -423,12 +413,7 @@ namespace Proto.Promises
                 _previous = node;
             }
 
-            [MethodImpl(InlineOption)]
-            internal static bool TrySetCanceled(CancelationRef _this, int sourceId)
-                => _this != null && _this.TrySetCanceled(sourceId);
-
-            [MethodImpl(InlineOption)]
-            private bool TrySetCanceled(int sourceId)
+            internal bool TryCancel(int sourceId)
             {
                 _smallFields._locker.Enter();
                 if (sourceId != SourceId | _state != State.Pending)
@@ -438,6 +423,36 @@ namespace Proto.Promises
                 }
                 InvokeCallbacksAlreadyLocked();
                 return true;
+            }
+
+            internal void Cancel(int sourceId)
+            {
+                _smallFields._locker.Enter();
+                bool idsMismatch = sourceId != SourceId;
+                var state = _state;
+                if (idsMismatch | state != State.Pending)
+                {
+                    _smallFields._locker.Exit();
+                    // Only throw if this was disposed. If this was already canceled, do nothing.
+                    if (idsMismatch | state == State.Disposed)
+                    {
+                        throw new ObjectDisposedException(nameof(CancelationSource));
+                    }
+                    return;
+                }
+                InvokeCallbacksAlreadyLocked();
+            }
+
+            // Internal Cancel method skipping the disposed check.
+            internal void CancelUnsafe()
+            {
+                _smallFields._locker.Enter();
+                if (_state != State.Pending)
+                {
+                    _smallFields._locker.Exit();
+                    return;
+                }
+                InvokeCallbacksAlreadyLocked();
             }
 
             private void InvokeCallbacksAlreadyLocked()
@@ -485,14 +500,10 @@ namespace Proto.Promises
                 }
             }
 
-            [MethodImpl(InlineOption)]
-            internal static bool TryDispose(CancelationRef _this, int sourceId)
-                => _this != null && _this.TryDispose(sourceId);
-
             internal bool TryDispose(int sourceId)
             {
                 _smallFields._locker.Enter();
-                if (!TryIncrementSourceId(sourceId))
+                if (_state == State.Disposed || !TryIncrementSourceId(sourceId))
                 {
                     _smallFields._locker.Exit();
                     return false;
@@ -503,7 +514,20 @@ namespace Proto.Promises
                 return true;
             }
 
-            // Internal dispose method skipping the id check.
+            internal void Dispose(int sourceId)
+            {
+                _smallFields._locker.Enter();
+                if (_state == State.Disposed || !TryIncrementSourceId(sourceId))
+                {
+                    _smallFields._locker.Exit();
+                    throw new ObjectDisposedException(nameof(CancelationSource));
+                }
+
+                ThrowIfInPool(this);
+                DisposeLocked();
+            }
+
+            // Internal Dispose method skipping the disposed check.
             internal void DisposeUnsafe()
             {
                 ThrowIfInPool(this);
@@ -548,11 +572,7 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static bool TryRetainUser(CancelationRef _this, int tokenId)
-                => _this != null && _this.TryRetainUser(tokenId);
-
-            [MethodImpl(InlineOption)]
-            private bool TryRetainUser(int tokenId)
+            internal bool TryRetainUser(int tokenId)
             {
                 _smallFields._locker.Enter();
                 if (tokenId != TokenId | _state == State.Disposed)
@@ -571,11 +591,7 @@ namespace Proto.Promises
             }
 
             [MethodImpl(InlineOption)]
-            internal static bool TryReleaseUser(CancelationRef _this, int tokenId)
-                => _this != null && _this.TryReleaseUser(tokenId);
-
-            [MethodImpl(InlineOption)]
-            private bool TryReleaseUser(int tokenId)
+            internal bool TryReleaseUser(int tokenId)
             {
                 _smallFields._locker.Enter();
                 if (tokenId != TokenId)
@@ -645,18 +661,6 @@ namespace Proto.Promises
                     _links.Pop().UnhookAndDispose();
                 }
                 ObjectPool.MaybeRepool(this);
-            }
-
-            internal void Cancel()
-            {
-                // Same as TrySetCanceled, but without checking the SourceId.
-                _smallFields._locker.Enter();
-                if (_state != State.Pending)
-                {
-                    _smallFields._locker.Exit();
-                    return;
-                }
-                InvokeCallbacksAlreadyLocked();
             }
 
 #if !PROTO_PROMISE_DEVELOPER_MODE
@@ -755,7 +759,7 @@ namespace Proto.Promises
                     ThrowIfInPool(this);
                     try
                     {
-                        _target.Cancel();
+                        _target.CancelUnsafe();
                     }
                     finally
                     {
@@ -905,7 +909,7 @@ namespace Proto.Promises
 
                 [MethodImpl(InlineOption)]
                 public void Invoke()
-                    => _target.Cancel();
+                    => _target.CancelUnsafe();
             }
         } // class CancelationRef
 
@@ -1248,9 +1252,9 @@ namespace Proto.Promises
             {
                 // We don't need the synchronous invoke check when this is created.
 #if NETCOREAPP3_0_OR_GREATER
-                var registration = token.UnsafeRegister(state => state.UnsafeAs<CancelationRef>().Cancel(), this);
+                var registration = token.UnsafeRegister(state => state.UnsafeAs<CancelationRef>().CancelUnsafe(), this);
 #else
-                var registration = token.Register(state => state.UnsafeAs<CancelationRef>().Cancel(), this, false);
+                var registration = token.Register(state => state.UnsafeAs<CancelationRef>().CancelUnsafe(), this, false);
 #endif
                 SetCancellationTokenRegistration(registration);
             }

--- a/Package/Core/InternalShared/HelperFunctionsInternal.cs
+++ b/Package/Core/InternalShared/HelperFunctionsInternal.cs
@@ -174,7 +174,7 @@ namespace Proto.Promises
             => dict.TryGetValue(key, out value) && dict.Remove(key);
 #endif
 
-        internal static CancelationSource MaybeJoinCancelationTokens(CancelationToken first, CancelationToken second, out CancelationToken maybeJoinedToken)
+        internal static MaybemaybeJoinedCancelationSource MaybeJoinCancelationTokens(CancelationToken first, CancelationToken second, out CancelationToken maybeJoinedToken)
         {
             if (first == second | !first.CanBeCanceled)
             {
@@ -193,7 +193,27 @@ namespace Proto.Promises
             }
             var source = CancelationSource.New(first, second);
             maybeJoinedToken = source.Token;
-            return source;
+            return new MaybemaybeJoinedCancelationSource(source);
+        }
+
+        internal readonly struct MaybemaybeJoinedCancelationSource: IDisposable
+        {
+            private readonly CancelationSource _source;
+
+            [MethodImpl(InlineOption)]
+            public MaybemaybeJoinedCancelationSource(CancelationSource source)
+            {
+                _source = source;
+            }
+
+            [MethodImpl(InlineOption)]
+            public void Dispose()
+            {
+                if (_source != default)
+                {
+                    _source.Dispose();
+                }
+            }
         }
 
         internal static void SetOrAdd<T>(this IList<T> list, in T value, int index)

--- a/Package/Core/Linq/Internal/AggregateByInternal.cs
+++ b/Package/Core/Linq/Internal/AggregateByInternal.cs
@@ -200,7 +200,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -233,7 +233,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -279,7 +279,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -314,7 +314,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -529,7 +529,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -563,7 +563,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -611,7 +611,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -656,7 +656,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }

--- a/Package/Core/Linq/Internal/CountByInternal.cs
+++ b/Package/Core/Linq/Internal/CountByInternal.cs
@@ -337,7 +337,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -369,7 +369,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -407,7 +407,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -440,7 +440,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }

--- a/Package/Core/Linq/Internal/DistinctInternal.cs
+++ b/Package/Core/Linq/Internal/DistinctInternal.cs
@@ -101,7 +101,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -132,7 +132,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -313,7 +313,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -344,7 +344,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -383,7 +383,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -418,7 +418,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }

--- a/Package/Core/Linq/Internal/ExceptInternal.cs
+++ b/Package/Core/Linq/Internal/ExceptInternal.cs
@@ -111,7 +111,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _firstAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                     // Use the same cancelation token for both enumerators.
                     _secondAsyncEnumerator._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -140,7 +140,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _secondAsyncEnumerator.DisposeAsync();
@@ -351,7 +351,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _firstAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                     // Use the same cancelation token for both enumerators.
                     _secondAsyncEnumerator._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -380,7 +380,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _secondAsyncEnumerator.DisposeAsync();
@@ -433,7 +433,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _firstAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                     // Use the same cancelation token for both enumerators.
                     _secondAsyncEnumerator._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -466,7 +466,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _secondAsyncEnumerator.DisposeAsync();

--- a/Package/Core/Linq/Internal/GroupByInternal.cs
+++ b/Package/Core/Linq/Internal/GroupByInternal.cs
@@ -372,7 +372,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
                     try
@@ -411,7 +411,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -456,7 +456,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
                     try
@@ -492,7 +492,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -538,7 +538,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
                     try
@@ -578,7 +578,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -623,7 +623,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We could do await Lookup<TKey, TElement>.GetOrCreateAsync(...), but it's more efficient to do it manually so we won't allocate the Lookup class and a separate async state machine.
                     try
@@ -660,7 +660,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }

--- a/Package/Core/Linq/Internal/GroupJoinInternal.cs
+++ b/Package/Core/Linq/Internal/GroupJoinInternal.cs
@@ -264,7 +264,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredOuterAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                     // Use the same cancelation token for both enumerators.
                     _innerAsyncEnumerator._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -306,7 +306,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         emptyInnerElements.Dispose();
                         lookup.Dispose();
                         try
@@ -373,7 +373,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredOuterAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                     // Use the same cancelation token for both enumerators.
                     _innerAsyncEnumerator._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -418,7 +418,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         emptyInnerElements.Dispose();
                         lookup.Dispose();
                         try

--- a/Package/Core/Linq/Internal/IntersectInternal.cs
+++ b/Package/Core/Linq/Internal/IntersectInternal.cs
@@ -111,7 +111,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _firstAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                     // Use the same cancelation token for both enumerators.
                     _secondAsyncEnumerator._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -140,7 +140,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _secondAsyncEnumerator.DisposeAsync();
@@ -351,7 +351,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _firstAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                     // Use the same cancelation token for both enumerators.
                     _secondAsyncEnumerator._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -380,7 +380,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _secondAsyncEnumerator.DisposeAsync();
@@ -433,7 +433,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _firstAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                     // Use the same cancelation token for both enumerators.
                     _secondAsyncEnumerator._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -466,7 +466,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _secondAsyncEnumerator.DisposeAsync();

--- a/Package/Core/Linq/Internal/JoinInternal.cs
+++ b/Package/Core/Linq/Internal/JoinInternal.cs
@@ -259,7 +259,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredOuterAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                     // Use the same cancelation token for both enumerators.
                     _innerAsyncEnumerator._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -300,7 +300,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         lookup.Dispose();
                         try
                         {
@@ -366,7 +366,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredOuterAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                     // Use the same cancelation token for both enumerators.
                     _innerAsyncEnumerator._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -410,7 +410,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         lookup.Dispose();
                         try
                         {

--- a/Package/Core/Linq/Internal/MergeInternal.cs
+++ b/Package/Core/Linq/Internal/MergeInternal.cs
@@ -95,7 +95,7 @@ namespace Proto.Promises
                 // This may be called multiple times. It's fine because it checks internally if it's already canceled.
                 try
                 {
-                    _cancelationToken._ref.Cancel();
+                    _cancelationToken._ref.CancelUnsafe();
                 }
                 catch (Exception e)
                 {

--- a/Package/Core/Linq/Internal/OrderByInternal.cs
+++ b/Package/Core/Linq/Internal/OrderByInternal.cs
@@ -374,7 +374,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredSource._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -421,7 +421,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         var source = _configuredSource;
                         Dispose();
                         await source.DisposeAsync();
@@ -628,7 +628,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredSource._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -677,7 +677,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         var source = _configuredSource;
                         Dispose();
                         await source.DisposeAsync();
@@ -847,7 +847,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredSource._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -899,7 +899,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         var source = _configuredSource;
                         Dispose();
                         await source.DisposeAsync();

--- a/Package/Core/Linq/Internal/SelectInternal.cs
+++ b/Package/Core/Linq/Internal/SelectInternal.cs
@@ -135,7 +135,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -151,7 +151,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -186,7 +186,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -202,7 +202,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -337,7 +337,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -354,7 +354,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -389,7 +389,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -406,7 +406,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }

--- a/Package/Core/Linq/Internal/SelectManyInternal.cs
+++ b/Package/Core/Linq/Internal/SelectManyInternal.cs
@@ -202,7 +202,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We don't dispose the enumerators until the owner is disposed.
                     // This is in case any enumerator contains TempCollections that they will still be valid until the owner is disposed.
@@ -224,7 +224,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _configuredAsyncEnumerator.DisposeAsync();
@@ -284,7 +284,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We don't dispose the enumerators until the owner is disposed.
                     // This is in case any enumerator contains TempCollections that they will still be valid until the owner is disposed.
@@ -306,7 +306,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _configuredAsyncEnumerator.DisposeAsync();
@@ -530,7 +530,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We don't dispose the enumerators until the owner is disposed.
                     // This is in case any enumerator contains TempCollections that they will still be valid until the owner is disposed.
@@ -553,7 +553,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _configuredAsyncEnumerator.DisposeAsync();
@@ -613,7 +613,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We don't dispose the enumerators until the owner is disposed.
                     // This is in case any enumerator contains TempCollections that they will still be valid until the owner is disposed.
@@ -636,7 +636,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _configuredAsyncEnumerator.DisposeAsync();
@@ -877,7 +877,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We don't dispose the enumerators until the owner is disposed.
                     // This is in case any enumerator contains TempCollections that they will still be valid until the owner is disposed.
@@ -900,7 +900,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _configuredAsyncEnumerator.DisposeAsync();
@@ -964,7 +964,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We don't dispose the enumerators until the owner is disposed.
                     // This is in case any enumerator contains TempCollections that they will still be valid until the owner is disposed.
@@ -987,7 +987,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _configuredAsyncEnumerator.DisposeAsync();
@@ -1225,7 +1225,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We don't dispose the enumerators until the owner is disposed.
                     // This is in case any enumerator contains TempCollections that they will still be valid until the owner is disposed.
@@ -1249,7 +1249,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _configuredAsyncEnumerator.DisposeAsync();
@@ -1313,7 +1313,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     // We don't dispose the enumerators until the owner is disposed.
                     // This is in case any enumerator contains TempCollections that they will still be valid until the owner is disposed.
@@ -1337,7 +1337,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _configuredAsyncEnumerator.DisposeAsync();

--- a/Package/Core/Linq/Internal/SkipWhileInternal.cs
+++ b/Package/Core/Linq/Internal/SkipWhileInternal.cs
@@ -259,7 +259,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredSource._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -282,7 +282,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredSource.DisposeAsync();
                     }
                 }
@@ -314,7 +314,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredSource._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -337,7 +337,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredSource.DisposeAsync();
                     }
                 }
@@ -369,7 +369,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredSource._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -393,7 +393,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredSource.DisposeAsync();
                     }
                 }
@@ -425,7 +425,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredSource._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -449,7 +449,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredSource.DisposeAsync();
                     }
                 }

--- a/Package/Core/Linq/Internal/TakeWhileInternal.cs
+++ b/Package/Core/Linq/Internal/TakeWhileInternal.cs
@@ -243,7 +243,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredSource._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -262,7 +262,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredSource.DisposeAsync();
                     }
                 }
@@ -294,7 +294,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredSource._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -313,7 +313,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredSource.DisposeAsync();
                     }
                 }
@@ -345,7 +345,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredSource._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -365,7 +365,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredSource.DisposeAsync();
                     }
                 }
@@ -397,7 +397,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredSource._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -417,7 +417,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredSource.DisposeAsync();
                     }
                 }

--- a/Package/Core/Linq/Internal/UnionByInternal.cs
+++ b/Package/Core/Linq/Internal/UnionByInternal.cs
@@ -204,7 +204,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _firstAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = Internal.MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = Internal.MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                     // Use the same cancelation token for both enumerators.
                     _secondAsyncEnumerator._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -236,7 +236,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _firstAsyncEnumerator.DisposeAsync();
@@ -289,7 +289,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _firstAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = Internal.MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = Internal.MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                     // Use the same cancelation token for both enumerators.
                     _secondAsyncEnumerator._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -325,7 +325,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         try
                         {
                             await _firstAsyncEnumerator.DisposeAsync();

--- a/Package/Core/Linq/Internal/UnionInternal.cs
+++ b/Package/Core/Linq/Internal/UnionInternal.cs
@@ -583,7 +583,7 @@ namespace Proto.Promises
             {
                 // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                 var enumerableRef = _configuredFirst._enumerator._target;
-                var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
                 // Use the same cancelation token for both enumerators.
                 _second._target._cancelationToken = enumerableRef._cancelationToken;
 
@@ -634,7 +634,7 @@ namespace Proto.Promises
                 }
                 finally
                 {
-                    joinedCancelationSource.TryDispose();
+                    maybeJoinedCancelationSource.Dispose();
                     // Disposal logic is exactly the same as DisposeAsyncWithoutStart, we copy it here instead of calling the method so that we only have 1 async state machine.
                     var firstEnumerator = _configuredFirst;
                     var nextEnumerator = _second;

--- a/Package/Core/Linq/Internal/WhereInternal.cs
+++ b/Package/Core/Linq/Internal/WhereInternal.cs
@@ -145,7 +145,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -165,7 +165,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -200,7 +200,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -220,7 +220,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -364,7 +364,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -385,7 +385,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }
@@ -420,7 +420,7 @@ namespace Proto.Promises
                 {
                     // The enumerator may have been configured with a cancelation token. We need to join the passed in token before starting iteration.
                     var enumerableRef = _configuredAsyncEnumerator._enumerator._target;
-                    var joinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
+                    var maybeJoinedCancelationSource = MaybeJoinCancelationTokens(enumerableRef._cancelationToken, cancelationToken, out enumerableRef._cancelationToken);
 
                     try
                     {
@@ -441,7 +441,7 @@ namespace Proto.Promises
                     }
                     finally
                     {
-                        joinedCancelationSource.TryDispose();
+                        maybeJoinedCancelationSource.Dispose();
                         await _configuredAsyncEnumerator.DisposeAsync();
                     }
                 }

--- a/Package/Core/PromiseGroups/Internal/PromiseEachGroupInternal.cs
+++ b/Package/Core/PromiseGroups/Internal/PromiseEachGroupInternal.cs
@@ -92,7 +92,7 @@ namespace Proto.Promises
                 {
                     try
                     {
-                        _cancelationRef.Cancel();
+                        _cancelationRef.CancelUnsafe();
                     }
                     catch (Exception e)
                     {

--- a/Package/Core/PromiseGroups/Internal/PromiseGroupBaseInternal.cs
+++ b/Package/Core/PromiseGroups/Internal/PromiseGroupBaseInternal.cs
@@ -106,7 +106,7 @@ namespace Proto.Promises
                     // This may be called multiple times. It's fine because it checks internally if it's already canceled.
                     try
                     {
-                        _cancelationRef.Cancel();
+                        _cancelationRef.CancelUnsafe();
                     }
                     catch (Exception e)
                     {

--- a/Package/Core/PromiseGroups/Internal/PromiseRaceGroupInternal.cs
+++ b/Package/Core/PromiseGroups/Internal/PromiseRaceGroupInternal.cs
@@ -64,7 +64,7 @@ namespace Proto.Promises
                     // This may be called multiple times. It's fine because it checks internally if it's already canceled.
                     try
                     {
-                        _cancelationRef.Cancel();
+                        _cancelationRef.CancelUnsafe();
                     }
                     catch (Exception e)
                     {

--- a/Package/Core/PromiseGroups/PromiseRaceGroup.cs
+++ b/Package/Core/PromiseGroups/PromiseRaceGroup.cs
@@ -123,7 +123,7 @@ namespace Proto.Promises
             // and catch any exceptions to propagate them out of WaitAsync().
             try
             {
-                _cancelationRef.Cancel();
+                _cancelationRef.CancelUnsafe();
             }
             catch (Exception e)
             {
@@ -290,7 +290,7 @@ namespace Proto.Promises
             // and catch any exceptions to propagate them out of WaitAsync().
             try
             {
-                _cancelationRef.Cancel();
+                _cancelationRef.CancelUnsafe();
             }
             catch (Exception e)
             {

--- a/Package/Core/PromiseGroups/PromiseRaceWithIndexGroup.cs
+++ b/Package/Core/PromiseGroups/PromiseRaceWithIndexGroup.cs
@@ -124,7 +124,7 @@ namespace Proto.Promises
             // and catch any exceptions to propagate them out of WaitAsync().
             try
             {
-                _cancelationRef.Cancel();
+                _cancelationRef.CancelUnsafe();
             }
             catch (Exception e)
             {
@@ -293,7 +293,7 @@ namespace Proto.Promises
             // and catch any exceptions to propagate them out of WaitAsync().
             try
             {
-                _cancelationRef.Cancel();
+                _cancelationRef.CancelUnsafe();
             }
             catch (Exception e)
             {

--- a/Package/Core/Promises/Internal/CancelInternal.cs
+++ b/Package/Core/Promises/Internal/CancelInternal.cs
@@ -57,11 +57,11 @@ namespace Proto.Promises
 
                 [MethodImpl(InlineOption)]
                 internal void Register(CancelationToken cancelationToken, ICancelable owner)
-                    => cancelationToken.TryRegister(owner, out _cancelationRegistration);
+                    => _cancelationRegistration = cancelationToken.Register(owner);
 
                 [MethodImpl(InlineOption)]
                 internal void RegisterWithoutImmediateInvoke(CancelationToken cancelationToken, ICancelable owner, out bool alreadyCanceled)
-                    => cancelationToken.TryRegisterWithoutImmediateInvoke(owner, out _cancelationRegistration, out alreadyCanceled);
+                    => _cancelationRegistration = cancelationToken.RegisterWithoutImmediateInvoke(owner, out alreadyCanceled);
 
                 [MethodImpl(InlineOption)]
                 internal bool TrySetCompleted()

--- a/Package/Core/Promises/Internal/ParallelAsyncInternal.cs
+++ b/Package/Core/Promises/Internal/ParallelAsyncInternal.cs
@@ -91,7 +91,7 @@ namespace Proto.Promises
                     promise._lockAndLaunchNext = 0;
                     var cancelRef = CancelationRef.GetOrCreate();
                     promise._cancelationRef = cancelRef;
-                    cancelationToken.TryRegister(promise, out promise._externalCancelationRegistration);
+                    promise._externalCancelationRegistration = cancelationToken.Register<ICancelable>(promise);
                     promise._asyncEnumerator = enumerable.GetAsyncEnumerator(new CancelationToken(cancelRef, cancelRef.TokenId));
                     if (Promise.Config.AsyncFlowExecutionContextEnabled)
                     {
@@ -425,7 +425,7 @@ namespace Proto.Promises
                     // This may be called multiple times. It's fine because it checks internally if it's already canceled.
                     try
                     {
-                        _cancelationRef.Cancel();
+                        _cancelationRef.CancelUnsafe();
                     }
                     catch (Exception e)
                     {

--- a/Package/Core/Promises/Internal/ParallelInternal.cs
+++ b/Package/Core/Promises/Internal/ParallelInternal.cs
@@ -246,7 +246,7 @@ namespace Proto.Promises
                     promise._completionState = Promise.State.Resolved;
                     promise._stopExecuting = false;
                     promise._cancelationRef = CancelationRef.GetOrCreate();
-                    cancelationToken.TryRegister(promise, out promise._externalCancelationRegistration);
+                    promise._externalCancelationRegistration = cancelationToken.Register<ICancelable>(promise);
                     if (Promise.Config.AsyncFlowExecutionContextEnabled)
                     {
                         promise._executionContext = ExecutionContext.Capture();
@@ -422,7 +422,7 @@ namespace Proto.Promises
                     // This may be called multiple times. It's fine because it checks internally if it's already canceled.
                     try
                     {
-                        _cancelationRef.Cancel();
+                        _cancelationRef.CancelUnsafe();
                     }
                     catch (Exception e)
                     {

--- a/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
+++ b/Package/Core/Threading/Internal/AsyncSynchronizationPromisesInternal.cs
@@ -69,7 +69,7 @@ namespace Proto.Promises
                 {
                     ThrowIfInPool(this);
                     // We register without immediate invoke because we hold a spin lock here, and we don't want to cause a deadlock from it trying to re-enter from the invoke.
-                    cancelationToken.TryRegisterWithoutImmediateInvoke<ICancelable>(this, out _cancelationRegistration, out var alreadyCanceled);
+                    _cancelationRegistration = cancelationToken.RegisterWithoutImmediateInvoke<ICancelable>(this, out var alreadyCanceled);
                     return alreadyCanceled;
                 }
 

--- a/Package/Core/Utilities/Internal/ProgressInternal.cs
+++ b/Package/Core/Utilities/Internal/ProgressInternal.cs
@@ -186,7 +186,7 @@ namespace Proto.Promises
 
                 SetCreatedStacktrace(instance, 2);
                 // Hook up the cancelation last.
-                cancelationToken.TryRegister(instance, out instance._cancelationRegistration);
+                instance._cancelationRegistration = cancelationToken.Register<ICancelable>(instance);
                 return instance;
             }
 

--- a/Package/Tests/CoreTests/APIs/EachTests.cs
+++ b/Package/Tests/CoreTests/APIs/EachTests.cs
@@ -332,7 +332,10 @@ namespace ProtoPromiseTests.APIs
                 {
                     tryCompleters[args[i].completeIndex].Invoke();
                 }
-                cancelationSource.TryDispose();
+                if (!disposeCancelationSourceEarly)
+                {
+                    cancelationSource.Dispose();
+                }
             }, SynchronizationOption.Synchronous)
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }
@@ -435,7 +438,7 @@ namespace ProtoPromiseTests.APIs
                 cancelationSource.Cancel();
                 Assert.False(await asyncEnumerator.MoveNextAsync());
                 await asyncEnumerator.DisposeAsync();
-                cancelationSource.TryDispose();
+                cancelationSource.Dispose();
             }, SynchronizationOption.Synchronous)
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }
@@ -665,7 +668,10 @@ namespace ProtoPromiseTests.APIs
                 {
                     tryCompleters[args[i].completeIndex].Invoke();
                 }
-                cancelationSource.TryDispose();
+                if (!disposeCancelationSourceEarly)
+                {
+                    cancelationSource.Dispose();
+                }
             }, SynchronizationOption.Synchronous)
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }
@@ -780,7 +786,7 @@ namespace ProtoPromiseTests.APIs
                 cancelationSource.Cancel();
                 Assert.False(await asyncEnumerator.MoveNextAsync());
                 await asyncEnumerator.DisposeAsync();
-                cancelationSource.TryDispose();
+                cancelationSource.Dispose();
             }, SynchronizationOption.Synchronous)
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }

--- a/Package/Tests/CoreTests/APIs/PromiseCancelationTests.cs
+++ b/Package/Tests/CoreTests/APIs/PromiseCancelationTests.cs
@@ -345,7 +345,7 @@ namespace ProtoPromiseTests.APIs
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve());
                 Assert.IsFalse(deferred.TryReject("Fail value"));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => cancelationSource.Cancel());
+                cancelationSource.Cancel();
 
                 Assert.IsTrue(canceled);
 
@@ -373,7 +373,7 @@ namespace ProtoPromiseTests.APIs
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve(1));
                 Assert.IsFalse(deferred.TryReject("Fail value"));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => cancelationSource.Cancel());
+                cancelationSource.Cancel();
 
                 Assert.IsTrue(canceled);
 
@@ -511,10 +511,7 @@ namespace ProtoPromiseTests.APIs
                     onCancelCapture: cv => ++cancelCount
                 );
                 cancelationSource.Cancel();
-
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() =>
-                    cancelationSource.Cancel()
-                );
+                cancelationSource.Cancel();
 
                 Assert.AreEqual(TestHelper.onCancelCallbacks, cancelCount);
 
@@ -534,10 +531,7 @@ namespace ProtoPromiseTests.APIs
                     onCancelCapture: cv => ++cancelCount
                 );
                 cancelationSource.Cancel();
-
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() =>
-                    cancelationSource.Cancel()
-                );
+                cancelationSource.Cancel();
 
                 Assert.AreEqual(TestHelper.onCancelCallbacks, cancelCount);
 

--- a/Package/Tests/CoreTests/APIs/PromiseGroups/PromiseEachGroupTests.cs
+++ b/Package/Tests/CoreTests/APIs/PromiseGroups/PromiseEachGroupTests.cs
@@ -360,7 +360,10 @@ namespace ProtoPromiseTests.APIs.PromiseGroups
                 tryCompleters[args[i].completeIndex].Invoke();
             }
             Assert.True(runComplete);
-            cancelationSource.TryDispose();
+            if (!disposeCancelationSourceEarly)
+            {
+                cancelationSource.Dispose();
+            }
 
             runPromise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }
@@ -467,7 +470,7 @@ namespace ProtoPromiseTests.APIs.PromiseGroups
                 cancelationSource.Cancel();
                 Assert.False(await asyncEnumerator.MoveNextAsync());
                 await asyncEnumerator.DisposeAsync();
-                cancelationSource.TryDispose();
+                cancelationSource.Dispose();
             }, SynchronizationOption.Synchronous)
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }
@@ -525,7 +528,10 @@ namespace ProtoPromiseTests.APIs.PromiseGroups
                     Assert.AreEqual(Promise.State.Canceled, asyncEnumerator.Current.State);
                 }
                 await asyncEnumerator.DisposeAsync();
-                cancelationSource.TryDispose();
+                if (!disposeCancelationSourceEarly)
+                {
+                    cancelationSource.Dispose();
+                }
             }, SynchronizationOption.Synchronous)
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }
@@ -630,7 +636,7 @@ namespace ProtoPromiseTests.APIs.PromiseGroups
                 cancelationSource.Cancel();
                 Assert.False(await asyncEnumerator.MoveNextAsync());
                 await asyncEnumerator.DisposeAsync();
-                cancelationSource.TryDispose();
+                cancelationSource.Dispose();
             }, SynchronizationOption.Synchronous)
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }
@@ -1024,7 +1030,10 @@ namespace ProtoPromiseTests.APIs.PromiseGroups
                 tryCompleters[args[i].completeIndex].Invoke();
             }
             Assert.True(runComplete);
-            cancelationSource.TryDispose();
+            if (!disposeCancelationSourceEarly)
+            {
+                cancelationSource.Dispose();
+            }
 
             runPromise.WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }
@@ -1143,7 +1152,7 @@ namespace ProtoPromiseTests.APIs.PromiseGroups
                 cancelationSource.Cancel();
                 Assert.False(await asyncEnumerator.MoveNextAsync());
                 await asyncEnumerator.DisposeAsync();
-                cancelationSource.TryDispose();
+                cancelationSource.Dispose();
             }, SynchronizationOption.Synchronous)
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }
@@ -1205,7 +1214,10 @@ namespace ProtoPromiseTests.APIs.PromiseGroups
                     Assert.AreEqual(Promise.State.Canceled, asyncEnumerator.Current.State);
                 }
                 await asyncEnumerator.DisposeAsync();
-                cancelationSource.TryDispose();
+                if (!disposeCancelationSourceEarly)
+                {
+                    cancelationSource.Dispose();
+                }
             }, SynchronizationOption.Synchronous)
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }
@@ -1322,7 +1334,7 @@ namespace ProtoPromiseTests.APIs.PromiseGroups
                 cancelationSource.Cancel();
                 Assert.False(await asyncEnumerator.MoveNextAsync());
                 await asyncEnumerator.DisposeAsync();
-                cancelationSource.TryDispose();
+                cancelationSource.Dispose();
             }, SynchronizationOption.Synchronous)
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
         }

--- a/Package/Tests/CoreTests/Concurrency/AwaitConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/AwaitConcurrencyTests.cs
@@ -191,7 +191,6 @@ namespace ProtoPromiseTests.Concurrency
         {
             var deferred = default(Promise.Deferred);
             var promise = default(Promise);
-            var cancelationSource = default(CancelationSource);
             var tryCompleter = TestHelper.GetTryCompleterVoid(completeType, rejectValue);
 
             Promise.State result = Promise.State.Pending;
@@ -235,8 +234,6 @@ namespace ProtoPromiseTests.Concurrency
                 },
                 teardown: () =>
                 {
-                    cancelationSource.TryDispose();
-
                     Assert.AreNotEqual(Promise.State.Pending, result);
                     switch (completeType)
                     {
@@ -260,7 +257,6 @@ namespace ProtoPromiseTests.Concurrency
         {
             var deferred = default(Promise<int>.Deferred);
             var promise = default(Promise<int>);
-            var cancelationSource = default(CancelationSource);
             var tryCompleter = TestHelper.GetTryCompleterT(completeType, 1, rejectValue);
 
             Promise.State result = Promise.State.Pending;
@@ -304,8 +300,6 @@ namespace ProtoPromiseTests.Concurrency
                 },
                 teardown: () =>
                 {
-                    cancelationSource.TryDispose();
-
                     Assert.AreNotEqual(Promise.State.Pending, result);
                     switch (completeType)
                     {

--- a/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseAllGroupConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseAllGroupConcurrencyTests.cs
@@ -104,7 +104,10 @@ namespace ProtoPromiseTests.Concurrency.PromiseGroups
                 () =>
                 {
                     helper.Teardown();
-                    cancelationSource.TryDispose();
+                    if (withCancelation)
+                    {
+                        cancelationSource.Dispose();
+                    }
                     Assert.IsTrue(helper.Success);
                 },
                 parallelActions

--- a/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseAllResultsGroupConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseAllResultsGroupConcurrencyTests.cs
@@ -103,7 +103,10 @@ namespace ProtoPromiseTests.Concurrency.PromiseGroups
                 () =>
                 {
                     helper.Teardown();
-                    cancelationSource.TryDispose();
+                    if (withCancelation)
+                    {
+                        cancelationSource.Dispose();
+                    }
                     Assert.IsTrue(helper.Success);
                 },
                 parallelActions

--- a/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseEachGroupConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseEachGroupConcurrencyTests.cs
@@ -145,8 +145,14 @@ namespace ProtoPromiseTests.Concurrency.PromiseGroups
                 () =>
                 {
                     helper.Teardown();
-                    groupCancelationSource.TryDispose();
-                    iterationCancelationSource.TryDispose();
+                    if (cancelationType.HasFlag(EachCancelationType.Group))
+                    {
+                        groupCancelationSource.Dispose();
+                    }
+                    if (cancelationType.HasFlag(EachCancelationType.Iteration))
+                    {
+                        iterationCancelationSource.Dispose();
+                    }
                     Assert.IsTrue(helper.Success);
                 },
                 parallelActions
@@ -261,8 +267,14 @@ namespace ProtoPromiseTests.Concurrency.PromiseGroups
                 () =>
                 {
                     helper.Teardown();
-                    groupCancelationSource.TryDispose();
-                    iterationCancelationSource.TryDispose();
+                    if (cancelationType.HasFlag(EachCancelationType.Group))
+                    {
+                        groupCancelationSource.Dispose();
+                    }
+                    if (cancelationType.HasFlag(EachCancelationType.Iteration))
+                    {
+                        iterationCancelationSource.Dispose();
+                    }
                     Assert.IsTrue(helper.Success);
                 },
                 parallelActions

--- a/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseMergeGroupConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseMergeGroupConcurrencyTests.cs
@@ -93,7 +93,10 @@ namespace ProtoPromiseTests.Concurrency.PromiseGroups
                 () =>
                 {
                     helper.Teardown();
-                    cancelationSource.TryDispose();
+                    if (withCancelation)
+                    {
+                        cancelationSource.Dispose();
+                    }
                     Assert.IsTrue(helper.Success);
                 },
                 parallelActions
@@ -185,7 +188,10 @@ namespace ProtoPromiseTests.Concurrency.PromiseGroups
                 () =>
                 {
                     helper.Teardown();
-                    cancelationSource.TryDispose();
+                    if (withCancelation)
+                    {
+                        cancelationSource.Dispose();
+                    }
                     Assert.IsTrue(helper.Success);
                 },
                 parallelActions

--- a/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseMergeResultsGroupConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseMergeResultsGroupConcurrencyTests.cs
@@ -93,7 +93,10 @@ namespace ProtoPromiseTests.Concurrency.PromiseGroups
                 () =>
                 {
                     helper.Teardown();
-                    cancelationSource.TryDispose();
+                    if (withCancelation)
+                    {
+                        cancelationSource.Dispose();
+                    }
                     Assert.IsTrue(helper.Success);
                 },
                 parallelActions
@@ -184,7 +187,10 @@ namespace ProtoPromiseTests.Concurrency.PromiseGroups
                 () =>
                 {
                     helper.Teardown();
-                    cancelationSource.TryDispose();
+                    if (withCancelation)
+                    {
+                        cancelationSource.Dispose();
+                    }
                     Assert.IsTrue(helper.Success);
                 },
                 parallelActions

--- a/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseRaceGroupConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseRaceGroupConcurrencyTests.cs
@@ -103,7 +103,10 @@ namespace ProtoPromiseTests.Concurrency.PromiseGroups
                 () =>
                 {
                     helper.Teardown();
-                    cancelationSource.TryDispose();
+                    if (withCancelation)
+                    {
+                        cancelationSource.Dispose();
+                    }
                     Assert.IsTrue(helper.Success);
                 },
                 parallelActions
@@ -183,7 +186,10 @@ namespace ProtoPromiseTests.Concurrency.PromiseGroups
                 () =>
                 {
                     helper.Teardown();
-                    cancelationSource.TryDispose();
+                    if (withCancelation)
+                    {
+                        cancelationSource.Dispose();
+                    }
                     Assert.IsTrue(helper.Success);
                 },
                 parallelActions

--- a/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseRaceWithIndexGroupConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseRaceWithIndexGroupConcurrencyTests.cs
@@ -103,7 +103,10 @@ namespace ProtoPromiseTests.Concurrency.PromiseGroups
                 () =>
                 {
                     helper.Teardown();
-                    cancelationSource.TryDispose();
+                    if (withCancelation)
+                    {
+                        cancelationSource.Dispose();
+                    }
                     Assert.IsTrue(helper.Success);
                 },
                 parallelActions
@@ -183,7 +186,10 @@ namespace ProtoPromiseTests.Concurrency.PromiseGroups
                 () =>
                 {
                     helper.Teardown();
-                    cancelationSource.TryDispose();
+                    if (withCancelation)
+                    {
+                        cancelationSource.Dispose();
+                    }
                     Assert.IsTrue(helper.Success);
                 },
                 parallelActions

--- a/Package/Tests/CoreTests/Concurrency/Threading/AsyncLockConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/Threading/AsyncLockConcurrencyTests.cs
@@ -224,7 +224,7 @@ namespace ProtoPromiseTests.Concurrency.Threading
                         }
                         if (delayCancel && exitedCount != 0)
                         {
-                            cancelationSource.TryCancel();
+                            cancelationSource.Cancel();
                         }
                     }
                 });
@@ -322,7 +322,7 @@ namespace ProtoPromiseTests.Concurrency.Threading
                         }
                         if (delayCancel && exitedCount != 0)
                         {
-                            cancelationSource.TryCancel();
+                            cancelationSource.Cancel();
                         }
                     }
                 });

--- a/Package/Tests/CoreTests/Concurrency/WaitAsyncConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/WaitAsyncConcurrencyTests.cs
@@ -171,7 +171,10 @@ namespace ProtoPromiseTests.Concurrency
 
                     TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
                     TestHelper.SpinUntil(() => didContinue, timeout, $"didContinue: {didContinue}");
-                    cancelationSource.TryDispose();
+                    if (withCancelation)
+                    {
+                        cancelationSource.Dispose();
+                    }
                 },
                 actions: parallelActions.ToArray()
             );
@@ -281,7 +284,10 @@ namespace ProtoPromiseTests.Concurrency
 
                     TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
                     TestHelper.SpinUntil(() => didContinue, timeout, $"didContinue: {didContinue}");
-                    cancelationSource.TryDispose();
+                    if (withCancelation)
+                    {
+                        cancelationSource.Dispose();
+                    }
                 },
                 actions: parallelActions.ToArray()
             );

--- a/Package/Tests/Helpers/TestHelper.cs
+++ b/Package/Tests/Helpers/TestHelper.cs
@@ -384,7 +384,7 @@ namespace ProtoPromiseTests
             }
 
             var deferred = Promise.NewDeferred();
-            cancelationToken.TryRegister(() => deferred.TryCancel(), out _);
+            var registration = cancelationToken.Register(() => deferred.TryCancel());
             switch (completeType)
             {
                 case CompleteType.Resolve:
@@ -399,7 +399,9 @@ namespace ProtoPromiseTests
                 default:
                     throw new Exception();
             }
-            return deferred.Promise;
+            return registration.IsRegistered
+                ? deferred.Promise.Finally(registration.Dispose)
+                : deferred.Promise;
         }
 
         public static Promise<T> BuildPromise<T, TReject>(CompleteType completeType, bool isAlreadyComplete, T value, TReject reason, CancelationToken cancelationToken, out Action tryCompleter)
@@ -426,7 +428,7 @@ namespace ProtoPromiseTests
             }
 
             var deferred = Promise<T>.NewDeferred();
-            cancelationToken.TryRegister(() => deferred.TryCancel(), out _);
+            var registration = cancelationToken.Register(() => deferred.TryCancel());
             switch (completeType)
             {
                 case CompleteType.Resolve:
@@ -441,7 +443,9 @@ namespace ProtoPromiseTests
                 default:
                     throw new Exception();
             }
-            return deferred.Promise;
+            return registration.IsRegistered
+                ? deferred.Promise.Finally(registration.Dispose)
+                : deferred.Promise;
         }
 
         public static Promise ThenDuplicate(this Promise promise, CancelationToken cancelationToken = default(CancelationToken))

--- a/Package/UnityHelpers/2018.3/Internal/PromiseYielderInternal.cs
+++ b/Package/UnityHelpers/2018.3/Internal/PromiseYielderInternal.cs
@@ -515,7 +515,7 @@ namespace Proto.Promises
                 routine._deferred = Promise.NewDeferred();
                 runner = runner ? runner : PromiseBehaviour.Instance;
                 routine.Current = yieldInstruction;
-                cancelationToken.TryRegister((routine, runner), cv => cv.routine.OnCancel(cv.runner), out routine._cancelationRegistration);
+                routine._cancelationRegistration = cancelationToken.Register((routine, runner), cv => cv.routine.OnCancel(cv.runner));
 
                 runner.StartCoroutine(routine);
                 return routine._deferred.Promise;


### PR DESCRIPTION
- Deprecated `CancelationSource.{IsValid, TryCancel, TryDispose}`.
- Deprecated `CancelationToken.{TryRegister, TryRegisterWithoutImmediateInvoke}`.
- Added `CancelationToken.RegisterWithoutImmediateInvoke` APIs.
- Changed behavior of `CancelationSource.Cancel` to not throw if it's called more than once.
- Changed behavior of `CancelationSource.{Cancel, Dispose}` to throw `ObjectDisposedException` if it was disposed, or `NullReferenceException` if it's default.