### PR TITLE
Deprecate `{IsValid*, Try*}` APIs.

### DIFF
--- a/Package/Core/InternalShared/DebugInternal.cs
+++ b/Package/Core/InternalShared/DebugInternal.cs
@@ -162,7 +162,9 @@ namespace Proto.Promises
         }
         internal static void ValidateArgument(Promise arg, string argName, int skipFrames)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             if (!arg.IsValid)
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 throw new InvalidArgumentException(argName,
                     "Promise is invalid. Call `GetRetainer()` if you intend to await multiple times.",
@@ -252,7 +254,9 @@ namespace Proto.Promises
 
         internal static void ValidateOperation(Promise promise, int skipFrames)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             if (!promise.IsValid)
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 throw new InvalidOperationException("Promise is invalid." +
                     " Call `GetRetainer()` if you intend to await multiple times.",
@@ -270,7 +274,9 @@ namespace Proto.Promises
 
             private void ValidateAwait(PromiseRefBase other, short promiseId, bool awaited)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 if (new Promise(other, promiseId).IsValid == false)
+#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     // Awaiting or returning an invalid from the callback is not allowed.
                     if (awaited)
@@ -492,7 +498,9 @@ namespace Proto.Promises
 
         static partial void ValidateElement(Promise promise, string argName, int skipFrames)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             if (!promise.IsValid)
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 throw new InvalidElementException(argName,
                     $"A promise is invalid in {argName}." +
@@ -522,7 +530,9 @@ namespace Proto.Promises
 
         static partial void ValidateElement(Promise<T> promise, string argName, int skipFrames)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             if (!promise.IsValid)
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 throw new InvalidElementException(argName,
                     $"A promise is invalid in {argName}." +

--- a/Package/Core/Promises/Deferred.cs
+++ b/Package/Core/Promises/Deferred.cs
@@ -8,6 +8,7 @@
 #pragma warning disable IDE0270 // Use coalesce expression
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -41,7 +42,7 @@ namespace Proto.Promises
 #if PROMISE_DEBUG // If the reference is null, this is invalid. We only check in DEBUG mode for performance.
                     if (_this == null)
                     {
-                        throw new InvalidOperationException("DeferredBase.Promise: instance is not valid.", Internal.GetFormattedStacktrace(1));
+                        throw new NullReferenceException();
                     }
 #endif
                     return new Promise((Internal.PromiseRefBase) _this, _promiseId);
@@ -51,6 +52,8 @@ namespace Proto.Promises
             /// <summary>
             /// Get whether or not this instance and the attached <see cref="Promise"/> are valid.
             /// </summary>
+            [Obsolete("Due to object pooling, this property is inherently unsafe. Prefer != default, and remember to set your Deferred fields to default when you complete them.", false)]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public bool IsValid
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -60,6 +63,8 @@ namespace Proto.Promises
             /// <summary>
             /// Get whether or not this instance is valid and the attached <see cref="Promise"/> is still pending.
             /// </summary>
+            [Obsolete("Due to object pooling, this property is inherently unsafe. Prefer != default, and remember to set your Deferred fields to default when you complete them.", false)]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public bool IsValidAndPending
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -116,13 +121,14 @@ namespace Proto.Promises
             /// <summary>
             /// Reject the linked <see cref="Promise"/> with <paramref name="reason"/>.
             /// </summary>
-            /// <exception cref="InvalidOperationException"/>
+            /// <exception cref="InvalidOperationException">This was already completed.</exception>
+            /// <exception cref="NullReferenceException">This is a default value.</exception>
             public void Reject<TReject>(TReject reason)
             {
                 var _this = _ref;
-                if (_this?.TryIncrementDeferredId(_deferredId) != true)
+                if (!_this.TryIncrementDeferredId(_deferredId))
                 {
-                    throw new InvalidOperationException("DeferredBase.Reject: instance is not valid or already complete.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("The deferred was already completed.", Internal.GetFormattedStacktrace(1));
                 }
                 _this.RejectDirect(Internal.CreateRejectContainer(reason, 1, null, _this));
             }
@@ -131,6 +137,7 @@ namespace Proto.Promises
             /// Try to reject the linked <see cref="Promise"/> with <paramref name="reason"/>.
             /// <para/> Returns true if successful, false otherwise.
             /// </summary>
+            [Obsolete("Prefer != default and Reject.", false), EditorBrowsable(EditorBrowsableState.Never)]
             public bool TryReject<TReject>(TReject reason)
             {
                 var _this = _ref;
@@ -145,14 +152,15 @@ namespace Proto.Promises
             /// <summary>
             /// Cancel the linked <see cref="Promise"/>.
             /// </summary>
-            /// <exception cref="InvalidOperationException"/>
+            /// <exception cref="InvalidOperationException">This was already completed.</exception>
+            /// <exception cref="NullReferenceException">This is a default value.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void Cancel()
             {
                 var _this = _ref;
-                if (_this?.TryIncrementDeferredId(_deferredId) != true)
+                if (!_this.TryIncrementDeferredId(_deferredId))
                 {
-                    throw new InvalidOperationException("DeferredBase.Cancel: instance is not valid or already complete.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("The deferred was already completed.", Internal.GetFormattedStacktrace(1));
                 }
                 _this.CancelDirect();
             }
@@ -161,7 +169,7 @@ namespace Proto.Promises
             /// Try to cancel the linked <see cref="Promise"/>.
             /// <para/> Returns true if successful, false otherwise.
             /// </summary>
-            [MethodImpl(Internal.InlineOption)]
+            [Obsolete("Prefer != default and Cancel.", false), EditorBrowsable(EditorBrowsableState.Never)]
             public bool TryCancel()
             {
                 var _this = _ref;
@@ -234,6 +242,8 @@ namespace Proto.Promises
             /// <summary>
             /// Get whether or not this instance and the attached <see cref="Promise"/> are valid.
             /// </summary>
+            [Obsolete("Due to object pooling, this property is inherently unsafe. Prefer != default, and remember to set your Deferred fields to default when you complete them.", false)]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public bool IsValid
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -243,6 +253,8 @@ namespace Proto.Promises
             /// <summary>
             /// Get whether or not this instance is valid and the attached <see cref="Promise"/> is still pending.
             /// </summary>
+            [Obsolete("Due to object pooling, this property is inherently unsafe. Prefer != default, and remember to set your Deferred fields to default when you complete them.", false)]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public bool IsValidAndPending
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -270,14 +282,15 @@ namespace Proto.Promises
             /// <summary>
             /// Resolve the linked <see cref="Promise"/>.
             /// </summary>
-            /// <exception cref="InvalidOperationException"/>
+            /// <exception cref="InvalidOperationException">This was already completed.</exception>
+            /// <exception cref="NullReferenceException">This is a default value.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void Resolve()
             {
                 var _this = _ref;
-                if (_this?.TryIncrementDeferredId(_deferredId) != true)
+                if (!_this.TryIncrementDeferredId(_deferredId))
                 {
-                    throw new InvalidOperationException("Deferred.Resolve: instance is not valid or already complete.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("The deferred was already completed.", Internal.GetFormattedStacktrace(1));
                 }
                 _this.ResolveDirectVoid();
             }
@@ -286,20 +299,29 @@ namespace Proto.Promises
             /// Try to resolve the linked <see cref="Promise"/>.
             /// <para/> Returns true if successful, false otherwise.
             /// </summary>
-            [MethodImpl(Internal.InlineOption)]
+            [Obsolete("Prefer != default and Resolve.", false), EditorBrowsable(EditorBrowsableState.Never)]
             public bool TryResolve()
-                => Internal.PromiseRefBase.DeferredPromise<Internal.VoidResult>.TryResolveVoid(_ref, _deferredId);
+            {
+                var _this = _ref;
+                if (_this?.TryIncrementDeferredId(_deferredId) == true)
+                {
+                    _this.ResolveDirectVoid();
+                    return true;
+                }
+                return false;
+            }
 
             /// <summary>
             /// Reject the linked <see cref="Promise"/> with <paramref name="reason"/>.
             /// </summary>
-            /// <exception cref="InvalidOperationException"/>
+            /// <exception cref="InvalidOperationException">This was already completed.</exception>
+            /// <exception cref="NullReferenceException">This is a default value.</exception>
             public void Reject<TReject>(TReject reason)
             {
                 var _this = _ref;
-                if (_this?.TryIncrementDeferredId(_deferredId) != true)
+                if (!_this.TryIncrementDeferredId(_deferredId))
                 {
-                    throw new InvalidOperationException("Deferred.Reject: instance is not valid or already complete.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("The deferred was already completed.", Internal.GetFormattedStacktrace(1));
                 }
                 _this.RejectDirect(Internal.CreateRejectContainer(reason, 1, null, _this));
             }
@@ -308,6 +330,7 @@ namespace Proto.Promises
             /// Try to reject the linked <see cref="Promise"/> with <paramref name="reason"/>.
             /// <para/> Returns true if successful, false otherwise.
             /// </summary>
+            [Obsolete("Prefer != default and Reject.", false), EditorBrowsable(EditorBrowsableState.Never)]
             public bool TryReject<TReject>(TReject reason)
             {
                 var _this = _ref;
@@ -322,14 +345,15 @@ namespace Proto.Promises
             /// <summary>
             /// Cancel the linked <see cref="Promise"/>.
             /// </summary>
-            /// <exception cref="InvalidOperationException"/>
+            /// <exception cref="InvalidOperationException">This was already completed.</exception>
+            /// <exception cref="NullReferenceException">This is a default value.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void Cancel()
             {
                 var _this = _ref;
-                if (_this?.TryIncrementDeferredId(_deferredId) != true)
+                if (!_this.TryIncrementDeferredId(_deferredId))
                 {
-                    throw new InvalidOperationException("Deferred.Cancel: instance is not valid or already complete.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("The deferred was already completed.", Internal.GetFormattedStacktrace(1));
                 }
                 _this.CancelDirect();
             }
@@ -338,7 +362,7 @@ namespace Proto.Promises
             /// Try to cancel the linked <see cref="Promise"/>.
             /// <para/> Returns true if successful, false otherwise.
             /// </summary>
-            [MethodImpl(Internal.InlineOption)]
+            [Obsolete("Prefer != default and Cancel.", false), EditorBrowsable(EditorBrowsableState.Never)]
             public bool TryCancel()
             {
                 var _this = _ref;
@@ -428,6 +452,8 @@ namespace Proto.Promises
             /// <summary>
             /// Get whether or not this instance and the attached <see cref="Promise"/> are valid.
             /// </summary>
+            [Obsolete("Due to object pooling, this property is inherently unsafe. Prefer != default, and remember to set your Deferred fields to default when you complete them.", false)]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public bool IsValid
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -437,6 +463,8 @@ namespace Proto.Promises
             /// <summary>
             /// Get whether or not this instance is valid and the attached <see cref="Promise"/> is still pending.
             /// </summary>
+            [Obsolete("Due to object pooling, this property is inherently unsafe. Prefer != default, and remember to set your Deferred fields to default when you complete them.", false)]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public bool IsValidAndPending
             {
                 [MethodImpl(Internal.InlineOption)]
@@ -464,14 +492,15 @@ namespace Proto.Promises
             /// <summary>
             /// Resolve the linked <see cref="Promise"/> with <paramref name="value"/>.
             /// </summary>
-            /// <exception cref="InvalidOperationException"/>
+            /// <exception cref="InvalidOperationException">This was already completed.</exception>
+            /// <exception cref="NullReferenceException">This is a default value.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void Resolve(T value)
             {
                 var _this = _ref;
-                if (_this?.TryIncrementDeferredId(_deferredId) != true)
+                if (!_this.TryIncrementDeferredId(_deferredId))
                 {
-                    throw new InvalidOperationException("Deferred.Resolve: instance is not valid or already complete.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("The deferred was already completed.", Internal.GetFormattedStacktrace(1));
                 }
                 _this.ResolveDirect(value);
             }
@@ -480,20 +509,29 @@ namespace Proto.Promises
             /// Try to resolve the linked <see cref="Promise"/> with <paramref name="value"/>.
             /// <para/> Returns true if successful, false otherwise.
             /// </summary>
-            [MethodImpl(Internal.InlineOption)]
+            [Obsolete("Prefer != default and Resolve.", false), EditorBrowsable(EditorBrowsableState.Never)]
             public bool TryResolve(T value)
-                => Internal.PromiseRefBase.DeferredPromise<T>.TryResolve(_ref, _deferredId, value);
+            {
+                var _this = _ref;
+                if (_this?.TryIncrementDeferredId(_deferredId) == true)
+                {
+                    _this.ResolveDirect(value);
+                    return true;
+                }
+                return false;
+            }
 
             /// <summary>
             /// Reject the linked <see cref="Promise"/> with <paramref name="reason"/>.
             /// </summary>
-            /// <exception cref="InvalidOperationException"/>
+            /// <exception cref="InvalidOperationException">This was already completed.</exception>
+            /// <exception cref="NullReferenceException">This is a default value.</exception>
             public void Reject<TReject>(TReject reason)
             {
                 var _this = _ref;
-                if (_this?.TryIncrementDeferredId(_deferredId) != true)
+                if (!_this.TryIncrementDeferredId(_deferredId))
                 {
-                    throw new InvalidOperationException("Deferred.Reject: instance is not valid or already complete.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("The deferred was already completed.", Internal.GetFormattedStacktrace(1));
                 }
                 _this.RejectDirect(Internal.CreateRejectContainer(reason, 1, null, _this));
             }
@@ -502,6 +540,7 @@ namespace Proto.Promises
             /// Try to reject the linked <see cref="Promise"/> with <paramref name="reason"/>.
             /// <para/> Returns true if successful, false otherwise.
             /// </summary>
+            [Obsolete("Prefer != default and Reject.", false), EditorBrowsable(EditorBrowsableState.Never)]
             public bool TryReject<TReject>(TReject reason)
             {
                 var _this = _ref;
@@ -516,14 +555,15 @@ namespace Proto.Promises
             /// <summary>
             /// Cancel the linked <see cref="Promise"/>.
             /// </summary>
-            /// <exception cref="InvalidOperationException"/>
+            /// <exception cref="InvalidOperationException">This was already completed.</exception>
+            /// <exception cref="NullReferenceException">This is a default value.</exception>
             [MethodImpl(Internal.InlineOption)]
             public void Cancel()
             {
                 var _this = _ref;
-                if (_this?.TryIncrementDeferredId(_deferredId) != true)
+                if (!_this.TryIncrementDeferredId(_deferredId))
                 {
-                    throw new InvalidOperationException("Deferred.Cancel: instance is not valid or already complete.", Internal.GetFormattedStacktrace(1));
+                    throw new InvalidOperationException("The deferred was already completed.", Internal.GetFormattedStacktrace(1));
                 }
                 _this.CancelDirect();
             }
@@ -532,7 +572,7 @@ namespace Proto.Promises
             /// Try to cancel the linked <see cref="Promise"/>.
             /// <para/> Returns true if successful, false otherwise.
             /// </summary>
-            [MethodImpl(Internal.InlineOption)]
+            [Obsolete("Prefer != default and Cancel.", false), EditorBrowsable(EditorBrowsableState.Never)]
             public bool TryCancel()
             {
                 var _this = _ref;

--- a/Package/Core/Promises/Internal/DeferredInternal.cs
+++ b/Package/Core/Promises/Internal/DeferredInternal.cs
@@ -101,28 +101,6 @@ namespace Proto.Promises
                 }
 
                 [MethodImpl(InlineOption)]
-                internal static bool TryResolve(DeferredPromise<TResult> _this, int deferredId, in TResult value)
-                {
-                    if (_this?.TryIncrementDeferredId(deferredId) == true)
-                    {
-                        _this.ResolveDirect(value);
-                        return true;
-                    }
-                    return false;
-                }
-
-                [MethodImpl(InlineOption)]
-                internal static bool TryResolveVoid(DeferredPromise<TResult> _this, int deferredId)
-                {
-                    if (_this?.TryIncrementDeferredId(deferredId) == true)
-                    {
-                        _this.ResolveDirectVoid();
-                        return true;
-                    }
-                    return false;
-                }
-
-                [MethodImpl(InlineOption)]
                 internal void ResolveDirect(in TResult value)
                 {
                     ThrowIfInPool(this);

--- a/Package/Core/Promises/Promise.cs
+++ b/Package/Core/Promises/Promise.cs
@@ -44,13 +44,6 @@ namespace Proto.Promises
 #endif // UNITY_2021_2_OR_NEWER || !UNITY_2018_3_OR_NEWER
 
         /// <summary>
-        /// Gets whether this instance is valid to be awaited.
-        /// </summary>
-        public bool IsValid
-            // I would prefer to have a null ref only valid if the promise was created from Promise.Resolved, but it's more efficient to allow default values to be valid.
-            => _ref?.GetIsValid(_id) != false;
-
-        /// <summary>
         /// Mark this as awaited and prevent any further awaits or callbacks on this.
         /// <para/>NOTE: It is imperative to terminate your promise chains with Forget so that any uncaught rejections will be reported and objects repooled (if pooling is enabled).
         /// </summary>

--- a/Package/Core/Promises/PromiseT.cs
+++ b/Package/Core/Promises/PromiseT.cs
@@ -59,13 +59,6 @@ namespace Proto.Promises
 #endif // UNITY_2021_2_OR_NEWER || !UNITY_2018_3_OR_NEWER
 
         /// <summary>
-        /// Gets whether this instance is valid to be awaited.
-        /// </summary>
-        public bool IsValid
-            // I would prefer to have a null ref only valid if the promise was created from Promise.Resolved, but it's more efficient to allow default values to be valid.
-            => _ref?.GetIsValid(_id) != false;
-
-        /// <summary>
         /// Cast to <see cref="Promise"/>.
         /// </summary>
         [MethodImpl(Internal.InlineOption)]

--- a/Package/Core/Promises/PromiseT_Deprecated.cs
+++ b/Package/Core/Promises/PromiseT_Deprecated.cs
@@ -22,6 +22,14 @@ namespace Proto.Promises
     public readonly partial struct Promise<T> : IEquatable<Promise<T>>
     {
         /// <summary>
+        /// Gets whether this instance is valid to be awaited.
+        /// </summary>
+        [Obsolete("Due to object pooling, this property is inherently unsafe. This will be removed in a future version.", false), EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsValid
+            // I would prefer to have a null ref only valid if the promise was created from Promise.Resolved, but it's more efficient to allow default values to be valid.
+            => _ref?.GetIsValid(_id) != false;
+
+        /// <summary>
         /// Mark this as awaited and get a new <see cref="Promise{T}"/> of <typeparamref name="T"/> that inherits the state of this and can be awaited multiple times until <see cref="Forget"/> is called on it.
         /// <para/><see cref="Forget"/> must be called when you are finished with it.
         /// <para/>NOTE: You should not return a preserved <see cref="Promise{T}"/> from a public API. Use <see cref="Duplicate"/> to get a <see cref="Promise{T}"/> that is publicly safe.

--- a/Package/Core/Promises/Promise_Deprecated.cs
+++ b/Package/Core/Promises/Promise_Deprecated.cs
@@ -14,6 +14,14 @@ namespace Proto.Promises
     partial struct Promise
     {
         /// <summary>
+        /// Gets whether this instance is valid to be awaited.
+        /// </summary>
+        [Obsolete("Due to object pooling, this property is inherently unsafe. This will be removed in a future version.", false), EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsValid
+            // I would prefer to have a null ref only valid if the promise was created from Promise.Resolved, but it's more efficient to allow default values to be valid.
+            => _ref?.GetIsValid(_id) != false;
+
+        /// <summary>
         /// Mark this as awaited and get a new <see cref="Promise"/> that inherits the state of this and can be awaited multiple times until <see cref="Forget"/> is called on it.
         /// <para/><see cref="Forget"/> must be called when you are finished with it.
         /// <para/>NOTE: You should not return a preserved <see cref="Promise"/> from a public API. Use <see cref="Duplicate"/> to get a <see cref="Promise"/> that is publicly safe.

--- a/Package/Tests/CoreTests/APIs/APlus_2_1_PromiseStates.cs
+++ b/Package/Tests/CoreTests/APIs/APlus_2_1_PromiseStates.cs
@@ -28,7 +28,6 @@ namespace ProtoPromiseTests.APIs
                 string state = null;
 
                 var deferred = Promise.NewDeferred();
-                Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
                     .Then(() => state = Resolved, () => state = Rejected)
@@ -36,13 +35,10 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsNull(state);
 
                 deferred.Resolve();
-                Assert.IsFalse(deferred.IsValidAndPending);
-
                 Assert.AreEqual(Resolved, state);
 
                 state = null;
                 deferred = Promise.NewDeferred();
-                Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
                     .Then(() => state = Resolved, () => state = Rejected)
@@ -50,8 +46,6 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsNull(state);
 
                 deferred.Reject("Fail Value");
-                Assert.IsFalse(deferred.IsValidAndPending);
-
                 Assert.AreEqual(Rejected, state);
             }
 
@@ -62,7 +56,6 @@ namespace ProtoPromiseTests.APIs
                 string state = null;
 
                 var deferred = Promise.NewDeferred<int>();
-                Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
                     .Then(v => state = Resolved, () => state = Rejected)
@@ -70,13 +63,10 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsNull(state);
 
                 deferred.Resolve(1);
-                Assert.IsFalse(deferred.IsValidAndPending);
-
                 Assert.AreEqual(Resolved, state);
 
                 state = null;
                 deferred = Promise.NewDeferred<int>();
-                Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
                     .Then(v => state = Resolved, () => state = Rejected)
@@ -84,8 +74,6 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsNull(state);
 
                 deferred.Reject("Fail Value");
-                Assert.IsFalse(deferred.IsValidAndPending);
-
                 Assert.AreEqual(Rejected, state);
             }
         }
@@ -121,10 +109,8 @@ namespace ProtoPromiseTests.APIs
                     Assert.IsTrue(voidResolved);
                     Assert.IsFalse(voidRejected);
 
-                    Assert.IsFalse(deferred.TryResolve());
-                    Assert.Throws<InvalidOperationException>(() => deferred.Resolve());
-                    Assert.IsFalse(deferred.TryReject(RejectValue));
-                    Assert.Throws<InvalidOperationException>(() => deferred.Reject(RejectValue));
+                    Assert.Catch<InvalidOperationException>(() => deferred.Resolve());
+                    Assert.Catch<InvalidOperationException>(() => deferred.Reject(RejectValue));
 
                     promiseRetainer.WaitAsync()
                         .Then(() => voidResolved = true, () => voidRejected = true)
@@ -151,10 +137,8 @@ namespace ProtoPromiseTests.APIs
                     Assert.IsTrue(intResolved);
                     Assert.IsFalse(intRejected);
 
-                    Assert.IsFalse(deferred.TryResolve(1));
-                    Assert.Throws<InvalidOperationException>(() => deferred.Resolve(1));
-                    Assert.IsFalse(deferred.TryReject(RejectValue));
-                    Assert.Throws<InvalidOperationException>(() => deferred.Reject(RejectValue));
+                    Assert.Catch<InvalidOperationException>(() => deferred.Resolve(1));
+                    Assert.Catch<InvalidOperationException>(() => deferred.Reject(RejectValue));
 
                     promiseRetainer.WaitAsync()
                         .Then(_ => intResolved = true, () => intRejected = true)
@@ -187,8 +171,7 @@ namespace ProtoPromiseTests.APIs
                         onReject: s => Assert.Fail("Promise was rejected when it should have been resolved."),
                         onUnknownRejection: () => Assert.Fail("Promise was rejected when it should have been resolved.")
                     );
-                    Assert.IsFalse(deferred.TryResolve(100));
-                    Assert.Throws<InvalidOperationException>(() => deferred.Resolve(100));
+                    Assert.Catch<InvalidOperationException>(() => deferred.Resolve(100));
 
                     Assert.AreEqual(expected, result);
                 }
@@ -226,10 +209,8 @@ namespace ProtoPromiseTests.APIs
                     Assert.IsFalse(voidResolved);
                     Assert.IsTrue(voidRejected);
 
-                    Assert.IsFalse(deferred.TryResolve());
-                    Assert.Throws<InvalidOperationException>(() => deferred.Resolve());
-                    Assert.IsFalse(deferred.TryReject(RejectValue));
-                    Assert.Throws<InvalidOperationException>(() => deferred.Reject(RejectValue));
+                    Assert.Catch<InvalidOperationException>(() => deferred.Resolve());
+                    Assert.Catch<InvalidOperationException>(() => deferred.Reject(RejectValue));
 
                     promiseRetainer.WaitAsync()
                         .Then(() => voidResolved = true, () => voidRejected = true)
@@ -256,10 +237,8 @@ namespace ProtoPromiseTests.APIs
                     Assert.IsFalse(intResolved);
                     Assert.IsTrue(intRejected);
 
-                    Assert.IsFalse(deferred.TryResolve(1));
-                    Assert.Throws<InvalidOperationException>(() => deferred.Resolve(1));
-                    Assert.IsFalse(deferred.TryReject(RejectValue));
-                    Assert.Throws<InvalidOperationException>(() => deferred.Reject(RejectValue));
+                    Assert.Catch<InvalidOperationException>(() => deferred.Resolve(1));
+                    Assert.Catch<InvalidOperationException>(() => deferred.Reject(RejectValue));
 
                     promiseRetainer.WaitAsync()
                         .Then(_ => intResolved = true, () => intRejected = true)
@@ -288,8 +267,7 @@ namespace ProtoPromiseTests.APIs
 
                     Assert.AreEqual(expected, rejection);
 
-                    Assert.IsFalse(deferred.TryReject("Different Fail Value"));
-                    Assert.Throws<InvalidOperationException>(() => deferred.Reject("Different Fail Value"));
+                    Assert.Catch<InvalidOperationException>(() => deferred.Reject("Different Fail Value"));
                     TestHelper.AddCallbacks<int, string, string>(promiseRetainer.WaitAsync(),
                         onResolve: () => Assert.Fail("Promise was resolved when it should have been rejected."),
                         onReject: failValue =>
@@ -321,8 +299,7 @@ namespace ProtoPromiseTests.APIs
 
                     Assert.AreEqual(expected, rejection);
 
-                    Assert.IsFalse(deferred.TryReject("Different Fail Value"));
-                    Assert.Throws<InvalidOperationException>(() => deferred.Reject("Different Fail Value"));
+                    Assert.Catch<InvalidOperationException>(() => deferred.Reject("Different Fail Value"));
                     TestHelper.AddCallbacks<int, bool, string, string>(promiseRetainer.WaitAsync(),
                         onResolve: v => Assert.Fail("Promise was resolved when it should have been rejected."),
                         onReject: failValue =>

--- a/Package/Tests/CoreTests/APIs/APlus_2_2_TheThenMethod.cs
+++ b/Package/Tests/CoreTests/APIs/APlus_2_2_TheThenMethod.cs
@@ -309,8 +309,7 @@ namespace ProtoPromiseTests.APIs
                     );
                     deferred.Resolve();
 
-                    Assert.IsFalse(deferred.TryResolve());
-                    Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve());
+                    Assert.Catch<Proto.Promises.InvalidOperationException>(() => deferred.Resolve());
 
                     Assert.AreEqual(
                         (TestHelper.resolveVoidVoidCallbacks + TestHelper.resolveVoidConvertCallbacks +
@@ -337,8 +336,7 @@ namespace ProtoPromiseTests.APIs
                     );
                     deferred.Resolve(1);
 
-                    Assert.IsFalse(deferred.TryResolve(1));
-                    Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve(100));
+                    Assert.Catch<Proto.Promises.InvalidOperationException>(() => deferred.Resolve(100));
 
                     Assert.AreEqual(
                         (TestHelper.resolveTVoidCallbacks + TestHelper.resolveTConvertCallbacks +
@@ -452,8 +450,7 @@ namespace ProtoPromiseTests.APIs
                 );
                 deferred.Reject("Fail value");
 
-                Assert.IsFalse(deferred.TryReject("Fail value"));
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
+                Assert.Catch<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
 
                 Assert.AreEqual(
                     (TestHelper.rejectVoidVoidCallbacks + TestHelper.rejectVoidConvertCallbacks +
@@ -475,8 +472,7 @@ namespace ProtoPromiseTests.APIs
                 );
                 deferred.Reject("Fail value");
 
-                Assert.IsFalse(deferred.TryReject("Fail value"));
-                Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
+                Assert.Catch<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
 
                 Assert.AreEqual(
                     (TestHelper.rejectTVoidCallbacks + TestHelper.rejectTConvertCallbacks + TestHelper.rejectTTCallbacks +

--- a/Package/Tests/CoreTests/APIs/AsyncFunctionTests.cs
+++ b/Package/Tests/CoreTests/APIs/AsyncFunctionTests.cs
@@ -907,7 +907,10 @@ namespace ProtoPromiseTests.APIs
             var deferred = isPending ? Promise.NewDeferred() : default(Promise.Deferred);
             _promise = isPending ? deferred.Promise : Promise.Resolved();
             FuncVoid().Forget();
-            deferred.TryResolve();
+            if (isPending)
+            {
+                deferred.Resolve();
+            }
         }
 
         private async Promise FuncVoid()
@@ -936,7 +939,10 @@ namespace ProtoPromiseTests.APIs
             var deferred = isPending ? Promise.NewDeferred() : default(Promise.Deferred);
             _promise = isPending ? deferred.Promise : Promise.Resolved();
             FuncT().Forget();
-            deferred.TryResolve();
+            if (isPending)
+            {
+                deferred.Resolve();
+            }
         }
 
         private async Promise<int> FuncT()

--- a/Package/Tests/CoreTests/APIs/AwaitTests.cs
+++ b/Package/Tests/CoreTests/APIs/AwaitTests.cs
@@ -903,7 +903,10 @@ namespace ProtoPromiseTests.APIs
             bool completed = false;
 
             Func();
-            deferred.TryResolve();
+            if (isPending)
+            {
+                deferred.Resolve();
+            }
 
             Assert.IsTrue(completed);
 
@@ -923,7 +926,10 @@ namespace ProtoPromiseTests.APIs
             bool completed = false;
 
             Func();
-            deferred.TryResolve(1);
+            if (isPending)
+            {
+                deferred.Resolve(1);
+            }
 
             Assert.IsTrue(completed);
 
@@ -992,7 +998,10 @@ namespace ProtoPromiseTests.APIs
             bool completed = false;
 
             Func();
-            deferred.TryResolve();
+            if (isPending)
+            {
+                deferred.Resolve();
+            }
             TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
 
             Assert.IsTrue(completed);
@@ -1013,7 +1022,10 @@ namespace ProtoPromiseTests.APIs
             bool completed = false;
 
             Func();
-            deferred.TryResolve(1);
+            if (isPending)
+            {
+                deferred.Resolve(1);
+            }
             TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
 
             Assert.IsTrue(completed);

--- a/Package/Tests/CoreTests/APIs/FirstTests.cs
+++ b/Package/Tests/CoreTests/APIs/FirstTests.cs
@@ -356,7 +356,7 @@ namespace ProtoPromiseTests.APIs
 
             Assert.IsFalse(resolved);
 
-            deferred1.TryResolve();
+            deferred1.Resolve();
 
             Assert.IsTrue(resolved);
         }
@@ -382,7 +382,7 @@ namespace ProtoPromiseTests.APIs
 
             Assert.IsFalse(resolved);
 
-            deferred1.TryResolve(5);
+            deferred1.Resolve(5);
 
             Assert.IsTrue(resolved);
         }

--- a/Package/Tests/CoreTests/APIs/Linq/AsyncEnumerableTests.cs
+++ b/Package/Tests/CoreTests/APIs/Linq/AsyncEnumerableTests.cs
@@ -122,7 +122,7 @@ namespace ProtoPromiseTests.APIs.Linq
             runner
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
 
-            if (deferred.IsValid)
+            if (!consumerIsAsync)
             {
                 deferred.Promise.Forget();
             }
@@ -334,7 +334,7 @@ namespace ProtoPromiseTests.APIs.Linq
             runner
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
 
-            if (deferred.IsValid)
+            if (!consumerIsAsync)
             {
                 deferred.Promise.Forget();
             }
@@ -437,7 +437,7 @@ namespace ProtoPromiseTests.APIs.Linq
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
             Assert.True(runnerIsComplete);
 
-            if (deferred.IsValid)
+            if (!iteratorIsAsync && !consumerIsAsync)
             {
                 deferred.Promise.Forget();
             }

--- a/Package/Tests/CoreTests/APIs/Linq/Operators/ToAsyncEnumerableTests.cs
+++ b/Package/Tests/CoreTests/APIs/Linq/Operators/ToAsyncEnumerableTests.cs
@@ -127,7 +127,7 @@ namespace ProtoPromiseTests.APIs.Linq
             runner
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
 
-            if (deferred.IsValid)
+            if (!consumerIsAsync)
             {
                 deferred.Promise.Forget();
             }
@@ -343,7 +343,7 @@ namespace ProtoPromiseTests.APIs.Linq
             runner
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
 
-            if (deferred.IsValid)
+            if (!consumerIsAsync)
             {
                 deferred.Promise.Forget();
             }
@@ -447,7 +447,7 @@ namespace ProtoPromiseTests.APIs.Linq
                 .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
             Assert.True(runnerIsComplete);
 
-            if (deferred.IsValid)
+            if (!iteratorIsAsync && !consumerIsAsync)
             {
                 deferred.Promise.Forget();
             }

--- a/Package/Tests/CoreTests/APIs/MiscellaneousTests.cs
+++ b/Package/Tests/CoreTests/APIs/MiscellaneousTests.cs
@@ -33,7 +33,6 @@ namespace ProtoPromiseTests.APIs
         public void PromiseIsValidBeforeAwaited_void()
         {
             var promise = Promise.Resolved();
-            Assert.IsTrue(promise.IsValid);
             promise.Forget();
         }
 
@@ -41,7 +40,6 @@ namespace ProtoPromiseTests.APIs
         public void PromiseIsValidBeforeAwaited_T()
         {
             var promise = Promise.Resolved(42);
-            Assert.IsTrue(promise.IsValid);
             promise.Forget();
         }
 
@@ -50,12 +48,7 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred = Promise.NewDeferred();
             var promise = deferred.Promise;
-
-            Assert.IsTrue(promise.IsValid);
-
             promise.Then(() => { }).Forget();
-
-            Assert.IsFalse(promise.IsValid);
 
 #if PROMISE_DEBUG
             Assert.Throws<InvalidOperationException>(() => promise.GetAwaiter());
@@ -180,12 +173,7 @@ namespace ProtoPromiseTests.APIs
         {
             var deferred = Promise.NewDeferred<int>();
             var promise = deferred.Promise;
-
-            Assert.IsTrue(promise.IsValid);
-
             promise.Then(v => { }).Forget();
-
-            Assert.IsFalse(promise.IsValid);
 
 #if PROMISE_DEBUG
             Assert.Throws<InvalidOperationException>(() => promise.GetAwaiter());

--- a/Package/Tests/CoreTests/APIs/NewAndRunTests.cs
+++ b/Package/Tests/CoreTests/APIs/NewAndRunTests.cs
@@ -128,7 +128,10 @@ namespace ProtoPromiseTests.APIs
 
             TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
 
-            TestHelper.GetTryCompleterVoid(completeType, "Reject").Invoke(deferred);
+            if (!throwInAction)
+            {
+                TestHelper.GetCompleterVoid(completeType, "Reject").Invoke(deferred);
+            }
 
             TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
             Assert.True(invoked);
@@ -195,7 +198,10 @@ namespace ProtoPromiseTests.APIs
 
             TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
 
-            TestHelper.GetTryCompleterVoid(completeType, "Reject").Invoke(deferred);
+            if (!throwInAction)
+            {
+                TestHelper.GetCompleterVoid(completeType, "Reject").Invoke(deferred);
+            }
 
             TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
             Assert.True(invoked);
@@ -262,7 +268,10 @@ namespace ProtoPromiseTests.APIs
 
             TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
 
-            TestHelper.GetTryCompleterT(completeType, expectedResolveValue, "Reject").Invoke(deferred);
+            if (!throwInAction)
+            {
+                TestHelper.GetCompleterT(completeType, expectedResolveValue, "Reject").Invoke(deferred);
+            }
 
             TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
             Assert.True(invoked);
@@ -331,7 +340,10 @@ namespace ProtoPromiseTests.APIs
 
             TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
 
-            TestHelper.GetTryCompleterT(completeType, expectedResolveValue, "Reject").Invoke(deferred);
+            if (!throwInAction)
+            {
+                TestHelper.GetCompleterT(completeType, expectedResolveValue, "Reject").Invoke(deferred);
+            }
 
             TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
             Assert.True(invoked);

--- a/Package/Tests/CoreTests/APIs/ParallelForEachAsyncTests.cs
+++ b/Package/Tests/CoreTests/APIs/ParallelForEachAsyncTests.cs
@@ -376,11 +376,11 @@ namespace ProtoPromiseTests.APIs
                                 throw expected;
                             });
                     }
-                    else
+                    else if (item == 10)
                     {
-                        deferred.TryResolve();
-                        return Promise.Resolved();
+                        deferred.Resolve();
                     }
+                    return Promise.Resolved();
                 }, cts.Token, maxDegreeOfParallelism: 2)
                     .Catch((Exception e) => actual = e)
                     .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(2));

--- a/Package/Tests/CoreTests/APIs/ParallelForTests.cs
+++ b/Package/Tests/CoreTests/APIs/ParallelForTests.cs
@@ -333,11 +333,11 @@ namespace ProtoPromiseTests.APIs
                                 throw expected;
                             });
                     }
-                    else
+                    else if (item == 10)
                     {
-                        deferred.TryResolve();
-                        return Promise.Resolved();
+                        deferred.Resolve();
                     }
+                    return Promise.Resolved();
                 }, cts.Token, maxDegreeOfParallelism: 2)
                     .Catch((Exception e) => actual = e)
                     .WaitWithTimeout(TimeSpan.FromSeconds(2));

--- a/Package/Tests/CoreTests/APIs/PromiseCancelationTests.cs
+++ b/Package/Tests/CoreTests/APIs/PromiseCancelationTests.cs
@@ -46,7 +46,6 @@ namespace ProtoPromiseTests.APIs
                 string state = null;
 
                 var deferred = Promise.NewDeferred();
-                Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
                     .Then(() => state = Resolved, () => state = Rejected)
@@ -55,13 +54,10 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsNull(state);
 
                 deferred.Resolve();
-                Assert.IsFalse(deferred.IsValidAndPending);
-
                 Assert.AreEqual(Resolved, state);
 
                 state = null;
                 deferred = Promise.NewDeferred();
-                Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
                     .Then(() => state = Resolved, () => state = Rejected)
@@ -70,13 +66,11 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsNull(state);
 
                 deferred.Reject("Fail Value");
-                Assert.IsFalse(deferred.IsValidAndPending);
 
                 state = null;
                 CancelationSource cancelationSource = CancelationSource.New();
                 deferred = Promise.NewDeferred();
                 cancelationSource.Token.Register(deferred);
-                Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
                     .Then(() => state = Resolved, () => state = Rejected)
@@ -85,8 +79,6 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsNull(state);
 
                 cancelationSource.Cancel();
-                Assert.IsFalse(deferred.IsValidAndPending);
-
                 Assert.AreEqual(Canceled, state);
                 cancelationSource.Dispose();
 
@@ -94,7 +86,6 @@ namespace ProtoPromiseTests.APIs
                 cancelationSource = CancelationSource.New();
                 deferred = Promise.NewDeferred();
                 cancelationSource.Token.Register(deferred);
-                Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
                     .Then(() => state = Resolved, () => state = Rejected)
@@ -103,8 +94,6 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsNull(state);
 
                 cancelationSource.Cancel();
-                Assert.IsFalse(deferred.IsValidAndPending);
-
                 Assert.AreEqual(Canceled, state);
                 cancelationSource.Dispose();
             }
@@ -116,7 +105,6 @@ namespace ProtoPromiseTests.APIs
                 string state = null;
 
                 var deferred = Promise.NewDeferred<int>();
-                Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
                     .Then(v => state = Resolved, () => state = Rejected)
@@ -125,13 +113,10 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsNull(state);
 
                 deferred.Resolve(1);
-                Assert.IsFalse(deferred.IsValidAndPending);
-
                 Assert.AreEqual(Resolved, state);
 
                 state = null;
                 deferred = Promise.NewDeferred<int>();
-                Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
                     .Then(v => state = Resolved, () => state = Rejected)
@@ -140,13 +125,11 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsNull(state);
 
                 deferred.Reject("Fail Value");
-                Assert.IsFalse(deferred.IsValidAndPending);
 
                 state = null;
                 CancelationSource cancelationSource = CancelationSource.New();
                 deferred = Promise.NewDeferred<int>();
                 cancelationSource.Token.Register(deferred);
-                Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
                     .Then(v => state = Resolved, () => state = Rejected)
@@ -155,8 +138,6 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsNull(state);
 
                 cancelationSource.Cancel();
-                Assert.IsFalse(deferred.IsValidAndPending);
-
                 Assert.AreEqual(Canceled, state);
                 cancelationSource.Dispose();
 
@@ -164,7 +145,6 @@ namespace ProtoPromiseTests.APIs
                 cancelationSource = CancelationSource.New();
                 deferred = Promise.NewDeferred<int>();
                 cancelationSource.Token.Register(deferred);
-                Assert.IsTrue(deferred.IsValidAndPending);
 
                 deferred.Promise
                     .Then(v => state = Resolved, () => state = Rejected)
@@ -173,8 +153,6 @@ namespace ProtoPromiseTests.APIs
                 Assert.IsNull(state);
 
                 cancelationSource.Cancel();
-                Assert.IsFalse(deferred.IsValidAndPending);
-
                 Assert.AreEqual(Canceled, state);
                 cancelationSource.Dispose();
             }
@@ -209,11 +187,8 @@ namespace ProtoPromiseTests.APIs
 
                 deferred.Resolve();
 
-                Assert.IsFalse(deferred.TryResolve());
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve());
-                Assert.IsFalse(deferred.TryReject("Fail value"));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
-                Assert.IsFalse(deferred.TryCancel());
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Cancel());
 
                 Assert.IsTrue(resolved);
@@ -234,11 +209,8 @@ namespace ProtoPromiseTests.APIs
 
                 deferred.Resolve(1);
 
-                Assert.IsFalse(deferred.TryResolve(1));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve(1));
-                Assert.IsFalse(deferred.TryReject("Fail value"));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
-                Assert.IsFalse(deferred.TryCancel());
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Cancel());
 
                 Assert.IsTrue(resolved);
@@ -274,11 +246,8 @@ namespace ProtoPromiseTests.APIs
 
                 deferred.Reject("Fail Value");
 
-                Assert.IsFalse(deferred.TryResolve());
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve());
-                Assert.IsFalse(deferred.TryReject("Fail value"));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
-                Assert.IsFalse(deferred.TryCancel());
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Cancel());
 
                 Assert.IsTrue(rejected);
