### PR TITLE
Run core tests on ubuntu-arm

### DIFF
--- a/.github/workflows/dotnet-core-tests.yml
+++ b/.github/workflows/dotnet-core-tests.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   dotnet-core-tests:
     name: ${{ matrix.config }}-${{ matrix.objectPooling.name }}-${{ matrix.devMode.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     
     strategy:
       fail-fast: false


### PR DESCRIPTION
Arm architecture has a weaker memory model than x64, so we want to run tests on it to ensure thread safety.