### PR TITLE
Add `Promise(<T>).AppendResult` extensions

### DIFF
--- a/Package/Core/PromiseGroups/PromiseRaceWithIndexGroup.cs
+++ b/Package/Core/PromiseGroups/PromiseRaceWithIndexGroup.cs
@@ -5,6 +5,7 @@
 #endif
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -14,6 +15,10 @@ namespace Proto.Promises
     /// <summary>
     /// A structured concurrency group used to race promises, incorporating their indices. Waits for the first promise to resolve.
     /// </summary>
+    /// <remarks>
+    /// This type is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+    /// </remarks>
+    [Obsolete("Prefer Promise.AppendResult(int) and PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode, StackTraceHidden]
 #endif
@@ -180,6 +185,10 @@ namespace Proto.Promises
     /// <summary>
     /// A structured concurrency group used to race promises, incorporating their indices. Waits for the first promise to resolve.
     /// </summary>
+    /// <remarks>
+    /// This type is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+    /// </remarks>
+    [Obsolete("Prefer Promise.AppendResult(int) and PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
 #if !PROTO_PROMISE_DEVELOPER_MODE
     [DebuggerNonUserCode, StackTraceHidden]
 #endif

--- a/Package/Core/Promises/PromiseExtensions.cs
+++ b/Package/Core/Promises/PromiseExtensions.cs
@@ -19,7 +19,6 @@ namespace Proto.Promises
     {
         // AppendResult are extension methods instead of instance methods in case users want to add their own AppendResult extensions with ValueTuple arity greater than 2.
         // Instance methods would take precedence, causing results to be ((T1, T2), T3) instead of (T1, T2, T3).
-        // TODO: Optimize these to avoid delegates.
 
         /// <summary>
         /// Appends a result to the specified <paramref name="promise"/>, transforming it into a <see cref="Promise{T}"/>
@@ -33,7 +32,7 @@ namespace Proto.Promises
         /// when the <paramref name="promise"/> is resolved, or otherwise adopts the state of <paramref name="promise"/>.
         /// </returns>
         public static Promise<TAppend> AppendResult<TAppend>(this Promise promise, TAppend value)
-            => promise.Then(value, v => v);
+            => Internal.PromiseRefBase.CallbackHelperResult<TAppend>.AppendResult(promise, value);
 
         /// <summary>
         /// Appends <paramref name="value"/> to the result of the specified <paramref name="promise"/>, transforming it into a <see cref="Promise{T}"/>
@@ -48,6 +47,6 @@ namespace Proto.Promises
         /// <paramref name="value"/> when the <paramref name="promise"/> is resolved, or otherwise adopts the state of <paramref name="promise"/>.
         /// </returns>
         public static Promise<(T, TAppend)> AppendResult<T, TAppend>(this in Promise<T> promise, TAppend value)
-            => promise.Then(value, (v, r) => (r, v));
+            => Internal.PromiseRefBase.CallbackHelperResult<T>.AppendResult(promise, value);
     } // class PromiseExtensions
 }// namespace Proto.Promises

--- a/Package/Core/Promises/PromiseExtensions.cs
+++ b/Package/Core/Promises/PromiseExtensions.cs
@@ -1,0 +1,53 @@
+﻿#if PROTO_PROMISE_DEBUG_ENABLE || (!PROTO_PROMISE_DEBUG_DISABLE && DEBUG)
+#define PROMISE_DEBUG
+#else
+#undef PROMISE_DEBUG
+#endif
+
+using System;
+using System.Diagnostics;
+
+namespace Proto.Promises
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="Promise"/> and <see cref="Promise{T}"/>.
+    /// </summary>
+#if !PROTO_PROMISE_DEVELOPER_MODE
+    [DebuggerNonUserCode, StackTraceHidden]
+#endif
+    public static class PromiseExtensions
+    {
+        // AppendResult are extension methods instead of instance methods in case users want to add their own AppendResult extensions with ValueTuple arity greater than 2.
+        // Instance methods would take precedence, causing results to be ((T1, T2), T3) instead of (T1, T2, T3).
+        // TODO: Optimize these to avoid delegates.
+
+        /// <summary>
+        /// Appends a result to the specified <paramref name="promise"/>, transforming it into a <see cref="Promise{T}"/>
+        /// that will yield the <paramref name="value"/> when the <paramref name="promise"/> is resolved.
+        /// </summary>
+        /// <typeparam name="TAppend">The type of the <paramref name="value"/> to append to the <paramref name="promise"/>.</typeparam>
+        /// <param name="promise">The <see cref="Promise"/> to which the result will be appended.</param>
+        /// <param name="value">The value that will be yielded from the returned <see cref="Promise{T}"/> when the <paramref name="promise"/> is resolved.</param>
+        /// <returns>
+        /// A new <see cref="Promise{T}"/> that will be resolved with the specified <paramref name="value"/>
+        /// when the <paramref name="promise"/> is resolved, or otherwise adopts the state of <paramref name="promise"/>.
+        /// </returns>
+        public static Promise<TAppend> AppendResult<TAppend>(this Promise promise, TAppend value)
+            => promise.Then(value, v => v);
+
+        /// <summary>
+        /// Appends <paramref name="value"/> to the result of the specified <paramref name="promise"/>, transforming it into a <see cref="Promise{T}"/>
+        /// of <see cref="ValueTuple{T, TAppend}"/> that will yield both the original result and the appended <paramref name="value"/> when the <paramref name="promise"/> is resolved.
+        /// </summary>
+        /// <typeparam name="T">The type of the result of <paramref name="promise"/>.</typeparam>
+        /// <typeparam name="TAppend">The type of the <paramref name="value"/> to append to the result of <paramref name="promise"/>.</typeparam>
+        /// <param name="promise">The <see cref="Promise"/> to which the result will be appended.</param>
+        /// <param name="value">The value that will appended to the result of the <paramref name="promise"/>.</param>
+        /// <returns>
+        /// A new <see cref="Promise{T}"/> of <see cref="ValueTuple{T, TAppend}"/> that will yield both the original result and the appended
+        /// <paramref name="value"/> when the <paramref name="promise"/> is resolved, or otherwise adopts the state of <paramref name="promise"/>.
+        /// </returns>
+        public static Promise<(T, TAppend)> AppendResult<T, TAppend>(this in Promise<T> promise, TAppend value)
+            => promise.Then(value, (v, r) => (r, v));
+    } // class PromiseExtensions
+}// namespace Proto.Promises

--- a/Package/Core/Promises/PromiseExtensions.cs.meta
+++ b/Package/Core/Promises/PromiseExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b626d6e8787452b408dbcaac2f8728c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Core/Promises/PromiseStaticEach.cs
+++ b/Package/Core/Promises/PromiseStaticEach.cs
@@ -15,6 +15,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each(Promise promise1, Promise promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -25,6 +28,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each(Promise promise1, Promise promise2, Promise promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -36,6 +42,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -48,6 +57,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each(params Promise[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -60,6 +72,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each(ReadOnlySpan<Promise> promises)
             => Each(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -67,6 +82,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each(IEnumerable<Promise> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -76,6 +94,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise>
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -108,24 +129,36 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<Promise<T>.ResultContainer> Each<T>(Promise<T> promise1, Promise<T> promise2)
             => Promise<T>.Each(promise1, promise2);
 
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<Promise<T>.ResultContainer> Each<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
             => Promise<T>.Each(promise1, promise2, promise3);
 
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<Promise<T>.ResultContainer> Each<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
             => Promise<T>.Each(promise1, promise2, promise3, promise4);
 
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<Promise<T>.ResultContainer> Each<T>(params Promise<T>[] promises)
             => Promise<T>.Each(promises);
 
@@ -135,6 +168,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<Promise<T>.ResultContainer> Each<T>(ReadOnlySpan<Promise<T>> promises)
             => Promise<T>.Each(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -142,12 +178,18 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<Promise<T>.ResultContainer> Each<T>(IEnumerable<Promise<T>> promises)
             => Promise<T>.Each(promises);
 
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<Promise<T>.ResultContainer> Each<T, TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
             => Promise<T>.Each(promises);
     }
@@ -157,6 +199,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each(Promise<T> promise1, Promise<T> promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -167,6 +212,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -178,6 +226,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -190,6 +241,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each(params Promise<T>[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -202,6 +256,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each(ReadOnlySpan<Promise<T>> promises)
             => Each(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -209,6 +266,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each(IEnumerable<Promise<T>> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -218,6 +278,9 @@ namespace Proto.Promises
         /// <summary>
         /// Creates an <see cref="AsyncEnumerable{T}"/> that will yield the results of the supplied promises as those promises complete.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseEachGroup{T}"/> instead.
+        /// </remarks>
         public static AsyncEnumerable<ResultContainer> Each<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
         {
             ValidateArgument(promises, nameof(promises), 1);

--- a/Package/Core/Promises/PromiseStaticMerge.cs
+++ b/Package/Core/Promises/PromiseStaticMerge.cs
@@ -17,6 +17,11 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when all promises have resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <param name="promise1">The first promise to combine.</param>
+        /// <param name="promise2">The second promise to combine.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise All(Promise promise1, Promise promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -28,6 +33,12 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when all promises have resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <param name="promise1">The first promise to combine.</param>
+        /// <param name="promise2">The second promise to combine.</param>
+        /// <param name="promise3">The third promise to combine.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise All(Promise promise1, Promise promise2, Promise promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -40,6 +51,13 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when all promises have resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <param name="promise1">The first promise to combine.</param>
+        /// <param name="promise2">The second promise to combine.</param>
+        /// <param name="promise3">The third promise to combine.</param>
+        /// <param name="promise4">The fourth promise to combine.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise All(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -53,6 +71,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when all <paramref name="promises"/> have resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <param name="promises">The promises to combine.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise All(params Promise[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -66,6 +88,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when all <paramref name="promises"/> have resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <param name="promises">The promises to combine.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise All(ReadOnlySpan<Promise> promises)
             => All(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -74,6 +100,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when all <paramref name="promises"/> have resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <param name="promises">The promises to combine.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise All(IEnumerable<Promise> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -84,6 +114,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when all <paramref name="promises"/> have resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <param name="promises">The promises to combine.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise All<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise>
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -129,6 +163,9 @@ namespace Proto.Promises
         /// <param name="promise1">The first promise to combine.</param>
         /// <param name="promise2">The second promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All<T>(Promise<T> promise1, Promise<T> promise2, IList<T> valueContainer = null)
             => Promise<T>.All(promise1, promise2, valueContainer);
 
@@ -140,6 +177,9 @@ namespace Proto.Promises
         /// <param name="promise2">The second promise to combine.</param>
         /// <param name="promise3">The third promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, IList<T> valueContainer = null)
             => Promise<T>.All(promise1, promise2, promise3, valueContainer);
 
@@ -152,6 +192,9 @@ namespace Proto.Promises
         /// <param name="promise3">The third promise to combine.</param>
         /// <param name="promise4">The fourth promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4, IList<T> valueContainer = null)
             => Promise<T>.All(promise1, promise2, promise3, promise4, valueContainer);
 
@@ -159,6 +202,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve with a list of values in the same order as <paramref name="promises"/> when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <param name="promises">The promises to combine.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All<T>(params Promise<T>[] promises)
             => Promise<T>.All(promises);
 
@@ -169,6 +216,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve with a list of values in the same order as <paramref name="promises"/> when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <param name="promises">The promises to combine.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise All<T>(ReadOnlySpan<Promise<T>> promises)
             => Promise<T>.All(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -179,6 +230,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All<T>(IEnumerable<Promise<T>> promises, IList<T> valueContainer = null)
             => Promise<T>.All(promises, valueContainer);
 
@@ -188,6 +242,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The enumerator of promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All<T, TEnumerator>(TEnumerator promises, IList<T> valueContainer = null) where TEnumerator : IEnumerator<Promise<T>>
             => Promise<T>.All(promises, valueContainer);
 
@@ -233,6 +290,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve with the value of <paramref name="promise1"/> when both promises have resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<T1> Merge<T1>(Promise<T1> promise1, Promise promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -300,6 +360,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<(T1, T2)> Merge<T1, T2>(Promise<T1> promise1, Promise<T2> promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -316,6 +379,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<(T1, T2)> Merge<T1, T2>(Promise<T1> promise1, Promise<T2> promise2, Promise promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -373,6 +439,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2, T3}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<(T1, T2, T3)> Merge<T1, T2, T3>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -391,6 +460,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2, T3}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<(T1, T2, T3)> Merge<T1, T2, T3>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -453,6 +525,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2, T3, T4}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<(T1, T2, T3, T4)> Merge<T1, T2, T3, T4>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -473,6 +548,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2, T3, T4}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<(T1, T2, T3, T4)> Merge<T1, T2, T3, T4>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise promise5)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -540,6 +618,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<(T1, T2, T3, T4, T5)> Merge<T1, T2, T3, T4, T5>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -562,6 +643,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<(T1, T2, T3, T4, T5)> Merge<T1, T2, T3, T4, T5>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise promise6)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -634,6 +718,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<(T1, T2, T3, T4, T5, T6)> Merge<T1, T2, T3, T4, T5, T6>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -658,6 +745,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<(T1, T2, T3, T4, T5, T6)> Merge<T1, T2, T3, T4, T5, T6>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6, Promise promise7)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -735,6 +825,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<(T1, T2, T3, T4, T5, T6, T7)> Merge<T1, T2, T3, T4, T5, T6, T7>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6, Promise<T7> promise7)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -761,6 +854,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeGroup"/> instead.
+        /// </remarks>
         public static Promise<(T1, T2, T3, T4, T5, T6, T7)> Merge<T1, T2, T3, T4, T5, T6, T7>(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6, Promise<T7> promise7, Promise promise8)
         {
             ValidateArgument(promise1, nameof(promise1), 1);

--- a/Package/Core/Promises/PromiseStaticMergeSettled.cs
+++ b/Package/Core/Promises/PromiseStaticMergeSettled.cs
@@ -33,6 +33,9 @@ namespace Proto.Promises
         /// <param name="promise1">The first promise to combine.</param>
         /// <param name="promise2">The second promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(Promise promise1, Promise promise2, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -47,6 +50,9 @@ namespace Proto.Promises
         /// <param name="promise2">The second promise to combine.</param>
         /// <param name="promise3">The third promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(Promise promise1, Promise promise2, Promise promise3, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -63,6 +69,9 @@ namespace Proto.Promises
         /// <param name="promise3">The third promise to combine.</param>
         /// <param name="promise4">The 4th promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(Promise promise1, Promise promise2, Promise promise3, Promise promise4, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -76,6 +85,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve with a list of <see cref="ResultContainer"/>s in the same order as <paramref name="promises"/> when they have all completed.
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(params Promise[] promises)
             => AllSettled(promises, new ResultContainer[promises.Length]);
 
@@ -87,6 +99,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(ReadOnlySpan<Promise> promises, IList<ResultContainer> valueContainer = null)
             => AllSettled(promises.GetPersistedEnumerator(), valueContainer);
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -96,6 +111,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(Promise[] promises, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -107,6 +125,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(IEnumerable<Promise> promises, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -118,6 +139,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The enumerator of promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled<TEnumerator>(TEnumerator promises, IList<ResultContainer> valueContainer = null) where TEnumerator : IEnumerator<Promise>
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -209,6 +233,9 @@ namespace Proto.Promises
         /// <param name="promise1">The first promise to combine.</param>
         /// <param name="promise2">The second promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<Promise<T>.ResultContainer>> AllSettled<T>(Promise<T> promise1, Promise<T> promise2, IList<Promise<T>.ResultContainer> valueContainer = null)
             => Promise<T>.AllSettled(promise1, promise2, valueContainer);
 
@@ -219,6 +246,9 @@ namespace Proto.Promises
         /// <param name="promise2">The second promise to combine.</param>
         /// <param name="promise3">The third promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<Promise<T>.ResultContainer>> AllSettled<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, IList<Promise<T>.ResultContainer> valueContainer = null)
             => Promise<T>.AllSettled(promise1, promise2, promise3, valueContainer);
 
@@ -230,6 +260,9 @@ namespace Proto.Promises
         /// <param name="promise3">The third promise to combine.</param>
         /// <param name="promise4">The fourth promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<Promise<T>.ResultContainer>> AllSettled<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4, IList<Promise<T>.ResultContainer> valueContainer = null)
             => Promise<T>.AllSettled(promise1, promise2, promise3, promise4, valueContainer);
 
@@ -237,6 +270,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve with a list of <see cref="Promise{T}.ResultContainer"/>s in the same order as <paramref name="promises"/> when they have all completed.
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<Promise<T>.ResultContainer>> AllSettled<T>(params Promise<T>[] promises)
             => Promise<T>.AllSettled(promises);
 
@@ -248,6 +284,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<Promise<T>.ResultContainer>> AllSettled<T>(ReadOnlySpan<Promise<T>> promises, IList<Promise<T>.ResultContainer> valueContainer = null)
             => Promise<T>.AllSettled(promises.GetPersistedEnumerator(), valueContainer);
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -257,6 +296,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<Promise<T>.ResultContainer>> AllSettled<T>(IEnumerable<Promise<T>> promises, IList<Promise<T>.ResultContainer> valueContainer = null)
             => Promise<T>.AllSettled(promises, valueContainer);
 
@@ -265,6 +307,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The enumerator of promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<Promise<T>.ResultContainer>> AllSettled<T, TEnumerator>(TEnumerator promises, IList<Promise<T>.ResultContainer> valueContainer = null) where TEnumerator : IEnumerator<Promise<T>>
             => Promise<T>.AllSettled(promises, valueContainer);
 
@@ -310,6 +355,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(ResultContainer, ResultContainer)> MergeSettled(Promise promise1, Promise promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -363,6 +411,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, ResultContainer)> MergeSettled<T1>(Promise<T1> promise1, Promise promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -417,6 +468,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve with the values of the promises when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer)> MergeSettled<T1, T2>(Promise<T1> promise1, Promise<T2> promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -477,6 +531,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(ResultContainer, ResultContainer, ResultContainer)> MergeSettled(
             Promise promise1, Promise promise2, Promise promise3)
         {
@@ -536,6 +593,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1>(
             Promise<T1> promise1, Promise promise2, Promise promise3)
         {
@@ -595,6 +655,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer)> MergeSettled<T1, T2>(
             Promise<T1> promise1, Promise<T2> promise2, Promise promise3)
         {
@@ -654,6 +717,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer)> MergeSettled<T1, T2, T3>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3)
         {
@@ -720,6 +786,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled(
             Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
@@ -784,6 +853,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1>(
             Promise<T1> promise1, Promise promise2, Promise promise3, Promise promise4)
         {
@@ -848,6 +920,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1, T2>(
             Promise<T1> promise1, Promise<T2> promise2, Promise promise3, Promise promise4)
         {
@@ -913,6 +988,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer)> MergeSettled<T1, T2, T3>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise promise4)
         {
@@ -978,6 +1056,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer)> MergeSettled<T1, T2, T3, T4>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4)
         {
@@ -1049,6 +1130,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled(
             Promise promise1, Promise promise2, Promise promise3, Promise promise4, Promise promise5)
         {
@@ -1118,6 +1202,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1>(
             Promise<T1> promise1, Promise promise2, Promise promise3, Promise promise4, Promise promise5)
         {
@@ -1187,6 +1274,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1, T2>(
             Promise<T1> promise1, Promise<T2> promise2, Promise promise3, Promise promise4, Promise promise5)
         {
@@ -1257,6 +1347,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1, T2, T3>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise promise4, Promise promise5)
         {
@@ -1327,6 +1420,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer)> MergeSettled<T1, T2, T3, T4>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise promise5)
         {
@@ -1397,6 +1493,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer)> MergeSettled<T1, T2, T3, T4, T5>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5)
         {
@@ -1474,6 +1573,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled(
             Promise promise1, Promise promise2, Promise promise3, Promise promise4, Promise promise5, Promise promise6)
         {
@@ -1549,6 +1651,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1>(
             Promise<T1> promise1, Promise promise2, Promise promise3, Promise promise4, Promise promise5, Promise promise6)
         {
@@ -1624,6 +1729,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1, T2>(
             Promise<T1> promise1, Promise<T2> promise2, Promise promise3, Promise promise4, Promise promise5, Promise promise6)
         {
@@ -1699,6 +1807,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1, T2, T3>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise promise4, Promise promise5, Promise promise6)
         {
@@ -1774,6 +1885,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1, T2, T3, T4>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise promise5, Promise promise6)
         {
@@ -1849,6 +1963,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer)> MergeSettled<T1, T2, T3, T4, T5>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise promise6)
         {
@@ -1924,6 +2041,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer)> MergeSettled<T1, T2, T3, T4, T5, T6>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6)
         {
@@ -2006,6 +2126,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled(
             Promise promise1, Promise promise2, Promise promise3, Promise promise4, Promise promise5, Promise promise6, Promise promise7)
         {
@@ -2086,6 +2209,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1>(
             Promise<T1> promise1, Promise promise2, Promise promise3, Promise promise4, Promise promise5, Promise promise6, Promise promise7)
         {
@@ -2166,6 +2292,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1, T2>(
             Promise<T1> promise1, Promise<T2> promise2, Promise promise3, Promise promise4, Promise promise5, Promise promise6, Promise promise7)
         {
@@ -2246,6 +2375,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1, T2, T3>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise promise4, Promise promise5, Promise promise6, Promise promise7)
         {
@@ -2326,6 +2458,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1, T2, T3, T4>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise promise5, Promise promise6, Promise promise7)
         {
@@ -2406,6 +2541,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, ResultContainer, ResultContainer)> MergeSettled<T1, T2, T3, T4, T5>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise promise6, Promise promise7)
         {
@@ -2486,6 +2624,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, ResultContainer)> MergeSettled<T1, T2, T3, T4, T5, T6>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6, Promise promise7)
         {
@@ -2566,6 +2707,9 @@ namespace Proto.Promises
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve with the result container of each promise when they have all completed.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseMergeResultsGroup"/> instead.
+        /// </remarks>
         public static Promise<(Promise<T1>.ResultContainer, Promise<T2>.ResultContainer, Promise<T3>.ResultContainer, Promise<T4>.ResultContainer, Promise<T5>.ResultContainer, Promise<T6>.ResultContainer, Promise<T7>.ResultContainer)> MergeSettled<T1, T2, T3, T4, T5, T6, T7>(
             Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3, Promise<T4> promise4, Promise<T5> promise5, Promise<T6> promise6, Promise<T7> promise7)
         {

--- a/Package/Core/Promises/PromiseStaticRace.cs
+++ b/Package/Core/Promises/PromiseStaticRace.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Proto.Promises
 {
@@ -15,6 +16,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the promises has resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise Race(Promise promise1, Promise promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -26,6 +30,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the promises has resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise Race(Promise promise1, Promise promise2, Promise promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -38,6 +45,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the promises has resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise Race(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -51,6 +61,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the <paramref name="promises"/> has resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise Race(params Promise[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -64,6 +77,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the <paramref name="promises"/> has resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise Race(ReadOnlySpan<Promise> promises)
             => Race(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -72,6 +88,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the <paramref name="promises"/> has resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise Race(IEnumerable<Promise> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -82,6 +101,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the <paramref name="promises"/> has resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise Race<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise>
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -135,6 +157,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="int"/> that will resolve when the first of the promises has resolved with the index of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> RaceWithIndex(Promise promise1, Promise promise2)
         {
 
@@ -147,6 +173,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="int"/> that will resolve when the first of the promises has resolved with the index of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> RaceWithIndex(Promise promise1, Promise promise2, Promise promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -159,6 +189,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="int"/> that will resolve when the first of the promises has resolved with the index of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> RaceWithIndex(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -172,6 +206,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="int"/> that will resolve when the first of the promises has resolved with the index of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> RaceWithIndex(params Promise[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -185,6 +223,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="int"/> that will resolve when the first of the promises has resolved with the index of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> RaceWithIndex(ReadOnlySpan<Promise> promises)
             => RaceWithIndex(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -193,6 +235,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the <paramref name="promises"/> has resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> RaceWithIndex(IEnumerable<Promise> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -203,6 +249,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="int"/> that will resolve when the first of the promises has resolved with the index of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> RaceWithIndex<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise>
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -261,6 +311,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> Race<T>(Promise<T> promise1, Promise<T> promise2)
             => Promise<T>.Race(promise1, promise2);
 
@@ -268,6 +321,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> Race<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
             => Promise<T>.Race(promise1, promise2, promise3);
 
@@ -275,6 +331,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> Race<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
             => Promise<T>.Race(promise1, promise2, promise3, promise4);
 
@@ -282,6 +341,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> Race<T>(params Promise<T>[] promises)
             => Promise<T>.Race(promises);
 
@@ -292,6 +354,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> Race<T>(ReadOnlySpan<Promise<T>> promises)
             => Promise<T>.Race(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -300,6 +365,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> Race<T>(IEnumerable<Promise<T>> promises)
             => Promise<T>.Race(promises);
 
@@ -307,6 +375,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> Race<T, TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
             => Promise<T>.Race(promises);
 
@@ -314,6 +385,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the promises has resolved.
         /// If all promises are rejected or canceled, the returned <see cref="Promise"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise First(Promise promise1, Promise promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -325,6 +399,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the promises has resolved.
         /// If all promises are rejected or canceled, the returned <see cref="Promise"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise First(Promise promise1, Promise promise2, Promise promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -337,6 +414,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the promises has resolved.
         /// If all promises are rejected or canceled, the returned <see cref="Promise"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise First(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -350,6 +430,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the <paramref name="promises"/> has resolved.
         /// If all promises are rejected or canceled, the returned <see cref="Promise"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise First(params Promise[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -363,6 +446,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the <paramref name="promises"/> has resolved.
         /// If all promises are rejected or canceled, the returned <see cref="Promise"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise First(ReadOnlySpan<Promise> promises)
             => First(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -371,6 +457,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the <paramref name="promises"/> has resolved.
         /// If all promises are rejected or canceled, the returned <see cref="Promise"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise First(IEnumerable<Promise> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -381,6 +470,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the <paramref name="promises"/> has resolved.
         /// If all promises are rejected or canceled, the returned <see cref="Promise"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise First<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise>
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -438,6 +530,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="int"/> that will resolve when the first of the promises has resolved with the index of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> FirstWithIndex(Promise promise1, Promise promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -449,6 +545,7 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="int"/> that will resolve when the first of the promises has resolved with the index of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> FirstWithIndex(Promise promise1, Promise promise2, Promise promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -461,6 +558,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="int"/> that will resolve when the first of the promises has resolved with the index of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> FirstWithIndex(Promise promise1, Promise promise2, Promise promise3, Promise promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -474,6 +575,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="int"/> that will resolve when the first of the promises has resolved with the index of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> FirstWithIndex(params Promise[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -487,6 +592,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="int"/> that will resolve when the first of the promises has resolved with the index of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> FirstWithIndex(ReadOnlySpan<Promise> promises)
             => FirstWithIndex(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -495,6 +604,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise"/> that will resolve when the first of the <paramref name="promises"/> has resolved.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> FirstWithIndex(IEnumerable<Promise> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -505,6 +618,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="int"/> that will resolve when the first of the promises has resolved with the index of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{TAppend}(Promise, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<int>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<int> FirstWithIndex<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise>
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -567,6 +684,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> First<T>(Promise<T> promise1, Promise<T> promise2)
             => Promise<T>.First(promise1, promise2);
 
@@ -574,6 +694,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> First<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
             => Promise<T>.First(promise1, promise2, promise3);
 
@@ -581,6 +704,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> First<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
             => Promise<T>.First(promise1, promise2, promise3, promise4);
 
@@ -588,6 +714,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> First<T>(params Promise<T>[] promises)
             => Promise<T>.First(promises);
 
@@ -598,6 +727,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> First<T>(ReadOnlySpan<Promise<T>> promises)
             => Promise<T>.First(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -606,6 +738,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> First<T>(IEnumerable<Promise<T>> promises)
             => Promise<T>.First(promises);
 
@@ -613,6 +748,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup"/> instead.
+        /// </remarks>
         public static Promise<T> First<T, TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
             => Promise<T>.First(promises);
 
@@ -620,6 +758,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex<T>(Promise<T> promise1, Promise<T> promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -631,6 +773,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<in(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -643,6 +789,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -656,6 +806,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex<T>(params Promise<T>[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -669,6 +823,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex<T>(ReadOnlySpan<Promise<T>> promises)
             => RaceWithIndex<T, Internal.PersistedSpanEnumerator<Promise<T>>>(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -677,6 +835,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex<T>(IEnumerable<Promise<T>> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -687,6 +849,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex<T, TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -749,6 +915,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex<T>(Promise<T> promise1, Promise<T> promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -760,6 +930,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -772,6 +946,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex<T>(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -785,6 +963,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex<T>(params Promise<T>[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -798,6 +980,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex<T>(ReadOnlySpan<Promise<T>> promises)
             => FirstWithIndex<T, Internal.PersistedSpanEnumerator<Promise<T>>>(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -806,6 +992,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex<T>(IEnumerable<Promise<T>> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -816,6 +1006,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex<T, TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
         {
             ValidateArgument(promises, nameof(promises), 1);

--- a/Package/Core/Promises/PromiseTStatic.cs
+++ b/Package/Core/Promises/PromiseTStatic.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -19,17 +20,23 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> Race(Promise<T> promise1, Promise<T> promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
             ValidateArgument(promise2, nameof(promise2), 1);
             return Race(Internal.GetEnumerator(promise1, promise2));
         }
-        
+
         /// <summary>
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> Race(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -42,6 +49,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> Race(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -55,6 +65,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the <paramref name="promises"/> has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> Race(params Promise<T>[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -68,6 +81,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the <paramref name="promises"/> has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> Race(ReadOnlySpan<Promise<T>> promises)
             => Race(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -76,6 +92,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the <paramref name="promises"/> has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> Race(IEnumerable<Promise<T>> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -86,6 +105,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the <paramref name="promises"/> has resolved with the same value as that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> Race<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -150,6 +172,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> First(Promise<T> promise1, Promise<T> promise2)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -161,6 +186,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> First(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -173,6 +201,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the promises has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> First(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -186,6 +217,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the <paramref name="promises"/> has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> First(params Promise<T>[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -199,6 +233,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the <paramref name="promises"/> has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> First(ReadOnlySpan<Promise<T>> promises)
             => First(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -207,6 +244,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the <paramref name="promises"/> has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> First(IEnumerable<Promise<T>> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -217,6 +257,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve when the first of the <paramref name="promises"/> has resolved with the same value as that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<T> First<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -289,6 +332,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex(Promise<T> promise1, Promise<T> promise2)
             => Promise.RaceWithIndex(promise1, promise2);
 
@@ -296,6 +343,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
             => Promise.RaceWithIndex(promise1, promise2, promise3);
 
@@ -303,6 +354,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
             => Promise.RaceWithIndex(promise1, promise2, promise3, promise4);
 
@@ -310,6 +365,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex(params Promise<T>[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -323,6 +382,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex(ReadOnlySpan<Promise<T>> promises)
             => RaceWithIndex(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -331,6 +394,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex(IEnumerable<Promise<T>> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -341,6 +408,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.Race or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> RaceWithIndex<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
             => Promise.RaceWithIndex<T, TEnumerator>(promises);
 
@@ -348,6 +419,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex(Promise<T> promise1, Promise<T> promise2)
             => Promise.FirstWithIndex(promise1, promise2);
 
@@ -355,6 +430,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3)
             => Promise.FirstWithIndex(promise1, promise2, promise3);
 
@@ -362,6 +441,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4)
             => Promise.FirstWithIndex(promise1, promise2, promise3, promise4);
 
@@ -369,6 +452,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex(params Promise<T>[] promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -382,6 +469,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex(ReadOnlySpan<Promise<T>> promises)
             => FirstWithIndex(promises.GetPersistedEnumerator());
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -390,6 +481,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex(IEnumerable<Promise<T>> promises)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -400,6 +495,10 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> of <see cref="ValueTuple{T1, T2}"/> that will resolve when the first of the promises has resolved with the index and result of that promise.
         /// If all promises are rejected or canceled, the returned <see cref="Promise{T}"/> will be canceled or rejected with the same reason as the last <see cref="Promise{T}"/> that is rejected or canceled.
         /// </summary>
+        /// <remarks>
+        /// This function is obsolete. Prefer <see cref="PromiseExtensions.AppendResult{T, TAppend}(in Promise{T}, TAppend)"/> and <see cref="PromiseRaceGroup{T}"/> instead.
+        /// </remarks>
+        [Obsolete("Prefer Promise.AppendResult(int) and Promise<T>.First or PromiseRaceGroup<(T, int)>", false), EditorBrowsable(EditorBrowsableState.Never)]
         public static Promise<(int winIndex, T result)> FirstWithIndex<TEnumerator>(TEnumerator promises) where TEnumerator : IEnumerator<Promise<T>>
             => Promise.FirstWithIndex<T, TEnumerator>(promises);
 
@@ -426,6 +525,9 @@ namespace Proto.Promises
         /// <param name="promise1">The first promise to combine.</param>
         /// <param name="promise2">The second promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All(Promise<T> promise1, Promise<T> promise2, IList<T> valueContainer = null)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -441,6 +543,9 @@ namespace Proto.Promises
         /// <param name="promise2">The second promise to combine.</param>
         /// <param name="promise3">The third promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, IList<T> valueContainer = null)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -458,6 +563,9 @@ namespace Proto.Promises
         /// <param name="promise3">The third promise to combine.</param>
         /// <param name="promise4">The fourth promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4, IList<T> valueContainer = null)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -471,6 +579,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve with a list of values in the same order as <paramref name="promises"/> when they have all resolved.
         /// If any promise is rejected or canceled, the returned <see cref="Promise{T}"/> will immediately be canceled or rejected with the same reason.
         /// </summary>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All(params Promise<T>[] promises)
             => All(promises, new T[promises.Length]);
 
@@ -483,6 +594,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All(ReadOnlySpan<Promise<T>> promises, IList<T> valueContainer = null)
             => All(promises.GetPersistedEnumerator(), valueContainer);
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -493,6 +607,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All(Promise<T>[] promises, IList<T> valueContainer = null)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -505,6 +622,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All(IEnumerable<Promise<T>> promises, IList<T> valueContainer = null)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -517,6 +637,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The enumerator of promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the resolved values. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<T>> All<TEnumerator>(TEnumerator promises, IList<T> valueContainer = null) where TEnumerator : IEnumerator<Promise<T>>
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -622,6 +745,9 @@ namespace Proto.Promises
         /// <param name="promise1">The first promise to combine.</param>
         /// <param name="promise2">The second promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(Promise<T> promise1, Promise<T> promise2, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -636,6 +762,9 @@ namespace Proto.Promises
         /// <param name="promise2">The second promise to combine.</param>
         /// <param name="promise3">The third promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -652,6 +781,9 @@ namespace Proto.Promises
         /// <param name="promise3">The third promise to combine.</param>
         /// <param name="promise4">The fourth promise to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(Promise<T> promise1, Promise<T> promise2, Promise<T> promise3, Promise<T> promise4, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promise1, nameof(promise1), 1);
@@ -665,6 +797,9 @@ namespace Proto.Promises
         /// Returns a <see cref="Promise{T}"/> that will resolve with a list of <see cref="ResultContainer"/>s in the same order as <paramref name="promises"/> when they have all completed.
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(params Promise<T>[] promises)
             => AllSettled(promises, new ResultContainer[promises.Length]);
 
@@ -676,6 +811,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(ReadOnlySpan<Promise<T>> promises, IList<ResultContainer> valueContainer = null)
             => AllSettled(promises.GetPersistedEnumerator(), valueContainer);
 #endif // !UNITY_2018_3_OR_NEWER || UNITY_2021_2_OR_NEWER
@@ -685,6 +823,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(Promise<T>[] promises, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -696,6 +837,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled(IEnumerable<Promise<T>> promises, IList<ResultContainer> valueContainer = null)
         {
             ValidateArgument(promises, nameof(promises), 1);
@@ -707,6 +851,9 @@ namespace Proto.Promises
         /// </summary>
         /// <param name="promises">The enumerator of promises to combine.</param>
         /// <param name="valueContainer">Optional list that will be used to contain the result containers. If it is not provided, a new one will be created.</param>
+        /// <remarks>
+        /// Consider using <see cref="PromiseAllResultsGroup{T}"/> instead.
+        /// </remarks>
         public static Promise<IList<ResultContainer>> AllSettled<TEnumerator>(TEnumerator promises, IList<ResultContainer> valueContainer = null) where TEnumerator : IEnumerator<Promise<T>>
         {
             ValidateArgument(promises, nameof(promises), 1);

--- a/Package/Tests/CoreTests/APIs/FirstTests.cs
+++ b/Package/Tests/CoreTests/APIs/FirstTests.cs
@@ -665,6 +665,7 @@ namespace ProtoPromise.Tests.APIs
             cancelationSource.Dispose();
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         [Test]
         public void FirstWithIndex_2_void(
             [Values(0, 1)] int winIndex,
@@ -940,5 +941,6 @@ namespace ProtoPromise.Tests.APIs
             Assert.AreEqual(winIndex, resultIndex);
             Assert.AreEqual(1, result);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Package/Tests/CoreTests/APIs/PromiseGroups/PromiseRaceWithIndexGroupTests.cs
+++ b/Package/Tests/CoreTests/APIs/PromiseGroups/PromiseRaceWithIndexGroupTests.cs
@@ -12,6 +12,7 @@ using System.Linq;
 
 namespace ProtoPromise.Tests.APIs.PromiseGroups
 {
+#pragma warning disable CS0618 // Type or member is obsolete
     public class PromiseRaceWithIndexGroupTests
     {
         [SetUp]

--- a/Package/Tests/CoreTests/APIs/RaceTests.cs
+++ b/Package/Tests/CoreTests/APIs/RaceTests.cs
@@ -333,6 +333,7 @@ namespace ProtoPromise.Tests.APIs
             Assert.IsTrue(invoked);
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         [Test]
         public void RaceWithIndex_2_void(
             [Values(0, 1)] int winIndex,
@@ -608,5 +609,6 @@ namespace ProtoPromise.Tests.APIs
             Assert.AreEqual(winIndex, resultIndex);
             Assert.AreEqual(1, result);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Package/Tests/CoreTests/APIs/UncaughtRejectionTests.cs
+++ b/Package/Tests/CoreTests/APIs/UncaughtRejectionTests.cs
@@ -625,6 +625,7 @@ namespace ProtoPromise.Tests.APIs
             }
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         [Test, TestCaseSource(nameof(GetExpectedRejections))]
         public void PromiseRaceWithIndex_UncaughtRejectionIsSentToUncaughtRejectionHandler_void(object expectedRejectionValue)
         {
@@ -742,6 +743,7 @@ namespace ProtoPromise.Tests.APIs
                 Promise.Config.UncaughtRejectionHandler = currentRejectionHandler;
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         [Test, TestCaseSource(nameof(GetExpectedRejections))]
         public void PromiseFirst_UncaughtRejectionIsSuppressed_void(object expectedRejectionValue)
@@ -837,6 +839,7 @@ namespace ProtoPromise.Tests.APIs
             }
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         [Test, TestCaseSource(nameof(GetExpectedRejections))]
         public void PromiseFirstWithIndex_UncaughtRejectionIsSuppressed_void(object expectedRejectionValue)
         {
@@ -930,6 +933,7 @@ namespace ProtoPromise.Tests.APIs
                 Promise.Config.UncaughtRejectionHandler = currentRejectionHandler;
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
 #if !UNITY_WEBGL
         private static IEnumerable<TestCaseData> GetExpectedRejectionsAndTimeout()

--- a/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseRaceWithIndexGroupConcurrencyTests.cs
+++ b/Package/Tests/CoreTests/Concurrency/PromiseGroups/PromiseRaceWithIndexGroupConcurrencyTests.cs
@@ -14,6 +14,7 @@ using System.Linq;
 
 namespace ProtoPromise.Tests.Concurrency.PromiseGroups
 {
+#pragma warning disable CS0618 // Type or member is obsolete
     public class PromiseRaceWithIndexGroupConcurrencyTests
     {
         const string rejectValue = "Fail";


### PR DESCRIPTION
Deprecated `*WithIndex` functions and types.
Added remarks xml docs to point users to newer promise groups.