@@ -299,11 +268,8 @@ namespace ProtoPromiseTests.APIs
 
                 deferred.Reject("Fail Value");
 
-                Assert.IsFalse(deferred.TryResolve(1));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve(1));
-                Assert.IsFalse(deferred.TryReject("Fail value"));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
-                Assert.IsFalse(deferred.TryCancel());
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Cancel());
 
                 Assert.IsTrue(rejected);
@@ -341,9 +307,7 @@ namespace ProtoPromiseTests.APIs
 
                 cancelationSource.Cancel();
 
-                Assert.IsFalse(deferred.TryResolve());
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve());
-                Assert.IsFalse(deferred.TryReject("Fail value"));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
                 cancelationSource.Cancel();
 
@@ -369,9 +333,7 @@ namespace ProtoPromiseTests.APIs
 
                 cancelationSource.Cancel();
 
-                Assert.IsFalse(deferred.TryResolve(1));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Resolve(1));
-                Assert.IsFalse(deferred.TryReject("Fail value"));
                 Assert.Throws<Proto.Promises.InvalidOperationException>(() => deferred.Reject("Fail value"));
                 cancelationSource.Cancel();
 

--- a/Package/Tests/CoreTests/Concurrency/AwaitConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/AwaitConcurrencyTests.cs
@@ -63,7 +63,7 @@ namespace ProtoPromiseTests.Concurrency
             );
 
             promiseRetainer.Dispose();
