### PR TITLE
Add async Linq `ToDictionary` overloads for KVP and tuple sequences

### DIFF
--- a/Package/Core/Linq/Operators/ToDictionaryAsync.cs
+++ b/Package/Core/Linq/Operators/ToDictionaryAsync.cs
@@ -12,6 +12,72 @@ namespace Proto.Promises.Linq
 {
     partial class AsyncEnumerable
     {
+        /// <summary>
+        /// Creates a <see cref="Dictionary{TKey, TValue}"/> from an async-enumerable sequence using the specified <paramref name="comparer"/> to compare keys.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the keys from elements of <paramref name="source"/>.</typeparam>
+        /// <typeparam name="TValue">The type of the values from elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
+        /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
+        /// <returns>A <see cref="Promise{T}"/> whose result will be a <see cref="Dictionary{TKey, TValue}"/> that contains keys and values from the <paramref name="source"/>.</returns>
+        /// <exception cref="ArgumentException"><paramref name="source"/> contains one or more duplicate keys.</exception>
+        public static Promise<Dictionary<TKey, TValue>> ToDictionaryAsync<TKey, TValue>(this AsyncEnumerable<(TKey Key, TValue Value)> source, IEqualityComparer<TKey> comparer = null, CancelationToken cancelationToken = default)
+        {
+            return Impl(source.GetAsyncEnumerator(cancelationToken));
+
+            async Promise<Dictionary<TKey, TValue>> Impl(AsyncEnumerator<(TKey, TValue)> asyncEnumerator)
+            {
+                try
+                {
+                    var dictionary = new Dictionary<TKey, TValue>(comparer);
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        var (key, value) = asyncEnumerator.Current;
+                        dictionary.Add(key, value);
+                    }
+                    return dictionary;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Dictionary{TKey, TValue}"/> from an async-enumerable sequence using the specified <paramref name="comparer"/> to compare keys.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the keys from elements of <paramref name="source"/>.</typeparam>
+        /// <typeparam name="TValue">The type of the values from elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
+        /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
+        /// <returns>A <see cref="Promise{T}"/> whose result will be a <see cref="Dictionary{TKey, TValue}"/> that contains keys and values from the <paramref name="source"/>.</returns>
+        /// <exception cref="ArgumentException"><paramref name="source"/> contains one or more duplicate keys.</exception>
+        public static Promise<Dictionary<TKey, TValue>> ToDictionaryAsync<TKey, TValue>(this AsyncEnumerable<KeyValuePair<TKey, TValue>> source, IEqualityComparer<TKey> comparer = null, CancelationToken cancelationToken = default)
+        {
+            return Impl(source.GetAsyncEnumerator(cancelationToken));
+
+            async Promise<Dictionary<TKey, TValue>> Impl(AsyncEnumerator<KeyValuePair<TKey, TValue>> asyncEnumerator)
+            {
+                try
+                {
+                    var dictionary = new Dictionary<TKey, TValue>(comparer);
+                    while (await asyncEnumerator.MoveNextAsync())
+                    {
+                        var kvp = asyncEnumerator.Current;
+                        dictionary.Add(kvp.Key, kvp.Value);
+                    }
+                    return dictionary;
+                }
+                finally
+                {
+                    await asyncEnumerator.DisposeAsync();
+                }
+            }
+        }
+
         #region KeySelector
         /// <summary>
         /// Creates a <see cref="Dictionary{TKey, TValue}"/> from an async-enumerable sequence using the specified <paramref name="comparer"/> to compare keys.

--- a/Package/Core/Linq/Operators/ToDictionaryAsync.cs
+++ b/Package/Core/Linq/Operators/ToDictionaryAsync.cs
@@ -17,7 +17,7 @@ namespace Proto.Promises.Linq
         /// </summary>
         /// <typeparam name="TKey">The type of the keys from elements of <paramref name="source"/>.</typeparam>
         /// <typeparam name="TValue">The type of the values from elements of <paramref name="source"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
         /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
         /// <returns>A <see cref="Promise{T}"/> whose result will be a <see cref="Dictionary{TKey, TValue}"/> that contains keys and values from the <paramref name="source"/>.</returns>
@@ -50,7 +50,7 @@ namespace Proto.Promises.Linq
         /// </summary>
         /// <typeparam name="TKey">The type of the keys from elements of <paramref name="source"/>.</typeparam>
         /// <typeparam name="TValue">The type of the values from elements of <paramref name="source"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
         /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
         /// <returns>A <see cref="Promise{T}"/> whose result will be a <see cref="Dictionary{TKey, TValue}"/> that contains keys and values from the <paramref name="source"/>.</returns>
@@ -84,7 +84,7 @@ namespace Proto.Promises.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
         /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
@@ -108,7 +108,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
@@ -132,7 +132,7 @@ namespace Proto.Promises.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
         /// <param name="cancelationToken">The optional cancelation token to be used for canceling the sequence at any time.</param>
@@ -156,7 +156,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
@@ -180,7 +180,7 @@ namespace Proto.Promises.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
         /// <returns>A <see cref="Promise{T}"/> whose result will be a <see cref="Dictionary{TKey, TValue}"/> that contains values of type <typeparamref name="TSource"/> selected from the source sequence.</returns>
@@ -203,7 +203,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
@@ -226,7 +226,7 @@ namespace Proto.Promises.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
         /// <returns>A <see cref="Promise{T}"/> whose result will be a <see cref="Dictionary{TKey, TValue}"/> that contains values of type <typeparamref name="TSource"/> selected from the source sequence.</returns>
@@ -249,7 +249,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
@@ -366,7 +366,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
@@ -394,7 +394,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/> that will be passed to <paramref name="keySelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
@@ -422,7 +422,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
@@ -450,7 +450,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
@@ -478,7 +478,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
@@ -505,7 +505,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
@@ -532,7 +532,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
@@ -559,7 +559,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
@@ -587,7 +587,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
@@ -617,7 +617,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
@@ -647,7 +647,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
@@ -677,7 +677,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
@@ -707,7 +707,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
@@ -736,7 +736,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
@@ -765,7 +765,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
         /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
@@ -794,7 +794,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
@@ -822,7 +822,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">An async transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
@@ -850,7 +850,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">An async transform function to produce a result element value from each element.</param>
@@ -878,7 +878,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="elementSelector">An async transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
@@ -906,7 +906,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="elementSelector">An async transform function to produce a result element value from each element.</param>
@@ -934,7 +934,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">An async transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
@@ -961,7 +961,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="elementSelector">An async transform function to produce a result element value from each element.</param>
@@ -988,7 +988,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="elementSelector">An async transform function to produce a result element value from each element.</param>
         /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
@@ -1015,7 +1015,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="elementSelector">An async transform function to produce a result element value from each element.</param>
@@ -1043,7 +1043,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
         /// <param name="elementSelector">An async transform function to produce a result element value from each element.</param>
@@ -1073,7 +1073,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
@@ -1103,7 +1103,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
         /// <param name="elementSelector">An async transform function to produce a result element value from each element.</param>
@@ -1133,7 +1133,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="source">An async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
@@ -1163,7 +1163,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
         /// <param name="elementSelector">An async transform function to produce a result element value from each element.</param>
@@ -1192,7 +1192,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
@@ -1221,7 +1221,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>
         /// <param name="elementSelector">An async transform function to produce a result element value from each element.</param>
@@ -1250,7 +1250,7 @@ namespace Proto.Promises.Linq
         /// <typeparam name="TElement">The type of the key returned by <paramref name="elementSelector"/>.</typeparam>
         /// <typeparam name="TKeyCapture">The type of the captured value that will be passed to <paramref name="keySelector"/>.</typeparam>
         /// <typeparam name="TElementCapture">The type of the captured value that will be passed to <paramref name="elementSelector"/>.</typeparam>
-        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> for.</param>
+        /// <param name="configuredSource">A configured async-enumerable sequence to create a <see cref="Dictionary{TKey, TValue}"/> from.</param>
         /// <param name="captureKeyValue">The extra value that will be passed to <paramref name="keySelector"/>.</param>
         /// <param name="keySelector">An async function  to extract a key from each element.</param>
         /// <param name="captureElementValue">The extra value that will be passed to <paramref name="elementSelector"/>.</param>

--- a/Package/Tests/CoreTests/APIs/Linq/Operators/ToDictionaryAsyncTests.cs
+++ b/Package/Tests/CoreTests/APIs/Linq/Operators/ToDictionaryAsyncTests.cs
@@ -429,6 +429,54 @@ namespace ProtoPromiseTests.APIs.Linq
         }
 
         [Test]
+        public void ToDictionary_Tuple()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new[] { 42, 25, 39 };
+                var res = xs.Select(x => (x, x)).ToAsyncEnumerable().ToDictionaryAsync();
+                CollectionAssert.AreEqual(xs.ToDictionary(x => x), await res);
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void ToDictionary_Tuple_DuplicateKeyThrows()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new[] { 42, 25, 39, 25 };
+                var res = xs.Select(x => (x, x)).ToAsyncEnumerable().ToDictionaryAsync();
+                await TestHelper.AssertThrowsAsync<ArgumentException>(() => res);
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void ToDictionary_KVP()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new[] { 42, 25, 39 };
+                var res = xs.Select(x => new KeyValuePair<int, int>(x, x)).ToAsyncEnumerable().ToDictionaryAsync();
+                CollectionAssert.AreEqual(xs.ToDictionary(x => x), await res);
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void ToDictionary_KVP_DuplicateKeyThrows()
+        {
+            Promise.Run(async () =>
+            {
+                var xs = new[] { 42, 25, 39, 25 };
+                var res = xs.Select(x => new KeyValuePair<int, int>(x, x)).ToAsyncEnumerable().ToDictionaryAsync();
+                await TestHelper.AssertThrowsAsync<ArgumentException>(() => res);
+            }, SynchronizationOption.Synchronous)
+                .WaitWithTimeoutWhileExecutingForegroundContext(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
         public void ToDictionary_FromArray_KeySelector(
             [Values] bool configured,
             [Values] bool asyncKey,


### PR DESCRIPTION
Resolves #535.