-            TestHelper.GetTryCompleterVoid(completeType, rejectValue).Invoke(deferred);
+            TestHelper.GetCompleterVoid(completeType, rejectValue).Invoke(deferred);
             Assert.AreEqual(ThreadHelper.multiExecutionCount, invokedCount);
         }
 
@@ -141,7 +141,7 @@ namespace ProtoPromiseTests.Concurrency
             );
 
             promiseRetainer.Dispose();
-            TestHelper.GetTryCompleterT(completeType, 1, rejectValue).Invoke(deferred);
+            TestHelper.GetCompleterT(completeType, 1, rejectValue).Invoke(deferred);
             Assert.AreEqual(ThreadHelper.multiExecutionCount, invokedCount);
         }
 
@@ -191,7 +191,7 @@ namespace ProtoPromiseTests.Concurrency
         {
             var deferred = default(Promise.Deferred);
             var promise = default(Promise);
-            var tryCompleter = TestHelper.GetTryCompleterVoid(completeType, rejectValue);
+            var completer = TestHelper.GetCompleterVoid(completeType, rejectValue);
 
             Promise.State result = Promise.State.Pending;
 
@@ -230,7 +230,7 @@ namespace ProtoPromiseTests.Concurrency
                 },
                 parallelActions: new Action[]
                 {
-                    () => tryCompleter(deferred)
+                    () => completer(deferred)
                 },
                 teardown: () =>
                 {
@@ -257,7 +257,7 @@ namespace ProtoPromiseTests.Concurrency
         {
             var deferred = default(Promise<int>.Deferred);
             var promise = default(Promise<int>);
-            var tryCompleter = TestHelper.GetTryCompleterT(completeType, 1, rejectValue);
+            var completer = TestHelper.GetCompleterT(completeType, 1, rejectValue);
 
             Promise.State result = Promise.State.Pending;
 
@@ -296,7 +296,7 @@ namespace ProtoPromiseTests.Concurrency
                 },
                 parallelActions: new Action[]
                 {
-                    () => tryCompleter(deferred)
+                    () => completer(deferred)
                 },
                 teardown: () =>
                 {

--- a/Package/Tests/CoreTests/Concurrency/DeferredConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/DeferredConcurrencyTests.cs
@@ -34,18 +34,22 @@ namespace ProtoPromiseTests.Concurrency
             deferred.Promise
                 .Then(() => { Interlocked.Increment(ref invokedCount); })
                 .Forget();
-            int failedTryResolveCount = 0;
+            int failedResolveCount = 0;
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() =>
             {
-                if (!deferred.TryResolve())
+                try
                 {
-                    Interlocked.Increment(ref failedTryResolveCount);
+                    deferred.Resolve();
+                }
+                catch (InvalidOperationException)
+                {
+                    Interlocked.Increment(ref failedResolveCount);
                 }
             });
 
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
+            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedResolveCount); // Resolve should succeed once.
             Assert.AreEqual(1, invokedCount);
         }
 
@@ -57,18 +61,22 @@ namespace ProtoPromiseTests.Concurrency
             deferred.Promise
                 .Then(v => { Interlocked.Increment(ref invokedCount); })
                 .Forget();
-            int failedTryResolveCount = 0;
+            int failedResolveCount = 0;
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() =>
             {
-                if (!deferred.TryResolve(1))
+                try
                 {
-                    Interlocked.Increment(ref failedTryResolveCount);
+                    deferred.Resolve(1);
+                }
+                catch (InvalidOperationException)
+                {
+                    Interlocked.Increment(ref failedResolveCount);
                 }
             });
 
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
+            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedResolveCount); // Resolve should succeed once.
             Assert.AreEqual(1, invokedCount);
         }
 
@@ -80,18 +88,22 @@ namespace ProtoPromiseTests.Concurrency
             deferred.Promise
                 .Catch(() => { Interlocked.Increment(ref invokedCount); })
                 .Forget();
-            int failedTryResolveCount = 0;
+            int failedRejectCount = 0;
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() =>
             {
-                if (!deferred.TryReject("Reject"))
+                try
                 {
-                    Interlocked.Increment(ref failedTryResolveCount);
+                    deferred.Reject("Reject");
+                }
+                catch (InvalidOperationException)
+                {
+                    Interlocked.Increment(ref failedRejectCount);
                 }
             });
 
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
+            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedRejectCount); // Reject should succeed once.
             Assert.AreEqual(1, invokedCount);
         }
 
@@ -103,18 +115,22 @@ namespace ProtoPromiseTests.Concurrency
             deferred.Promise
                 .Catch(() => { Interlocked.Increment(ref invokedCount); })
                 .Forget();
-            int failedTryResolveCount = 0;
+            int failedRejectCount = 0;
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() =>
             {
-                if (!deferred.TryReject("Reject"))
+                try
                 {
-                    Interlocked.Increment(ref failedTryResolveCount);
+                    deferred.Reject("Reject");
+                }
+                catch (InvalidOperationException)
+                {
+                    Interlocked.Increment(ref failedRejectCount);
                 }
             });
 
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
+            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedRejectCount); // Reject should succeed once.
             Assert.AreEqual(1, invokedCount);
         }
 
@@ -126,18 +142,22 @@ namespace ProtoPromiseTests.Concurrency
             deferred.Promise
                 .CatchCancelation(() => { Interlocked.Increment(ref invokedCount); })
                 .Forget();
-            int failedTryResolveCount = 0;
+            int failedCancelCount = 0;
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() =>
             {
-                if (!deferred.TryCancel())
+                try
                 {
-                    Interlocked.Increment(ref failedTryResolveCount);
+                    deferred.Cancel();
+                }
+                catch (InvalidOperationException)
+                {
+                    Interlocked.Increment(ref failedCancelCount);
                 }
             });
 
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
+            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedCancelCount); // Cancel should succeed once.
             Assert.AreEqual(1, invokedCount);
         }
 
@@ -149,18 +169,22 @@ namespace ProtoPromiseTests.Concurrency
             deferred.Promise
                 .CatchCancelation(() => { Interlocked.Increment(ref invokedCount); })
                 .Forget();
-            int failedTryResolveCount = 0;
+            int failedCancelCount = 0;
 
             var threadHelper = new ThreadHelper();
             threadHelper.ExecuteMultiActionParallel(() =>
             {
-                if (!deferred.TryCancel())
+                try
                 {
-                    Interlocked.Increment(ref failedTryResolveCount);
+                    deferred.Cancel();
+                }
+                catch (InvalidOperationException)
+                {
+                    Interlocked.Increment(ref failedCancelCount);
                 }
             });
 
-            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedTryResolveCount); // TryResolve should succeed once.
+            Assert.AreEqual(ThreadHelper.multiExecutionCount - 1, failedCancelCount); // Cancel should succeed once.
             Assert.AreEqual(1, invokedCount);
         }
 

--- a/Package/Tests/CoreTests/Concurrency/PromiseConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/PromiseConcurrencyTests.cs
@@ -279,7 +279,7 @@ namespace ProtoPromiseTests.Concurrency
             var returnDeferred = default(Promise.Deferred);
             var returnPromise = default(Promise);
             Action threadBarrier = null;
-            var tryCompleter = TestHelper.GetTryCompleterVoid(completeType, rejectValue);
+            var completer = TestHelper.GetCompleterVoid(completeType, rejectValue);
 
             Promise.State result = Promise.State.Pending;
 
@@ -310,7 +310,7 @@ namespace ProtoPromiseTests.Concurrency
                     },
                     parallelActions: new Action[]
                     {
-                        () => tryCompleter(returnDeferred)
+                        () => completer(returnDeferred)
                     },
                     teardown: () =>
                     {
@@ -339,7 +339,7 @@ namespace ProtoPromiseTests.Concurrency
             var returnDeferred = default(Promise<int>.Deferred);
             var returnPromise = default(Promise<int>);
             Action threadBarrier = null;
-            var tryCompleter = TestHelper.GetTryCompleterT(completeType, 1, rejectValue);
+            var completer = TestHelper.GetCompleterT(completeType, 1, rejectValue);
 
             Promise.State result = Promise.State.Pending;
 
@@ -370,7 +370,7 @@ namespace ProtoPromiseTests.Concurrency
                     },
                     parallelActions: new Action[]
                     {
-                        () => tryCompleter(returnDeferred)
+                        () => completer(returnDeferred)
                     },
                     teardown: () =>
                     {

--- a/Package/Tests/CoreTests/Concurrency/Utilities/AsyncLazyConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/Utilities/AsyncLazyConcurrencyTests.cs
@@ -64,7 +64,10 @@ namespace ProtoPromiseTests.Concurrency.Utilities
                 {
                     TestHelper.ExecuteForegroundCallbacksAndWaitForThreadsToComplete();
                     Assert.AreEqual(1, invokedCount);
-                    deferred.TryResolve(expectedResult);
+                    if (waitForDeferred)
+                    {
+                        deferred.Resolve(expectedResult);
+                    }
                     Assert.AreEqual(1, invokedCount);
                 },
                 // parallel actions, repeated to generate offsets
@@ -89,7 +92,7 @@ namespace ProtoPromiseTests.Concurrency.Utilities
                     .Forget();
             };
 
-            new ThreadHelper().ExecuteParallelActionsWithOffsets(true, // Repeat the parallel actions for as many available hardware threads.
+            new ThreadHelper().ExecuteParallelActionsWithOffsets(false,
                 // setup
                 () =>
                 {
@@ -108,7 +111,7 @@ namespace ProtoPromiseTests.Concurrency.Utilities
                     Assert.AreEqual(1, invokedCount);
                 },
                 // parallel actions
-                () => deferred.TryResolve(expectedResult),
+                () => deferred.Resolve(expectedResult),
                 // repeated to generate offsets
                 parallelAction,
                 parallelAction,

--- a/Package/Tests/Helpers/TestHelper.cs
+++ b/Package/Tests/Helpers/TestHelper.cs
@@ -264,28 +264,30 @@ namespace ProtoPromiseTests
 
         public static Action<Promise.Deferred> GetTryCompleterVoid<TReject>(CompleteType completeType, TReject rejectValue)
         {
+            // TODO: Remove try/catch, update calling tests.
             switch (completeType)
             {
                 case CompleteType.Resolve:
-                    return deferred => deferred.TryResolve();
+                    return deferred => { try { deferred.Resolve(); } catch { } };
                 case CompleteType.Reject:
-                    return deferred => deferred.TryReject(rejectValue);
+                    return deferred => { try { deferred.Reject(rejectValue); } catch { } };
                 case CompleteType.Cancel:
-                    return deferred => deferred.TryCancel();
+                    return deferred => { try { deferred.Cancel(); } catch { } };
             }
             throw new Exception();
         }
 
         public static Action<Promise<T>.Deferred> GetTryCompleterT<T, TReject>(CompleteType completeType, T resolveValue, TReject rejectValue)
         {
+            // TODO: Remove try/catch, update calling tests.
             switch (completeType)
             {
                 case CompleteType.Resolve:
-                    return deferred => deferred.TryResolve(resolveValue);
+                    return deferred => { try { deferred.Resolve(resolveValue); } catch { } };
                 case CompleteType.Reject:
-                    return deferred => deferred.TryReject(rejectValue);
+                    return deferred => { try { deferred.Reject(rejectValue); } catch { } };
                 case CompleteType.Cancel:
-                    return deferred => deferred.TryCancel();
+                    return deferred => { try { deferred.Cancel(); } catch { } };
             }
             throw new Exception();
         }
@@ -308,16 +310,17 @@ namespace ProtoPromiseTests
             }
 
             var deferred = Promise.NewDeferred();
+            // TODO: Remove try/catch, update calling tests.
             switch (completeType)
             {
                 case CompleteType.Resolve:
-                    tryCompleter = () => deferred.TryResolve();
+                    tryCompleter = () => { try { deferred.Resolve(); } catch { } };
                     break;
                 case CompleteType.Reject:
-                    tryCompleter = () => deferred.TryReject(reason);
+                    tryCompleter = () => { try { deferred.Reject(reason); } catch { } };
                     break;
                 case CompleteType.Cancel:
-                    tryCompleter = () => deferred.TryCancel();
+                    tryCompleter = () => { try { deferred.Cancel(); } catch { } };
                     break;
                 default:
                     throw new Exception();
@@ -343,16 +346,17 @@ namespace ProtoPromiseTests
             }
 
             var deferred = Promise<T>.NewDeferred();
+            // TODO: Remove try/catch, update calling tests.
             switch (completeType)
             {
                 case CompleteType.Resolve:
-                    tryCompleter = () => deferred.TryResolve(value);
+                    tryCompleter = () => { try { deferred.Resolve(value); } catch { } };
                     break;
                 case CompleteType.Reject:
-                    tryCompleter = () => deferred.TryReject(reason);
+                    tryCompleter = () => { try { deferred.Reject(reason); } catch { } };
                     break;
                 case CompleteType.Cancel:
-                    tryCompleter = () => deferred.TryCancel();
+                    tryCompleter = () => { try { deferred.Cancel(); } catch { } };
                     break;
                 default:
                     throw new Exception();
@@ -384,17 +388,18 @@ namespace ProtoPromiseTests
             }
 
             var deferred = Promise.NewDeferred();
-            var registration = cancelationToken.Register(() => deferred.TryCancel());
+            var registration = cancelationToken.Register(deferred);
+            // TODO: Remove try/catch, update calling tests.
             switch (completeType)
             {
                 case CompleteType.Resolve:
-                    tryCompleter = () => deferred.TryResolve();
+                    tryCompleter = () => { try { deferred.Resolve(); } catch { } };
                     break;
                 case CompleteType.Reject:
-                    tryCompleter = () => deferred.TryReject(reason);
+                    tryCompleter = () => { try { deferred.Reject(reason); } catch { } };
                     break;
                 case CompleteType.Cancel:
-                    tryCompleter = () => deferred.TryCancel();
+                    tryCompleter = () => { try { deferred.Cancel(); } catch { } };
                     break;
                 default:
                     throw new Exception();
@@ -428,17 +433,18 @@ namespace ProtoPromiseTests
             }
 
             var deferred = Promise<T>.NewDeferred();
-            var registration = cancelationToken.Register(() => deferred.TryCancel());
+            var registration = cancelationToken.Register(deferred);
+            // TODO: Remove try/catch, update calling tests.
             switch (completeType)
             {
                 case CompleteType.Resolve:
-                    tryCompleter = () => deferred.TryResolve(value);
+                    tryCompleter = () => { try { deferred.Resolve(value); } catch { } };
                     break;
                 case CompleteType.Reject:
-                    tryCompleter = () => deferred.TryReject(reason);
+                    tryCompleter = () => { try { deferred.Reject(reason); } catch { } };
                     break;
                 case CompleteType.Cancel:
-                    tryCompleter = () => deferred.TryCancel();
+                    tryCompleter = () => { try { deferred.Cancel(); } catch { } };
                     break;
                 default:
                     throw new Exception();

--- a/Package/Tests/UnityTests/PromiseYielderTests.cs
+++ b/Package/Tests/UnityTests/PromiseYielderTests.cs
@@ -114,10 +114,10 @@ namespace ProtoPromiseTests.Unity
                 {
                     yield return endOfFrame;
 
-                    if (_eofDeferred.IsValidAndPending)
+                    if (_eofDeferred != default)
                     {
                         var deferred = _eofDeferred;
-                        _eofDeferred = default(Promise<ValueTuple<int, int>>.Deferred);
+                        _eofDeferred = default;
                         _eofWaitOneFrameFunc()
                             .Then(ValueTuple.Create(deferred, Time.frameCount), cv => deferred.Resolve(ValueTuple.Create(cv.Item2, Time.frameCount)))
                             .Forget();
@@ -127,10 +127,10 @@ namespace ProtoPromiseTests.Unity
 
             private void Update()
             {
-                if (_updateDeferred.IsValidAndPending)
+                if (_updateDeferred != default)
                 {
                     var deferred = _updateDeferred;
-                    _updateDeferred = default(Promise<ValueTuple<int, int>>.Deferred);
+                    _updateDeferred = default;
                     _updateWaitOneFrameFunc()
                         .Then(ValueTuple.Create(deferred, Time.frameCount), cv => deferred.Resolve(ValueTuple.Create(cv.Item2, Time.frameCount)))
                         .Forget();


### PR DESCRIPTION
- Deprecated `Promise(<T>).Deferred.{IsValid*, Try*}` APIs.
- Deprecated `Promise(<T>).IsValid`.